### PR TITLE
Remove the glam dependency from focal_length_in_pixels

### DIFF
--- a/crates/re_data_store/src/object_properties.rs
+++ b/crates/re_data_store/src/object_properties.rs
@@ -53,7 +53,7 @@ impl ObjectProps {
             .unwrap_or_else(|| {
                 let distance = pinhole
                     .focal_length()
-                    .unwrap_or_else(|| pinhole.focal_length_in_pixels().y);
+                    .unwrap_or_else(|| pinhole.focal_length_in_pixels().y());
                 ordered_float::NotNan::new(distance).unwrap_or_default()
             })
             .into()

--- a/crates/re_log_types/src/field_types/transform.rs
+++ b/crates/re_log_types/src/field_types/transform.rs
@@ -146,9 +146,8 @@ impl Pinhole {
     ///
     /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
     #[inline]
-    #[cfg(feature = "glam")]
-    pub fn focal_length_in_pixels(&self) -> glam::Vec2 {
-        glam::vec2(self.image_from_cam[0][0], self.image_from_cam[1][1])
+    pub fn focal_length_in_pixels(&self) -> Vec2D {
+        [self.image_from_cam[0][0], self.image_from_cam[1][1]].into()
     }
 
     /// Focal length.

--- a/crates/re_log_types/src/field_types/vec.rs
+++ b/crates/re_log_types/src/field_types/vec.rs
@@ -27,6 +27,18 @@ use crate::msg_bundle::Component;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Vec2D(pub [f32; 2]);
 
+impl Vec2D {
+    #[inline]
+    pub fn x(&self) -> f32 {
+        self.0[0]
+    }
+
+    #[inline]
+    pub fn y(&self) -> f32 {
+        self.0[1]
+    }
+}
+
 impl From<[f32; 2]> for Vec2D {
     fn from(v: [f32; 2]) -> Self {
         Self(v)
@@ -127,6 +139,23 @@ impl ArrowDeserialize for Vec2D {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Vec3D(pub [f32; 3]);
+
+impl Vec3D {
+    #[inline]
+    pub fn x(&self) -> f32 {
+        self.0[0]
+    }
+
+    #[inline]
+    pub fn y(&self) -> f32 {
+        self.0[1]
+    }
+
+    #[inline]
+    pub fn z(&self) -> f32 {
+        self.0[2]
+    }
+}
 
 impl From<[f32; 3]> for Vec3D {
     fn from(v: [f32; 3]) -> Self {

--- a/crates/re_viewer/src/ui/transform_cache.rs
+++ b/crates/re_viewer/src/ui/transform_cache.rs
@@ -213,7 +213,7 @@ impl TransformCache {
                             .get(child_path)
                             .pinhole_image_plane_distance(pinhole);
 
-                        let scale = distance / pinhole.focal_length_in_pixels().y;
+                        let scale = distance / pinhole.focal_length_in_pixels().y();
                         let translation = (-pinhole.principal_point() * scale).extend(distance);
                         let parent_from_child = glam::Mat4::from_scale_rotation_translation(
                             glam::vec3(scale, scale, 1.0),


### PR DESCRIPTION
This was causing issues in running unit tests on packages that don't enable the glam feature
e.g.
```
$ cargo bench -p re_data_store

error[E0599]: no method named `focal_length_in_pixels` found for reference `&re_log_types::Pinhole` in the current scope
  --> crates/re_data_store/src/object_properties.rs:56:48
   |
56 |                     .unwrap_or_else(|| pinhole.focal_length_in_pixels().y);
   |                                                ^^^^^^^^^^^^^^^^^^^^^^ help: there is a method with a similar name: `focal_length`
```

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
