### PR TITLE
Move shell-scripts into scripts folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This is written for anyone who wants to contribute to the Rerun repository.
 Rerun is an open core company, and this repository is dual-licensed under MIT and APACHE. However, this repository is NOT YET open source, but IT WILL BE. Therefore we ask you to avoid making public clones of this repository, but in other respects treat it as any other open source GitHub project.
 
 ## Setup
-First up, you need to install the Rust toolchain: <https://rustup.rs/>. Then run `./setup_dev.sh`.
+First up, you need to install the Rust toolchain: <https://rustup.rs/>. Then run `./scripts/setup_dev.sh`.
 
 ## Structure
 The main crates are found in the `crates/` folder, with examples in the `examples/` folder.
@@ -24,7 +24,7 @@ We use [cargo deny](https://github.com/EmbarkStudios/cargo-deny) to check our de
 
 Configure your editor to run `cargo fmt` on save. Also configure it to strip trailing whitespace, an to end each file with a newline. Settings for VSCode can be found in the `.vscode` folder and should be applied automatically. If you are using another editor, consider adding good setting to this repository!
 
-To check everything in one go, run `./check.sh`. `check.sh` should ideally check approximately the same things as our CI.
+To check everything in one go, run `./scripts/check.sh`. `check.sh` should ideally check approximately the same things as our CI.
 
 ### Optional
 You can use [bacon](https://github.com/Canop/bacon) to automatically check your code on each save. For instance, running just `bacon` will re-run `cargo cranky` each time you change a rust file. See `bacon.toml` for more.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We don't have any pre-built binaries yet, so you need to build Rerun from source
 
 First up, you need to install the Rust toolchain: https://rustup.rs/
 
-Then, setup the rest of the required tools by running `./setup.sh`.
+Then, setup the rest of the required tools by running `./scripts/setup.sh`.
 
 ## Installing the Rerun viewer
 After running the setup above, you can build and install the rerun viewer with:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # This scripts runs various CI-like checks in a convenient way.
-set -eux
+
+set -eu
+script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$script_path/.."
+set -x
 
 RUSTFLAGS="-D warnings"
 RUSTDOCFLAGS="-D warnings" # https://github.com/emilk/egui/pull/1454

--- a/scripts/check_python.sh
+++ b/scripts/check_python.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # This scripts checks our Python SDK
-set -eux
+
+set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/.."
+set -x"
 
 source crates/re_sdk_python/setup_env.sh
 maturin build -m crates/re_sdk_python/Cargo.toml

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 
 set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd "$script_path"
+cd "$script_path/.."
 set -x
 
 # eframe dependencies needed on run on Linux and Fedora Rawhide:

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -3,10 +3,10 @@
 
 set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd "$script_path"
+cd "$script_path/.."
 set -x
 
-./setup.sh
+./scripts/setup.sh
 cargo install cargo-cranky # Uses lints defined in Cranky.toml. See https://github.com/ericseppanen/cargo-cranky
 cargo install cargo-deny # https://github.com/EmbarkStudios/cargo-deny
 


### PR DESCRIPTION
Keep the root a bit more tidy.

I also made a separate `scripts/check_python.sh` for when you are iterating on the Python SDK.