### PR TITLE
Prevent `vec_from_np_array` from allocating on the happy path

### DIFF
--- a/crates/re_sdk_python/src/python_bridge.rs
+++ b/crates/re_sdk_python/src/python_bridge.rs
@@ -6,6 +6,7 @@ use bytemuck::allocation::pod_collect_to_vec;
 use itertools::Itertools as _;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use std::borrow::Cow;
 
 use re_log_types::{LoggedData, *};
 
@@ -159,14 +160,14 @@ fn parse_obj_path(obj_path: &str) -> PyResult<ObjPath> {
     parse_obj_path_comps(obj_path).map(ObjPath::from)
 }
 
-fn vec_from_np_array<T: numpy::Element, D: numpy::ndarray::Dimension>(
-    array: &numpy::PyReadonlyArray<'_, T, D>,
-) -> Vec<T> {
+fn vec_from_np_array<'a, T: numpy::Element, D: numpy::ndarray::Dimension>(
+    array: &'a numpy::PyReadonlyArray<'_, T, D>,
+) -> Cow<'a, [T]> {
     let array = array.as_array();
     if let Some(slice) = array.to_slice() {
-        slice.to_vec()
+        Cow::Borrowed(slice)
     } else {
-        array.iter().cloned().collect()
+        Cow::Owned(array.iter().cloned().collect())
     }
 }
 


### PR DESCRIPTION
`vec_from_np_array` nows returns a `Cow`, to avoid unnecessary allocations in the very likely case that the backing numpy array is indeed contiguous.
See https://github.com/rerun-io/rerun/pull/106#pullrequestreview-1115704816 for context.

`Cow` implements `Deref` and friends which makes this PR quite trivial it seems.