### PR TITLE
check hermeticity at build time

### DIFF
--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -67,7 +67,7 @@ log = "0.4"
 pollster = "0.2"
 rand = "0.8"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3" , features = ["env-filter"]}
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 winit = "0.27"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 

--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -79,7 +79,7 @@ mod file_server_impl {
     static FILE_SERVER: RwLock<Option<FileServer>> = RwLock::new(None);
 
     /// A file server capable of watching filesystem events in the background and
-    /// (soon) resolve #import clauses in files.
+    /// resolve #import clauses in files.
     pub struct FileServer {
         watcher: RecommendedWatcher,
         events_rx: Receiver<Event>,


### PR DESCRIPTION
Currently, building a wasm release while referencing shaders from outside the workspace will result in the app crashing at runtime, because we do not embed assets living outside of the workspace.

This PR makes sure to check for hermeticity at build time instead.

E.g. here's a wasm build trying to embed an external shader through an #import clause:
```
$ RUST_BACKTRACE=0 cargo run-wasm --example renderer_standalone
error: failed to run custom build command for `re_renderer v0.1.0 (/home/cmc/dev/rerun-io/rerun/crates/re_renderer)`

Caused by:
  process didn't exit successfully: `/home/cmc/dev/rerun-io/rerun/target/wasm-examples-target/debug/build/re_renderer-3b4c461b8863effe/build-script-build` (exit status: 101)
  --- stdout
  ...

  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: trying to import "/tmp/kek.wgsl" which lives outside of the workspace, this is illegal in release and/or WASM builds!', crates/re_renderer/build.rs:110:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Tests:
- [x] native debug build referencing external import should work
- [x] native release build referencing external import should fail
- [x] any wasm build referencing external import should fail
- ~[ ] native debug build referencing external asset should work~
- ~[ ] native release build referencing external asset should fail~
- ~[ ] any wasm build referencing external asset should fail~
