### PR TITLE
make sure taplo CLI & taplo LSP agree on indentation

### DIFF
--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,2 @@
+[formatting]
+indent_string = "  "


### PR DESCRIPTION
For various reasons, it can happen that the taplo LSP server that your editor runs has different defaults than the taplo CLI that `just` and our CI run.
In particular, this is true for the number of spaces used for indentation.

In practice, this means that your editor will always break the CI when you edit a toml file...

This PR commits taplo defaults to the repo so that both LSP and CLI agree no matter what.

(Note that I would have loved to dump the entire default configuration, but `taplo config default` just doesn't work on my end :man_shrugging:)