### PR TITLE
Refactor how vectors of data is stored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,8 @@ dependencies = [
  "ahash",
  "criterion",
  "itertools",
+ "log",
+ "log-once",
  "mimalloc",
  "nohash-hasher",
  "puffin",

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -12,6 +12,8 @@ re_log_types = { path = "../re_log_types" }
 
 ahash = "0.8"
 itertools = "0.10"
+log = "0.4"
+log-once = "0.3"
 nohash-hasher = "0.2"
 tracing = "0.1"
 

--- a/crates/re_data_store/src/storage.rs
+++ b/crates/re_data_store/src/storage.rs
@@ -379,15 +379,13 @@ impl<Time: 'static + Copy + Ord> DataStoreTypeErased<Time> {
             DataType::Color => handle_type!(Color, data_types::Color),
             DataType::Vec2 => handle_type!(Vec2, data_types::Vec2),
             DataType::BBox2D => handle_type!(BBox2D, re_log_types::BBox2D),
-            DataType::LineSegments2D => handle_type!(LineSegments2D, data_types::LineSegments2D),
             DataType::Vec3 => handle_type!(Vec3, data_types::Vec3),
             DataType::Box3 => handle_type!(Box3, re_log_types::Box3),
-            DataType::Path3D => handle_type!(Path3D, data_types::Path3D),
-            DataType::LineSegments3D => handle_type!(LineSegments3D, data_types::LineSegments3D),
             DataType::Mesh3D => handle_type!(Mesh3D, re_log_types::Mesh3D),
             DataType::Camera => handle_type!(Camera, re_log_types::Camera),
             DataType::Tensor => handle_type!(Tensor, re_log_types::Tensor),
             DataType::Space => handle_type!(Space, ObjPath),
+            DataType::DataVec => handle_type!(DataVec, DataVec),
         }
     }
 }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -254,7 +254,7 @@ impl LoggedData {
     pub fn data_type(&self) -> DataType {
         match self {
             Self::Single(data) | Self::BatchSplat(data) => data.data_type(),
-            Self::Batch { data, .. } => data.data_type(),
+            Self::Batch { data, .. } => data.element_data_type(),
         }
     }
 }

--- a/crates/re_log_types/src/objects.rs
+++ b/crates/re_log_types/src/objects.rs
@@ -26,12 +26,12 @@ impl ObjectType {
             Self::Image => &["space", "color", "tensor", "meter"],
             Self::Point2D => &["space", "color", "pos", "radius"],
             Self::BBox2D => &["space", "color", "bbox", "stroke_width", "label"],
-            Self::LineSegments2D => &["space", "color", "line_segments", "stroke_width"],
+            Self::LineSegments2D => &["space", "color", "points", "stroke_width"],
 
             Self::Point3D => &["space", "color", "pos", "radius"],
             Self::Box3D => &["space", "color", "obb", "stroke_width"],
             Self::Path3D => &["space", "color", "points", "stroke_width"],
-            Self::LineSegments3D => &["space", "color", "line_segments", "stroke_width"],
+            Self::LineSegments3D => &["space", "color", "points", "stroke_width"],
             Self::Mesh3D => &["space", "color", "mesh"],
             Self::Camera => &["space", "color", "camera"],
         }

