### PR TITLE
deep_sdf example: use absolute paths

### DIFF
--- a/examples/deep_sdf/download_dataset.py
+++ b/examples/deep_sdf/download_dataset.py
@@ -3,6 +3,7 @@
 import io
 import os
 import requests
+from pathlib import Path
 import zipfile
 
 
@@ -25,7 +26,7 @@ def download_and_extract(url, path):
 def download_dataset(name):
     url = f"https://casual-effects.com/g3d/data10/research/model/{name}/{name}.zip"
 
-    dir = f"dataset"
+    dir = Path(os.path.dirname(__file__)).joinpath("dataset")
     os.makedirs(dir, exist_ok=True)
 
     download_and_extract(url, f"{dir}/{name}")

--- a/examples/deep_sdf/main.py
+++ b/examples/deep_sdf/main.py
@@ -21,7 +21,7 @@ results. log the Objectron dataset.
 
 Setup:
 ```sh
-(cd examples/deep_sdf && ./download_dataset.py)
+./examples/deep_sdf/download_dataset.py
 ```
 
 Run:
@@ -101,7 +101,7 @@ if __name__ == '__main__':
         # which is `127.0.0.1:9876`.
         rerun.connect(args.addr)
 
-    cachedir = f"cache"
+    cachedir = Path(os.path.dirname(__file__)).joinpath("cache")
     os.makedirs(cachedir, exist_ok=True)
 
     for path in args.path:


### PR DESCRIPTION
So we can run the scripts from any folder
