### PR TITLE
Add components into the timeline for arrow as well

### DIFF
--- a/crates/re_data_store/src/object_tree.rs
+++ b/crates/re_data_store/src/object_tree.rs
@@ -111,9 +111,7 @@ impl ObjectTree {
             Default::default()
         });
 
-        if let Some(data) = data {
-            fields.add(msg_id, time_point, data);
-        }
+        fields.add(msg_id, time_point, data);
 
         pending_clears
     }
@@ -309,7 +307,7 @@ pub struct DataColumns {
 }
 
 impl DataColumns {
-    pub fn add(&mut self, msg_id: MsgId, time_point: &TimePoint, data: &LoggedData) {
+    pub fn add(&mut self, msg_id: MsgId, time_point: &TimePoint, data: Option<&LoggedData>) {
         for (timeline, time_value) in time_point.iter() {
             self.times
                 .entry(*timeline)
@@ -319,15 +317,17 @@ impl DataColumns {
                 .insert(msg_id);
         }
 
-        let mono_or_multi = match data {
-            LoggedData::Null(_) | LoggedData::Single(_) => MonoOrMulti::Mono,
-            LoggedData::Batch { .. } | LoggedData::BatchSplat(_) => MonoOrMulti::Multi,
-        };
+        if let Some(data) = data {
+            let mono_or_multi = match data {
+                LoggedData::Null(_) | LoggedData::Single(_) => MonoOrMulti::Mono,
+                LoggedData::Batch { .. } | LoggedData::BatchSplat(_) => MonoOrMulti::Multi,
+            };
 
-        self.per_type
-            .entry((data.data_type(), mono_or_multi))
-            .or_default()
-            .insert(msg_id);
+            self.per_type
+                .entry((data.data_type(), mono_or_multi))
+                .or_default()
+                .insert(msg_id);
+        }
     }
 
     pub fn summary(&self) -> String {


### PR DESCRIPTION
Ideally this would come from the re_arrow_store since it's fairly redundant with the Index buckets, but was an easy enough add for now.

![image](https://user-images.githubusercontent.com/3312232/208781904-4094e13e-acb5-4427-93b7-308ab729440c.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
