### PR TITLE
document custom linkers and split debuginfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,78 @@ See [`rerun_py/USAGE.md`](rerun_py/USAGE.md).
 
 # Development
 Take a look at [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Improving compile times
+
+As of today, we link everything statically in both debug and release builds, which makes custom linkers and split debuginfo the two most impactful tools we have at our disposal in order to improve compile times.
+
+These tools can configured through your `Cargo` configuration, available at `$HOME/.cargo/config.toml`.
+
+### macOS
+
+On macOS, use the [zld](https://github.com/michaeleisel/zld) linker and keep debuginfo in a single separate file.
+
+Pre-requisites:
+- Install [zld](https://github.com/michaeleisel/zld): `brew install michaeleisel/zld/zld`.
+
+`config.toml` (x64):
+```toml
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C",
+    "link-arg=-fuse-ld=/usr/local/bin/zld",
+    "-C",
+    "split-debuginfo=packed",
+]
+```
+
+`config.toml` (M1):
+```toml
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C",
+    "link-arg=-fuse-ld=/opt/homebrew/bin/zld",
+    "-C",
+    "split-debuginfo=packed",
+]
+```
+
+### Linux
+
+On Linux, use the [mold](https://github.com/rui314/mold) linker and keep DWARF debuginfo in separate files.
+
+Pre-requisites:
+- Install [mold](https://github.com/rui314/mold) through your package manager.
+
+`config.toml`:
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = [
+    "-C",
+    "link-arg=-fuse-ld=/usr/bin/mold",
+    "-C",
+    "split-debuginfo=unpacked",
+]
+```
+
+### Windows
+
+On Windows, use LLVM's `lld` linker and keep debuginfo in a single separate file.
+
+Pre-requisites:
+- Install `lld`:
+```
+cargo install -f cargo-binutils
+rustup component add llvm-tools-preview
+```
+
+`config.toml`:
+```toml
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+rustflags = [
+    "-C",
+    "split-debuginfo=packed",
+]
+```


### PR DESCRIPTION
Documents how to leverage custom linkers and split debuginfo (which finally shipped for Linux in Rust 1.65) for all major platforms.

[rendered](https://github.com/rerun-io/rerun/blob/ca101fd043c37c19dc2df6f06b8f1de6f4ecec74/README.md#improving-compile-times)

### Linux demo

Before:
```
$ time $(cargo build --no-default-features --features wgpu -p rerun -q)
real    0m0.178s
user    0m0.125s
sys     0m0.049s

$ touch ./crates/re_renderer/src/resource_pools/render_pipeline_pool.rs

$ time $(cargo build --no-default-features --features wgpu -p rerun -q)
real    0m11.543s
user    0m9.690s
sys     0m2.258s
```

After:
```
$ time $(cargo build --no-default-features --features wgpu -p rerun -q)
real    0m0.190s
user    0m0.151s
sys     0m0.034s

$ touch ./crates/re_renderer/src/resource_pools/render_pipeline_pool.rs

$ time $(cargo build --no-default-features --features wgpu -p rerun -q)
real    0m2.547s
user    0m1.809s
sys     0m0.761s
```
