### PR TITLE
Create `re_log` library to wrap `tracing` and `log_once`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,21 +36,21 @@ You can view higher log levels with `export RUST_LOG=debug` or `export RUST_LOG=
 ## Rust code
 
 ### Error handling and logging
+We log problems using our own `re_log` crate (which is currently a wrapper around [`tracing`](https://crates.io/crates/tracing/)).
+
 * An error should never happen in silence.
 * Validate code invariants using `assert!`.
 * Validate user data and return errors using [`thiserror`](https://crates.io/crates/thiserror).
 * Attach context to errors as they bubble up the stack using [`anyhow`](https://crates.io/crates/anyhow).
-* Log errors using `log::error!` or `log_once::error_once!`.
-* If a problem is recoverable, use `tracing::warn!` or `log_once::warn_once!`.
-* If an event is of interest to the user, log it using `tracing::info!` or `log_once::info_once!`.
+* Log errors using `re_log::error!` or `re_log::error_once!`.
+* If a problem is recoverable, use `re_log::warn!` or `re_log::warn_once!`.
+* If an event is of interest to the user, log it using `re_log::info!` or `re_log::info_once!`.
 * The code should only panic if there is a bug in the code.
 * Never ignore an error: either pass it on, or log it.
 * Handle each error exactly once. If you log it, don't pass it on. If you pass it on, don't log it.
 
 
 ### Libraries
-We use [`tracing`](https://crates.io/crates/tracing/) for logging.
-
 We use [`thiserror`](https://crates.io/crates/thiserror) for errors in our libraries, and [`anyhow`](https://crates.io/crates/anyhow) for type-erased errors in applications.
 
 For faster hashing, we use [`ahash`](https://crates.io/crates/ahash) (`ahash::HashMap`, …).
@@ -77,7 +77,7 @@ You can also use the `todo()!` macro during development, but again it won't pass
 
 
 ### Misc
-Use debug-formatting (`{:?}`) when logging strings in logs and error messages. This will surround the string with quotes and escape newlines, tabs, etc. For instance: `tracing::warn!("Unknown key: {key:?}");`.
+Use debug-formatting (`{:?}`) when logging strings in logs and error messages. This will surround the string with quotes and escape newlines, tabs, etc. For instance: `re_log::warn!("Unknown key: {key:?}");`.
 
 Use `re_error::format(err)` when displaying an error.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,12 +2220,12 @@ dependencies = [
  "image",
  "itertools",
  "mimalloc",
+ "re_log",
  "re_log_types",
  "re_viewer",
  "re_web_server",
  "re_ws_comms",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "webbrowser",
  "zip",
@@ -2271,12 +2271,12 @@ dependencies = [
  "itertools",
  "mimalloc",
  "prost",
+ "re_log",
  "re_log_types",
  "re_viewer",
  "re_web_server",
  "re_ws_comms",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "webbrowser",
 ]
@@ -2689,14 +2689,13 @@ dependencies = [
  "ahash 0.8.0",
  "criterion",
  "itertools",
- "log-once",
  "mimalloc",
  "nohash-hasher",
  "puffin",
+ "re_log",
  "re_log_types",
  "serde",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -2704,6 +2703,14 @@ name = "re_error"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "re_log"
+version = "0.1.0"
+dependencies = [
+ "log-once",
+ "tracing",
 ]
 
 [[package]]
@@ -2732,9 +2739,8 @@ dependencies = [
  "bincode",
  "crossbeam",
  "ctrlc",
- "re_error",
+ "re_log",
  "re_log_types",
- "tracing",
 ]
 
 [[package]]
@@ -2749,10 +2755,10 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "rand",
+ "re_log",
  "re_log_types",
  "re_sdk_comms",
  "re_viewer",
- "tracing",
  "tracing-subscriber",
  "uuid",
 ]
@@ -2790,7 +2796,6 @@ dependencies = [
  "image",
  "instant",
  "itertools",
- "log-once",
  "macaw",
  "mint",
  "nohash-hasher",
@@ -2799,6 +2804,7 @@ dependencies = [
  "rand",
  "re_data_store",
  "re_error",
+ "re_log",
  "re_log_types",
  "re_string_interner",
  "re_ws_comms",
@@ -2807,7 +2813,6 @@ dependencies = [
  "serde_json",
  "three-d",
  "three-d-asset",
- "tracing",
  "tracing-wasm",
  "typenum",
  "vec1",
@@ -2820,8 +2825,8 @@ dependencies = [
  "futures-util",
  "glob",
  "hyper",
+ "re_log",
  "tokio",
- "tracing",
  "tracing-subscriber",
 ]
 
@@ -2836,10 +2841,10 @@ dependencies = [
  "futures-util",
  "parking_lot",
  "re_error",
+ "re_log",
  "re_log_types",
  "tokio",
  "tokio-tungstenite",
- "tracing",
  "tungstenite",
 ]
 
@@ -2892,11 +2897,11 @@ dependencies = [
  "mimalloc",
  "puffin",
  "puffin_http",
+ "re_log",
  "re_sdk_comms",
  "re_viewer",
  "re_ws_comms",
  "tokio",
- "tracing",
  "tracing-subscriber",
 ]
 

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -15,15 +15,14 @@ serde = ["dep:serde", "re_log_types/serde"]
 
 
 [dependencies]
+re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types" }
 
 ahash = "0.8"
 itertools = "0.10"
-log-once = "0.4"
 nohash-hasher = "0.2"
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 thiserror = "1.0"
-tracing = "0.1"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/re_data_store/src/data_store.rs
+++ b/crates/re_data_store/src/data_store.rs
@@ -45,7 +45,7 @@ impl DataStore {
             }
             std::collections::hash_map::Entry::Occupied(entry) => {
                 if entry.get().0 != time_type {
-                    tracing::warn!("Time source {time_source:?} has multiple time types");
+                    re_log::warn!("Time source {time_source:?} has multiple time types");
                 }
                 &mut entry.into_mut().1
             }

--- a/crates/re_data_store/src/objects.rs
+++ b/crates/re_data_store/src/objects.rs
@@ -573,7 +573,7 @@ impl<'s> Objects<'s> {
             if let Some(obj_type) = obj_types.get(obj_path.obj_type_path()) {
                 self.query_object(obj_store, time_query, obj_path, obj_type);
             } else {
-                log_once::warn_once!("Missing ObjectType for {:?}", obj_path.obj_type_path());
+                re_log::warn_once!("Missing ObjectType for {:?}", obj_path.obj_type_path());
             }
         }
     }
@@ -739,7 +739,7 @@ fn as_vec_of_vec2<'s>(what: &str, data_vec: &'s DataVec) -> Option<&'s Vec<[f32;
     if let DataVec::Vec2(vec) = data_vec {
         Some(vec)
     } else {
-        log_once::warn_once!(
+        re_log::warn_once!(
             "Expected {what} to be Vec<Vec2>, got Vec<{:?}>",
             data_vec.element_data_type()
         );
@@ -751,7 +751,7 @@ fn as_vec_of_vec3<'s>(what: &str, data_vec: &'s DataVec) -> Option<&'s Vec<[f32;
     if let DataVec::Vec3(vec) = data_vec {
         Some(vec)
     } else {
-        log_once::warn_once!(
+        re_log::warn_once!(
             "Expected {what} to be Vec<Vec3>, got Vec<{:?}>",
             data_vec.element_data_type()
         );

--- a/crates/re_data_store/src/query.rs
+++ b/crates/re_data_store/src/query.rs
@@ -108,7 +108,7 @@ fn get_primary_batch<'a, T>(
 ) -> Option<&'a Batch<T>> {
     match batch_or_splat {
         BatchOrSplat::Splat(_) => {
-            tracing::error!("Primary field {field_name:?} was a batch-splat.");
+            re_log::error!("Primary field {field_name:?} was a batch-splat.");
             None
         }
         BatchOrSplat::Batch(batch) => Some(batch),

--- a/crates/re_log/Cargo.toml
+++ b/crates/re_log/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "re_log"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.63"
+license = "MIT OR Apache-2.0"
+publish = false
+
+
+[dependencies]
+log-once = "0.4"
+tracing = "0.1"

--- a/crates/re_log/README.md
+++ b/crates/re_log/README.md
@@ -1,0 +1,1 @@
+Helpers for handling errors.

--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -1,0 +1,17 @@
+//! Text logging (nothing to do with rerun logging) for use in rerun libraries.
+//!
+//! * `trace`: spammy things
+//! * `debug`: things that might be useful when debugging
+//! * `info`: things that we want to show to users
+//! * `warn`: problems that we can recover from
+//! * `error`: problems that lead to loss of functionality or data
+//!
+//! The `warn_once` etc macros are for when you want to surpress repeated
+//! logging of the exact same message.
+
+pub use tracing::{debug, error, info, trace, warn};
+
+// The `re_log::info_once!(…)` etc are nice helpers, but the `log-once` crate is a bit lacking.
+// In the future we should implement our own `tracing` layer and de-duplicate based on the callsite,
+// similar to how the log console in a browser will automatically supress duplicates.
+pub use log_once::{debug_once, error_once, info_once, trace_once, warn_once};

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -13,11 +13,10 @@ server = []
 
 
 [dependencies]
-re_error = { path = "../re_error" }
+re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types", features = ["serde"] }
 
 anyhow = "1.0.56"
 bincode = "1.3"
 crossbeam = "0.8"
 ctrlc = { version = "3.0", features = ["termination"] }
-tracing = "0.1"

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -24,7 +24,7 @@ pub fn serve(addr: impl std::net::ToSocketAddrs) -> anyhow::Result<Receiver<LogM
                         spawn_client(stream, tx);
                     }
                     Err(err) => {
-                        tracing::warn!("Failed to accept incoming SDK client: {err:?}");
+                        re_log::warn!("Failed to accept incoming SDK client: {err:?}");
                     }
                 }
             }
@@ -41,10 +41,10 @@ fn spawn_client(stream: std::net::TcpStream, tx: Sender<LogMsg>) {
             stream.peer_addr()
         ))
         .spawn(move || {
-            tracing::info!("New SDK client connected: {:?}", stream.peer_addr());
+            re_log::info!("New SDK client connected: {:?}", stream.peer_addr());
 
             if let Err(err) = run_client(stream, &tx) {
-                tracing::warn!("Closing connection to client: {err:?}");
+                re_log::warn!("Closing connection to client: {err:?}");
             }
         })
         .expect("Failed to spawn thread");
@@ -87,7 +87,7 @@ fn run_client(mut stream: std::net::TcpStream, tx: &Sender<LogMsg>) -> anyhow::R
         packet.resize(packet_size as usize, 0_u8);
         stream.read_exact(&mut packet)?;
 
-        tracing::trace!("Received log message of size {packet_size}.");
+        re_log::trace!("Received log message of size {packet_size}.");
 
         let msg = crate::decode_log_msg(&packet)?;
 

--- a/crates/re_sdk_comms/src/tcp_client.rs
+++ b/crates/re_sdk_comms/src/tcp_client.rs
@@ -36,7 +36,7 @@ impl TcpClient {
         if self.stream.is_some() {
             Ok(())
         } else {
-            tracing::debug!("Connecting to {:?}…", self.addrs);
+            re_log::debug!("Connecting to {:?}…", self.addrs);
             match TcpStream::connect(&self.addrs[..]) {
                 Ok(mut stream) => {
                     if let Err(err) = stream.write(&crate::PROTOCOL_VERSION.to_le_bytes()) {
@@ -66,7 +66,7 @@ impl TcpClient {
         self.connect()?;
 
         if let Some(stream) = &mut self.stream {
-            tracing::trace!("Sending a packet of size {}…", packet.len());
+            re_log::trace!("Sending a packet of size {}…", packet.len());
             if let Err(err) = stream.write(&(packet.len() as u32).to_le_bytes()) {
                 self.stream = None;
                 anyhow::bail!(
@@ -93,9 +93,9 @@ impl TcpClient {
     pub fn flush(&mut self) {
         if let Some(stream) = &mut self.stream {
             if let Err(err) = stream.flush() {
-                tracing::warn!("Failed to flush: {err:?}");
+                re_log::warn!("Failed to flush: {err:?}");
             }
         }
-        tracing::trace!("TCP stream flushed.");
+        re_log::trace!("TCP stream flushed.");
     }
 }

--- a/crates/re_sdk_python/Cargo.toml
+++ b/crates/re_sdk_python/Cargo.toml
@@ -22,6 +22,7 @@ extension-module = ["pyo3/extension-module"]
 
 
 [dependencies]
+re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types" }
 re_sdk_comms = { path = "../re_sdk_comms", features = ["client"] }
 re_viewer = { path = "../re_viewer", optional = true }
@@ -33,7 +34,6 @@ numpy = "0.17"
 once_cell = "1.12"
 pyo3 = "0.17"
 rand = { version = "0.8", features = ["std_rng"] }
-tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = "1.1"
 

--- a/crates/re_sdk_python/src/python_bridge.rs
+++ b/crates/re_sdk_python/src/python_bridge.rs
@@ -238,7 +238,7 @@ fn show() -> Result<(), PyErr> {
     drop(sdk);
 
     if log_messages.is_empty() {
-        tracing::info!("Nothing logged, so nothing to show");
+        re_log::info!("Nothing logged, so nothing to show");
     } else {
         let (tx, rx) = std::sync::mpsc::channel();
         for log_msg in log_messages {
@@ -252,7 +252,7 @@ fn show() -> Result<(), PyErr> {
 
 #[pyfunction]
 fn save(path: &str) -> Result<(), PyErr> {
-    tracing::trace!("Saving file to {path:?}…");
+    re_log::trace!("Saving file to {path:?}…");
 
     let mut sdk = Sdk::global();
     if sdk.is_connected() {
@@ -265,11 +265,11 @@ fn save(path: &str) -> Result<(), PyErr> {
     drop(sdk);
 
     if log_messages.is_empty() {
-        tracing::info!("Nothing logged, so nothing to save");
+        re_log::info!("Nothing logged, so nothing to save");
     }
 
     if !path.ends_with(".rrd") {
-        tracing::warn!("Expected path to end with .rrd, got {path:?}");
+        re_log::warn!("Expected path to end with .rrd, got {path:?}");
     }
 
     match std::fs::File::create(path) {
@@ -279,7 +279,7 @@ fn save(path: &str) -> Result<(), PyErr> {
                     "Failed to write to file at {path:?}: {err}",
                 )))
             } else {
-                tracing::info!("Rerurn data file saved to {path:?}");
+                re_log::info!("Rerurn data file saved to {path:?}");
                 Ok(())
             }
         }

--- a/crates/re_sdk_python/src/sdk.rs
+++ b/crates/re_sdk_python/src/sdk.rs
@@ -46,7 +46,7 @@ impl Sdk {
                 remote.set_addr(addr);
             }
             Sender::Buffered(messages) => {
-                tracing::debug!("Connecting to remote…");
+                re_log::debug!("Connecting to remote…");
                 let mut client = re_sdk_comms::Client::new(addr);
                 for msg in messages.drain(..) {
                     client.send(msg);
@@ -60,7 +60,7 @@ impl Sdk {
     #[allow(unused)] // only used with "re_viewer" feature
     pub fn disconnect(&mut self) {
         if !matches!(&self.sender, &Sender::Buffered(_)) {
-            tracing::debug!("Switching to buffered.");
+            re_log::debug!("Switching to buffered.");
             self.sender = Sender::Buffered(Default::default());
         }
     }
@@ -86,7 +86,7 @@ impl Sdk {
     pub fn register_type(&mut self, obj_type_path: &ObjTypePath, typ: ObjectType) {
         if let Some(prev_type) = self.registered_types.get(obj_type_path) {
             if *prev_type != typ {
-                tracing::warn!("Registering different types to the same object type path: {obj_type_path:?}. First you used {prev_type:?}, then {typ:?}");
+                re_log::warn!("Registering different types to the same object type path: {obj_type_path:?}. First you used {prev_type:?}, then {typ:?}");
             }
         } else {
             self.registered_types.insert(obj_type_path.clone(), typ);
@@ -102,7 +102,7 @@ impl Sdk {
     pub fn send(&mut self, log_msg: LogMsg) {
         if !self.has_sent_begin_recording_msg {
             if let Some(recording_id) = self.recording_id {
-                tracing::debug!("Beginning new recording with recording id {recording_id}");
+                re_log::debug!("Beginning new recording with recording id {recording_id}");
                 self.sender.send(
                     BeginRecordingMsg {
                         msg_id: MsgId::random(),

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -21,6 +21,7 @@ puffin = ["dep:puffin", "dep:puffin_http", "eframe/puffin"]
 [dependencies]
 re_data_store = { path = "../re_data_store", features = ["puffin", "serde"] }
 re_error = { path = "../re_error" }
+re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types", features = ["save", "load"] }
 re_string_interner = { path = "../re_string_interner" }
 re_ws_comms = { path = "../re_ws_comms", features = ["client"] }
@@ -41,7 +42,6 @@ glow = "0.11"
 image = { version = "0.23", default-features = false, features = ["png"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 itertools = "0.10"
-log-once = "0.4"
 macaw = { version = "0.17", features = ["with_serde"] }
 mint = "0.5"
 nohash-hasher = "0.2"
@@ -56,7 +56,6 @@ three-d-asset = { version = "0.1.0", default-features = false, features = [
     "image",
     "obj",
 ] }
-tracing = "0.1"
 vec1 = "1.8"
 
 # native:

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -75,7 +75,7 @@ impl App {
             let egui_ctx = _egui_ctx.clone();
 
             ctrlc::set_handler(move || {
-                tracing::debug!("Ctrl-C detected - Closing viewer.");
+                re_log::debug!("Ctrl-C detected - Closing viewer.");
                 ctrl_c.store(true, std::sync::atomic::Ordering::SeqCst);
                 egui_ctx.request_repaint(); // so that we notice that we should close
             })
@@ -124,7 +124,7 @@ impl eframe::App for App {
             let start = instant::Instant::now();
             while let Ok(msg) = rx.try_recv() {
                 if let LogMsg::BeginRecordingMsg(msg) = &msg {
-                    tracing::info!("Begginning a new recording: {:?}", msg.info);
+                    re_log::info!("Begginning a new recording: {:?}", msg.info);
                     self.state.selected_rec_id = msg.info.recording_id;
                 }
 
@@ -510,11 +510,11 @@ fn save_to_file(log_db: &LogDb, path: &std::path::PathBuf) {
     match save_to_file_impl(log_db, path) {
         // TODO(emilk): show a popup instead of logging result
         Ok(()) => {
-            tracing::info!("Data saved to {:?}", path);
+            re_log::info!("Data saved to {:?}", path);
         }
         Err(err) => {
             let msg = format!("Failed saving data to {path:?}: {}", re_error::format(&err));
-            tracing::error!("{msg}");
+            re_log::error!("{msg}");
             rfd::MessageDialog::new()
                 .set_level(rfd::MessageLevel::Error)
                 .set_description(&msg)
@@ -550,16 +550,16 @@ fn load_file_path(path: &std::path::Path) -> Option<LogDb> {
         load_rrd(file)
     }
 
-    tracing::info!("Loading {path:?}…");
+    re_log::info!("Loading {path:?}…");
 
     match load_file_path_impl(path) {
         Ok(new_log_db) => {
-            tracing::info!("Loaded {path:?}");
+            re_log::info!("Loaded {path:?}");
             Some(new_log_db)
         }
         Err(err) => {
             let msg = format!("Failed loading {path:?}: {}", re_error::format(&err));
-            tracing::error!("{msg}");
+            re_log::error!("{msg}");
             rfd::MessageDialog::new()
                 .set_level(rfd::MessageLevel::Error)
                 .set_description(&msg)
@@ -573,12 +573,12 @@ fn load_file_path(path: &std::path::Path) -> Option<LogDb> {
 fn load_file_contents(name: &str, read: impl std::io::Read) -> Option<LogDb> {
     match load_rrd(read) {
         Ok(log_db) => {
-            tracing::info!("Loaded {name:?}");
+            re_log::info!("Loaded {name:?}");
             Some(log_db)
         }
         Err(err) => {
             let msg = format!("Failed loading {name:?}: {}", re_error::format(&err));
-            tracing::error!("{msg}");
+            re_log::error!("{msg}");
             rfd::MessageDialog::new()
                 .set_level(rfd::MessageLevel::Error)
                 .set_description(&msg)

--- a/crates/re_viewer/src/misc/clipboard.rs
+++ b/crates/re_viewer/src/misc/clipboard.rs
@@ -17,9 +17,9 @@ impl Clipboard {
     pub fn set_text(&mut self, text: String) {
         if let Some(clipboard) = &mut self.arboard {
             if let Err(err) = clipboard.set_text(text) {
-                tracing::error!("Failed to copy image to clipboard: {err}",);
+                re_log::error!("Failed to copy image to clipboard: {err}",);
             } else {
-                tracing::info!("Image copied to clipboard");
+                re_log::info!("Image copied to clipboard");
             }
         }
     }
@@ -36,9 +36,9 @@ impl Clipboard {
             };
             // TODO(emilk): show a quick popup in gui instead of logging
             if let Err(err) = clipboard.set_image(image_data) {
-                tracing::error!("Failed to copy image to clipboard: {err}");
+                re_log::error!("Failed to copy image to clipboard: {err}");
             } else {
-                tracing::info!("Image copied to clipboard");
+                re_log::info!("Image copied to clipboard");
             }
         }
     }
@@ -62,7 +62,7 @@ fn init_arboard() -> Option<arboard::Clipboard> {
     match arboard::Clipboard::new() {
         Ok(clipboard) => Some(clipboard),
         Err(err) => {
-            tracing::error!("Failed to initialize clipboard: {err}");
+            re_log::error!("Failed to initialize clipboard: {err}");
             None
         }
     }

--- a/crates/re_viewer/src/misc/image_cache.rs
+++ b/crates/re_viewer/src/misc/image_cache.rs
@@ -31,7 +31,7 @@ fn tensor_to_image_pair(debug_name: String, tensor: &Tensor) -> (DynamicImage, R
     let dynamic_image = match tensor_to_dynamic_image(tensor) {
         Ok(dynamic_image) => dynamic_image,
         Err(err) => {
-            tracing::warn!("Bad image {debug_name:?}: {}", re_error::format(&err));
+            re_log::warn!("Bad image {debug_name:?}: {}", re_error::format(&err));
             DynamicImage::ImageRgb8(image::RgbImage::from_pixel(1, 1, image::Rgb([255, 0, 255])))
         }
     };

--- a/crates/re_viewer/src/misc/log_db.rs
+++ b/crates/re_viewer/src/misc/log_db.rs
@@ -68,7 +68,7 @@ impl LogDb {
 
         if let Some(previous_value) = previous_value {
             if previous_value != msg.obj_type {
-                tracing::warn!(
+                re_log::warn!(
                     "Object {} changed type from {:?} to {:?}",
                     msg.type_path,
                     previous_value,
@@ -76,7 +76,7 @@ impl LogDb {
                 );
             }
         } else {
-            tracing::debug!(
+            re_log::debug!(
                 "Registered object type {}: {:?}",
                 msg.type_path,
                 msg.obj_type
@@ -92,19 +92,19 @@ impl LogDb {
         if let Some(obj_type) = self.obj_types.get(obj_type_path) {
             let valid_members = obj_type.members();
             if !valid_members.contains(&field_name.as_str()) {
-                log_once::warn_once!(
+                re_log::warn_once!(
                     "Logged to {obj_type_path}.{field_name}, but the parent object ({obj_type:?}) does not have that field. Expected one of: {}",
                     valid_members.iter().format(", ")
                 );
             }
         } else {
-            log_once::warn_once!(
+            re_log::warn_once!(
                 "Logging to {obj_type_path}.{field_name} without first registering object type"
             );
         }
 
         if let Err(err) = self.data_store.insert(msg) {
-            tracing::warn!("Failed to add data to data_store: {err:?}");
+            re_log::warn!("Failed to add data to data_store: {err:?}");
         }
 
         self.time_points.insert(&msg.time_point);

--- a/crates/re_viewer/src/misc/profiler.rs
+++ b/crates/re_viewer/src/misc/profiler.rs
@@ -19,13 +19,13 @@ impl Profiler {
         let bind_addr = format!("0.0.0.0:{}", PORT);
         self.server = match puffin_http::Server::new(&bind_addr) {
             Ok(puffin_server) => {
-                tracing::info!(
+                re_log::info!(
                         "Started puffin profiling server. View with:  cargo install puffin_viewer && puffin_viewer"
                     );
                 Some(puffin_server)
             }
             Err(err) => {
-                tracing::warn!(
+                re_log::warn!(
                     "Failed to start puffin profiling server: {}",
                     re_error::format(&err)
                 );
@@ -45,9 +45,7 @@ fn start_puffin_viewer() {
     if let Err(err) = child {
         let cmd = format!("cargo install puffin_viewer && puffin_viewer --url {url}",);
         crate::Clipboard::with(|cliboard| cliboard.set_text(cmd.clone()));
-        tracing::warn!(
-            "Failed to start puffin_viewer: {err}. Try connecting manually with:  {cmd}"
-        );
+        re_log::warn!("Failed to start puffin_viewer: {err}. Try connecting manually with:  {cmd}");
 
         rfd::MessageDialog::new()
             .set_level(rfd::MessageLevel::Info)

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -44,7 +44,7 @@ fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
                     break;
                 }
             }
-            tracing::debug!("Shutting down ui_waker thread");
+            re_log::debug!("Shutting down ui_waker thread");
         })
         .unwrap();
     new_rx

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -31,7 +31,7 @@ impl RemoteViewerApp {
                     egui_ctx_clone.request_repaint(); // Wake up UI thread
                     std::ops::ControlFlow::Continue(())
                 } else {
-                    tracing::info!("Failed to send log message to viewer - closing");
+                    re_log::info!("Failed to send log message to viewer - closing");
                     std::ops::ControlFlow::Break(())
                 }
             },

--- a/crates/re_viewer/src/ui/context_panel.rs
+++ b/crates/re_viewer/src/ui/context_panel.rs
@@ -32,7 +32,7 @@ impl ContextPanel {
                 let msg = if let Some(msg) = ctx.log_db.get_log_msg(msg_id) {
                     msg
                 } else {
-                    tracing::warn!("Unknown msg_id selected. Resetting selection");
+                    re_log::warn!("Unknown msg_id selected. Resetting selection");
                     ctx.rec_cfg.selection = Selection::None;
                     return;
                 };

--- a/crates/re_viewer/src/ui/data_ui.rs
+++ b/crates/re_viewer/src/ui/data_ui.rs
@@ -58,7 +58,7 @@ pub(crate) fn view_instance(
                         }
                     }
                     Err(err) => {
-                        log_once::warn_once!("Bad data for {instance_id}: {err}");
+                        re_log::warn_once!("Bad data for {instance_id}: {err}");
                         ui.colored_label(
                             ui.visuals().error_fg_color,
                             format!("Data error: {:?}", err),
@@ -96,7 +96,7 @@ pub(crate) fn view_data(
             }
         }
         Err(err) => {
-            log_once::warn_once!("Bad data for {data_path}: {err}");
+            re_log::warn_once!("Bad data for {data_path}: {err}");
             ui.colored_label(
                 ui.visuals().error_fg_color,
                 format!("Data error: {:?}", err),

--- a/crates/re_viewer/src/ui/image_ui.rs
+++ b/crates/re_viewer/src/ui/image_ui.rs
@@ -330,10 +330,10 @@ fn image_options(
                     match dynamic_image.save(&path) {
                         // TODO(emilk): show a popup instead of logging result
                         Ok(()) => {
-                            tracing::info!("Image saved to {path:?}");
+                            re_log::info!("Image saved to {path:?}");
                         }
                         Err(err) => {
-                            tracing::error!("Failed saving image to {path:?}: {err}");
+                            re_log::error!("Failed saving image to {path:?}: {err}");
                         }
                     }
                 }
@@ -345,10 +345,10 @@ fn image_options(
                 {
                     match write_binary(&path, bytes) {
                         Ok(()) => {
-                            tracing::info!("Image saved to {path:?}");
+                            re_log::info!("Image saved to {path:?}");
                         }
                         Err(err) => {
-                            tracing::error!(
+                            re_log::error!(
                                 "Failed saving image to {path:?}: {}",
                                 re_error::format(&err)
                             );

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -327,7 +327,7 @@ impl SpaceStates {
         });
 
         if objects.has_any_2d() && objects.has_any_3d() {
-            log_once::warn_once!("Space {:?} has both 2D and 3D objects", space_name(space));
+            re_log::warn_once!("Space {:?} has both 2D and 3D objects", space_name(space));
         }
 
         if objects.has_any_2d() {

--- a/crates/re_viewer/src/ui/view3d/mesh_cache.rs
+++ b/crates/re_viewer/src/ui/view3d/mesh_cache.rs
@@ -20,7 +20,7 @@ impl CpuMeshCache {
         self.0
             .entry(mesh_id)
             .or_insert_with(|| {
-                tracing::debug!("Loading CPU mesh {name:?}…");
+                re_log::debug!("Loading CPU mesh {name:?}…");
 
                 let result = match mesh_data {
                     MeshSourceData::Mesh3D(mesh3d) => CpuMesh::load(name.to_owned(), mesh3d),
@@ -32,7 +32,7 @@ impl CpuMeshCache {
                 match result {
                     Ok(cpu_mesh) => Some(Arc::new(cpu_mesh)),
                     Err(err) => {
-                        tracing::warn!("Failed to load mesh {name:?}: {}", re_error::format(&err));
+                        re_log::warn!("Failed to load mesh {name:?}: {}", re_error::format(&err));
                         None
                     }
                 }
@@ -54,7 +54,7 @@ impl GpuMeshCache {
             .or_insert_with(|| match cpu_mesh.to_gpu(three_d) {
                 Ok(gpu_mesh) => Some(gpu_mesh),
                 Err(err) => {
-                    tracing::warn!(
+                    re_log::warn!(
                         "Failed to load mesh {:?}: {}",
                         cpu_mesh.name(),
                         re_error::format(&err)

--- a/crates/re_web_server/Cargo.toml
+++ b/crates/re_web_server/Cargo.toml
@@ -12,13 +12,14 @@ __ci = [] # when set: will compile despite missing wasm artifact, BUT IT WON'T R
 
 
 [dependencies]
+re_log = { path = "../re_log" }
+
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.0.0", default-features = false, features = [
   "macros",
   "rt-multi-thread",
 ] }
-tracing = "0.1"
 tracing-subscriber = "0.3"
 
 [build-dependencies]

--- a/crates/re_web_server/src/lib.rs
+++ b/crates/re_web_server/src/lib.rs
@@ -38,7 +38,7 @@ impl Service<Request<Body>> for Svc {
             "/re_viewer_bg.wasm" => &include_bytes!("../../../web_viewer/re_viewer_bg.wasm")[..],
             "/re_viewer.js" => &include_bytes!("../../../web_viewer/re_viewer.js")[..],
             _ => {
-                tracing::warn!("404 path: {}", req.uri().path());
+                re_log::warn!("404 path: {}", req.uri().path());
                 let body = Body::from(Vec::new());
                 let rsp = rsp.status(404).body(body).unwrap();
                 return future::ok(rsp);

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -25,11 +25,11 @@ tls = [
 
 [dependencies]
 re_error = { path = "../re_error" }
+re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types", features = ["serde"] }
 
 anyhow = "1.0.56"
 bincode = "1.3"
-tracing = "0.1"
 
 # Client:
 ewebsock = { version = "0.2", optional = true }

--- a/crates/re_ws_comms/src/client.rs
+++ b/crates/re_ws_comms/src/client.rs
@@ -15,45 +15,45 @@ impl Connection {
         url: String,
         on_log_msg: impl Fn(LogMsg) -> ControlFlow<()> + Send + 'static,
     ) -> Result<Self> {
-        tracing::info!("Connecting to {url:?}…");
+        re_log::info!("Connecting to {url:?}…");
         let sender = ewebsock::ws_connect(
             url,
             Box::new(move |event: WsEvent| match event {
                 WsEvent::Opened => {
-                    tracing::info!("Connection established");
+                    re_log::info!("Connection established");
                     ControlFlow::Continue(())
                 }
                 WsEvent::Message(message) => match message {
                     WsMessage::Binary(binary) => match decode_log_msg(&binary) {
                         Ok(log_msg) => on_log_msg(log_msg),
                         Err(err) => {
-                            tracing::error!("Failed to parse message: {}", re_error::format(&err));
+                            re_log::error!("Failed to parse message: {}", re_error::format(&err));
                             ControlFlow::Break(())
                         }
                     },
                     WsMessage::Text(text) => {
-                        tracing::warn!("Unexpected text message: {:?}", text);
+                        re_log::warn!("Unexpected text message: {:?}", text);
                         ControlFlow::Continue(())
                     }
                     WsMessage::Unknown(text) => {
-                        tracing::warn!("Unknown message: {:?}", text);
+                        re_log::warn!("Unknown message: {:?}", text);
                         ControlFlow::Continue(())
                     }
                     WsMessage::Ping(_data) => {
-                        tracing::warn!("Unexpected PING");
+                        re_log::warn!("Unexpected PING");
                         ControlFlow::Continue(())
                     }
                     WsMessage::Pong(_data) => {
-                        tracing::warn!("Unexpected PONG");
+                        re_log::warn!("Unexpected PONG");
                         ControlFlow::Continue(())
                     }
                 },
                 WsEvent::Error(error) => {
-                    tracing::error!("Connection error: {}", error);
+                    re_log::error!("Connection error: {}", error);
                     ControlFlow::Break(())
                 }
                 WsEvent::Closed => {
-                    tracing::info!("Connection to server closed.");
+                    re_log::info!("Connection to server closed.");
                     ControlFlow::Break(())
                 }
             }),

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -88,19 +88,19 @@ async fn accept_connection(
     tcp_stream: TcpStream,
     history: Arc<Mutex<Vec<Arc<[u8]>>>>,
 ) {
-    // let span = tracing::span!(
-    //     tracing::Level::INFO,
+    // let span = re_log::span!(
+    //     re_log::Level::INFO,
     //     "Connection",
     //     peer = _peer.to_string().as_str()
     // );
     // let _enter = span.enter();
 
-    tracing::info!("New WebSocket connection");
+    re_log::info!("New WebSocket connection");
 
     if let Err(e) = handle_connection(log_stream, tcp_stream, history).await {
         match e {
             Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
-            err => tracing::error!("Error processing connection: {err}"),
+            err => re_log::error!("Error processing connection: {err}"),
         }
     }
 }
@@ -130,10 +130,10 @@ async fn handle_connection(
             ws_msg = ws_receiver.next() => {
                 match ws_msg {
                     Some(Ok(msg)) => {
-                        tracing::debug!("Received message: {:?}", msg);
+                        re_log::debug!("Received message: {:?}", msg);
                     }
                     Some(Err(err)) => {
-                        tracing::warn!("Error message: {err:?}");
+                        re_log::warn!("Error message: {err:?}");
                         break;
                     }
                     None => {

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -16,6 +16,7 @@ server = ["dep:re_sdk_comms"]
 
 
 [dependencies]
+re_log = { path = "../re_log" }
 re_viewer = { path = "../re_viewer", features = ["puffin"] }
 re_ws_comms = { path = "../re_ws_comms", features = ["client"] }
 
@@ -24,7 +25,6 @@ puffin = { version = "0.13" }
 ## Optional dependencies
 puffin_http = { version = "0.10", optional = true }
 re_sdk_comms = { path = "../re_sdk_comms", optional=true, features = ["server"] }
-tracing = "0.1"
 
 ## Native dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rerun/src/main.rs
+++ b/crates/rerun/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
             let bind_addr = format!("127.0.0.1:{}", args.port);
             match re_sdk_comms::serve(&bind_addr) {
                 Ok(rx) => {
-                    tracing::info!("Hosting SDK server on {bind_addr}");
+                    re_log::info!("Hosting SDK server on {bind_addr}");
                     re_viewer::run_native_viewer_with_rx(rx);
                 }
                 Err(err) => {

--- a/examples/nyud/Cargo.toml
+++ b/examples/nyud/Cargo.toml
@@ -13,6 +13,7 @@ web = ["re_ws_comms", "re_web_server", "tokio", "webbrowser"]
 
 
 [dependencies]
+re_log = { path = "../../crates/re_log" }
 re_log_types = { path = "../../crates/re_log_types" }
 re_viewer = { path = "../../crates/re_viewer" }
 
@@ -23,7 +24,6 @@ glam = "0.20"
 image = { version = "0.23", default-features = false, features = ["pnm"] }
 itertools = "0.10"
 mimalloc = "0.1.29"
-tracing = "0.1"
 tracing-subscriber = "0.3"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 

--- a/examples/nyud/src/lib.rs
+++ b/examples/nyud/src/lib.rs
@@ -68,7 +68,7 @@ fn log_dataset_zip(path: &Path, logger: &Logger<'_>) {
     let file = std::fs::File::open(path).unwrap();
     let mut archive = zip::ZipArchive::new(file).unwrap();
     let dir = select_first_dir(&mut archive);
-    tracing::info!("Logging dir {dir:?}…");
+    re_log::info!("Logging dir {dir:?}…");
 
     let mut file_contents = vec![];
 
@@ -105,7 +105,7 @@ fn log_dataset_zip(path: &Path, logger: &Logger<'_>) {
             && file_name.starts_with(&dir)
             && (file_name.ends_with(".pgm") || file_name.ends_with(".ppm"))
         {
-            tracing::debug!("{:?}…", file_name);
+            re_log::debug!("{:?}…", file_name);
             drop(file);
             let mut file = archive.by_index(i).unwrap();
 
@@ -233,7 +233,7 @@ fn log_dataset_zip(path: &Path, logger: &Logger<'_>) {
         }
     }
 
-    tracing::info!("Done logging {dir:?}.");
+    re_log::info!("Done logging {dir:?}.");
 }
 
 fn select_first_dir<R: std::io::Read + std::io::Seek>(archive: &mut zip::ZipArchive<R>) -> String {

--- a/examples/nyud/src/main.rs
+++ b/examples/nyud/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
         }
     });
 
-    tracing::debug!("Starting viewer…");
+    re_log::debug!("Starting viewer…");
     re_viewer::run_native_viewer_with_rx(rerun_rx);
     handle.join().ok();
 }

--- a/examples/objectron/Cargo.toml
+++ b/examples/objectron/Cargo.toml
@@ -13,6 +13,7 @@ web = ["re_ws_comms", "re_web_server", "tokio", "webbrowser"]
 
 
 [dependencies]
+re_log = { path = "../../crates/re_log" }
 re_log_types = { path = "../../crates/re_log_types" }
 re_viewer = { path = "../../crates/re_viewer" }
 
@@ -23,7 +24,6 @@ image = { version = "0.23", default-features = false, features = ["jpeg"] }
 itertools = "0.10"
 mimalloc = "0.1.29"
 prost = "0.10"
-tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Optional:

--- a/examples/objectron/src/lib.rs
+++ b/examples/objectron/src/lib.rs
@@ -124,7 +124,7 @@ fn log_annotation_pbdata(
                 world_space.clone(),
             ));
         } else {
-            tracing::error!("Unsupported type: {}", object.r#type);
+            re_log::error!("Unsupported type: {}", object.r#type);
         }
 
         logger.log(data_msg(

--- a/examples/objectron/src/main.rs
+++ b/examples/objectron/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
         }
     });
 
-    tracing::debug!("Starting viewer…");
+    re_log::debug!("Starting viewer…");
     re_viewer::run_native_viewer_with_rx(rerun_rx);
     handle.join().ok();
 }


### PR DESCRIPTION
Mostly a cosmetic consistency improvement, as all text logging now uses `re_log::` instead of either `tracing::` or `log_once::`.

But it is also shorter, and lets us more easily switch out `log_once` in the future.

It is a bit confusing though that `re_log` has nothing to do with rerun logging, i.e. logging of rich data.