### PR TITLE
Move global_allocator from lib.rs to main.rs

### DIFF
--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -10,9 +10,6 @@ use std::sync::mpsc::Receiver;
 
 use re_log_types::LogMsg;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 /// The Rerun Viewer and Server
 ///
 /// Features:

--- a/crates/rerun/src/main.rs
+++ b/crates/rerun/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     // Log to stdout (if you run with `RUST_LOG=debug`).


### PR DESCRIPTION
Libraries should never set a global allocator, only binaries. The problem this caused was:

```
./main.py ./dataset/avocado.glb
Traceback (most recent call last):
  File "/home/cmc/dev/rerun-io/rerun/examples/deep_sdf/./main.py", line 41, in <module>
    import rerun_sdk as rerun
  File "/home/cmc/dev/rerun-io/rerun/rerun_py/rerun_sdk/__init__.py", line 9, in <module>
    from rerun_sdk import rerun_sdk as rerun_rs # type: ignore
ImportError: /home/cmc/dev/rerun-io/rerun/rerun_py/rerun_sdk/rerun_sdk.cpython-310-x86_64-linux-gnu.so: cannot allocate memory in static TLS block
```