### PR TITLE
Don't panic when indexing into a batch which doesn't have that index

### DIFF
--- a/crates/re_data_store/src/stores/field_store.rs
+++ b/crates/re_data_store/src/stores/field_store.rs
@@ -134,9 +134,10 @@ impl<Time: 'static + Copy + Ord> FieldStore<Time> {
                             }
                             BatchOrSplat::Batch(batch) => {
                                 if let Some(index) = instance_index {
-                                    let value = batch.get_index(index).expect("Batches should be self-consistent");
-                                    time_msgid_index.push((*time, *msg_id));
-                                    values.push(value.clone());
+                                    if let Some(value) = batch.get_index(index) {
+                                        time_msgid_index.push((*time, *msg_id));
+                                        values.push(value.clone());
+                                    }
                                 } else {
                                     for (_index_hash, _, value) in batch.iter() {
                                         time_msgid_index.push((*time, *msg_id));


### PR DESCRIPTION
Stupid bug, I don't know what I was thinking. Indexing into a batch should never panic, and it's fine to have multiple fields with different indices in them.

Bug reported by @nikolausWest on Slack

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)
