### PR TITLE
The update to rust-1.64 requires moving to maturin 13.5

### DIFF
--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -2,7 +2,7 @@
 
 [build-system]
 build-backend = "maturin"
-requires = ["maturin==0.13,<0.14"]
+requires = ["maturin>=0.13.5,<0.14"]
 
 [project]
 name = "rerun_sdk"


### PR DESCRIPTION
This was a regression from https://github.com/rerun-io/rerun/pull/110

Before:
```
jleibs@bullfrog-ubuntu:~/rerun$ pip install ./rerun_py
Processing ./rerun_py
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      💥 maturin failed
        Caused by: Failed to parse Cargo.toml at Cargo.toml
        Caused by: invalid type: map, expected a string for key `package.license`
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-35bxt2h8', '--interpreter', '/home/jleibs/rerun/venv/bin/python3']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-35bxt2h8 --interpreter /home/jleibs/rerun/venv/bin/python3`
      [end of output]
```

After:
```
jleibs@bullfrog-ubuntu:~/rerun$ pip install ./rerun_py
Processing ./rerun_py
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: numpy in ./venv/lib/python3.10/site-packages (from rerun_sdk==0.1.0) (1.23.3)
Building wheels for collected packages: rerun_sdk
  Building wheel for rerun_sdk (pyproject.toml) ... done
  Created wheel for rerun_sdk: filename=rerun_sdk-0.1.0-cp310-cp310-linux_x86_64.whl size=9022480 sha256=046e0566802fc25c3d9ce0b9b1bd4467bb5c8a374665df6ba83f30fd00c046ea
  Stored in directory: /tmp/pip-ephem-wheel-cache-7qon6106/wheels/99/d7/9a/12abd434f979116715c100c77f26a326c3aed6f1a4d4623515
Successfully built rerun_sdk
Installing collected packages: rerun_sdk
  Attempting uninstall: rerun_sdk
    Found existing installation: rerun_sdk 0.1.0
    Uninstalling rerun_sdk-0.1.0:
      Successfully uninstalled rerun_sdk-0.1.0
Successfully installed rerun_sdk-0.1.0
```
