### PR TITLE
Add profiling scopes to point3d scene population

### DIFF
--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -137,6 +137,8 @@ where
         &mut self,
         positions: impl Iterator<Item = glam::Vec3>,
     ) -> PointsBuilder<'_, PerPointUserData> {
+        crate::profile_function!();
+
         debug_assert_eq!(self.0.vertices.len(), self.0.colors.len());
         debug_assert_eq!(self.0.vertices.len(), self.0.user_data.len());
 
@@ -261,6 +263,7 @@ where
     /// If the iterator provides more values than there are points, the extra values will be ignored.
     #[inline]
     pub fn radii(self, radii: impl Iterator<Item = Size>) -> Self {
+        crate::profile_function!();
         for (point, radius) in self.vertices.iter_mut().zip(radii) {
             point.radius = radius;
         }
@@ -282,6 +285,7 @@ where
     /// If the iterator provides more values than there are points, the extra values will be ignored.
     #[inline]
     pub fn colors(self, colors: impl Iterator<Item = Color32>) -> Self {
+        crate::profile_function!();
         for (c, color) in self.colors.iter_mut().zip(colors) {
             *c = color;
         }
@@ -304,6 +308,7 @@ where
     /// User data is currently not available on the GPU.
     #[inline]
     pub fn user_data(self, data: impl Iterator<Item = PerPointUserData>) -> Self {
+        crate::profile_function!();
         for (d, data) in self.user_data.iter_mut().zip(data) {
             *d = data;
         }


### PR DESCRIPTION
Classic:
![Screen Shot 2023-01-20 at 14 12 56](https://user-images.githubusercontent.com/1148717/213703278-4c30db3a-a391-41a3-a825-050e00cdd379.png)

Arrow:
![Screen Shot 2023-01-20 at 14 23 48](https://user-images.githubusercontent.com/1148717/213705142-bd56e7e5-8c5d-43a6-abe2-eefd99cb5343.png)


So `SceneSpatial::load_objects` goes from 8.5ms to 15ms. That's not great.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
