### PR TITLE
Use the same 1000/1000 bench configuration as for our old benchmarks

### DIFF
--- a/crates/re_query/benches/obj_query_benchmark.rs
+++ b/crates/re_query/benches/obj_query_benchmark.rs
@@ -16,9 +16,9 @@ use re_query::{query_entity_with_primary, visit_components3};
 // ---
 
 #[cfg(not(debug_assertions))]
-const NUM_FRAMES: u32 = 100;
+const NUM_FRAMES: u32 = 1_000;
 #[cfg(not(debug_assertions))]
-const NUM_POINTS: u32 = 100;
+const NUM_POINTS: u32 = 1_000;
 
 // `cargo test` also runs the benchmark setup code, so make sure they run quickly:
 #[cfg(debug_assertions)]
@@ -39,6 +39,8 @@ fn obj_mono_points(c: &mut Criterion) {
 
         {
             let mut group = c.benchmark_group("arrow_mono_points");
+            // Mono-insert is slow -- decrease the sample size
+            group.sample_size(10);
             group.throughput(criterion::Throughput::Elements(
                 (NUM_POINTS * NUM_FRAMES) as _,
             ));


### PR DESCRIPTION
Because mono-insert is slow we need to turn down the number of samples so this isn't overly obnoxious.

```
arrow_mono_points/insert
                        time:   [1.7914 s 2.1563 s 2.5772 s]
                        thrpt:  [388.02 Kelem/s 463.77 Kelem/s 558.24 Kelem/s]

arrow_mono_points/query
                        time:   [4.1229 ms 4.1434 ms 4.1738 ms]
                        thrpt:  [239.59 Kelem/s 241.35 Kelem/s 242.55 Kelem/s]

arrow_batch_points/insert
                        time:   [667.68 µs 668.45 µs 669.29 µs]
                        thrpt:  [1.4941 Gelem/s 1.4960 Gelem/s 1.4977 Gelem/s]

arrow_batch_points/query
                        time:   [25.254 µs 25.300 µs 25.347 µs]
                        thrpt:  [39.453 Melem/s 39.526 Melem/s 39.598 Melem/s]
```

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
