### PR TITLE
Default to unknown if meaning isn't specified

### DIFF
--- a/rerun_py/rerun/components/tensor.py
+++ b/rerun_py/rerun/components/tensor.py
@@ -97,7 +97,7 @@ class TensorArray(pa.ExtensionArray):  # type: ignore[misc]
 
         meaning = build_dense_union(
             TensorType.storage_type["meaning"].type,
-            discriminant=("Unknown" if meaning == bindings.TensorDataMeaning.Unknown else "ClassId"),
+            discriminant=("ClassId" if meaning == bindings.TensorDataMeaning.ClassId else "Unknown"),
             data=pa.array([True], type=pa.bool_()),
         )
 


### PR DESCRIPTION
This was causing all images to default to segmentation images, but we ignore meaning on RGB images.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
