### PR TITLE
Check wasm32-unknown-unknown in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,10 @@
 targets = [
-    { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-linux-android" },
+    { triple = "wasm32-unknown-unknown" },
     { triple = "x86_64-apple-darwin" },
     { triple = "x86_64-pc-windows-msvc" },
-    { triple = "aarch64-linux-android" },
+    { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-unknown-linux-musl" },
 ]
 


### PR DESCRIPTION
This is quite important to keep the WASM binary size down.