### PR TITLE
Fix sdk handling numpy views

### DIFF
--- a/crates/re_sdk_python/example.py
+++ b/crates/re_sdk_python/example.py
@@ -25,7 +25,6 @@ def log_dummy_data(args):
         # TODO(nikolausWest): Make setting the color here optional
         rgba = [200, 0, 100, 200]
         colors = np.array([rgba])
-        # TODO(nikolausWest): Figure out why this copy is needed.
         rerun.log_points("depth3D", sample.point_cloud.copy(), colors)
 
         rerun.log_image("rgb", sample.rgb_image)

--- a/crates/re_sdk_python/python/rerun_sdk/__init__.py
+++ b/crates/re_sdk_python/python/rerun_sdk/__init__.py
@@ -157,18 +157,22 @@ def log_depth_image(obj_path, image, meter=None, space=None):
     log_tensor(obj_path, image, meter=meter, space=space)
 
 
-def log_tensor(obj_path, image, meter=None, space=None):
+def log_tensor(obj_path, tensor, meter=None, space=None):
     """
     If no `space` is given, the space name "2D" will be used.
     """
-    if image.dtype == 'uint8':
-        rerun_rs.log_tensor_u8(obj_path, image, meter, space)
-    elif image.dtype == 'uint16':
-        rerun_rs.log_tensor_u16(obj_path, image, meter, space)
-    elif image.dtype == 'float32':
-        rerun_rs.log_tensor_f32(obj_path, image, meter, space)
-    elif image.dtype == 'float64':
+    # Workaround to handle that `rerun_rs` can't handle numpy views correctly.
+    # TODO(nikolausWest): Remove this extra copy once underlying issue in Rust SDK is fixed.
+    tensor = tensor if tensor.base is None else tensor.copy()
+
+    if tensor.dtype == 'uint8':
+        rerun_rs.log_tensor_u8(obj_path, tensor, meter, space)
+    elif tensor.dtype == 'uint16':
+        rerun_rs.log_tensor_u16(obj_path, tensor, meter, space)
+    elif tensor.dtype == 'float32':
+        rerun_rs.log_tensor_f32(obj_path, tensor, meter, space)
+    elif tensor.dtype == 'float64':
         rerun_rs.log_tensor_f32(
-            obj_path, image.astype('float32'), meter, space)
+            obj_path, tensor.astype('float32'), meter, space)
     else:
-        raise TypeError(f"Unsupported dtype: {image.dtype}")
+        raise TypeError(f"Unsupported dtype: {tensor.dtype}")


### PR DESCRIPTION
Comes after #40

Push the workaround of copying all numpy array views before passing to the Rust SDK into the Python SDK