### PR TITLE
ui_waker: coalesce batched repaint requests into one

### DIFF
--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -73,7 +73,7 @@ pub fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
                     }
 
                     // Finally, let's try to coalesce all LogMsgs that are already buffered.
-                    while let Ok(msg) = rx.recv() {
+                    while let Ok(msg) = rx.try_recv() {
                         num_coalesced += 1;
                         if tx.send(msg).is_err() {
                             break 'outer;


### PR DESCRIPTION
Update:

Taking a step back, I do not think the reasoning below is correct: even though the proposed solution _does_ fix the issue, I still think I got the cause wrong.
Still, the fact that coalescing those repaint requests fixes the issue might be a good indicator of what's going on for someone that knows better?

Stuff I'd like to try when I get some time:
- [x] Reproduce in other environments:
  - [x] On X11 at the very least
  - [x] Ideally on macOS and/or windows
  - [ ] what happens on web btw?
- [ ] Try with something other than text entries

----

#### Background

This started with me trying to load large `.rrd` files full of `TextExtries` into the viewer.

Unfortunately, more often than not, doing so would lead to a complete deadlock of the app.
After fiddling around with it for while, I eventually came to the conclusion that the quantity of data had no bearing on the issue: speed of ingestion was the real culprit.

So, here's what this looks like in practice:

https://user-images.githubusercontent.com/2910679/194756000-1b51bfb1-6892-4eab-beea-ea21948be5e3.mp4

Sometimes everything would deadlock before we could even spawn a window yet, sometimes it would all work fine, sometimes it would deadlock later on and leave us with a totally unresponsive window. :man_shrugging: 

I spent hours trying to find anything suspicious on our end, tried running everything through a [patched version of our `deadlock_detection`](https://github.com/emilk/egui/pull/2121) feature... to no avail.

So in the end I just threw `ThreadSanitizer` at it, and started sifting through the noise, until stumbling upon that one:
<details>
  <summary>Race report</summary>

```
==================
WARNING: ThreadSanitizer: data race (pid=110820)
  Write of size 1 at 0x7fdbd06c5f28 by thread T72:
    #0 std::sync::mpsc::mpsc_queue::Node$LT$T$GT$::new::h62f6ad56baf75023 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mpsc_queue.rs:56:27 (rerun+0x633843)
    #1 std::sync::mpsc::mpsc_queue::Queue$LT$T$GT$::push::hf321233e7864582c /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mpsc_queue.rs:71:21 (rerun+0x633843)
    #2 std::sync::mpsc::shared::Packet$LT$T$GT$::send::h1eb087514fb163bd /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/shared.rs:167:9 (rerun+0x5b4780)
    #3 std::sync::mpsc::Sender$LT$T$GT$::send::h021f55ba7ec50c40 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mod.rs:830:45 (rerun+0x5e5ec6)
    #4 calloop::sources::channel::Sender$LT$T$GT$::send::he918bc92e5f3f9db /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/channel.rs:54:9 (rerun+0x639712)
    #5 winit::platform_impl::platform::wayland::event_loop::proxy::EventLoopProxy$LT$T$GT$::send_event::h3e636a243e064204 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/wayland/event_loop/proxy.rs:28:9 (rerun+0x639712)
    #6 winit::platform_impl::platform::EventLoopProxy$LT$T$GT$::send_event::h1dc5a2d1c0145e37 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/mod.rs:765:62 (rerun+0x5edb05)
    #7 winit::event_loop::EventLoopProxy$LT$T$GT$::send_event::h309cf11a3f2a7ce9 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/event_loop.rs:371:9 (rerun+0x5edb05)
    #8 winit::platform_impl::platform::EventLoopProxy$LT$T$GT$::send_event::h1dc5a2d1c0145e37 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/mod.rs:765:62 (rerun+0x5edb05)
    #9 winit::event_loop::EventLoopProxy$LT$T$GT$::send_event::h309cf11a3f2a7ce9 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/event_loop.rs:371:9 (rerun+0x5edb05)
    #10 eframe::native::run::glow_integration::GlowWinitApp::init_run_state::_$u7b$$u7b$closure$u7d$$u7d$::h8348d3c0554d5062 (.llvm.13786725030453180608) /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:393:21 (rerun+0x628aad)
    #11 eframe::native::run::glow_integration::GlowWinitApp::init_run_state::_$u7b$$u7b$closure$u7d$$u7d$::h8348d3c0554d5062 (.llvm.13786725030453180608) /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:393:21 (rerun+0x628aad)
    #12 _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..Fn$LT$Args$GT$$GT$::call::hcdf8b664a6167b66 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/alloc/src/boxed.rs:1952:9 (rerun+0xc8d087)
    #13 egui::context::Context::request_repaint::he25a2ea8df8ec6dc /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/egui/src/context.rs:574:13 (rerun+0xca6936)
    #14 re_viewer::native::wake_up_ui_thread_on_each_msg::_$u7b$$u7b$closure$u7d$$u7d$::ha130ac59889b9144 /home/cmc/dev/rerun-io/rerun/crates/re_viewer/src/native.rs:69:21 (rerun+0x2ec833)
    #15 std::sys_common::backtrace::__rust_begin_short_backtrace::h4a859d1c82c8549e /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sys_common/backtrace.rs:122:18 (rerun+0x2ec833)
    #16 std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::he3491b2dc1817528 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/mod.rs:514:17 (rerun+0x2354df)
    #17 _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::h9ab0e1d546f5fdfa /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/panic/unwind_safe.rs:271:9 (rerun+0x2354df)
    #18 std::panicking::try::do_call::hc89a74f2d2b2030d (.llvm.13767084675051296314) /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:464:40 (rerun+0x2354df)
    #19 __rust_try.llvm.13767084675051296314 <null> (rerun+0x235651)
    #20 __rust_try.llvm.13767084675051296314 <null> (rerun+0x235651)
    #21 std::panicking::try::h91230ffad4250a3d /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:428:19 (rerun+0x22f3ed)
    #22 std::panic::catch_unwind::h339246369988fd3c /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panic.rs:137:14 (rerun+0x22f3ed)
    #23 std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::h6e1649d574bb4271 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/mod.rs:513:30 (rerun+0x4a7455)
    #24 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hcaf4e970a84d34ce /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:251:5 (rerun+0x4a7455)
    #25 std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::h6e1649d574bb4271 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/mod.rs:513:30 (rerun+0x4a7455)
    #26 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hcaf4e970a84d34ce /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:251:5 (rerun+0x4a7455)
    #27 _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h1d1291a36c8a17bd /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/alloc/src/boxed.rs:1938:9 (rerun+0x10264e2)
    #28 _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h256ed32ae3e64946 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/alloc/src/boxed.rs:1938:9 (rerun+0x10264e2)
    #29 std::sys::unix::thread::Thread::new::thread_start::h3822392bfa05e4bf /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sys/unix/thread.rs:108:17 (rerun+0x10264e2)

  Previous read of size 1 at 0x7fdbd06c5f28 by main thread:
    #0 core::option::Option$LT$T$GT$::is_some::h12b525a4e1dd08c0 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mpsc_queue.rs:94:25 (rerun+0x633462)
    #1 core::option::Option$LT$T$GT$::is_none::h8e56db496edf59c9 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/option.rs:600:10 (rerun+0x633462)
    #2 std::sync::mpsc::mpsc_queue::Queue$LT$T$GT$::pop::hf8c95b3b080cb8f5 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mpsc_queue.rs:94:25 (rerun+0x633462)
    #3 std::sync::mpsc::shared::Packet$LT$T$GT$::try_recv::h52ae390e7feb08e3 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/shared.rs:283:25 (rerun+0x5b50f2)
    #4 std::sync::mpsc::Receiver$LT$T$GT$::try_recv::h1a46224310fbb0ba /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mod.rs:1086:48 (rerun+0x5e6a71)
    #5 _$LT$calloop..sources..channel..Channel$LT$T$GT$$u20$as$u20$calloop..sources..EventSource$GT$::process_events::_$u7b$$u7b$closure$u7d$$u7d$::h45da6a11331f49da /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/channel.rs:186:23 (rerun+0x67781b)
    #6 _$LT$calloop..sources..ping..eventfd..PingSource$u20$as$u20$calloop..sources..EventSource$GT$::process_events::_$u7b$$u7b$closure$u7d$$u7d$::h7c6c95586ace1165 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/ping/eventfd.rs:133:21 (rerun+0x67781b)
    #7 _$LT$calloop..sources..generic..Generic$LT$F$C$E$GT$$u20$as$u20$calloop..sources..EventSource$GT$::process_events::h51de769c9d68a4e7 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/generic.rs:121:9 (rerun+0x67781b)
    #8 _$LT$calloop..sources..ping..eventfd..PingSource$u20$as$u20$calloop..sources..EventSource$GT$::process_events::h612339cebc41320d /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/ping/eventfd.rs:122:9 (rerun+0x5f9729)
    #9 _$LT$calloop..sources..channel..Channel$LT$T$GT$$u20$as$u20$calloop..sources..EventSource$GT$::process_events::h9c13e1d6d7c66582 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/channel.rs:184:9 (rerun+0x5f9729)
    #10 _$LT$core..cell..RefCell$LT$calloop..sources..DispatcherInner$LT$S$C$F$GT$$GT$$u20$as$u20$calloop..sources..EventDispatcher$LT$Data$GT$$GT$::process_events::he6edd9b293fca933 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/sources/mod.rs:305:9 (rerun+0x630b2b)
    #11 calloop::loop_logic::EventLoop$LT$Data$GT$::dispatch_events::h22597859b44b581a /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/loop_logic.rs:300:31 (rerun+0x673953)
    #12 calloop::loop_logic::EventLoop$LT$Data$GT$::dispatch::ha9ea60ef40558b0c /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/calloop-0.10.1/src/loop_logic.rs:395:9 (rerun+0x673953)
    #13 winit::platform_impl::platform::wayland::event_loop::EventLoop$LT$T$GT$::loop_dispatch::h2bd14950bdd16801 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/wayland/event_loop/mod.rs:578:9 (rerun+0x5d2d07)
    #14 winit::platform_impl::platform::wayland::event_loop::EventLoop$LT$T$GT$::run_return::hbf5f2c62f4cdf939 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/wayland/event_loop/mod.rs:326:41 (rerun+0x5d2d07)
    #15 winit::platform_impl::platform::EventLoop$LT$T$GT$::run_return::h630f061716eca5fd /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/mod.rs:748:56 (rerun+0x66d512)
    #16 _$LT$winit..event_loop..EventLoop$LT$T$GT$$u20$as$u20$winit..platform..run_return..EventLoopExtRunReturn$GT$::run_return::h651fb1d16e5256f5 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform/run_return.rs:62:9 (rerun+0x5e5275)
    #17 eframe::native::run::run_and_return::h1af77cc9ebf66fbd /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:84:5 (rerun+0x6137e3)
    #18 eframe::native::run::glow_integration::run_glow::_$u7b$$u7b$closure$u7d$$u7d$::h60aff58b0f52d760 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:622:17 (rerun+0x63f5f7)
    #19 eframe::native::run::with_event_loop::_$u7b$$u7b$closure$u7d$$u7d$::hb092526a3f1b81e8 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:73:9 (rerun+0x63f5f7)
    #20 std::thread::local::LocalKey$LT$T$GT$::try_with::h75b1fd20c5ca288a /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:446:16 (rerun+0x63f5f7)
    #21 std::thread::local::LocalKey$LT$T$GT$::with::h67b2ba92a034f2cf /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:422:9 (rerun+0x63f5f7)
    #22 eframe::native::run::with_event_loop::haf5f1fcb717e3dce /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:66:5 (rerun+0x613507)
    #23 eframe::native::run::glow_integration::run_glow::h4ee1e5bfe07bc94a /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:615:13 (rerun+0x5c08b1)
    #24 eframe::run_native::h95f3effd4687f3e2 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/lib.rs:172:13 (rerun+0x5f9f2a)
    #25 re_viewer::native::run_native_app::hf9e9cba639e0fba1 /home/cmc/dev/rerun-io/rerun/crates/re_viewer/src/native.rs:26:5 (rerun+0x25d65e)
    #26 rerun::run_impl::_$u7b$$u7b$closure$u7d$$u7d$::h3b1146dba2664667 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/lib.rs:109:9 (rerun+0x1c7b15)
    #27 _$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h7a54e9aed52e5e7b /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/future/mod.rs:91:19 (rerun+0x1c7b15)
    #28 rerun::run::_$u7b$$u7b$closure$u7d$$u7d$::h8759a8c8e8d9244c /home/cmc/dev/rerun-io/rerun/crates/rerun/src/lib.rs:51:19 (rerun+0x1c7b15)
    #29 _$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h7ff6fc3489c6ab1c /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/future/mod.rs:91:19 (rerun+0x1c7b15)
    #30 rerun::main::_$u7b$$u7b$closure$u7d$$u7d$::h9e433b0e052133d4 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/main.rs:9:33 (rerun+0x1c7b15)
    #31 _$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h4a009427dc9909e9 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/future/mod.rs:91:19 (rerun+0x1c7b15)
    #32 tokio::park::thread::CachedParkThread::block_on::_$u7b$$u7b$closure$u7d$$u7d$::h181c7dbe7c1b1d06 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/park/thread.rs:267:54 (rerun+0x1c3601)
    #33 tokio::coop::with_budget::_$u7b$$u7b$closure$u7d$$u7d$::h26bc834cc42bb50b /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/coop.rs:102:9 (rerun+0x1c3601)
    #34 std::thread::local::LocalKey$LT$T$GT$::try_with::hd0be219114febd64 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:446:16 (rerun+0x1c3601)
    #35 std::thread::local::LocalKey$LT$T$GT$::with::h87bd5ae677cdc1a8 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:422:9 (rerun+0x1c3601)
    #36 tokio::coop::with_budget::hcc8ad8e02963c4b0 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/park/thread.rs:267:31 (rerun+0x1c431a)
    #37 tokio::coop::budget::h965923cf179b7a2c /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/coop.rs:72:5 (rerun+0x1c431a)
    #38 tokio::park::thread::CachedParkThread::block_on::h25d1169e2b7608dd /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/park/thread.rs:267:31 (rerun+0x1c431a)
    #39 tokio::runtime::enter::Enter::block_on::h81f9c695afbd538f /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/runtime/enter.rs:152:13 (rerun+0x1bd73a)
    #40 tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h9dc37f3f89bbf246 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/runtime/scheduler/multi_thread/mod.rs:79:9 (rerun+0x1cbc50)
    #41 tokio::runtime::Runtime::block_on::h7968cf186d064cfa /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/runtime/mod.rs:492:44 (rerun+0x1c9e89)
    #42 rerun::main::h44b460c069cd1790 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/main.rs:9:5 (rerun+0x1bc95f)
    #43 core::ops::function::FnOnce::call_once::h493ed50f49a4f4df /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:251:5 (rerun+0x1c838f)
    #44 std::sys_common::backtrace::__rust_begin_short_backtrace::h145502d44a24cd0c /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sys_common/backtrace.rs:122:18 (rerun+0x1c838f)
    #45 std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::ha9ebec418a54ac0b (.llvm.3159832719650688495) /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/rt.rs:166:18 (rerun+0x1c82dd)
    #46 core::ops::function::impls::_$LT$impl$u20$core..ops..function..FnOnce$LT$A$GT$$u20$for$u20$$RF$F$GT$::call_once::h248dff5e79533422 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:286:13 (rerun+0x1013d7e)
    #47 std::panicking::try::do_call::hc031f29adbe33d80 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:464:40 (rerun+0x1013d7e)
    #48 std::panicking::try::h9f7609afecc42072 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:428:19 (rerun+0x1013d7e)
    #49 std::panic::catch_unwind::h344e032ff5b69e7d /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panic.rs:137:14 (rerun+0x1013d7e)
    #50 std::rt::lang_start_internal::_$u7b$$u7b$closure$u7d$$u7d$::h11826fdb0bdc3875 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/rt.rs:148:48 (rerun+0x1013d7e)
    #51 std::panicking::try::do_call::h8b8431a67998dfb4 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:464:40 (rerun+0x1013d7e)
    #52 std::panicking::try::h3d485c1442da5ae3 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:428:19 (rerun+0x1013d7e)
    #53 std::panic::catch_unwind::h078b92e3011d3925 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panic.rs:137:14 (rerun+0x1013d7e)
    #54 std::rt::lang_start_internal::h85eeec1856f297d7 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/rt.rs:148:20 (rerun+0x1013d7e)
    #55 <null> <null> (libc.so.6+0x232cf) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)
    #56 <null> <null> (libc.so.6+0x232cf) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)

  Thread T72 'ui_waker' (tid=110895, running) created by main thread at:
    #0 pthread_create /rustc/llvm/src/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1022:3 (rerun+0x139bad)
    #1 std::sys::unix::thread::Thread::new::hf5349d6a7db1c96f /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sys/unix/thread.rs:87:19 (rerun+0x1026350)
    #2 std::thread::Builder::spawn_unchecked::h5ebdc14a411af0f4 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/mod.rs:469:32 (rerun+0x4a6f8d)
    #3 std::thread::Builder::spawn::h1c37b386ec34e168 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/mod.rs:401:18 (rerun+0x4a6f8d)
    #4 re_viewer::native::wake_up_ui_thread_on_each_msg::he6df9e463f56a33a /home/cmc/dev/rerun-io/rerun/crates/re_viewer/src/native.rs:48:5 (rerun+0x2938db)
    #5 rerun::run_impl::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h851ef0eae88ac549 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/lib.rs:110:22 (rerun+0x1c6257)
    #6 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h4b62ad2dd99e36f4 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:251:5 (rerun+0x1c6257)
    #7 _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::ha2c7c062c719fa6d /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/alloc/src/boxed.rs:1938:9 (rerun+0x42cfad)
    #8 re_viewer::native::run_native_app::_$u7b$$u7b$closure$u7d$$u7d$::hc983d12241e78fbf /home/cmc/dev/rerun-io/rerun/crates/re_viewer/src/native.rs:31:13 (rerun+0x25d187)
    #9 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hcb4723d793a60001 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:251:5 (rerun+0x25d187)
    #10 _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h482474ae026707ac /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/alloc/src/boxed.rs:1938:9 (rerun+0x63ac5d)
    #11 eframe::native::run::glow_integration::GlowWinitApp::init_run_state::hc2770ec7e5a5fc97 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:399:27 (rerun+0x5c00fd)
    #12 _$LT$eframe..native..run..glow_integration..GlowWinitApp$u20$as$u20$eframe..native..run..WinitApp$GT$::on_event::ha126ef9daff40f71 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:540:25 (rerun+0x5c00fd)
    #13 eframe::native::run::run_and_return::_$u7b$$u7b$closure$u7d$$u7d$::hd34849934b40fbff /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:117:22 (rerun+0x5dab57)
    #14 winit::platform_impl::platform::wayland::event_loop::EventLoop$LT$T$GT$::run_return::hbf5f2c62f4cdf939 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/wayland/event_loop/mod.rs:241:9 (rerun+0x5d287e)
    #15 winit::platform_impl::platform::EventLoop$LT$T$GT$::run_return::h630f061716eca5fd /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform_impl/linux/mod.rs:748:56 (rerun+0x66d512)
    #16 _$LT$winit..event_loop..EventLoop$LT$T$GT$$u20$as$u20$winit..platform..run_return..EventLoopExtRunReturn$GT$::run_return::h651fb1d16e5256f5 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.27.2/src/platform/run_return.rs:62:9 (rerun+0x5e5275)
    #17 eframe::native::run::run_and_return::h1af77cc9ebf66fbd /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:84:5 (rerun+0x6137e3)
    #18 eframe::native::run::glow_integration::run_glow::_$u7b$$u7b$closure$u7d$$u7d$::h60aff58b0f52d760 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:622:17 (rerun+0x63f5f7)
    #19 eframe::native::run::with_event_loop::_$u7b$$u7b$closure$u7d$$u7d$::hb092526a3f1b81e8 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:73:9 (rerun+0x63f5f7)
    #20 std::thread::local::LocalKey$LT$T$GT$::try_with::h75b1fd20c5ca288a /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:446:16 (rerun+0x63f5f7)
    #21 std::thread::local::LocalKey$LT$T$GT$::with::h67b2ba92a034f2cf /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:422:9 (rerun+0x63f5f7)
    #22 eframe::native::run::with_event_loop::haf5f1fcb717e3dce /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:66:5 (rerun+0x613507)
    #23 eframe::native::run::glow_integration::run_glow::h4ee1e5bfe07bc94a /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/native/run.rs:615:13 (rerun+0x5c08b1)
    #24 eframe::run_native::h95f3effd4687f3e2 /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/3ec170c/crates/eframe/src/lib.rs:172:13 (rerun+0x5f9f2a)
    #25 re_viewer::native::run_native_app::hf9e9cba639e0fba1 /home/cmc/dev/rerun-io/rerun/crates/re_viewer/src/native.rs:26:5 (rerun+0x25d65e)
    #26 rerun::run_impl::_$u7b$$u7b$closure$u7d$$u7d$::h3b1146dba2664667 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/lib.rs:109:9 (rerun+0x1c7b15)
    #27 _$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h7a54e9aed52e5e7b /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/future/mod.rs:91:19 (rerun+0x1c7b15)
    #28 rerun::run::_$u7b$$u7b$closure$u7d$$u7d$::h8759a8c8e8d9244c /home/cmc/dev/rerun-io/rerun/crates/rerun/src/lib.rs:51:19 (rerun+0x1c7b15)
    #29 _$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h7ff6fc3489c6ab1c /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/future/mod.rs:91:19 (rerun+0x1c7b15)
    #30 rerun::main::_$u7b$$u7b$closure$u7d$$u7d$::h9e433b0e052133d4 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/main.rs:9:33 (rerun+0x1c7b15)
    #31 _$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h4a009427dc9909e9 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/future/mod.rs:91:19 (rerun+0x1c7b15)
    #32 tokio::park::thread::CachedParkThread::block_on::_$u7b$$u7b$closure$u7d$$u7d$::h181c7dbe7c1b1d06 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/park/thread.rs:267:54 (rerun+0x1c3601)
    #33 tokio::coop::with_budget::_$u7b$$u7b$closure$u7d$$u7d$::h26bc834cc42bb50b /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/coop.rs:102:9 (rerun+0x1c3601)
    #34 std::thread::local::LocalKey$LT$T$GT$::try_with::hd0be219114febd64 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:446:16 (rerun+0x1c3601)
    #35 std::thread::local::LocalKey$LT$T$GT$::with::h87bd5ae677cdc1a8 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/thread/local.rs:422:9 (rerun+0x1c3601)
    #36 tokio::coop::with_budget::hcc8ad8e02963c4b0 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/park/thread.rs:267:31 (rerun+0x1c431a)
    #37 tokio::coop::budget::h965923cf179b7a2c /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/coop.rs:72:5 (rerun+0x1c431a)
    #38 tokio::park::thread::CachedParkThread::block_on::h25d1169e2b7608dd /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/park/thread.rs:267:31 (rerun+0x1c431a)
    #39 tokio::runtime::enter::Enter::block_on::h81f9c695afbd538f /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/runtime/enter.rs:152:13 (rerun+0x1bd73a)
    #40 tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h9dc37f3f89bbf246 /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/runtime/scheduler/multi_thread/mod.rs:79:9 (rerun+0x1cbc50)
    #41 tokio::runtime::Runtime::block_on::h7968cf186d064cfa /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/runtime/mod.rs:492:44 (rerun+0x1c9e89)
    #42 rerun::main::h44b460c069cd1790 /home/cmc/dev/rerun-io/rerun/crates/rerun/src/main.rs:9:5 (rerun+0x1bc95f)
    #43 core::ops::function::FnOnce::call_once::h493ed50f49a4f4df /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:251:5 (rerun+0x1c838f)
    #44 std::sys_common::backtrace::__rust_begin_short_backtrace::h145502d44a24cd0c /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sys_common/backtrace.rs:122:18 (rerun+0x1c838f)
    #45 std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::ha9ebec418a54ac0b (.llvm.3159832719650688495) /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/rt.rs:166:18 (rerun+0x1c82dd)
    #46 core::ops::function::impls::_$LT$impl$u20$core..ops..function..FnOnce$LT$A$GT$$u20$for$u20$$RF$F$GT$::call_once::h248dff5e79533422 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/core/src/ops/function.rs:286:13 (rerun+0x1013d7e)
    #47 std::panicking::try::do_call::hc031f29adbe33d80 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:464:40 (rerun+0x1013d7e)
    #48 std::panicking::try::h9f7609afecc42072 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:428:19 (rerun+0x1013d7e)
    #49 std::panic::catch_unwind::h344e032ff5b69e7d /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panic.rs:137:14 (rerun+0x1013d7e)
    #50 std::rt::lang_start_internal::_$u7b$$u7b$closure$u7d$$u7d$::h11826fdb0bdc3875 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/rt.rs:148:48 (rerun+0x1013d7e)
    #51 std::panicking::try::do_call::h8b8431a67998dfb4 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:464:40 (rerun+0x1013d7e)
    #52 std::panicking::try::h3d485c1442da5ae3 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panicking.rs:428:19 (rerun+0x1013d7e)
    #53 std::panic::catch_unwind::h078b92e3011d3925 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/panic.rs:137:14 (rerun+0x1013d7e)
    #54 std::rt::lang_start_internal::h85eeec1856f297d7 /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/rt.rs:148:20 (rerun+0x1013d7e)
    #55 <null> <null> (libc.so.6+0x232cf) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)
    #56 <null> <null> (libc.so.6+0x232cf) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)

SUMMARY: ThreadSanitizer: data race /rustc/f83e0266cf7aaa4b41505c49a5fd9c2363166522/library/std/src/sync/mpsc/mpsc_queue.rs:56:27 in std::sync::mpsc::mpsc_queue::Node$LT$T$GT$::new::h62f6ad56baf75023
```

</details>

What's going here (as far as I understand, please correct me if I'm wrong) is this: on native targets, `wake_up_ui_thread_on_each_msg` will catch each incoming raw datapoint (aka. `LogMsg`) and notify `egui` that the UI needs to be updated, which will in turn notify `eframe`, which will notify `winit` and so on until we finally reach the platform-dependent libraries sitting at the edge.

In my case, that would be the [Smithay](https://github.com/Smithay) ecosystem of libraries, as I'm targeting wayland.
Upon receiving a repaint request event, `smithay` will simply queue it into a mpsc channel using their [`calloop`](https://github.com/Smithay/calloop) abstraction.

Now it turns out that, for reasons unknown to me and that I don't want to spend any more time looking into, there's a data race lurking in there somewhere (i.e. in smithay / calloop) that is almost impossible to hit... Unless of course you are ingesting 100k `TextEntries` (which is 300k `LogMsg`, i.e. 300k repaint requests) in a couple hundreds of microseconds, in which case you are almost guaranteed to hit that race.

And once you do, it's game over: the communication pipeline with wayland is deadlocked and the entire window becomes unresponsive. Your only way out is a `SIGKILL`.

#### Mitigation

This PR mitigates the issue simply by coalescing batches of repaint requests.

In practice, this make the wayland issue completely disappear.
And, beyond wayland, it just seems like a decent performance improvement that should apply to all platforms anyway?

If it is indeed the right approach, then perhaps this should be done directly inside `egui` so that it benefits every caller of `request_repaint()`.

But then again, I've been knee deep into backtraces for so long that I might just be talking absolute non-sense and missing something completely obvious here so... you tell me.