### PR TITLE
Add tensor width/height flipping & use permuted_axis to obtain view

### DIFF
--- a/crates/re_tensor_ops/src/dimension_mapping.rs
+++ b/crates/re_tensor_ops/src/dimension_mapping.rs
@@ -12,10 +12,10 @@ pub struct DimensionMapping {
     pub height: Option<usize>,
 
     /// Flip the width
-    pub flip_width: bool,
+    pub invert_width: bool,
 
     /// Flip the height
-    pub flip_height: bool,
+    pub invert_height: bool,
 
     // Which dim?
     pub channel: Option<usize>,
@@ -29,8 +29,8 @@ impl DimensionMapping {
             height: Some(0),
             channel: None,
             selectors: (2..tensor.num_dim()).collect(),
-            flip_width: false,
-            flip_height: false,
+            invert_width: false,
+            invert_height: false,
         }
     }
 }

--- a/crates/re_viewer/src/ui/tensor_dimension_mapper.rs
+++ b/crates/re_viewer/src/ui/tensor_dimension_mapper.rs
@@ -198,7 +198,7 @@ pub fn dimension_mapping_ui(
             egui::Grid::new("imagegrid").num_columns(2).show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.label("Width:");
-                    ui.toggle_value(&mut dimension_mapping.flip_width, "Flip");
+                    ui.toggle_value(&mut dimension_mapping.invert_width, "Flip");
                 });
                 tensor_dimension_ui(
                     ui,
@@ -214,7 +214,7 @@ pub fn dimension_mapping_ui(
 
                 ui.horizontal(|ui| {
                     ui.label("Height:");
-                    ui.toggle_value(&mut dimension_mapping.flip_height, "Flip");
+                    ui.toggle_value(&mut dimension_mapping.invert_height, "Flip");
                 });
                 tensor_dimension_ui(
                     ui,

--- a/crates/re_viewer/src/ui/view_tensor.rs
+++ b/crates/re_viewer/src/ui/view_tensor.rs
@@ -166,10 +166,10 @@ fn selected_tensor_slice<'a, T: Copy>(
         // 0 and 1 are width/height, the rest are rearranged by dimension_mapping.selectors
         slice.index_axis_inplace(Axis(2), *selector_value as _);
     }
-    if state.dimension_mapping.flip_height {
+    if state.dimension_mapping.invert_height {
         slice.invert_axis(Axis(0));
     }
-    if state.dimension_mapping.flip_width {
+    if state.dimension_mapping.invert_width {
         slice.invert_axis(Axis(1));
     }
 


### PR DESCRIPTION
swapping width/height in particular no longer done by transpose but via permute

![flip](https://user-images.githubusercontent.com/1220815/193145251-9eeb809d-3983-459b-ac23-f5d614fdf01f.gif)
