### PR TITLE
Fix clipboard usage on Windows

### DIFF
--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_arch = "wasm32"))]
-mod clipboard;
+pub mod clipboard;
 pub(crate) mod color_map;
 pub(crate) mod image_cache;
 #[cfg(feature = "glow")]
@@ -12,9 +12,6 @@ pub(crate) mod time_control_ui;
 mod time_range;
 mod time_real;
 mod viewer_context;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) use clipboard::Clipboard;
 
 use image_cache::ImageCache;
 pub(crate) use time_control::{TimeControl, TimeView};

--- a/crates/re_viewer/src/misc/profiler.rs
+++ b/crates/re_viewer/src/misc/profiler.rs
@@ -45,7 +45,7 @@ fn start_puffin_viewer() {
 
     if let Err(err) = child {
         let cmd = format!("cargo install puffin_viewer && puffin_viewer --url {url}",);
-        crate::Clipboard::with(|cliboard| cliboard.set_text(cmd.clone()));
+        crate::misc::clipboard::set_text(cmd.clone());
         re_log::warn!("Failed to start puffin_viewer: {err}. Try connecting manually with:  {cmd}");
 
         rfd::MessageDialog::new()

--- a/crates/re_viewer/src/ui/image_ui.rs
+++ b/crates/re_viewer/src/ui/image_ui.rs
@@ -319,12 +319,10 @@ fn image_options(
     #[cfg(not(target_arch = "wasm32"))]
     if ui.button("Click to copy image").clicked() {
         let rgba = dynamic_image.to_rgba8();
-        crate::Clipboard::with(|clipboard| {
-            clipboard.set_image(
-                [rgba.width() as _, rgba.height() as _],
-                bytemuck::cast_slice(rgba.as_raw()),
-            );
-        });
+        crate::misc::clipboard::set_image(
+            [rgba.width() as _, rgba.height() as _],
+            bytemuck::cast_slice(rgba.as_raw()),
+        );
     }
 
     // TODO(emilk): support saving images on web


### PR DESCRIPTION
As [was just pointed out to me](https://github.com/emilk/egui/issues/2109), `arboard` had a breaking change in 3.0 that meant you must absolutely not hold on to the `arboard::Clipboard` for longer than you are using it.

Thankfully, this just makes the code shorter and simpler.

See https://github.com/1Password/arboard/issues/84 for more details.