### PR TITLE
fix incorrect rectangle outline on hover of images

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -96,8 +96,6 @@ impl ScenePart for ImagesPartClassic {
                     return;
                 }
 
-                let rect = glam::vec2(tensor.shape()[0].size as f32, tensor.shape()[1].size as f32);
-
                 let instance_hash =
                     instance_hash_if_interactive(obj_path, instance_index, properties.interactive);
 
@@ -111,6 +109,8 @@ impl ScenePart for ImagesPartClassic {
                 );
 
                 if instance_hash.is_some() && hovered_instance == instance_hash {
+                    let rect =
+                        glam::vec2(tensor.shape()[1].size as f32, tensor.shape()[0].size as f32);
                     scene
                         .primitives
                         .line_strips
@@ -226,8 +226,6 @@ impl ImagesPart {
                     return Ok(());
                 }
 
-                let rect = glam::vec2(tensor.shape()[0].size as f32, tensor.shape()[1].size as f32);
-
                 let instance_hash = {
                     if properties.interactive {
                         InstanceIdHash::from_path_and_arrow_instance(ent_path, &instance)
@@ -246,6 +244,8 @@ impl ImagesPart {
                 let paint_props = paint_properties(color, None);
 
                 if instance_hash.is_some() && hovered_instance == instance_hash {
+                    let rect =
+                        glam::vec2(tensor.shape()[1].size as f32, tensor.shape()[0].size as f32);
                     scene
                         .primitives
                         .line_strips


### PR DESCRIPTION
before:
<img width="521" alt="image" src="https://user-images.githubusercontent.com/1220815/212144877-15938fcb-c070-4ee2-b152-d1fe410c1f5b.png">


after:
<img width="659" alt="image" src="https://user-images.githubusercontent.com/1220815/212144685-45737cc0-0727-4ff9-b56d-534fefe0ee23.png">


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
