### PR TITLE
Fix new space views spawned with wrong nav mode

### DIFF
--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -108,7 +108,7 @@ impl SpaceView {
     }
 
     /// List of objects a space view queries by default.
-    fn default_queried_objects(
+    pub fn default_queried_objects(
         ctx: &ViewerContext<'_>,
         category: ViewCategory,
         root_space: &SpaceInfo,

--- a/crates/re_viewer/src/ui/view_category.rs
+++ b/crates/re_viewer/src/ui/view_category.rs
@@ -27,6 +27,18 @@ pub enum ViewCategory {
     Tensor,
 }
 
+impl ViewCategory {
+    pub fn icon(&self) -> &'static str {
+        match self {
+            ViewCategory::Text => "📃",
+            ViewCategory::TimeSeries => "📈",
+            ViewCategory::BarChart => "📊",
+            ViewCategory::Spatial => "🖼",
+            ViewCategory::Tensor => "🇹",
+        }
+    }
+}
+
 pub type ViewCategorySet = enumset::EnumSet<ViewCategory>;
 
 pub fn categorize_obj_path(

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -1,18 +1,13 @@
 //! The viewport panel.
 //!
 //! Contains all space views.
-//!
-//! To do:
-//! * [ ] Controlling visibility of objects inside each Space View
-//! * [ ] Transforming objects between spaces
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use ahash::HashMap;
 use itertools::Itertools as _;
 
-use nohash_hasher::{IntMap, IntSet};
-use re_data_store::{ObjPath, ObjPathComp, ObjectsProperties, TimeInt};
+use re_data_store::{ObjPath, ObjectsProperties, TimeInt};
 
 use crate::{
     misc::{
@@ -260,16 +255,7 @@ impl Viewport {
             true,
         )
         .show_header(ui, |ui| {
-            match space_view.category {
-                ViewCategory::Text => ui.label("📃"),
-                ViewCategory::TimeSeries => ui.label("📈"),
-                ViewCategory::BarChart => ui.label("📊"),
-                ViewCategory::Spatial => match space_view.view_state.state_spatial.nav_mode {
-                    super::view_spatial::SpatialNavigationMode::TwoD => ui.label("🖼"),
-                    super::view_spatial::SpatialNavigationMode::ThreeD => ui.label("🔭"),
-                },
-                ViewCategory::Tensor => ui.label("🇹"),
-            };
+            ui.label(space_view.category.icon());
 
             if ctx
                 .space_view_button_to(ui, space_view.name.clone(), *space_view_id)
@@ -495,74 +481,47 @@ impl Viewport {
             ui.menu_button("Add new space view…", |ui| {
                 ui.style_mut().wrap = Some(false);
 
-                let objects_per_root_grouped_by_category =
-                    objects_per_root_grouped_by_category(ctx);
+                let all_categories = enumset::EnumSet::<ViewCategory>::all();
 
                 for space_info in spaces_info.iter() {
-                    let categories = objects_per_root_grouped_by_category
-                        .get(&ObjPath::from(&space_info.path.to_components()[..1]));
-
-                    if let Some(categories) = categories {
-                        if categories.is_empty() {
+                    for category in all_categories {
+                        let obj_paths = SpaceView::default_queried_objects(
+                            ctx,
+                            category,
+                            space_info,
+                            spaces_info,
+                        );
+                        if obj_paths.is_empty() {
                             continue;
                         }
 
-                        let transforms = TransformCache::determine_transforms(
-                            spaces_info,
-                            space_info,
-                            &ObjectsProperties::default(),
-                        );
-
-                        if ui.button(space_info.path.to_string()).clicked() {
+                        if ui
+                            .button(format!("{} {}", category.icon(), space_info.path))
+                            .clicked()
+                        {
                             ui.close_menu();
 
-                            for (category, obj_paths) in categories {
-                                let scene_spatial =
-                                    query_scene_spatial(ctx, obj_paths, &transforms);
-                                let new_space_view_id = self.add_space_view(SpaceView::new(
-                                    ctx,
-                                    *category,
-                                    space_info,
-                                    spaces_info,
-                                    scene_spatial.preferred_navigation_mode(),
-                                ));
-                                ctx.set_selection(Selection::SpaceView(new_space_view_id));
-                            }
+                            let transforms = TransformCache::determine_transforms(
+                                spaces_info,
+                                space_info,
+                                &ObjectsProperties::default(),
+                            );
+
+                            let scene_spatial = query_scene_spatial(ctx, &obj_paths, &transforms);
+                            let new_space_view_id = self.add_space_view(SpaceView::new(
+                                ctx,
+                                category,
+                                space_info,
+                                spaces_info,
+                                scene_spatial.preferred_navigation_mode(),
+                            ));
+                            ctx.set_selection(Selection::SpaceView(new_space_view_id));
                         }
                     }
                 }
             });
         });
     }
-}
-
-/// Returns iterator over all root paths, each with a list of object paths under it.
-fn objects_per_root<'a>(
-    ctx: &mut ViewerContext<'a>,
-) -> impl Iterator<Item = (ObjPath, Vec<ObjPath>)> + 'a {
-    let roots = &ctx.log_db.obj_db.tree.children;
-    roots.iter().map(|(root_path, root_tree)| {
-        let mut objects = Vec::new();
-        root_tree.visit_children_recursively(&mut |child_path| {
-            objects.push(child_path.clone());
-        });
-        let root_path: &[ObjPathComp] = &[root_path.clone()];
-        (ObjPath::from(root_path), objects)
-    })
-}
-
-/// Returns all map from all root paths to objects grouped by category.
-fn objects_per_root_grouped_by_category(
-    ctx: &mut ViewerContext<'_>,
-) -> IntMap<ObjPath, BTreeMap<ViewCategory, IntSet<ObjPath>>> {
-    objects_per_root(ctx)
-        .map(|(root, objects)| {
-            (
-                root,
-                group_by_category(ctx.rec_cfg.time_ctrl.timeline(), ctx.log_db, objects.iter()),
-            )
-        })
-        .collect()
 }
 
 fn visibility_button(ui: &mut egui::Ui, enabled: bool, visible: &mut bool) -> egui::Response {


### PR DESCRIPTION
This surfaces due to a change in how the navmode is determined. What happened is that we actually passed the wrong objects to the initial scene generation from which we derive heuristics.

Additionally, "Add new space view.." will no longer spawn several space views at once, but instead shows an entry for every category we have.

<img width="324" alt="image" src="https://user-images.githubusercontent.com/1220815/210849504-5b3f1a97-c7ca-4941-9fb6-d4559d300928.png">

We no longer show a different icon for spatial scenes in 3d versus 2d navmode - this is easier in the code and more consistent with the underlying model!

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
