### PR TITLE
Small file refactor: move blueprint to own file

### DIFF
--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -1,0 +1,100 @@
+use crate::misc::{space_info::SpacesInfo, ViewerContext};
+
+use super::viewport::Viewport;
+
+/// Defines the layout of the whole Viewer (or will, eventually).
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub(crate) struct Blueprint {
+    pub blueprint_panel_expanded: bool,
+    pub selection_panel_expanded: bool,
+    pub time_panel_expanded: bool,
+
+    pub viewport: Viewport,
+}
+
+impl Default for Blueprint {
+    fn default() -> Self {
+        Self {
+            blueprint_panel_expanded: true,
+            selection_panel_expanded: true,
+            time_panel_expanded: true,
+            viewport: Default::default(),
+        }
+    }
+}
+
+impl Blueprint {
+    pub fn blueprint_panel_and_viewport(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
+        crate::profile_function!();
+
+        let spaces_info = SpacesInfo::new(&ctx.log_db.obj_db, &ctx.rec_cfg.time_ctrl);
+
+        self.viewport.on_frame_start(ctx, &spaces_info);
+
+        self.blueprint_panel(ctx, ui, &spaces_info);
+
+        let viewport_frame = egui::Frame {
+            fill: ui.style().visuals.panel_fill,
+            ..Default::default()
+        };
+
+        egui::CentralPanel::default()
+            .frame(viewport_frame)
+            .show_inside(ui, |ui| {
+                self.viewport.viewport_ui(
+                    ui,
+                    ctx,
+                    &spaces_info,
+                    &mut self.selection_panel_expanded,
+                );
+            });
+    }
+
+    fn blueprint_panel(
+        &mut self,
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        spaces_info: &SpacesInfo,
+    ) {
+        let panel = egui::SidePanel::left("blueprint_panel")
+            .resizable(true)
+            .frame(ctx.re_ui.panel_frame())
+            .min_width(120.0)
+            .default_width(200.0);
+
+        panel.show_animated_inside(ui, self.blueprint_panel_expanded, |ui: &mut egui::Ui| {
+            ui.horizontal(|ui| {
+                ui.vertical_centered(|ui| {
+                    ui.strong("Blueprint");
+                });
+            });
+
+            ui.separator();
+
+            ui.vertical_centered(|ui| {
+                if ui
+                    .button("Auto-populate Viewport")
+                    .on_hover_text("Re-populate Viewport with automatically chosen Space Views")
+                    .clicked()
+                {
+                    self.viewport = Viewport::new(ctx, spaces_info);
+                }
+            });
+
+            ui.separator();
+
+            egui_extras::StripBuilder::new(ui)
+                .size(egui_extras::Size::remainder())
+                .size(egui_extras::Size::exact(20.0))
+                .vertical(|mut strip| {
+                    strip.cell(|ui| {
+                        self.viewport.tree_ui(ctx, ui);
+                    });
+                    strip.cell(|ui| {
+                        self.viewport.create_new_blueprint_ui(ctx, ui, spaces_info);
+                    });
+                });
+        });
+    }
+}

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -1,36 +1,37 @@
 mod annotations;
-pub use annotations::{Annotations, DefaultColor};
-
 mod auto_layout;
-
-mod viewport;
-pub(crate) use self::viewport::{Blueprint, SpaceViewId};
-
-mod space_view;
-use self::space_view::SpaceView;
-
+mod blueprint;
+mod class_description_ui;
+mod image_ui;
 mod scene;
-use self::scene::SceneQuery;
-
 mod selection_history;
 mod selection_history_ui;
-pub use self::selection_history::{HistoricalSelection, SelectionHistory};
+mod space_view;
+mod view_plot;
+mod view_tensor;
+mod view_text;
+mod viewport;
 
 pub(crate) mod data_ui;
 pub(crate) mod event_log_view;
 pub(crate) mod kb_shortcuts;
+pub(crate) mod memory_panel;
 pub(crate) mod selection_panel;
 pub(crate) mod time_panel;
 
 pub mod view_spatial;
 
-mod class_description_ui;
-mod image_ui;
-mod view_plot;
-mod view_tensor;
-mod view_text;
+// ----
 
-pub(crate) mod memory_panel;
+use self::scene::SceneQuery;
+
+pub(crate) use self::blueprint::Blueprint;
+pub(crate) use self::space_view::{SpaceView, SpaceViewId};
+
+pub use self::annotations::{Annotations, DefaultColor};
+pub use self::selection_history::{HistoricalSelection, SelectionHistory};
+
+// ----
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum Preview {

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -1,12 +1,9 @@
 use nohash_hasher::{IntMap, IntSet};
 use re_data_store::{InstanceId, ObjPath, ObjectTree, ObjectsProperties, TimeInt};
 
-use crate::{
-    misc::{
-        space_info::{SpaceInfo, SpacesInfo},
-        ViewerContext,
-    },
-    ui::SpaceViewId,
+use crate::misc::{
+    space_info::{SpaceInfo, SpacesInfo},
+    ViewerContext,
 };
 
 use super::{
@@ -35,6 +32,20 @@ pub enum ViewCategory {
     Tensor,
     Text,
     Plot,
+}
+
+// ----------------------------------------------------------------------------
+
+/// A unique id for each space view.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
+pub struct SpaceViewId(uuid::Uuid);
+
+impl SpaceViewId {
+    pub fn random() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Very small clean-up. Just moves code around a bit, and renamed `ViewportBlueprint` to just `Viewport`

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
