### PR TITLE
Fix typo in example_car.py

### DIFF
--- a/rerun_py/rerun_sdk/examples/example_car.py
+++ b/rerun_py/rerun_sdk/examples/example_car.py
@@ -233,7 +233,7 @@ class SimpleDepthCamera:
         )
 
 
-def generate_dummy_data(num_frames: int) -> Iterator[SampleFrame]:
+def generate_car_data(num_frames: int) -> Iterator[SampleFrame]:
     """This function generates dummy data to log."""
     # Generate some fake data
     im_w = 480


### PR DESCRIPTION
Rename got missed; example wasn't working.