--- a/crates/re_sdk_python/src/python_bridge.rs
+++ b/crates/re_sdk_python/src/python_bridge.rs
@@ -302,7 +302,7 @@ fn log_points(
                 let colors: Vec<[u8; 4]> = colors
                     .as_slice()
                     .unwrap()
-                    .chunks(3)
+                    .chunks_exact(3)
                     .into_iter()
                     .map(|chunk| [chunk[0], chunk[1], chunk[2], 255])
                     .collect();
@@ -317,7 +317,7 @@ fn log_points(
                 let colors: Vec<[u8; 4]> = colors
                     .as_slice()
                     .unwrap()
-                    .chunks(4)
+                    .chunks_exact(4)
                     .into_iter()
                     .map(|chunk| [chunk[0], chunk[1], chunk[2], chunk[3]])
                     .collect();
@@ -341,7 +341,7 @@ fn log_points(
             let data: Vec<[f32; 2]> = positions
                 .as_slice()
                 .unwrap()
-                .chunks(2)
+                .chunks_exact(2)
                 .into_iter()
                 .map(|chunk| [chunk[0] as f32, chunk[1] as f32])
                 .collect();
@@ -351,7 +351,7 @@ fn log_points(
             let data: Vec<[f32; 3]> = positions
                 .as_slice()
                 .unwrap()
-                .chunks(3)
+                .chunks_exact(3)
                 .into_iter()
                 .map(|chunk| [chunk[0] as f32, chunk[1] as f32, chunk[2] as f32])
                 .collect();
@@ -406,7 +406,7 @@ fn log_path(
     let positions: Vec<[f32; 3]> = positions
         .as_slice()
         .unwrap()
-        .chunks(3)
+        .chunks_exact(3)
         .into_iter()
         .map(|chunk| [chunk[0], chunk[1], chunk[2]])
         .collect();
@@ -415,7 +415,7 @@ fn log_path(
         msg_id: MsgId::random(),
         time_point: time_point.clone(),
         data_path: DataPath::new(obj_path.clone(), "points".into()),
-        data: LoggedData::Single(Data::Path3D(positions)),
+        data: LoggedData::Single(Data::DataVec(DataVec::Vec3(positions))),
     }));
 
     if let Some(color) = color {
@@ -468,21 +468,21 @@ fn log_line_segments(
             let positions = positions
                 .as_slice()
                 .unwrap()
-                .chunks(4)
+                .chunks_exact(2)
                 .into_iter()
-                .map(|c| [[c[0], c[1]], [c[2], c[3]]])
+                .map(|c| [c[0], c[1]])
                 .collect();
-            (2, Data::LineSegments2D(positions))
+            (2, Data::DataVec(DataVec::Vec2(positions)))
         }
         [_, 3] => {
             let positions = positions
                 .as_slice()
                 .unwrap()
-                .chunks(6)
+                .chunks_exact(3)
                 .into_iter()
-                .map(|c| [[c[0], c[1], c[2]], [c[3], c[4], c[5]]])
+                .map(|c| [c[0], c[1], c[2]])
                 .collect();
-            (3, Data::LineSegments3D(positions))
+            (3, Data::DataVec(DataVec::Vec3(positions)))
         }
         _ => {
             return Err(PyTypeError::new_err(format!(

--- a/crates/re_viewer/src/misc.rs
+++ b/crates/re_viewer/src/misc.rs
@@ -102,9 +102,9 @@ pub fn calc_bbox_2d(objects: &re_data_store::Objects<'_>) -> emath::Rect {
     }
 
     for (_, obj) in objects.line_segments2d.iter() {
-        for [a, b] in obj.line_segments {
-            bbox.extend_with(a.into());
-            bbox.extend_with(b.into());
+        for pair in obj.points.chunks_exact(2) {
+            bbox.extend_with(pair[0].into());
+            bbox.extend_with(pair[1].into());
         }
     }
 
@@ -156,9 +156,9 @@ pub fn calc_bbox_3d(objects: &re_data_store::Objects<'_>) -> macaw::BoundingBox 
     }
 
     for (_, obj) in objects.line_segments3d.iter() {
-        for &[a, b] in obj.line_segments {
-            bbox.extend(a.into());
-            bbox.extend(b.into());
+        for pair in obj.points.chunks_exact(2) {
+            bbox.extend(pair[0].into());
+            bbox.extend(pair[1].into());
         }
     }
 

--- a/crates/re_viewer/src/misc/log_db.rs
+++ b/crates/re_viewer/src/misc/log_db.rs
@@ -273,18 +273,17 @@ impl DataColumns {
 
                 DataType::Vec2 => ("2D vector", "s"),
                 DataType::BBox2D => ("2D bounding box", "es"),
-                DataType::LineSegments2D => ("2D line segment list", "s"),
 
                 DataType::Vec3 => ("3D vector", "s"),
                 DataType::Box3 => ("3D box", "es"),
-                DataType::Path3D => ("3D path", "s"),
-                DataType::LineSegments3D => ("3D line segment list", "s"),
                 DataType::Mesh3D => ("mesh", "es"),
                 DataType::Camera => ("camera", "s"),
 
                 DataType::Tensor => ("tensor", "s"),
 
                 DataType::Space => ("space", "s"),
+
+                DataType::DataVec => ("vector", "s"),
             };
 
             summaries.push(plurality(set.len(), stem, plur));

--- a/crates/re_viewer/src/ui/context_panel.rs
+++ b/crates/re_viewer/src/ui/context_panel.rs
@@ -5,6 +5,8 @@ use re_log_types::{Data, DataMsg, DataPath, LogMsg, LoggedData, MsgId};
 
 use crate::{LogDb, Preview, Selection, ViewerContext};
 
+use super::space_view::ui_data_vec;
+
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub(crate) struct ContextPanel {}
@@ -130,7 +132,7 @@ pub(crate) fn view_object(
                     let msg_id = &msg_ids[0];
                     crate::space_view::ui_data(ctx, ui, msg_id, &data, preview);
                 } else {
-                    ui.label(format!("{} x {:?}", data_vec.len(), data_vec.data_type()));
+                    ui_data_vec(ui, &data_vec);
                 }
 
                 ui.end_row();
@@ -157,7 +159,7 @@ fn view_data(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui, data_path: &DataPat
         let msg_id = &msg_ids[0];
         show_detailed_data(ctx, ui, msg_id, &data);
     } else {
-        ui.label(format!("{} x {:?}", data_vec.len(), data_vec.data_type()));
+        ui_data_vec(ui, &data_vec);
     }
 
     Some(())

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -459,9 +459,6 @@ pub(crate) fn ui_data(
         Data::String(string) => ui.label(format!("{string:?}")),
 
         Data::Vec2([x, y]) => ui.label(format!("[{x:.1}, {y:.1}]")),
-        Data::LineSegments2D(linesegments) => {
-            ui.label(format!("{} 2D line segment(s)", linesegments.len()))
-        }
         Data::BBox2D(bbox) => ui.label(format!(
             "BBox2D(min: [{:.1} {:.1}], max: [{:.1} {:.1}])",
             bbox.min[0], bbox.min[1], bbox.max[0], bbox.max[1]
@@ -469,8 +466,6 @@ pub(crate) fn ui_data(
 
         Data::Vec3([x, y, z]) => ui.label(format!("[{x:.3}, {y:.3}, {z:.3}]")),
         Data::Box3(_) => ui.label("3D box"),
-        Data::Path3D(_) => ui.label("3D path"),
-        Data::LineSegments3D(segments) => ui.label(format!("{} 3D line segments", segments.len())),
         Data::Mesh3D(_) => ui.label("3D mesh"),
         Data::Camera(_) => ui.label("Camera"),
 
@@ -509,5 +504,15 @@ pub(crate) fn ui_data(
             // ui.label(space.to_string())
             ctx.space_button(ui, space)
         }
+
+        Data::DataVec(data_vec) => ui_data_vec(ui, data_vec),
     }
+}
+
+pub(crate) fn ui_data_vec(ui: &mut egui::Ui, data_vec: &DataVec) -> egui::Response {
+    ui.label(format!(
+        "{} x {:?}",
+        data_vec.len(),
+        data_vec.element_data_type(),
+    ))
 }

--- a/crates/re_viewer/src/ui/view3d/scene.rs
+++ b/crates/re_viewer/src/ui/view3d/scene.rs
@@ -181,16 +181,16 @@ impl Scene {
             crate::profile_scope!("line_segments3d");
             for (props, obj) in objects.line_segments3d.iter() {
                 let re_data_store::LineSegments3D {
-                    line_segments,
+                    points,
                     stroke_width,
                 } = *obj;
 
                 let line_radius = stroke_width.map_or_else(
                     || {
                         let bbox = macaw::BoundingBox::from_points(
-                            line_segments
-                                .iter()
-                                .flat_map(|&[a, b]| [Vec3::from(a), Vec3::from(b)]),
+                            points
+                                .chunks_exact(2)
+                                .flat_map(|pair| [Vec3::from(pair[0]), Vec3::from(pair[1])]),
                         );
                         let dist_to_camera = camera_plane.distance(bbox.center());
                         dist_to_camera * line_radius_from_distance
@@ -202,7 +202,10 @@ impl Scene {
 
                 scene.line_segments.push(LineSegments {
                     obj_path_hash: *props.obj_path.hash(),
-                    segments: line_segments.clone(),
+                    segments: points
+                        .chunks_exact(2)
+                        .map(|pair| [pair[0], pair[1]])
+                        .collect(),
                     radius: line_radius,
                     color,
                 });

--- a/examples/objectron/src/lib.rs
+++ b/examples/objectron/src/lib.rs
@@ -170,29 +170,52 @@ fn log_annotation_pbdata(
 
             if keypoints_2d.len() == 9 {
                 // Bounding box. First point is center.
-                let line_segments = vec![
-                    [keypoints_2d[1], keypoints_2d[2]],
-                    [keypoints_2d[1], keypoints_2d[3]],
-                    [keypoints_2d[4], keypoints_2d[2]],
-                    [keypoints_2d[4], keypoints_2d[3]],
+                let points = vec![
+                    keypoints_2d[1],
+                    keypoints_2d[2],
                     //
-                    [keypoints_2d[5], keypoints_2d[6]],
-                    [keypoints_2d[5], keypoints_2d[7]],
-                    [keypoints_2d[8], keypoints_2d[6]],
-                    [keypoints_2d[8], keypoints_2d[7]],
+                    keypoints_2d[1],
+                    keypoints_2d[3],
                     //
-                    [keypoints_2d[1], keypoints_2d[5]],
-                    [keypoints_2d[2], keypoints_2d[6]],
-                    [keypoints_2d[3], keypoints_2d[7]],
-                    [keypoints_2d[4], keypoints_2d[8]],
+                    keypoints_2d[4],
+                    keypoints_2d[2],
+                    //
+                    keypoints_2d[4],
+                    keypoints_2d[3],
+                    //
+                    //
+                    keypoints_2d[5],
+                    keypoints_2d[6],
+                    //
+                    keypoints_2d[5],
+                    keypoints_2d[7],
+                    //
+                    keypoints_2d[8],
+                    keypoints_2d[6],
+                    //
+                    keypoints_2d[8],
+                    keypoints_2d[7],
+                    //
+                    //
+                    keypoints_2d[1],
+                    keypoints_2d[5],
+                    //
+                    keypoints_2d[2],
+                    keypoints_2d[6],
+                    //
+                    keypoints_2d[3],
+                    keypoints_2d[7],
+                    //
+                    keypoints_2d[4],
+                    keypoints_2d[8],
                 ];
 
                 let obj_path = &data_path / "bbox2d";
                 logger.log(data_msg(
                     &time_point,
                     &obj_path,
-                    "line_segments",
-                    Data::LineSegments2D(line_segments),
+                    "points",
+                    Data::DataVec(DataVec::Vec2(points)),
                 ));
                 logger.log(data_msg(
                     &time_point,


### PR DESCRIPTION
Previously we had special Data types for a vector of points and line segments.

This PR simplifies this to instead use the type-erased `DataVec`.

This makes the code simpler, more general, and more dynamic - but it moves type checking into a later staged.

It's very likely we want to refactor and generalize this further, for instance to support tensors.