### PR TITLE
Rename `Data::Space` to `Data::ObjPath`

### DIFF
--- a/crates/re_data_store/benches/obj_query_benchmark.rs
+++ b/crates/re_data_store/benches/obj_query_benchmark.rs
@@ -60,7 +60,7 @@ fn mono_data_messages() -> Vec<DataMsg> {
                 msg_id: MsgId::random(),
                 time_point: time_point.clone(),
                 data_path: DataPath::new(obj_path, "space".into()),
-                data: LoggedData::Single(Data::Space("world".into())),
+                data: LoggedData::Single(Data::ObjPath("world".into())),
             });
         }
     }
@@ -104,7 +104,7 @@ fn batch_data_messages() -> Vec<DataMsg> {
             msg_id: MsgId::random(),
             time_point: time_point.clone(),
             data_path: DataPath::new(obj_path, "space".into()),
-            data: LoggedData::BatchSplat(Data::Space("world".into())),
+            data: LoggedData::BatchSplat(Data::ObjPath("world".into())),
         });
     }
 

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -203,7 +203,9 @@ impl LogDb {
         self.obj_db
             .add_data_msg(msg_id, time_point, data_path, data);
 
-        self.register_spaces(data);
+        if data_path.field_name == "space" {
+            self.register_spaces(data);
+        }
 
         {
             let mut new_timelines = TimePoint::default();
@@ -244,12 +246,14 @@ impl LogDb {
 
         // This is a bit hacky, and I don't like it,
         // but we need a single place to find all the spaces (ignoring time).
+        // This will be properly fixed when https://linear.app/rerun/issue/PRO-98/refactor-spaces is done
         match data {
-            LoggedData::Single(Data::Space(space)) | LoggedData::BatchSplat(Data::Space(space)) => {
+            LoggedData::Single(Data::ObjPath(space))
+            | LoggedData::BatchSplat(Data::ObjPath(space)) => {
                 register_space(space);
             }
             LoggedData::Batch {
-                data: DataVec::Space(spaces),
+                data: DataVec::ObjPath(spaces),
                 ..
             } => {
                 for space in spaces {

--- a/crates/re_data_store/src/object_tree.rs
+++ b/crates/re_data_store/src/object_tree.rs
@@ -134,7 +134,7 @@ impl DataColumns {
 
                 DataType::Tensor => ("tensor", "s"),
 
-                DataType::Space => ("space", "s"),
+                DataType::ObjPath => ("path", "s"),
 
                 DataType::Transform => ("transform", "s"),
 

--- a/crates/re_data_store/src/stores/field_store.rs
+++ b/crates/re_data_store/src/stores/field_store.rs
@@ -167,7 +167,7 @@ impl<Time: 'static + Copy + Ord> FieldStore<Time> {
             DataType::Mesh3D => handle_type!(Mesh3D, re_log_types::Mesh3D),
             DataType::Camera => handle_type!(Camera, re_log_types::Camera),
             DataType::Tensor => handle_type!(Tensor, re_log_types::Tensor),
-            DataType::Space => handle_type!(Space, ObjPath),
+            DataType::ObjPath => handle_type!(ObjPath, ObjPath),
             DataType::Transform => handle_type!(Transform, re_log_types::Transform),
             DataType::DataVec => handle_type!(DataVec, DataVec),
         }

--- a/crates/re_log_types/src/data.rs
+++ b/crates/re_log_types/src/data.rs
@@ -37,7 +37,7 @@ pub enum DataType {
     DataVec,
 
     // ----------------------------
-    Space,
+    ObjPath,
 
     Transform,
 }
@@ -146,7 +146,7 @@ pub mod data_types {
 
     impl DataTrait for crate::ObjPath {
         fn data_typ() -> DataType {
-            DataType::Space
+            DataType::ObjPath
         }
     }
 
@@ -190,8 +190,8 @@ pub enum Data {
 
     // ----------------------------
     // Meta:
-    /// Used for specifying which space data belongs to.
-    Space(ObjPath),
+    /// One object referring to another (a pointer).
+    ObjPath(ObjPath),
 
     Transform(Transform),
 }
@@ -217,7 +217,7 @@ impl Data {
             Self::Tensor(_) => DataType::Tensor,
             Self::DataVec(_) => DataType::DataVec,
 
-            Self::Space(_) => DataType::Space,
+            Self::ObjPath(_) => DataType::ObjPath,
 
             Self::Transform(_) => DataType::Transform,
         }
@@ -232,7 +232,7 @@ impl_into_enum!(Tensor, Data, Tensor);
 impl_into_enum!(Box3, Data, Box3);
 impl_into_enum!(Mesh3D, Data, Mesh3D);
 impl_into_enum!(Camera, Data, Camera);
-impl_into_enum!(ObjPath, Data, Space);
+impl_into_enum!(ObjPath, Data, ObjPath);
 impl_into_enum!(Transform, Data, Transform);
 
 // ----------------------------------------------------------------------------
@@ -261,7 +261,7 @@ pub enum DataVec {
     /// A vector of [`DataVec`] (vector of vectors)
     DataVec(Vec<DataVec>),
 
-    Space(Vec<ObjPath>),
+    ObjPath(Vec<ObjPath>),
 
     Transform(Vec<Transform>),
 }
@@ -290,7 +290,7 @@ macro_rules! data_map(
             $crate::Data::Camera($value) => $action,
             $crate::Data::Tensor($value) => $action,
             $crate::Data::DataVec($value) => $action,
-            $crate::Data::Space($value) => $action,
+            $crate::Data::ObjPath($value) => $action,
             $crate::Data::Transform($value) => $action,
         }
     });
@@ -320,7 +320,7 @@ macro_rules! data_vec_map(
             $crate::DataVec::Camera($vec) => $action,
             $crate::DataVec::Tensor($vec) => $action,
             $crate::DataVec::DataVec($vec) => $action,
-            $crate::DataVec::Space($vec) => $action,
+            $crate::DataVec::ObjPath($vec) => $action,
             $crate::DataVec::Transform($vec) => $action,
         }
     });
@@ -347,7 +347,7 @@ impl DataVec {
             Self::Tensor(_) => DataType::Tensor,
             Self::DataVec(_) => DataType::DataVec,
 
-            Self::Space(_) => DataType::Space,
+            Self::ObjPath(_) => DataType::ObjPath,
 
             Self::Transform(_) => DataType::Transform,
         }
@@ -380,7 +380,7 @@ impl DataVec {
             Self::Tensor(vec) => vec.last().cloned().map(Data::Tensor),
             Self::DataVec(vec) => vec.last().cloned().map(Data::DataVec),
 
-            Self::Space(vec) => vec.last().cloned().map(Data::Space),
+            Self::ObjPath(vec) => vec.last().cloned().map(Data::ObjPath),
 
             Self::Transform(vec) => vec.last().cloned().map(Data::Transform),
         }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -279,10 +279,10 @@ pub enum LoggedData {
 
     /// Log multiple values at once to a "multi-object".
     ///
-    /// The index becomes an "instance index" that, togher with the object-path, forms an "instance".
+    /// The index becomes an "instance index" that, together with the object-path, forms an "instance".
     Batch { indices: Vec<Index>, data: DataVec },
 
-    /// Log the same value for all instances of a mult-object.
+    /// Log the same value for all instances of a multi-object.
     ///
     /// You can only use this for optional fields such as `color`, `space` etc.
     /// You can NOT use it for primary fields such as `pos`.
@@ -325,7 +325,7 @@ impl_into_logged_data!(Tensor, Tensor);
 impl_into_logged_data!(Box3, Box3);
 impl_into_logged_data!(Mesh3D, Mesh3D);
 impl_into_logged_data!(Camera, Camera);
-impl_into_logged_data!(ObjPath, Space);
+impl_into_logged_data!(ObjPath, ObjPath);
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_viewer/src/ui/data_ui.rs
+++ b/crates/re_viewer/src/ui/data_ui.rs
@@ -357,9 +357,21 @@ pub(crate) fn ui_data(
             .response
         }
 
-        Data::Space(space) => {
-            // ui.label(space.to_string())
-            ctx.space_button(ui, space)
+        Data::ObjPath(obj_path) => {
+            // NOTE(emilk): Hack that will be fixed by https://linear.app/rerun/issue/PRO-98/refactor-spaces
+            let is_space = ctx.log_db.get_log_msg(msg_id).map_or(false, |log_msg| {
+                if let LogMsg::DataMsg(data_msg) = log_msg {
+                    data_msg.data_path.field_name == "space"
+                } else {
+                    false
+                }
+            });
+
+            if is_space {
+                ctx.space_button(ui, obj_path)
+            } else {
+                ctx.obj_path_button(ui, obj_path)
+            }
         }
 
         Data::DataVec(data_vec) => ui_data_vec(ui, data_vec),

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -474,7 +474,7 @@ fn log_camera(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -591,7 +591,7 @@ fn log_text_entry(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -691,7 +691,7 @@ fn log_rect(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -780,7 +780,7 @@ fn log_rects(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::BatchSplat(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::BatchSplat(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -853,7 +853,7 @@ fn log_point(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -928,7 +928,7 @@ fn log_points(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::BatchSplat(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::BatchSplat(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -1050,7 +1050,7 @@ fn log_path(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -1132,7 +1132,7 @@ fn log_line_segments(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -1203,7 +1203,7 @@ fn log_obb(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -1283,7 +1283,7 @@ fn log_tensor<T: TensorDataTypeTrait + numpy::Element + bytemuck::Pod>(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     if let Some(meter) = meter {
@@ -1366,7 +1366,7 @@ fn log_mesh_file(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())
@@ -1445,7 +1445,7 @@ fn log_image_file(
     sdk.send_data(
         &time_point,
         (&obj_path, "space"),
-        LoggedData::Single(Data::Space(parse_obj_path(&space)?)),
+        LoggedData::Single(Data::ObjPath(parse_obj_path(&space)?)),
     );
 
     Ok(())


### PR DESCRIPTION
This makes it more general, allowing one object to refer to another.

This will be useful for PRO-37 and PRO-36

We can build https://github.com/rerun-io/rerun/pull/187 upon this.
