### PR TITLE
Prevent rate limiting in CI

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           just-version: 1.5
 


### PR DESCRIPTION
Add GITHUB_TOKEN env to just workflow in CI to prevent rate limiting issue.

<!--
* Read [`CONTRIBUTING.md`](https://github.com/emilk/egui/blob/master/CONTRIBUTING.md).
* Include a screenshot or gif (if applicable).
* Add a line to `CHANGELOG.md` if this is a big enough change to warrant it.

Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
