### PR TITLE
Filter out wgpu spam in web console log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3246,8 @@ dependencies = [
  "smallvec",
  "three-d",
  "three-d-asset",
+ "tracing",
+ "tracing-subscriber",
  "tracing-wasm",
  "typenum",
  "uuid",
@@ -3313,6 +3324,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -4095,9 +4109,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
+ "matchers",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -120,5 +120,7 @@ puffin_http = { version = "0.11", optional = true }
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-wasm = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -11,8 +11,8 @@ pub async fn start(canvas_id: &str) -> std::result::Result<(), eframe::wasm_bind
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
 
-    // Redirect tracing to console.log and friends:
-    tracing_wasm::set_as_global_default();
+    // Redirect tracing to `console.log`:
+    redirect_tracing_to_console_log();
 
     let web_options = eframe::WebOptions {
         follow_system_theme: false,
@@ -54,4 +54,19 @@ fn get_url(info: &eframe::IntegrationInfo) -> String {
     } else {
         url
     }
+}
+
+fn redirect_tracing_to_console_log() {
+    use tracing_subscriber::layer::SubscriberExt as _;
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::Registry::default()
+            // Filtering out wgpu spam seems to mitigate https://linear.app/rerun/issue/PRO-256/wgpu-crashes-on-web
+            .with(tracing_subscriber::EnvFilter::new(
+                "info,wgpu_core=warn,wgpu_hal=warn",
+            ))
+            .with(tracing_wasm::WASMLayer::new(
+                tracing_wasm::WASMLayerConfig::default(),
+            )),
+    )
+    .expect("Failed to set tracing subscriber.");
 }


### PR DESCRIPTION
Closes PRO-255

This also seems to mitigate PRO-256. At least I fail to replicate it after this. If the problem with `PRO-256` is that it _sometimes_ crashes when there is any logging, then this PR will make the bug much less likely, but not solve it. So we still need to figure out PRO-256.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
