### PR TITLE
Track whether a datapath is a classic Field or an arrow Component

### DIFF
--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -62,6 +62,9 @@ pub enum Error {
         expected: DataType,
     },
 
+    #[error("Tried to write into classic store using arrow component")]
+    WrongFieldType,
+
     #[error(transparent)]
     MsgBundleError(#[from] msg_bundle::MsgBundleError),
 

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -162,7 +162,7 @@ impl ObjDb {
             let _pending_clears = self.tree.add_data_msg(
                 msg.msg_id,
                 &msg_bundle.time_point,
-                &DataPath::new(msg_bundle.obj_path.clone(), component.name),
+                &DataPath::new_arrow(msg_bundle.obj_path.clone(), component.name),
                 None,
             );
         }

--- a/crates/re_data_store/src/object_tree.rs
+++ b/crates/re_data_store/src/object_tree.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use itertools::Itertools;
 use re_log_types::{
-    DataPath, DataType, FieldName, LoggedData, MsgId, ObjPath, ObjPathComp, PathOp, TimeInt,
+    DataPath, DataType, FieldOrComponent, LoggedData, MsgId, ObjPath, ObjPathComp, PathOp, TimeInt,
     TimePoint, Timeline,
 };
 
@@ -51,7 +51,7 @@ pub struct ObjectTree {
     pub recursive_clears: BTreeMap<MsgId, TimePoint>,
 
     /// Data logged at this object path.
-    pub fields: BTreeMap<FieldName, DataColumns>,
+    pub fields: BTreeMap<FieldOrComponent, DataColumns>,
 }
 
 impl ObjectTree {
@@ -117,7 +117,7 @@ impl ObjectTree {
     }
 
     /// Add a path operation into the the object tree
-    ///j
+    ///
     /// Returns a collection of data paths to clear as a result of the operation
     /// Additional pending clear operations will be stored in the tree for future
     /// insertion.
@@ -152,7 +152,7 @@ impl ObjectTree {
                             .iter()
                             .map(|((data_type, multi_or_mono), _)| {
                                 (
-                                    DataPath::new(obj_path.clone(), *field_name),
+                                    DataPath::new_any(obj_path.clone(), *field_name),
                                     *data_type,
                                     *multi_or_mono,
                                 )
@@ -188,7 +188,7 @@ impl ObjectTree {
                             .iter()
                             .map(|((data_type, multi_or_mono), _)| {
                                 (
-                                    DataPath::new(next.path.clone(), *field_name),
+                                    DataPath::new_any(next.path.clone(), *field_name),
                                     *data_type,
                                     *multi_or_mono,
                                 )

--- a/crates/re_log_types/src/path/data_path.rs
+++ b/crates/re_log_types/src/path/data_path.rs
@@ -1,4 +1,32 @@
-use crate::path::{FieldName, ObjPath};
+use crate::{
+    path::{FieldName, ObjPath},
+    ComponentName,
+};
+
+/// A `DataPath` may contain either a classic `Field` or an arrow `Component`
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum FieldOrComponent {
+    Field(FieldName),
+    Component(ComponentName),
+}
+
+impl FieldOrComponent {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Field(field) | Self::Component(field) => field.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for FieldOrComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let field = match self {
+            Self::Field(field) | Self::Component(field) => field,
+        };
+        field.fmt(f)
+    }
+}
 
 /// A [`ObjPath`] plus a [`FieldName`].
 ///
@@ -10,12 +38,28 @@ pub struct DataPath {
     pub obj_path: ObjPath,
 
     /// "pos"
-    pub field_name: FieldName,
+    pub field_name: FieldOrComponent,
 }
 
 impl DataPath {
     #[inline]
     pub fn new(obj_path: ObjPath, field_name: FieldName) -> Self {
+        Self {
+            obj_path,
+            field_name: FieldOrComponent::Field(field_name),
+        }
+    }
+
+    #[inline]
+    pub fn new_arrow(obj_path: ObjPath, component_name: ComponentName) -> Self {
+        Self {
+            obj_path,
+            field_name: FieldOrComponent::Component(component_name),
+        }
+    }
+
+    #[inline]
+    pub fn new_any(obj_path: ObjPath, field_name: FieldOrComponent) -> Self {
         Self {
             obj_path,
             field_name,
@@ -28,8 +72,16 @@ impl DataPath {
     }
 
     #[inline]
-    pub fn field_name(&self) -> &FieldName {
+    pub fn field_name(&self) -> &FieldOrComponent {
         &self.field_name
+    }
+
+    #[inline]
+    pub fn is_arrow(&self) -> bool {
+        match self.field_name {
+            FieldOrComponent::Field(_) => false,
+            FieldOrComponent::Component(_) => true,
+        }
     }
 }
 

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -22,7 +22,7 @@ mod obj_path_impl;
 mod obj_type_path;
 mod parse_path;
 
-pub use data_path::DataPath;
+pub use data_path::{DataPath, FieldOrComponent};
 pub use index_path::{IndexPath, IndexPathHash};
 pub use obj_path::{ObjPath, ObjPathHash};
 pub use obj_path_impl::{ObjPathCompRef, ObjPathImpl};

--- a/crates/re_viewer/src/ui/data_ui/path.rs
+++ b/crates/re_viewer/src/ui/data_ui/path.rs
@@ -10,33 +10,37 @@ impl DataUi for DataPath {
         ui: &mut egui::Ui,
         preview: crate::ui::Preview,
     ) -> egui::Response {
-        let timeline = ctx.rec_cfg.time_ctrl.timeline();
-
-        if let Some(time_i64) = ctx.rec_cfg.time_ctrl.time_i64() {
-            let time_query = re_data_store::TimeQuery::LatestAt(time_i64);
-
-            match ctx
-                .log_db
-                .obj_db
-                .store
-                .query_data_path(timeline, &time_query, self)
-            {
-                Some(Ok((_, data_vec))) => {
-                    if data_vec.len() == 1 {
-                        let data = data_vec.last().unwrap();
-                        data.detailed_data_ui(ctx, ui, preview)
-                    } else {
-                        data_vec.data_ui(ctx, ui, preview)
-                    }
-                }
-                Some(Err(err)) => {
-                    re_log::warn_once!("Bad data for {self}: {err}");
-                    ui.label(ctx.re_ui.error_text(format!("Data error: {:?}", err)))
-                }
-                None => ui.label(ctx.re_ui.error_text(format!("No data at time {time_i64}"))),
-            }
+        if self.is_arrow() {
+            ui.label("TODO(jleibs): DataPath query for Arrow")
         } else {
-            ui.label(ctx.re_ui.error_text("No current time."))
+            let timeline = ctx.rec_cfg.time_ctrl.timeline();
+
+            if let Some(time_i64) = ctx.rec_cfg.time_ctrl.time_i64() {
+                let time_query = re_data_store::TimeQuery::LatestAt(time_i64);
+
+                match ctx
+                    .log_db
+                    .obj_db
+                    .store
+                    .query_data_path(timeline, &time_query, self)
+                {
+                    Some(Ok((_, data_vec))) => {
+                        if data_vec.len() == 1 {
+                            let data = data_vec.last().unwrap();
+                            data.detailed_data_ui(ctx, ui, preview)
+                        } else {
+                            data_vec.data_ui(ctx, ui, preview)
+                        }
+                    }
+                    Some(Err(err)) => {
+                        re_log::warn_once!("Bad data for {self}: {err}");
+                        ui.label(ctx.re_ui.error_text(format!("Data error: {:?}", err)))
+                    }
+                    None => ui.label(ctx.re_ui.error_text(format!("No data at time {time_i64}"))),
+                }
+            } else {
+                ui.label(ctx.re_ui.error_text("No current time."))
+            }
         }
     }
 }

--- a/crates/re_viewer/src/ui/time_panel.rs
+++ b/crates/re_viewer/src/ui/time_panel.rs
@@ -429,7 +429,7 @@ impl TimePanel {
                     continue; // ignore fields that have no data for the current timeline
                 }
 
-                let data_path = DataPath::new(tree.path.clone(), *field_name);
+                let data_path = DataPath::new_any(tree.path.clone(), *field_name);
 
                 let response = ui
                     .horizontal(|ui| {


### PR DESCRIPTION
When building the object tree we know whether it represents a classic field or an arrow component. This will let us start handling differences more gracefully in the timeline-view and selection-panel.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
