### PR TITLE
[re_renderer] bindgroup no longer has knowledge if samplers are gc'ed or not

### DIFF
--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -47,7 +47,7 @@ impl RenderContext {
             pipeline_layouts: _,
             bind_group_layouts: _,
             bind_groups,
-            samplers: _,
+            samplers,
             output_format_color: _,
             frame_index,
         } = self; // not all pools require maintenance
@@ -58,7 +58,7 @@ impl RenderContext {
 
         // Bind group maintenance must come before texture/buffer maintenance since it
         // registers texture/buffer use
-        bind_groups.frame_maintenance(*frame_index, textures);
+        bind_groups.frame_maintenance(*frame_index, textures, samplers);
 
         textures.frame_maintenance(*frame_index);
     }

--- a/crates/re_renderer/src/resource_pools/bind_group_pool.rs
+++ b/crates/re_renderer/src/resource_pools/bind_group_pool.rs
@@ -80,7 +80,12 @@ impl BindGroupPool {
         })
     }
 
-    pub fn frame_maintenance(&mut self, frame_index: u64, textures: &mut TexturePool) {
+    pub fn frame_maintenance(
+        &mut self,
+        frame_index: u64,
+        textures: &mut TexturePool,
+        samplers: &mut SamplerPool,
+    ) {
         self.pool.discard_unused_resources(frame_index);
 
         // Of what's left, update dependent resources.
@@ -90,7 +95,9 @@ impl BindGroupPool {
                     BindGroupEntry::TextureView(handle) => {
                         textures.register_resource_usage(*handle);
                     }
-                    BindGroupEntry::Sampler(_) => {} // Samplers don't track frame index
+                    BindGroupEntry::Sampler(handle) => {
+                        samplers.register_resource_usage(*handle);
+                    }
                 }
             }
         }

--- a/crates/re_renderer/src/resource_pools/sampler_pool.rs
+++ b/crates/re_renderer/src/resource_pools/sampler_pool.rs
@@ -66,4 +66,8 @@ impl SamplerPool {
     pub fn get(&self, handle: SamplerHandle) -> Result<&Sampler, PoolError> {
         self.pool.get_resource(handle)
     }
+
+    pub(super) fn register_resource_usage(&mut self, handle: SamplerHandle) {
+        let _ = self.get(handle);
+    }
 }


### PR DESCRIPTION
follow up to https://github.com/rerun-io/rerun/pull/196#discussion_r995477151 did KISS now after all (thought of having a `ResourcePoolImpl` that implements these for us, but discarded that quickly, not worth it (yet))
