### PR TITLE
Update zstd-sys v2.0.2+zstd.1.5.2 -> v2.0.3+zstd.1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.2+zstd.1.5.2"
+version = "2.0.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24faa29d97c8ddca9b37b680e3bd2d5439d864a9cac3a0640d086b71c908bb83"
+checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Should fix the cargo deny CI (again)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
