### PR TITLE
Nicer formatting of the bounding box

### DIFF
--- a/crates/re_format/src/lib.rs
+++ b/crates/re_format/src/lib.rs
@@ -36,6 +36,38 @@ fn test_format_number() {
     assert_eq!(format_number(1_234_567), "1 234 567");
 }
 
+/// Format a number with a decent number of decimals.
+pub fn format_f64(value: f64) -> String {
+    let is_integer = value.round() == value;
+    if is_integer {
+        return format!("{:.0}", value);
+    }
+
+    let magnitude = value.abs().log10();
+    let num_decimals = (3.5 - magnitude).round().max(1.0) as usize;
+    format!("{:.*}", num_decimals, value)
+}
+
+/// Format a number with a decent number of decimals.
+pub fn format_f32(value: f32) -> String {
+    format_f64(value as f64)
+}
+
+#[test]
+fn test_format_float() {
+    assert_eq!(format_f64(42.0), "42");
+    assert_eq!(format_f64(123_456_789.0), "123456789");
+    assert_eq!(format_f64(123_456_789.123_45), "123456789.1");
+    assert_eq!(format_f64(0.0000123456789), "0.00001235");
+    assert_eq!(format_f64(0.123456789), "0.1235");
+    assert_eq!(format_f64(1.23456789), "1.235");
+    assert_eq!(format_f64(12.3456789), "12.35");
+    assert_eq!(format_f64(123.456789), "123.5");
+    assert_eq!(format_f64(1234.56789), "1234.6");
+    assert_eq!(format_f64(12345.6789), "12345.7");
+    assert_eq!(format_f64(78.4321), "78.43");
+}
+
 /// Pretty format a large number by using SI notation (base 10), e.g.
 ///
 /// ```

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -1,5 +1,6 @@
 use macaw::BoundingBox;
 use re_data_store::{InstanceId, InstanceIdHash, ObjPath, ObjectsProperties};
+use re_format::format_f32;
 use re_log_types::Transform;
 
 use crate::misc::{
@@ -79,14 +80,22 @@ impl ViewSpatialState {
         match self.nav_mode {
             SpatialNavigationMode::TwoD => {
                 ui.label(format!(
-                    "Bounding box, x: [{} - {}], y: [{} - {}]",
-                    min.x, max.x, min.y, max.y,
+                    "Bounding box:\n  x: [{} - {}]\n  y: [{} - {}]",
+                    format_f32(min.x),
+                    format_f32(max.x),
+                    format_f32(min.y),
+                    format_f32(max.y),
                 ));
             }
             SpatialNavigationMode::ThreeD => {
                 ui.label(format!(
-                    "Bounding box, x: [{} - {}], y: [{} - {}], z: [{} - {}]",
-                    min.x, max.x, min.y, max.y, min.z, max.z
+                    "Bounding box:\n  x: [{} - {}]\n  y: [{} - {}]\n  z: [{} - {}]",
+                    format_f32(min.x),
+                    format_f32(max.x),
+                    format_f32(min.y),
+                    format_f32(max.y),
+                    format_f32(min.z),
+                    format_f32(max.z)
                 ));
                 self.state_3d.settings_ui(ctx, ui, &self.scene_bbox_accum);
             }


### PR DESCRIPTION
I had some time to kill on the plane.

Small improvement to the formatting of the bounding box text in the selection panel.

<img width="131" alt="Screen Shot 2022-12-31 at 07 37 19" src="https://user-images.githubusercontent.com/1148717/210110073-be55f44b-d144-45a2-b2a4-17ed7e0faa6b.png">

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
