### PR TITLE
Update dependencies: Python3.8, arrow==10.0.1, numpy>=1.23

### DIFF
--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 description = "The Rerun Logging SDK"
 keywords = ["computer-vision", "logging", "rerun"]
 license = { text = "MIT OR Apache-2.0" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 dependencies = ["numpy>=1.23", "pyarrow==10.0.1"]
 


### PR DESCRIPTION
On versions before 10.0.1 we run into a cmake issue when trying to pip install or build with maturin. There is sort of a dual problem here: (1) pyarrow source-builds have painful/broken toolchain deps, and (2) a modern windows install defaults to py311, but prebuilt wheel was only provided up to py310 for releases before 10.0.1.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
