### PR TITLE
Don't show msg_id in the timeline view

### DIFF
--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -158,6 +158,9 @@ impl ObjDb {
         self.register_obj_path(&msg_bundle.obj_path);
 
         for component in &msg_bundle.components {
+            if component.name == MsgId::name() {
+                continue;
+            }
             //TODO(jleibs): Actually handle pending clears
             let _pending_clears = self.tree.add_data_msg(
                 msg.msg_id,


### PR DESCRIPTION
When filing https://github.com/rerun-io/rerun/issues/717 I noticed that `msg_id` is one of the bigger contributors to noise in the timeline view.

`msg_id` is a special auto-component we add to every MsgBundle. It's not data that originates from the user and as such it just clutters the timeline without adding much value.

Before:
![image](https://user-images.githubusercontent.com/3312232/211561275-29989542-bea8-416d-b545-1583cd16392a.png)

After:
![image](https://user-images.githubusercontent.com/3312232/211561441-778f8b89-3a3b-4182-bd57-b3def13fcd82.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
