### PR TITLE
Fix deadlock when flushing messages

### DIFF
--- a/crates/re_sdk_comms/src/buffered_client.rs
+++ b/crates/re_sdk_comms/src/buffered_client.rs
@@ -137,8 +137,7 @@ fn msg_drop(msg_drop_rx: &Receiver<MsgMsg>, quit_rx: &Receiver<QuitMsg>) {
     loop {
         select! {
             recv(msg_drop_rx) -> msg_msg => {
-                if let Ok(_) = msg_msg {
-                } else {
+                if msg_msg.is_err() {
                     return; // channel has closed
                 }
             }
@@ -165,7 +164,7 @@ fn msg_encode(
                             re_log::trace!("Encoded message of size {}", packet.len());
                             PacketMsg::Packet(packet)
                         }
-                        MsgMsg::SetAddr(new_addr) => PacketMsg::SetAddr(new_addr.clone()),
+                        MsgMsg::SetAddr(new_addr) => PacketMsg::SetAddr(*new_addr),
                         MsgMsg::Flush => PacketMsg::Flush,
                     };
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -325,7 +325,7 @@ fn serve() -> PyResult<()> {
 }
 
 #[pyfunction]
-fn shutdown(py: Python) {
+fn shutdown(py: Python<'_>) {
     // Release the GIL in case any flushing behavior needs to
     // cleanup a python object.
     py.allow_threads(|| {


### PR DESCRIPTION
The way things were set up dropping Arrow messages was grabbing the GIL which would deadlock since the shutdown function was already holding the GIL before flushing. Fix this by (1) dropping messages in their own thread so we never block the tcp_sender and (2) releasing the GIL during shutdown since we aren't interacting with any python objects anyways.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
