### PR TITLE
Camera refactor: use standalone extrinsics/intrinsics more

### DIFF
--- a/crates/re_data_store/src/objects.rs
+++ b/crates/re_data_store/src/objects.rs
@@ -530,8 +530,11 @@ impl<'s> Mesh3D<'s> {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Camera<'s> {
-    // TODO(emilk): break up in parts
-    pub camera: &'s re_log_types::Camera,
+    pub extrinsics: &'s re_log_types::Extrinsics,
+    pub intrinsics: &'s Option<re_log_types::Intrinsics>,
+
+    /// The 2D space that this camera projects into.
+    pub target_space: &'s Option<ObjPath>,
 }
 
 impl<'s> Camera<'s> {
@@ -565,7 +568,11 @@ impl<'s> Camera<'s> {
                         instance_index: instance_index.copied().unwrap_or(IndexHash::NONE),
                         visible: *visible.unwrap_or(&true),
                     },
-                    data: Camera { camera },
+                    data: Camera {
+                        extrinsics: &camera.extrinsics,
+                        intrinsics: &camera.intrinsics,
+                        target_space: &camera.target_space,
+                    },
                 });
             },
         );

--- a/crates/re_viewer/src/ui/view3d/eye.rs
+++ b/crates/re_viewer/src/ui/view3d/eye.rs
@@ -16,15 +16,18 @@ pub struct Eye {
 }
 
 impl Eye {
-    pub fn from_camera(cam: &re_log_types::Camera) -> Eye {
-        let fov_y = if let Some(intrinsis) = cam.intrinsics {
+    pub fn from_camera(
+        extrinsics: &re_log_types::Extrinsics,
+        intrinsics: Option<&re_log_types::Intrinsics>,
+    ) -> Eye {
+        let fov_y = if let Some(intrinsis) = intrinsics {
             intrinsis.fov_y()
         } else {
             DEFAULT_FOV_Y
         };
 
         Self {
-            world_from_view: crate::misc::cam::world_from_view(&cam.extrinsics),
+            world_from_view: crate::misc::cam::world_from_view(extrinsics),
             fov_y,
         }
     }


### PR DESCRIPTION
Makes it easier to transition to the new refactored spaces and transform hierarchies.
