### PR TITLE
ci: keep apt up to date

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,7 +50,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
+      - run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
@@ -78,7 +80,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
+      - run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - run: sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
+      - run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
@@ -160,7 +162,9 @@ jobs:
           override: true
           components: rustfmt
 
-      - run: sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
+      - run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev # eframe reqs
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
What the title says: run `apt-get update` before trying to fetch anything from there.