### PR TITLE
Only look up annotations and default color once per batch

### DIFF
--- a/crates/re_viewer/src/ui/view_3d/scene.rs
+++ b/crates/re_viewer/src/ui/view_3d/scene.rs
@@ -172,6 +172,9 @@ impl Scene3D {
                 let mut show_labels = true;
                 let mut label_batch = Vec::new();
 
+                let annotations = self.annotation_map.find(obj_path);
+                let default_color = DefaultColor::ObjPath(obj_path);
+
                 visit_type_data_4(
                     obj_store,
                     &FieldName::from("pos"),
@@ -192,13 +195,8 @@ impl Scene3D {
                         let instance_id_hash =
                             InstanceIdHash::from_path_and_index(obj_path, instance_index);
 
-                        let annotations = self.annotation_map.find(obj_path);
                         let class_id = class_id.map(|i| ClassId(*i as _));
-                        let color = annotations.color(
-                            color,
-                            class_id.clone(),
-                            DefaultColor::ObjPath(obj_path),
-                        );
+                        let color = annotations.color(color, class_id.clone(), default_color);
 
                         show_labels = batch_size < 10;
                         if show_labels {


### PR DESCRIPTION
The object path doesn't change for the batch, so only look up the annotation context and default color once.

On the NYU dataset:

Before:
![image](https://user-images.githubusercontent.com/3312232/203657591-08ed378d-0a88-4568-b82e-9adbe5b32617.png)

After:
![image](https://user-images.githubusercontent.com/3312232/203657760-7f9e76ad-d491-4654-86dd-7f87d857b2ab.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
