### PR TITLE
Experimental memory tracker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,5 +61,22 @@
             ],
             "cwd": "${workspaceFolder}"
         },
+        {
+            "name": "Debug 'track_memory'",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=track_memory"
+                ],
+                "filter": {
+                    "name": "track_memory",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,6 +3014,7 @@ dependencies = [
  "puffin",
  "re_log",
  "re_log_types",
+ "re_mem_tracker",
  "re_string_interner",
  "serde",
  "thiserror",
@@ -3045,6 +3046,7 @@ dependencies = [
  "document-features",
  "nohash-hasher",
  "puffin",
+ "re_mem_tracker",
  "re_string_interner",
  "rmp-serde",
  "ruzstd",
@@ -3053,6 +3055,10 @@ dependencies = [
  "uuid",
  "zstd",
 ]
+
+[[package]]
+name = "re_mem_tracker"
+version = "0.1.0"
 
 [[package]]
 name = "re_renderer"
@@ -3187,6 +3193,7 @@ dependencies = [
  "re_error",
  "re_log",
  "re_log_types",
+ "re_mem_tracker",
  "re_renderer",
  "re_string_interner",
  "re_tensor_ops",
@@ -3309,6 +3316,7 @@ dependencies = [
  "re_error",
  "re_log",
  "re_log_types",
+ "re_mem_tracker",
  "re_sdk_comms",
  "re_viewer",
  "re_web_server",

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -20,6 +20,7 @@ serde = ["dep:serde", "re_log_types/serde"]
 [dependencies]
 re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types" }
+re_mem_tracker = { path = "../re_mem_tracker" }
 re_string_interner = { path = "../re_string_interner" }
 
 ahash = "0.8"

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -44,6 +44,8 @@ impl ObjDb {
         data_path: &DataPath,
         data: &LoggedData,
     ) {
+        // re_mem_tracker::track_allocs!("ObjDb");
+
         // Validate:
         {
             let obj_type_path = &data_path.obj_path.obj_type_path();
@@ -125,6 +127,8 @@ impl LogDb {
 
     pub fn add(&mut self, msg: LogMsg) {
         crate::profile_function!();
+        re_mem_tracker::track_allocs!("LogDb"); // TODO: also track in `Drop`!
+
         match &msg {
             LogMsg::BeginRecordingMsg(msg) => self.add_begin_recording_msg(msg),
             LogMsg::TypeMsg(msg) => self.add_type_msg(msg),

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -24,12 +24,14 @@ serde = ["dep:serde", "re_string_interner/serde"]
 
 
 [dependencies]
+re_mem_tracker = { path = "../re_mem_tracker" }
+re_string_interner = { path = "../re_string_interner" }
+
 ahash = "0.8"
 bytemuck = "1.11"
 chrono = { version = "0.4", features = ["js-sys", "wasmbind"] }
 document-features = "0.2"
 nohash-hasher = "0.2"
-re_string_interner = { path = "../re_string_interner" }
 thiserror = "1.0"
 uuid = { version = "1.1", features = ["serde", "v4", "js"] }
 

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -70,6 +70,8 @@ impl<'r, R: std::io::BufRead> Iterator for Decoder<'r, R> {
     type Item = anyhow::Result<LogMsg>;
     fn next(&mut self) -> Option<Self::Item> {
         crate::profile_function!();
+        re_mem_tracker::track_allocs!("LogMsg");
+
         use std::io::Read as _;
 
         let mut len = [0_u8; 8];
@@ -131,6 +133,8 @@ impl<'r> Iterator for Decoder<'r> {
     type Item = anyhow::Result<LogMsg>;
     fn next(&mut self) -> Option<Self::Item> {
         crate::profile_function!();
+        re_mem_tracker::track_allocs!("LogMsg");
+
         use std::io::Read as _;
 
         let mut len = [0_u8; 8];

--- a/crates/re_mem_tracker/Cargo.toml
+++ b/crates/re_mem_tracker/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "re_mem_tracker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false

--- a/crates/re_mem_tracker/README.md
+++ b/crates/re_mem_tracker/README.md
@@ -1,0 +1,1 @@
+Helpers for handling errors.

--- a/crates/re_mem_tracker/src/lib.rs
+++ b/crates/re_mem_tracker/src/lib.rs
@@ -1,0 +1,310 @@
+//! Track allocations and memory use.
+
+mod stats_tree;
+pub use stats_tree::*;
+
+use std::{
+    cell::RefCell,
+    sync::{
+        atomic::{AtomicIsize, AtomicUsize, Ordering::SeqCst},
+        Arc,
+    },
+};
+
+thread_local! {
+     static THREAD_ALLOC_STATS: InnerAllocStats = InnerAllocStats::new();
+}
+
+static GLOBAL_STATS: GlobalStats = GlobalStats::new();
+
+// ----------------------------------------------------------------------------
+
+struct GlobalStats {
+    /// Total number of allocations minus number of frees.
+    pub total_allocs: AtomicUsize,
+
+    /// Total bytes allocated minus those freed.
+    pub total_bytes: AtomicUsize,
+}
+
+impl GlobalStats {
+    pub const fn new() -> Self {
+        Self {
+            total_allocs: AtomicUsize::new(0),
+            total_bytes: AtomicUsize::new(0),
+        }
+    }
+}
+
+/// Total number of live allocations,
+/// and the number of bytes allocated.
+pub fn global_allocs_and_bytes() -> (usize, usize) {
+    (
+        GLOBAL_STATS.total_allocs.load(SeqCst),
+        GLOBAL_STATS.total_bytes.load(SeqCst),
+    )
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Default)]
+struct InnerAllocStats {
+    /// Total number of allocations minus number of frees.
+    pub total_allocs: AtomicIsize,
+
+    /// Total bytes allocated minus those freed.
+    pub total_bytes: AtomicIsize,
+
+    /// The allocations that no child scope has accounted for.
+    pub unaccounted_allocs: AtomicIsize,
+
+    /// The bytes that no child scope has accounted for.
+    pub unaccounted_bytes: AtomicIsize,
+}
+
+impl Clone for InnerAllocStats {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            total_allocs: AtomicIsize::new(self.total_allocs.load(SeqCst)),
+            total_bytes: AtomicIsize::new(self.total_bytes.load(SeqCst)),
+            unaccounted_allocs: AtomicIsize::new(self.unaccounted_allocs.load(SeqCst)),
+            unaccounted_bytes: AtomicIsize::new(self.unaccounted_bytes.load(SeqCst)),
+        }
+    }
+}
+
+impl InnerAllocStats {
+    pub const fn new() -> Self {
+        Self {
+            total_allocs: AtomicIsize::new(0),
+            total_bytes: AtomicIsize::new(0),
+            unaccounted_allocs: AtomicIsize::new(0),
+            unaccounted_bytes: AtomicIsize::new(0),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Clone, Default)]
+pub struct AllocStats(Arc<InnerAllocStats>);
+
+impl AllocStats {
+    /// Total number of allocations minus number of frees.
+    pub fn total_allocs(&self) -> isize {
+        self.0.total_allocs.load(SeqCst)
+    }
+
+    /// Total bytes allocated minus those freed.
+    pub fn total_bytes(&self) -> isize {
+        self.0.total_bytes.load(SeqCst)
+    }
+
+    /// The allocations that no child scope has accounted for.
+    pub fn unaccounted_allocs(&self) -> isize {
+        self.0.unaccounted_allocs.load(SeqCst)
+    }
+
+    /// The bytes that no child scope has accounted for.
+    pub fn unaccounted_bytes(&self) -> isize {
+        self.0.unaccounted_bytes.load(SeqCst)
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Default)]
+pub struct TrackingAllocator<InnerAllocator> {
+    allocator: InnerAllocator,
+}
+
+impl<InnerAllocator> TrackingAllocator<InnerAllocator> {
+    pub const fn new(allocator: InnerAllocator) -> Self {
+        Self { allocator }
+    }
+}
+
+#[allow(unsafe_code)]
+// SAFETY:
+// We just do book-keeping and then let another allocator do all the actual work.
+unsafe impl<InnerAllocator: std::alloc::GlobalAlloc> std::alloc::GlobalAlloc
+    for TrackingAllocator<InnerAllocator>
+{
+    #[allow(clippy::let_and_return)]
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        GLOBAL_STATS.total_allocs.fetch_add(1, SeqCst);
+        GLOBAL_STATS.total_bytes.fetch_add(layout.size(), SeqCst);
+
+        THREAD_ALLOC_STATS.with(|thread_stats| {
+            thread_stats.total_allocs.fetch_add(1, SeqCst);
+            thread_stats
+                .total_bytes
+                .fetch_add(layout.size() as _, SeqCst);
+            thread_stats.unaccounted_allocs.fetch_add(1, SeqCst);
+            thread_stats
+                .unaccounted_bytes
+                .fetch_add(layout.size() as _, SeqCst);
+        });
+
+        self.allocator.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        GLOBAL_STATS.total_allocs.fetch_sub(1, SeqCst);
+        GLOBAL_STATS.total_bytes.fetch_sub(layout.size(), SeqCst);
+
+        THREAD_ALLOC_STATS.with(|thread_stats| {
+            thread_stats.total_allocs.fetch_sub(1, SeqCst);
+            thread_stats
+                .total_bytes
+                .fetch_sub(layout.size() as _, SeqCst);
+            thread_stats.unaccounted_allocs.fetch_sub(1, SeqCst);
+            thread_stats
+                .unaccounted_bytes
+                .fetch_sub(layout.size() as _, SeqCst);
+        });
+
+        self.allocator.dealloc(ptr, layout);
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+thread_local! {
+    #[doc(hidden)]
+    pub static THREAD_TREE: RefCell<Tree> = Default::default();
+}
+
+pub fn thread_local_tree() -> Tree {
+    THREAD_TREE.with(|thread_stats| thread_stats.borrow().clone())
+}
+
+#[macro_export]
+macro_rules! track_allocs {
+    ($name:expr) => {
+        let _tracker_scope = $crate::TrackerScope::new(
+            &$crate::THREAD_TREE
+                .with(|thread_stats| thread_stats.borrow_mut().child($name).stats.clone()),
+        );
+    };
+}
+
+/// Created by the [`re_mem_tracker::track_allocs`].
+pub struct TrackerScope {
+    target: Arc<InnerAllocStats>,
+
+    start_stats: InnerAllocStats,
+
+    /// Prevent the scope from being sent between threads.
+    /// The scope must start/stop on the same thread.
+    /// In particular, we do NOT want this to migrate threads in some async code.
+    /// Workaround until `impl !Send for TrackerScope {}` is stable.
+    _dont_send_me: std::marker::PhantomData<*const ()>,
+}
+
+impl TrackerScope {
+    /// The `id` doesn't need to be static, but it should be unchanging,
+    /// and this is a good way to enforce it.
+    /// `data` can be changing, i.e. a name of a mesh or a texture.
+    #[inline]
+    pub fn new(target: &AllocStats) -> Self {
+        Self {
+            target: target.0.clone(),
+            start_stats: THREAD_ALLOC_STATS.with(|thread_stats| thread_stats.clone()),
+            _dont_send_me: Default::default(),
+        }
+    }
+}
+
+impl Drop for TrackerScope {
+    #[inline]
+    fn drop(&mut self) {
+        let stop_state = THREAD_ALLOC_STATS.with(|thread_stats| {
+            let stop_state = thread_stats.clone();
+            thread_stats
+                .unaccounted_allocs
+                .store(self.start_stats.unaccounted_allocs.load(SeqCst), SeqCst); // we will account for them
+            thread_stats
+                .unaccounted_bytes
+                .store(self.start_stats.unaccounted_bytes.load(SeqCst), SeqCst); // we will account for them
+            stop_state
+        });
+        let target: &InnerAllocStats = &*self.target;
+
+        target.total_allocs.fetch_add(
+            stop_state.total_allocs.load(SeqCst) - self.start_stats.total_allocs.load(SeqCst),
+            SeqCst,
+        );
+        target.total_bytes.fetch_add(
+            stop_state.total_bytes.load(SeqCst) - self.start_stats.total_bytes.load(SeqCst),
+            SeqCst,
+        );
+        target.unaccounted_allocs.fetch_add(
+            stop_state.unaccounted_allocs.load(SeqCst)
+                - self.start_stats.unaccounted_allocs.load(SeqCst),
+            SeqCst,
+        );
+        target.unaccounted_bytes.fetch_add(
+            stop_state.unaccounted_bytes.load(SeqCst)
+                - self.start_stats.unaccounted_bytes.load(SeqCst),
+            SeqCst,
+        );
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// Ignore all allocations within this scope.
+///
+/// Useful if you plan to deallocate them somewhere else, and so they shouldn't count.
+#[macro_export]
+macro_rules! ignore {
+    () => {
+        let _ignore_scope = $crate::IgnoreScope::default();
+    };
+}
+
+/// Created by the [`re_mem_tracker::ignore`].
+pub struct IgnoreScope {
+    start_stats: InnerAllocStats,
+
+    /// Prevent the scope from being sent between threads.
+    /// The scope must start/stop on the same thread.
+    /// In particular, we do NOT want this to migrate threads in some async code.
+    /// Workaround until `impl !Send for IgnoreScope {}` is stable.
+    _dont_send_me: std::marker::PhantomData<*const ()>,
+}
+
+impl Default for IgnoreScope {
+    /// The `id` doesn't need to be static, but it should be unchanging,
+    /// and this is a good way to enforce it.
+    /// `data` can be changing, i.e. a name of a mesh or a texture.
+    #[inline]
+    fn default() -> Self {
+        Self {
+            start_stats: THREAD_ALLOC_STATS.with(|thread_stats| thread_stats.clone()),
+            _dont_send_me: Default::default(),
+        }
+    }
+}
+
+impl Drop for IgnoreScope {
+    #[inline]
+    fn drop(&mut self) {
+        THREAD_ALLOC_STATS.with(|thread_stats| {
+            thread_stats
+                .total_allocs
+                .store(self.start_stats.total_allocs.load(SeqCst), SeqCst);
+            thread_stats
+                .total_bytes
+                .store(self.start_stats.total_bytes.load(SeqCst), SeqCst);
+            thread_stats
+                .unaccounted_allocs
+                .store(self.start_stats.unaccounted_allocs.load(SeqCst), SeqCst);
+            thread_stats
+                .unaccounted_bytes
+                .store(self.start_stats.unaccounted_bytes.load(SeqCst), SeqCst);
+        });
+    }
+}

--- a/crates/re_mem_tracker/src/stats_tree.rs
+++ b/crates/re_mem_tracker/src/stats_tree.rs
@@ -1,0 +1,19 @@
+use std::collections::BTreeMap;
+
+use crate::AllocStats;
+
+/// Describes a tree of allocation stats
+#[derive(Clone, Default)]
+pub struct Tree {
+    /// Statistics for this node (maybe leaf).
+    pub stats: AllocStats,
+
+    /// Children, if any.
+    pub children: BTreeMap<String, Tree>,
+}
+
+impl Tree {
+    pub fn child(&mut self, child: impl Into<String>) -> &mut Tree {
+        self.children.entry(child.into()).or_default()
+    }
+}

--- a/crates/re_mem_tracker/tests/test_mem_tracker.rs
+++ b/crates/re_mem_tracker/tests/test_mem_tracker.rs
@@ -1,0 +1,37 @@
+#[global_allocator]
+static GLOBAL: re_mem_tracker::TrackingAllocator<std::alloc::System> =
+    re_mem_tracker::TrackingAllocator::new(std::alloc::System);
+
+#[test]
+fn test_mem_tracker() {
+    // pre-allocate stats tree so they don't count:
+    {
+        re_mem_tracker::track_allocs!("outer");
+        re_mem_tracker::track_allocs!("inner");
+    }
+
+    let mut outer_vec = vec![];
+    let mut inner_vec = vec![];
+    {
+        re_mem_tracker::track_allocs!("outer");
+        outer_vec.resize(1024, 0_u8);
+        {
+            re_mem_tracker::track_allocs!("inner");
+            inner_vec.resize(256, 0_u8);
+        }
+    }
+
+    let mut tree = re_mem_tracker::thread_local_tree();
+    let outer = tree.child("outer");
+
+    assert_eq!(outer.stats.total_allocs(), 2);
+    assert_eq!(outer.stats.total_bytes(), 1024 + 256);
+    assert_eq!(outer.stats.unaccounted_allocs(), 1);
+    assert_eq!(outer.stats.unaccounted_bytes(), 1024);
+
+    let inner = outer.child("outer");
+    assert_eq!(inner.stats.total_allocs(), 1);
+    assert_eq!(inner.stats.total_bytes(), 256);
+    assert_eq!(inner.stats.unaccounted_allocs(), 1);
+    assert_eq!(inner.stats.unaccounted_bytes(), 256);
+}

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -42,10 +42,11 @@ re_data_store = { path = "../re_data_store", features = ["puffin", "serde"] }
 re_error = { path = "../re_error" }
 re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types", features = ["save", "load"] }
+re_mem_tracker = { path = "../re_mem_tracker" }
+re_renderer = { path = "../re_renderer", optional = true }
 re_string_interner = { path = "../re_string_interner" }
 re_tensor_ops = { path = "../re_tensor_ops" }
 re_ws_comms = { path = "../re_ws_comms", features = ["client"] }
-re_renderer = { path = "../re_renderer", optional = true }
 
 eframe = { version = "0.19", default-features = false, features = [
   "default_fonts",

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -1,0 +1,76 @@
+const SHOW_ALLOC_COUNT: bool = false;
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+pub struct MemoryPanel {}
+
+impl MemoryPanel {
+    #[allow(clippy::unused_self)]
+    pub fn ui(&mut self, ui: &mut egui::Ui) {
+        crate::profile_function!();
+
+        ui.style_mut().wrap = Some(false);
+
+        ui.heading("Memory profile");
+
+        let (total_allocs, total_bytes) = re_mem_tracker::global_allocs_and_bytes();
+        let tree = re_mem_tracker::thread_local_tree();
+
+        egui::Grid::new("grid").show(ui, |ui| {
+            row_ui(ui, "Total", total_bytes as _, total_allocs as _);
+
+            for (name, root) in &tree.children {
+                show_tree(ui, name, root);
+            }
+        });
+    }
+}
+
+fn show_tree(ui: &mut egui::Ui, name: &String, tree: &re_mem_tracker::Tree) {
+    row_ui(
+        ui,
+        &format!("{:?}", name),
+        tree.stats.total_bytes(),
+        tree.stats.total_allocs(),
+    );
+
+    // if !tree.children.is_empty() {
+    //     ui.indent(name, |ui| {
+    //         row_ui(
+    //             ui,
+    //             "Unaccounted",
+    //             tree.stats.total_bytes(),
+    //             tree.stats.total_allocs(),
+    //         );
+    //         for (name, tree) in &tree.children {
+    //             show_tree(ui, name, tree);
+    //         }
+    //     });
+    // }
+}
+
+fn row_ui(ui: &mut egui::Ui, name: &str, bytes: isize, num_allocs: isize) {
+    ui.monospace(name);
+    ui.monospace(format_bytes(bytes));
+    if SHOW_ALLOC_COUNT {
+        ui.monospace(format!("({} allocations)", format_number(num_allocs)));
+    }
+    ui.end_row();
+}
+
+fn format_number(num: isize) -> String {
+    num.to_string() // TODO: thousands-separators
+}
+
+fn format_bytes(bytes: isize) -> String {
+    if bytes < 0 {
+        format!("-{}", format_bytes(-bytes))
+    } else if bytes < 1_000 {
+        format!("{} B", bytes)
+    } else if bytes < 1_000_000 {
+        format!("{:.2} kB", bytes as f32 / 1_000.0)
+    } else if bytes < 1_000_000_000 {
+        format!("{:.2} MB", bytes as f32 / 1_000_000.0)
+    } else {
+        format!("{:.2} GB", bytes as f32 / 1_000_000_000.0)
+    }
+}

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod event_log_view;
 pub(crate) mod experimental_viewport_panel;
 pub(crate) mod image_ui;
 pub(crate) mod legend;
+pub(crate) mod memory_panel;
 pub(crate) mod selection_panel;
 pub(crate) mod text_entry_view;
 pub(crate) mod time_panel;

--- a/crates/re_viewer/src/ui/view3d/mod.rs
+++ b/crates/re_viewer/src/ui/view3d/mod.rs
@@ -562,6 +562,7 @@ fn paint_view(
             rect,
             callback: std::sync::Arc::new(egui_glow::CallbackFn::new(move |info, painter| {
                 glow_rendering::with_three_d_context(painter.gl(), |rendering| {
+                    re_mem_tracker::track_allocs!("three-d");
                     glow_rendering::paint_with_three_d(
                         rendering, &eye, &info, &scene, dark_mode, show_axes, painter,
                     );

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -27,6 +27,7 @@ glow = ["re_viewer/glow"]
 re_error = { path = "../re_error" }
 re_log = { path = "../re_log" }
 re_log_types = { path = "../re_log_types" }
+re_mem_tracker = { path = "../re_mem_tracker" }
 re_viewer = { path = "../re_viewer", features = [
   "puffin",
 ], default-features = false }

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -142,6 +142,7 @@ async fn connect_to_ws_url(
 
 fn load_file_to_channel(path: &std::path::Path) -> anyhow::Result<Receiver<LogMsg>> {
     use anyhow::Context as _;
+
     let file = std::fs::File::open(path).context("Failed to open file")?;
     let decoder = re_log_types::encoding::Decoder::new(file)?;
 
@@ -150,6 +151,7 @@ fn load_file_to_channel(path: &std::path::Path) -> anyhow::Result<Receiver<LogMs
     std::thread::Builder::new()
         .name("rrd_file_reader".into())
         .spawn(move || {
+            re_mem_tracker::track_allocs!("load_file_to_channel");
             for msg in decoder {
                 tx.send(msg.unwrap()).ok();
             }

--- a/crates/rerun/src/main.rs
+++ b/crates/rerun/src/main.rs
@@ -1,5 +1,6 @@
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: re_mem_tracker::TrackingAllocator<mimalloc::MiMalloc> =
+    re_mem_tracker::TrackingAllocator::new(mimalloc::MiMalloc);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
I've been thinking about how we can track how much memory different parts of the viewer is eating, and this is one attempt.

This adds a macro that creates a scope-object that tracks all allocations on the same thread until the object goes out of scope. This lets us very easily track all the allocations done during e.g. message ingestion into the `LogDb`.

It was some big shortcomings though:
* Only tracks allocations on the same thread.
* You must remember to add the macro to all paths that can allocate or deallocate memory for some system
* It doesn't work if allocate memory in one system and free it another

By "system" here I mean once place (e.g. an object or module) where we are interested in tracking allocations.

![Screen Shot 2022-10-23 at 20 36 00](https://user-images.githubusercontent.com/1148717/197462028-5be16c73-37cb-41d9-b2c7-51d325d069d4.png)
