### PR TITLE
Refactor: Remove unused `Option<ObjPath>` for space paths

### DIFF
--- a/crates/re_viewer/src/misc/viewer_context.rs
+++ b/crates/re_viewer/src/misc/viewer_context.rs
@@ -208,14 +208,14 @@ pub enum HoveredSpace {
     None,
     /// Hovering in a 2D space.
     TwoD {
-        space_2d: Option<ObjPath>,
+        space_2d: ObjPath,
         /// Where in this 2D space (+ depth)?
         pos: glam::Vec3,
     },
     /// Hovering in a 3D space.
     ThreeD {
         /// The 3D space with the camera(s)
-        space_3d: Option<ObjPath>,
+        space_3d: ObjPath,
 
         /// 2D spaces and pixel coordinates (with Z=depth)
         target_spaces: Vec<(ObjPath, Option<Ray3>, Option<glam::Vec3>)>,

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -171,7 +171,7 @@ impl ViewState {
     ) -> egui::Response {
         let response = ui
             .scope(|ui| {
-                view_2d::view_2d(ctx, ui, &mut self.state_2d, Some(space), scene);
+                view_2d::view_2d(ctx, ui, &mut self.state_2d, space, scene);
             })
             .response;
 
@@ -196,7 +196,7 @@ impl ViewState {
             state.space_specs = view_3d::SpaceSpecs::from_view_coordinates(coordinates);
             let response = ui
                 .scope(|ui| {
-                    view_3d::view_3d(ctx, ui, state, Some(space), scene, space_cameras);
+                    view_3d::view_3d(ctx, ui, state, space, scene, space_cameras);
                 })
                 .response;
 

--- a/crates/re_viewer/src/ui/view_2d/ui.rs
+++ b/crates/re_viewer/src/ui/view_2d/ui.rs
@@ -225,7 +225,7 @@ pub(crate) fn view_2d(
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut View2DState,
-    space: Option<&ObjPath>,
+    space: &ObjPath,
     mut scene: Scene2D,
 ) -> egui::Response {
     crate::profile_function!();
@@ -354,7 +354,7 @@ fn view_2d_scrollable(
     ctx: &mut ViewerContext<'_>,
     parent_ui: &mut egui::Ui,
     state: &mut View2DState,
-    space: Option<&ObjPath>,
+    space: &ObjPath,
     scene: &Scene2D,
 ) -> egui::Response {
     state.scene_bbox_accum = state.scene_bbox_accum.union(scene.bbox);
@@ -639,7 +639,7 @@ fn view_2d_scrollable(
 
 fn project_onto_other_spaces(
     ctx: &mut ViewerContext<'_>,
-    space: Option<&ObjPath>,
+    space: &ObjPath,
     response: &Response,
     space_from_ui: &RectTransform,
     z: f32,
@@ -647,7 +647,7 @@ fn project_onto_other_spaces(
     if let Some(pointer_in_screen) = response.hover_pos() {
         let pointer_in_space = space_from_ui.transform_pos(pointer_in_screen);
         ctx.rec_cfg.hovered_space_this_frame = HoveredSpace::TwoD {
-            space_2d: space.cloned(),
+            space_2d: space.clone(),
             pos: glam::vec3(pointer_in_space.x, pointer_in_space.y, z),
         };
     }
@@ -656,13 +656,13 @@ fn project_onto_other_spaces(
 fn show_projections_from_3d_space(
     ctx: &ViewerContext<'_>,
     ui: &egui::Ui,
-    space: Option<&ObjPath>,
+    space: &ObjPath,
     ui_from_space: &RectTransform,
     shapes: &mut Vec<Shape>,
 ) {
     if let HoveredSpace::ThreeD { target_spaces, .. } = &ctx.rec_cfg.hovered_space_previous_frame {
         for (space_2d, ray_2d, pos_2d) in target_spaces {
-            if Some(space_2d) == space {
+            if space_2d == space {
                 if let Some(pos_2d) = pos_2d {
                     // User is hovering a 2D point inside a 3D view.
                     let pos_in_ui = ui_from_space.transform_pos(pos2(pos_2d.x, pos_2d.y));

--- a/crates/re_viewer/src/ui/view_3d/ui.rs
+++ b/crates/re_viewer/src/ui/view_3d/ui.rs
@@ -330,7 +330,7 @@ pub(crate) fn view_3d(
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut View3DState,
-    space: Option<&ObjPath>,
+    space: &ObjPath,
     mut scene: Scene3D,
     space_cameras: &[SpaceCamera],
 ) -> egui::Response {
@@ -419,14 +419,7 @@ pub(crate) fn view_3d(
         hovered_instance.map_or(InstanceIdHash::NONE, |id| id.hash()),
     );
 
-    paint_view(
-        ui,
-        eye,
-        rect,
-        &scene,
-        ctx.render_ctx,
-        &space.map_or("<unnamed>".to_owned(), |space| space.to_string()),
-    );
+    paint_view(ui, eye, rect, &scene, ctx.render_ctx, &space.to_string());
 
     response
 }
@@ -561,7 +554,7 @@ fn show_projections_from_2d_space(
 ) {
     if let HoveredSpace::TwoD { space_2d, pos } = &ctx.rec_cfg.hovered_space_previous_frame {
         for cam in space_cameras {
-            if &cam.target_space == space_2d {
+            if cam.target_space.as_ref() == Some(space_2d) {
                 if let Some(ray) = cam.unproject_as_ray(glam::vec2(pos.x, pos.y)) {
                     // TODO(emilk): better visualization of a ray
                     let mut hit_pos = None;
@@ -602,7 +595,7 @@ fn project_onto_other_spaces(
     ctx: &mut ViewerContext<'_>,
     space_cameras: &[SpaceCamera],
     state: &mut View3DState,
-    space: Option<&ObjPath>,
+    space: &ObjPath,
     response: &egui::Response,
     orbit_eye: OrbitEye,
 ) {
@@ -632,7 +625,7 @@ fn project_onto_other_spaces(
         }
     }
     ctx.rec_cfg.hovered_space_this_frame = HoveredSpace::ThreeD {
-        space_3d: space.cloned(),
+        space_3d: space.clone(),
         target_spaces,
     }
 }


### PR DESCRIPTION
This is old legacy, from back when not everything has a `space`

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
