### PR TITLE
ALways silence the wgpu family of crates, unless told to be loud

### DIFF
--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -15,3 +15,22 @@ pub use tracing::{debug, error, info, trace, warn};
 // In the future we should implement our own `tracing` layer and de-duplicate based on the callsite,
 // similar to how the log console in a browser will automatically supress duplicates.
 pub use log_once::{debug_once, error_once, info_once, trace_once, warn_once};
+
+/// Set `RUST_LOG` environment variable to `info`, unless set,
+/// and also set some other log levels on crates that are too loud.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_default_rust_log_env() {
+    let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
+
+    for loud_crate in ["naga", "wgpu_core", "wgpu_hal"] {
+        if !rust_log.contains(&format!("{loud_crate}=")) {
+            rust_log += &format!(",{loud_crate}=warn");
+        }
+    }
+
+    std::env::set_var("RUST_LOG", rust_log);
+}
+
+pub fn default_log_filter() -> String {
+    "info,naga=warn,wgpu_core=warn,wgpu_hal=warn".to_owned()
+}

--- a/crates/re_renderer/examples/renderer_standalone.rs
+++ b/crates/re_renderer/examples/renderer_standalone.rs
@@ -557,9 +557,7 @@ fn main() {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        if std::env::var("RUST_LOG").is_err() {
-            std::env::set_var("RUST_LOG", "info,wgpu_core=warn,wgpu_hal=warn");
-        }
+        re_log::set_default_rust_log_env();
         tracing_subscriber::fmt::init();
 
         // Set size to a common physical resolution as a comparable start-up default.
@@ -599,7 +597,7 @@ fn redirect_tracing_to_console_log() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::Registry::default()
             .with(tracing_subscriber::EnvFilter::new(
-                "debug,wgpu_core=warn,wgpu_hal=warn",
+                re_log::default_log_filter(),
             ))
             .with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -57,7 +57,7 @@ fn redirect_tracing_to_console_log() {
         tracing_subscriber::Registry::default()
             // Filtering out wgpu spam seems to mitigate https://linear.app/rerun/issue/PRO-256/wgpu-crashes-on-web
             .with(tracing_subscriber::EnvFilter::new(
-                "info,wgpu_core=warn,wgpu_hal=warn",
+                re_log::default_log_filter(),
             ))
             .with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),

--- a/crates/rerun/src/main.rs
+++ b/crates/rerun/src/main.rs
@@ -6,10 +6,7 @@ static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if std::env::var("RUST_LOG").is_err() {
-        // Enable logging unless the user opts-out of it.
-        std::env::set_var("RUST_LOG", "info,wgpu_core=warn,wgpu_hal=warn");
-    }
+    re_log::set_default_rust_log_env();
     tracing_subscriber::fmt::init(); // log to stdout
 
     rerun::run(std::env::args()).await

--- a/rerun_py/README.md
+++ b/rerun_py/README.md
@@ -94,7 +94,7 @@ pip3 install target/wheels/*.whl
 
 
 ## Troubleshooting
-You can run with `RUST_LOG=debug,wgpu_core=warn,wgpu_hal=warn` to get more output out of the rerun SDK.
+You can run with `RUST_LOG=debug` to get more output out of the rerun SDK.
 
 If you are using an Apple-silicon Mac, make sure `rustc -vV` outputs `host: aarch64-apple-darwin`. If not, this should fix it:
 

--- a/rerun_py/USAGE.md
+++ b/rerun_py/USAGE.md
@@ -118,4 +118,4 @@ If you prefer, you can open the viewer directly from Python (blocking the Python
 To do so, don't call `rerun.connect()`. Instead, call `rerun.show()` at the end of your program and a window will pop up with your logged data.
 
 ## Troubleshooting
-You can set `RUST_LOG=debug,wgpu_core=warn,wgpu_hal=warn` before running your Python script and/or `rerun` process to get some verbose logging output.
+You can set `RUST_LOG=debug` before running your Python script and/or `rerun` process to get some verbose logging output.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -71,17 +71,12 @@ impl ThreadInfo {
 /// The python module is called "rerun_sdk".
 #[pymodule]
 fn rerun_sdk(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    if std::env::var("RUST_LOG").is_err() {
-        // Enable logging unless the user opts-out of it.
-        std::env::set_var("RUST_LOG", "info,wgpu_core=warn,wgpu_hal=warn");
-    }
-
     #[cfg(feature = "re_viewer")]
     re_memory::accounting_allocator::turn_on_tracking_if_env_var(
         re_viewer::env_vars::RERUN_TRACK_ALLOCATIONS,
     );
 
-    // Log to stdout (if you run with `RUST_LOG=debug`).
+    re_log::set_default_rust_log_env();
     tracing_subscriber::fmt::init();
 
     Sdk::global().set_recording_id(default_recording_id(py));


### PR DESCRIPTION
So now you can do `RUST_LOG=debug cargo r` without getting drowned in wgpu spam.

Related: https://github.com/gfx-rs/wgpu/issues/3206

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
