### PR TITLE
Fix tensor view fill scaling with preserved AR

### DIFF
--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -189,13 +189,13 @@ fn color_mapping_ui(ui: &mut egui::Ui, color_mapping: &mut ColorMapping) {
 enum TextureScaling {
     /// No scaling, texture size will match the tensor's width/height dimensions.
     None,
-    /// Scale the texture to fill the remaining space in the UI container.
-    Fill,
+    /// Scale the texture for the largest possible fit in the UI container.
+    Fit,
 }
 
 impl Default for TextureScaling {
     fn default() -> Self {
-        Self::Fill
+        Self::Fit
     }
 }
 
@@ -203,7 +203,7 @@ impl Display for TextureScaling {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TextureScaling::None => "None".fmt(f),
-            TextureScaling::Fill => "Fill".fmt(f),
+            TextureScaling::Fit => "Fit".fmt(f),
         }
     }
 }
@@ -247,7 +247,7 @@ impl TextureSettings {
         let img_size = Vec2::max(Vec2::splat(1.0), img_size); // better safe than sorry
         let desired_size = match self.scaling {
             TextureScaling::None => img_size + margin,
-            TextureScaling::Fill => {
+            TextureScaling::Fit => {
                 let desired_size = ui.available_size() - margin;
                 if self.keep_aspect_ratio {
                     let scale = (desired_size / img_size).min_elem();
@@ -287,7 +287,7 @@ impl TextureSettings {
                             ui.selectable_value(&mut self.scaling, e, e.to_string())
                         };
                         selectable_value(ui, TextureScaling::None);
-                        selectable_value(ui, TextureScaling::Fill);
+                        selectable_value(ui, TextureScaling::Fit);
                     });
                 ui.checkbox(&mut self.keep_aspect_ratio, "Keep aspect ratio");
             });


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

Fixes #345. As discussed in slack, making it fit completely inside the dock, rather then filling the dock entirely and adding a scrollbar along the larger axis. I guess it might make sense to rename it to "Fit" in the UI too.

![Screenshot from 2022-12-07 15-21-27](https://user-images.githubusercontent.com/4020369/206194075-11ed0c48-9b82-4707-bf28-8c64a9c1c612.png)
![Screenshot from 2022-12-07 15-21-32](https://user-images.githubusercontent.com/4020369/206194079-8db17119-b72b-4f7e-982d-25bdcc616146.png)
