### PR TITLE
re_datastore: testing/specifying `latest_components_at` :warning: 

### DIFF
--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -50,8 +50,7 @@ fn latest_components_at() {
                 ent_path,
             );
 
-            let components = components.map(|components| {
-                let mut components = components.to_vec();
+            let components = components.map(|mut components| {
                 components.sort();
                 components
             });


### PR DESCRIPTION
`latest_components_at` has been added a while ago as a way of efficiently computing all the components associated with a given entity at a given point in time (using latest-at-ish semantics).
It wasn't tested until now, and almost broke during the big range PR (#653), so here's a test suite.

And now for the tricky part: to do what it does efficiently, this API actually computes _an approximation_ by completely bypassing all the indexing logic and working directly at the bucketing level.
This causes two issues (which are demonstrated in the test suite added by this PR):
1. This is _extremely_ hard to reason about, as the results effectively depend on the internal state of the bucketing system, which is effectively a private, unstable ABI.
2. Depending on the bucket configuration, this can actually miss some components entirely, or return some that shouldn't be present.

If we're fine with this, then at least now it's specified in the form of a test suite.
Otherwise, this is a good opportunity to make this stricter, at the cost of performance.

cc @jleibs 