### PR TITLE
Additional context in tooltips on object paths and space views

### DIFF
--- a/crates/re_viewer/src/misc/viewer_context.rs
+++ b/crates/re_viewer/src/misc/viewer_context.rs
@@ -126,7 +126,9 @@ impl<'a> ViewerContext<'a> {
         space_view_id: SpaceViewId,
     ) -> egui::Response {
         let is_selected = self.selection() == Selection::SpaceView(space_view_id);
-        let response = ui.selectable_label(is_selected, text);
+        let response = ui
+            .selectable_label(is_selected, text)
+            .on_hover_text("SpaceView");
         if response.clicked() {
             self.set_selection(Selection::SpaceView(space_view_id));
         }
@@ -141,7 +143,9 @@ impl<'a> ViewerContext<'a> {
         obj_path: &ObjPath,
     ) -> egui::Response {
         let selection = Selection::SpaceViewObjPath(space_view_id, obj_path.clone());
-        let response = ui.selectable_label(self.selection() == selection, text);
+        let response = ui
+            .selectable_label(self.selection() == selection, text)
+            .on_hover_text("SpaceView Object");
         if response.clicked() {
             self.set_selection(selection);
         }

--- a/crates/re_viewer/src/ui/time_panel.rs
+++ b/crates/re_viewer/src/ui/time_panel.rs
@@ -323,6 +323,7 @@ impl TimePanel {
 
         if is_visible {
             response.on_hover_ui(|ui| {
+                ui.strong("Object");
                 ui.label(tree.path.to_string());
             });
         }
@@ -425,6 +426,7 @@ impl TimePanel {
 
                 if is_visible {
                     response.on_hover_ui(|ui| {
+                        ui.strong("Data");
                         ui.label(data_path.to_string());
                         let summary = data.summary();
                         if !summary.is_empty() {


### PR DESCRIPTION
Add some additional context information to tooltips in the tree views in Blueprints and the time panel.

![image](https://user-images.githubusercontent.com/135094/207893345-95a4d30c-8e38-482d-9b34-907a9818d6df.png)

![image](https://user-images.githubusercontent.com/135094/207893265-db8c1512-9dfa-430f-afd2-e8c1d7cbde80.png)

### Checklist
* [ ] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
