### PR TITLE
Update egui_dock to patched version with fixes for rust-analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "egui_dock"
 version = "0.2.0"
-source = "git+https://github.com/rerun-io/egui_dock?rev=096be40cc9fc7471eea48df9104fe62acfc96d2b#096be40cc9fc7471eea48df9104fe62acfc96d2b"
+source = "git+https://github.com/rerun-io/egui_dock?rev=b9ef7e3c0606cba87cb8f3cd6b07d74801be5cca#b9ef7e3c0606cba87cb8f3cd6b07d74801be5cca"
 dependencies = [
  "egui",
  "serde",

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -45,7 +45,7 @@ anyhow = "1.0"
 bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
 cgmath = { version = "0.18", features = ["mint"] }
 document-features = "0.2"
-egui_dock = { git = "https://github.com/rerun-io/egui_dock", rev = "096be40cc9fc7471eea48df9104fe62acfc96d2b", features = ["serde"] } # 2022-09-06
+egui_dock = { git = "https://github.com/rerun-io/egui_dock", rev = "b9ef7e3c0606cba87cb8f3cd6b07d74801be5cca", features = ["serde"] } # 2022-09-06 + workaround-ra-style
 fixed = { version = "1.17", features = ["serde"] }
 glam = { version = "0.20", features = ["mint"] } # can't update to 0.21 until a new version of `macaw` is released
 image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }


### PR DESCRIPTION
Rust-analyzer was complaining about space_view, which was bothering me...

![image](https://user-images.githubusercontent.com/3312232/194592361-5a8dc8bb-d3ca-42a8-85e9-03febbdd6373.png)

The fix is relatively straightforward:
https://github.com/rerun-io/egui_dock/commit/b9ef7e3c0606cba87cb8f3cd6b07d74801be5cca

Afterward:
![image](https://user-images.githubusercontent.com/3312232/194592574-baef4d7a-7de7-4908-b18d-e546fc48cb6b.png)
