### PR TITLE
Add CameraSpaceConvention enum to the logged Camera type 

### DIFF
--- a/crates/re_viewer/src/misc/viewer_context.rs
+++ b/crates/re_viewer/src/misc/viewer_context.rs
@@ -220,12 +220,14 @@ pub(crate) struct Caches {
 #[derive(Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Options {
     pub show_camera_mesh_in_3d: bool,
+    pub show_camera_axes_in_3d: bool,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
             show_camera_mesh_in_3d: true,
+            show_camera_axes_in_3d: true,
         }
     }
 }

--- a/crates/re_viewer/src/ui/view3d/camera.rs
+++ b/crates/re_viewer/src/ui/view3d/camera.rs
@@ -4,6 +4,7 @@ use macaw::{vec3, IsoTransform, Mat4, Quat, Vec3};
 
 pub const DEFAULT_FOV_Y: f32 = 55.0_f32 * std::f32::consts::TAU / 360.0;
 
+/// We use X=right, Y=up, Z=back.
 #[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Camera {
     pub world_from_view: IsoTransform,

--- a/examples/objectron/src/lib.rs
+++ b/examples/objectron/src/lib.rs
@@ -394,7 +394,7 @@ fn log_ar_camera(
     let w = ar_camera.image_resolution_width.unwrap() as f32;
     let h = ar_camera.image_resolution_height.unwrap() as f32;
 
-    // Because the dataset is collected in portrait:
+    // Because the dataset was collected in portrait:
     let swizzle_x_y = glam::Mat3::from_cols_array_2d(&[[0., 1., 0.], [1., 0., 0.], [0., 0., 1.]]);
     let intrinsics = swizzle_x_y * intrinsics * swizzle_x_y;
     let rot = rot * glam::Quat::from_axis_angle(glam::Vec3::Z, std::f32::consts::TAU / 4.0);
@@ -403,6 +403,7 @@ fn log_ar_camera(
     let camera = re_log_types::Camera {
         rotation: rot.into(),
         position: translation.into(),
+        camera_space_convention: CameraSpaceConvention::XRightYUpZBack,
         intrinsics: Some(intrinsics.to_cols_array_2d()),
         resolution: Some([w, h]),
     };


### PR DESCRIPTION
We use the +X=right, +Y=up, +Z=back system in the rerun renderer, but different users use different conventions.

We add an `enum` to help here.

This commit also adds code to show the user coordinate axes in the 3D view.