### PR TITLE
Python SDK: support for logging 3D OBBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 A rough time-line of major user-facing things added, removed and changed. Newest on top.
 
+* 2022-09-21: Python SDK: add `log_obb` ([#103](https://github.com/rerun-io/rerun/pull/103)).
 * 2022-09-20: Reduce memory use for image intensive applications ([#100](https://github.com/rerun-io/rerun/pull/100)).
 * 2022-09-17: Add 'timeless' data ([#96](https://github.com/rerun-io/rerun/pull/96)).
 * 2022-09-17: Time selection will now also include the latest data before the selection ([#98](https://github.com/rerun-io/rerun/pull/98)).

--- a/crates/re_sdk_python/python/rerun_sdk/__init__.py
+++ b/crates/re_sdk_python/python/rerun_sdk/__init__.py
@@ -412,10 +412,9 @@ def log_obb(
             half_size: ArrayLike,
             position: ArrayLike,
             rotation_q: ArrayLike,
-            timeless: bool = False,
             color: Optional[Sequence[int]] = None,
-            label: Optional[str] = None,
             stroke_width: Optional[float] = None,
+            timeless: bool = False,
             space: Optional[str] = None):
     """
     Log a 3D oriented bounding box, defined by its half size.
@@ -424,7 +423,6 @@ def log_obb(
     `position`: Array with [x, y, z] position of the OBB in world space.
     `rotation_q`: Array with quaternion coordinates [x, y, z, w] for the rotation from model to world space
     `color` is optional RGB or RGBA triplet in 0-255 sRGB.
-    `label` is an optional text to show inside the OBB.
     `stroke_width`: width of the OBB edges.
     `space`: The 3D space the OBB is in. Will default to "3D".
     """
@@ -435,7 +433,6 @@ def log_obb(
                      timeless,
                      color,
                      stroke_width,
-                     label,
                      space)
 
 

--- a/crates/re_sdk_python/src/python_bridge.rs
+++ b/crates/re_sdk_python/src/python_bridge.rs
@@ -904,10 +904,9 @@ fn log_obb(
     half_size: [f32; 3],
     position: [f32; 3],
     rotation_q: re_log_types::Quaternion,
-    timeless: bool,
     color: Option<Vec<u8>>,
-    label: Option<String>,
     stroke_width: Option<f32>,
+    timeless: bool,
     space: Option<String>,
 ) -> PyResult<()> {
     let mut sdk = Sdk::global();
@@ -935,14 +934,6 @@ fn log_obb(
             &time_point,
             (&obj_path, "color"),
             LoggedData::Single(Data::Color(color)),
-        );
-    }
-
-    if let Some(label) = label {
-        sdk.send_data(
-            &time_point,
-            (&obj_path, "label"),
-            LoggedData::Single(Data::String(label)),
         );
     }
 


### PR DESCRIPTION
This implements support for logging 3D oriented bounding boxes.

Tested with the Objectron example; I'll backport it to the objectron branch once this is merged.

This did raise a bunch of questions/observations, that might or might not be worth their own issues, depending on what y'all think. See my ramblings below :upside_down_face: 

Closes [PRO-104](https://linear.app/rerun/issue/PRO-104/python-sdk-3d-bounding-boxes)
Unblocks [PRO-127](https://linear.app/rerun/issue/PRO-127/port-objectron-example-to-python) / #102 

---

#### Single vs. batch log calls

I've only implemented the single log version in this case, i.e. one OBB at a time.

We don't seem to have specific rules regarding single versus batch yet: should we always have both? only batch? decide on a case by case basis?

Intuitely it'd seem that we should just implement everything as a batch call and do away with single calls entirely: it's consistent, it doesn't really impair the API UX in any way, and of course it has far less overhead... but my intuition is probably wrong on many levels :smile: 
Maybe implement single versions in terms of their batch counterpart at the very least?

This also ties in with [PRO-144](https://linear.app/rerun/issue/PRO-144/python-sdk-support-for-individual-metadata-and-paths-in-batch-calls) in a way.

#### Properties

In addition to the issue adressed by [PRO-144](https://linear.app/rerun/issue/PRO-144/python-sdk-support-for-individual-metadata-and-paths-in-batch-calls) (i.e.: how does one associate different properties to the individual datapoints within a batch?), this PR also raises the question of whether we should generalize the way we pass properties around in the python API in general?

Currently, all existing and upcoming logging endpoints in the python SDK reimplement their own logic wrt. to passing properties around: declaring them as parameters, checking wether they are defined, making sure they are of the right type, etc...
This seems brittle, especially as future properties get added. It also leads to inconsistencies between the various endpoints, etc.

As @emilk pointed out to me, we do have [a central registry](https://github.com/rerun-io/rerun/blob/main/crates/re_log_types/src/objects.rs#L33-L52) that specifies which property applies to what types, which can probably come in useful for this kind of thing.


