### PR TITLE
re_renderer: support 'cargo run' from anywhere

### DIFF
--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -12,16 +12,28 @@ macro_rules! include_file {
         {
             let mut resolver = $crate::new_recommended_file_resolver();
 
+            // There's no guarantee that users will `cargo run` from the workspace root, so
+            // we need to know where that is and make sure we look for shaders from there.
+            //
+            // Note that we grab the env-var at _compile time_, that way this will work for
+            // all cases: `cargo run`, `./rerun`, `python example.py`.
+            //
+            // `CARGO_WORKSPACE_DIR` is instantiated by our workspace's cargo config, see
+            // `.cargo/config.toml`.
+            let workspace_path = env!("CARGO_WORKSPACE_DIR");
+
             // The path returned by the `file!()` macro is always hermetic, which is actually
             // an issue for us in this case since we allow non-hermetic imports in debug
             // builds (we encourage them, even!).
             //
             // Thus, we need to do an actual OS canonicalization here, but it turns out that
             // `FileServer::watch()` already does it for us, so we're covered.
-            let path = ::std::path::Path::new(file!())
+            let file_path = ::std::path::Path::new(file!())
                 .parent()
                 .unwrap()
                 .join($path);
+
+            let path = ::std::path::Path::new(&workspace_path).join(&file_path);
 
             $crate::FileServer::get_mut(|fs| fs.watch(&mut resolver, &path, false)).unwrap()
         }


### PR DESCRIPTION
The shader hot-reloader was currently assuming that all debug builds were run from the workspace root, and would crash otherwise.

This makes sure one can run debug builds from anywhere.

Tests:
- [x] `cargo run` from workspace root
    `RUST_LOG=rerun=debug cargo run --no-default-features -p rerun -- examples/out/avocado.rrd`
- [x] `cargo run` from examples dir
    `RUST_LOG=rerun=debug cargo run --no-default-features -p rerun -- out/avocado.rrd`
- [x] `python run` from workspace root
    `./examples/deep_sdf/main.py --mesh_path ./examples/deep_sdf/dataset/avocado.glb`
- [x] `python run` from examples dir
    `./deep_sdf/main.py --mesh_path ./deep_sdf/dataset/avocado.glb`
- [x] `bin run` from workspace root
    `target/debug/rerun examples/out/avocado.rrd`
- [x] `bin run` from examples dir
    `../target/debug/rerun out/avocado.rrd`
