### PR TITLE
Fix zoom/pan navigation of the time panel

### DIFF
--- a/crates/re_viewer/src/ui/time_panel.rs
+++ b/crates/re_viewer/src/ui/time_panel.rs
@@ -237,6 +237,10 @@ impl TimePanel {
         // all the object rows:
         egui::ScrollArea::vertical()
             .auto_shrink([false; 2])
+            // We turn off `drag_to_scroll` so that the `ScrollArea` don't steal input from
+            // the earlier `interact_with_time_area`.
+            // We implement drag-to-scroll manually instead!
+            .drag_to_scroll(false)
             .show(ui, |ui| {
                 crate::profile_scope!("tree_ui");
                 if time_area_response.dragged_by(PointerButton::Primary) {


### PR DESCRIPTION
Part of https://github.com/rerun-io/rerun/issues/556

Since a few weeks you could only zoom/pan when hovering the top of the time panel (where the tick-marks are).

With this PR, you can now scroll/pan anywhere in the time panel streams view.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
