### PR TITLE
[re_renderer] fix texture row padding

### DIFF
--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -48,6 +48,16 @@ mod error_tracker;
 
 // ---------------------------------------------------------------------------
 
+// part of std, but unstable https://github.com/rust-lang/rust/issues/88581
+pub const fn next_multiple_of(cur: u32, rhs: u32) -> u32 {
+    match cur % rhs {
+        0 => cur,
+        r => cur + (rhs - r),
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 /// Profiling macro for feature "puffin"
 #[doc(hidden)]
 #[macro_export]

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -102,8 +102,7 @@ use bytemuck::Zeroable;
 use smallvec::smallvec;
 
 use crate::{
-    include_file,
-    renderer::utils::next_multiple_of,
+    include_file, next_multiple_of,
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroupHandleStrong,

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -19,8 +19,6 @@ pub use mesh_renderer::{MeshDrawData, MeshInstance};
 
 pub mod compositor;
 
-mod utils;
-
 use crate::{
     context::{RenderContext, SharedRendererData},
     wgpu_resources::WgpuResourcePools,

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -20,8 +20,7 @@ use itertools::Itertools;
 use smallvec::smallvec;
 
 use crate::{
-    include_file,
-    renderer::utils::next_multiple_of,
+    include_file, next_multiple_of,
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroupHandleStrong,

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -10,8 +10,7 @@ use std::num::NonZeroU64;
 use smallvec::smallvec;
 
 use crate::{
-    include_file,
-    renderer::utils::next_multiple_of,
+    include_file, next_multiple_of,
     resource_managers::{GpuTexture2DHandle, ResourceManagerError},
     view_builder::ViewBuilder,
     wgpu_resources::{

--- a/crates/re_renderer/src/renderer/utils.rs
+++ b/crates/re_renderer/src/renderer/utils.rs
@@ -1,7 +1,0 @@
-// part of std, but unstable https://github.com/rust-lang/rust/issues/88581
-pub const fn next_multiple_of(cur: u32, rhs: u32) -> u32 {
-    match cur % rhs {
-        0 => cur,
-        r => cur + (rhs - r),
-    }
-}


### PR DESCRIPTION
Got this thing wrong. Caused issues like this when used in re_viewer
![image](https://user-images.githubusercontent.com/1220815/205646808-e70af86e-5816-48e5-bbeb-a79d0d3ab821.png)

Simplified the logic now

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
