### PR TITLE
Make it an error to log a transform to a root object

### DIFF
--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -448,6 +448,7 @@ fn log_transform(
 ) -> PyResult<()> {
     let obj_path = parse_obj_path(obj_path)?;
     if obj_path.len() == 1 {
+        // Stop people from logging a transform to a root-object, such as "world" (which doesn't have a parent).
         return Err(PyTypeError::new_err("Transforms are between a child object and its parent, so root objects cannot have transforms"));
     }
     let mut sdk = Sdk::global();


### PR DESCRIPTION
Logging a transform to a root object (e.g. `world` makes no sense), so we should catch it early.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
