### PR TITLE
pyproject.toml: only depend on numpy

### DIFF
--- a/crates/re_sdk_python/pyproject.toml
+++ b/crates/re_sdk_python/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["opencv-python"]
+dependencies = ["numpy"]
 description = "The Rerun Logging SDK"
 keywords = ["computer-vision", "logging", "rerun"]
 license = {text = "MIT OR Apache-2.0"}


### PR DESCRIPTION
The actual rerun_sdk python project should only depend on numpy, not opencv.