### PR TITLE
add texture caching support to tensor viewer

### DIFF
--- a/crates/re_viewer/src/ui/view_tensor.rs
+++ b/crates/re_viewer/src/ui/view_tensor.rs
@@ -169,8 +169,7 @@ impl TextureSettings {
 
         // Either we don't have any texture allocated yet, or the current one has become
         // inappropriate: just create one and fill it.
-        println!("bumped");
-        ui.ctx().load_texture("tensor_tex", data, dbg!(self.filter))
+        ui.ctx().load_texture("tensor_tex", data, self.filter)
     }
 
     fn paint_texture(


### PR DESCRIPTION
- Tensor viewer will now allocate a new texture only when strictly necessary, rather than on every frame
- We still blit the tensor data onto the texture on every frame, no matter what
- No UX changes