### PR TITLE
Better orbitcamera indicator

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -480,7 +480,8 @@ pub fn view_3d(
                         orbit_eye.orbit_center + *axis * half_line_length,
                     )
                 }))
-                .radius(Size::new_points(1.0))
+                .radius(Size::new_points(0.75))
+                .flags(re_renderer::renderer::LineStripFlags::NO_COLOR_GRADIENT)
                 // TODO(andreas): Fade this out.
                 .color(re_renderer::Color32::WHITE);
 


### PR DESCRIPTION
Partially fixes #344. Partially because it replaces the previous point indicator (which didn't survive the wgpu port well!) but doesn't make it great either. Video illustrates this:

https://user-images.githubusercontent.com/1220815/210824217-dd2c2e85-991b-46e4-88d3-c8a61a0f8a66.mov


Solution written in the code comment:
```
            // TODO(andreas): Idea for nice depth perception:
            // Render the lines once with additive blending and depth test enabled
            // and another time without depth test. In both cases it needs to be rendered last,
            // something re_renderer doesn't support yet for primitives within renderers.
```

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
