### PR TITLE
Space view generation heuristics now always look at latest available data.

### DIFF
--- a/crates/re_data_store/src/object_properties.rs
+++ b/crates/re_data_store/src/object_properties.rs
@@ -151,7 +151,7 @@ fn query_transform_arrow(
     // transforms this is easy enough.
     let arrow_store = &obj_db.arrow_store;
 
-    let query = LatestAtQuery::new(*timeline, TimeInt::from(query_time?));
+    let query = LatestAtQuery::new(*timeline, query_time.map_or(TimeInt::MAX, TimeInt::from));
 
     let components = [Transform::name()];
 

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -113,10 +113,11 @@ impl Viewport {
                 SpaceView::default_queried_objects_by_category(ctx, space_info, &transforms)
             {
                 let scene_spatial = query_scene_spatial(ctx, &obj_paths, &transforms);
+                let preferred_navigation_mode =
+                    scene_spatial.preferred_navigation_mode(&space_info.path);
 
                 if category == ViewCategory::Spatial
-                    && scene_spatial.preferred_navigation_mode(&space_info.path)
-                        == SpatialNavigationMode::TwoD
+                    && preferred_navigation_mode == SpatialNavigationMode::TwoD
                     && scene_spatial.ui.images.len() > 1
                 {
                     // Multiple images (e.g. depth and rgb, or rgb and segmentation) in the same 2D scene.
@@ -181,7 +182,7 @@ impl Viewport {
                         category,
                         space_info,
                         &obj_paths,
-                        scene_spatial.preferred_navigation_mode(&space_info.path),
+                        preferred_navigation_mode,
                         transforms.clone(),
                     );
                     blueprint.add_space_view(space_view);


### PR DESCRIPTION
Before they'd look at the current data, causing different space views when resetting the blueprint e.g. while looking at timeless data.

Resetting spaceviews in objectron while putting the timeline onto timeless data before:
<img width="265" alt="image" src="https://user-images.githubusercontent.com/1220815/214366646-7b672384-c9f8-445d-a750-29730e3b5919.png">

and after:
<img width="263" alt="image" src="https://user-images.githubusercontent.com/1220815/214366035-6fd7a115-a4c8-4a46-85ec-0e8e02c78a7b.png">


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
