### PR TITLE
Post issues to Linear team named Product

### DIFF
--- a/.github/actions/create-linear-issue/action.yml
+++ b/.github/actions/create-linear-issue/action.yml
@@ -4,6 +4,9 @@ inputs:
   linear-api-token:
     description: "The API key for our Linear team"
     required: true
+  linear-team-name:
+    description: "The name of the team in Linear to copy issues to"
+    required: true
 
 runs:
   using: "node16"

--- a/.github/actions/create-linear-issue/index.js
+++ b/.github/actions/create-linear-issue/index.js
@@ -5,7 +5,8 @@ const github = require('@actions/github');
 
 const createLinearIssue = async function (client, title, description, githubUrl) {
     const teams = await client.teams();
-    const team = teams.nodes.filter(team => team.name == "Rerun")[0];
+    const teamName = core.getInput('linear-team-name');
+    const team = teams.nodes.filter(team => team.name == teamName)[0];
 
     const extendedDescription = `
 **This issue is a copy of an issue created on Github**

--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -19,3 +19,4 @@ jobs:
         uses: ./.github/actions/create-linear-issue
         with:
           linear-api-token: ${{ secrets.LINEAR_API_KEY }}
+          linear-team-name: ${{ secrets.LINEAR_ISSUE_INBOX_TEAM_NAME }}


### PR DESCRIPTION
This PR breaks out the last Rerun specific data from the create-linear-issue action, the name of the team to post new issues to. It also updates the related workflow to read that name from secrets so we don't have to update code to change the name.