### PR TITLE
Make all lines the same screen-space width

### DIFF
--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -251,7 +251,7 @@ pub struct LineStripInfo {
 impl Default for LineStripInfo {
     fn default() -> Self {
         Self {
-            radius: Size::AUTO,
+            radius: Size::NORMAL_LINE,
             color: Color32::WHITE,
             flags: LineStripFlags::empty(),
         }

--- a/crates/re_renderer/src/size.rs
+++ b/crates/re_renderer/src/size.rs
@@ -18,6 +18,9 @@ impl Size {
     /// Like [`Size::AUTO`], but larger by view builder setting.
     pub const AUTO_LARGE: Self = Self(-f32::INFINITY);
 
+    pub const NORMAL_LINE: Self = Self(-1.0);
+    pub const THICK_LINE: Self = Self(-2.0);
+
     /// Creates a new size in scene units.
     ///
     /// Values passed must be finite positive.

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -241,7 +241,7 @@ impl SceneSpatial {
                 };
                 line_batch
                     .add_segment(*a, *b)
-                    .radius(Size::AUTO)
+                    .radius(Size::NORMAL_LINE)
                     .color(color)
                     .user_data(instance_hash);
             }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
@@ -63,7 +63,8 @@ impl ScenePart for Boxes3DPartClassic {
                            stroke_width: Option<&f32>,
                            label: Option<&String>,
                            class_id: Option<&i32>| {
-                let mut line_radius = stroke_width.map_or(Size::AUTO, |w| Size::new_scene(w / 2.0));
+                let mut line_radius =
+                    stroke_width.map_or(Size::NORMAL_LINE, |w| Size::new_scene(w / 2.0));
 
                 let annotation_info = annotations
                     .class_description(class_id.map(|i| ClassId(*i as _)))
@@ -149,7 +150,7 @@ impl Boxes3DPart {
             let class_description = annotations.class_description(class_id);
             let annotation_info = class_description.annotation_info();
 
-            let mut radius = radius.map_or(Size::AUTO, |r| Size::new_scene(r.0));
+            let mut radius = radius.map_or(Size::NORMAL_LINE, |r| Size::new_scene(r.0));
             let mut color = to_ecolor(
                 annotation_info.color(color.map(move |c| c.to_array()).as_ref(), default_color),
             );

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -195,15 +195,9 @@ impl CamerasPart {
         ];
 
         let (line_radius, line_color) = if instance == hovered_instance {
-            (
-                re_renderer::Size::new_points(2.0),
-                SceneSpatial::HOVER_COLOR,
-            )
+            (re_renderer::Size::THICK_LINE, SceneSpatial::HOVER_COLOR)
         } else {
-            (
-                re_renderer::Size::new_points(1.0),
-                SceneSpatial::CAMERA_COLOR,
-            )
+            (re_renderer::Size::NORMAL_LINE, SceneSpatial::CAMERA_COLOR)
         };
         scene
             .primitives

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
@@ -74,7 +74,8 @@ impl ScenePart for Lines3DPartClassic {
                 let instance_hash =
                     instance_hash_if_interactive(obj_path, instance_index, properties.interactive);
 
-                let mut radius = stroke_width.map_or(Size::AUTO, |w| Size::new_scene(w / 2.0));
+                let mut radius =
+                    stroke_width.map_or(Size::NORMAL_LINE, |w| Size::new_scene(w / 2.0));
 
                 // TODO(andreas): support class ids for lines
                 let annotation_info = annotations.class_description(None).annotation_info();
@@ -149,7 +150,7 @@ impl Lines3DPart {
                 }
             };
 
-            let mut radius = radius.map_or(Size::AUTO, |r| Size::new_scene(r.0));
+            let mut radius = radius.map_or(Size::NORMAL_LINE, |r| Size::new_scene(r.0));
 
             // TODO(andreas): support class ids for lines
             let annotation_info = annotations.class_description(None).annotation_info();

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -474,7 +474,7 @@ pub fn view_3d(
                         orbit_eye.orbit_center + *axis * half_line_length,
                     )
                 }))
-                .radius(Size::new_points(0.75))
+                .radius(Size::THICK_LINE)
                 .flags(re_renderer::renderer::LineStripFlags::NO_COLOR_GRADIENT)
                 // TODO(andreas): Fade this out.
                 .color(re_renderer::Color32::WHITE);
@@ -617,7 +617,7 @@ fn show_projections_from_2d_space(
                     };
                     let origin = ray.point_along(0.0);
                     let end = ray.point_along(length);
-                    let radius = Size::new_points(1.5);
+                    let radius = Size::THICK_LINE;
 
                     scene
                         .primitives


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/796

Before:

![Screen Shot 2023-01-17 at 07 03 34](https://user-images.githubusercontent.com/1148717/212821862-a56da2e8-6e29-4cc2-905a-2eeba48abe19.png)

After:
![Screen Shot 2023-01-17 at 07 04 09](https://user-images.githubusercontent.com/1148717/212821960-9ef1c11f-0840-4328-ba93-789751634738.png)

Arguably the points are still too big, but that's a separate issue

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
