### PR TITLE
Improve the heuristic for the camera projection distance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,7 +3201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3770,10 +3769,10 @@ dependencies = [
  "criterion",
  "document-features",
  "itertools",
+ "macaw",
  "mimalloc",
  "nohash-hasher",
  "once_cell",
- "ordered-float",
  "puffin",
  "rand",
  "re_arrow_store",
@@ -4090,7 +4089,6 @@ dependencies = [
  "mint",
  "ndarray",
  "nohash-hasher",
- "ordered-float",
  "poll-promise",
  "puffin",
  "puffin_http",

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -24,9 +24,9 @@ ahash = "0.8"
 anyhow = "1.0"
 document-features = "0.2"
 itertools = "0.10"
+macaw = "0.17"
 nohash-hasher = "0.2"
 once_cell = "1.15.0"
-ordered-float = { version = "3.2", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 thiserror = "1.0"
 

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -80,7 +80,6 @@ macaw = { version = "0.17", features = ["with_serde"] }
 mint = "0.5"
 ndarray = "0.15"
 nohash-hasher = "0.2"
-ordered-float = { version = "3.2", features = ["serde"] }
 poll-promise = "0.1"
 rand = { version = "0.8", features = ["small_rng"] }
 rfd = "0.10"

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -178,6 +178,7 @@ impl SpaceView {
             spaces_info,
             space_info,
             self.data_blueprint.data_blueprints_projected(),
+            &self.view_state.state_spatial.scene_bbox_accum,
         );
 
         if self.allow_auto_adding_more_object {
@@ -261,6 +262,7 @@ impl SpaceView {
                         &spaces_info,
                         reference_space,
                         self.data_blueprint.data_blueprints_projected(),
+                        &self.view_state.state_spatial.scene_bbox_accum,
                     );
                     self.obj_tree_children_ui(ctx, ui, &spaces_info, subtree, &transforms);
                 }
@@ -460,7 +462,13 @@ impl SpaceView {
 
             ViewCategory::Spatial => {
                 let mut scene = view_spatial::SceneSpatial::default();
-                scene.load_objects(ctx, &query, &self.cached_transforms, highlights);
+                scene.load_objects(
+                    ctx,
+                    &query,
+                    &self.cached_transforms,
+                    highlights,
+                    &self.view_state.state_spatial,
+                );
                 self.view_state.ui_spatial(
                     ctx,
                     ui,

--- a/crates/re_viewer/src/ui/transform_cache.rs
+++ b/crates/re_viewer/src/ui/transform_cache.rs
@@ -55,6 +55,7 @@ impl TransformCache {
         spaces_info: &SpacesInfo,
         reference_space: &SpaceInfo,
         obj_properties: &ObjectsProperties,
+        scene_bbox: &macaw::BoundingBox,
     ) -> Self {
         crate::profile_function!();
 
@@ -70,6 +71,7 @@ impl TransformCache {
             glam::Mat4::IDENTITY,
             false,
             None,
+            scene_bbox,
         );
 
         // Walk up from the reference space to the highest reachable parent.
@@ -144,6 +146,7 @@ impl TransformCache {
                 reference_from_ancestor,
                 encountered_pinhole,
                 Some(&previous_space.path),
+                scene_bbox,
             );
             previous_space = parent_space;
         }
@@ -160,6 +163,7 @@ impl TransformCache {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn gather_descendents_transforms(
         &mut self,
         spaces_info: &SpacesInfo,
@@ -168,6 +172,7 @@ impl TransformCache {
         reference_from_obj: glam::Mat4,
         encountered_pinhole: bool,
         skipped_child_path: Option<&ObjPath>,
+        scene_bbox: &macaw::BoundingBox,
     ) {
         self.register_transform_for(
             space,
@@ -218,7 +223,7 @@ impl TransformCache {
 
                         let distance = obj_properties
                             .get(child_path)
-                            .pinhole_image_plane_distance(pinhole);
+                            .pinhole_image_plane_distance(scene_bbox);
 
                         let focal_length = pinhole.focal_length_in_pixels();
                         let focal_length = glam::vec2(focal_length.x(), focal_length.y());
@@ -243,6 +248,7 @@ impl TransformCache {
                     reference_from_obj_in_child,
                     encountered_pinhole,
                     None,
+                    scene_bbox,
                 );
             }
         }

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -166,6 +166,7 @@ impl SceneSpatial {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        view_spatial_state: &super::ViewSpatialState,
     ) {
         crate::profile_function!();
 
@@ -203,7 +204,7 @@ impl SceneSpatial {
         ];
 
         for part in parts {
-            part.load(self, ctx, query, transforms, highlights);
+            part.load(self, ctx, query, transforms, highlights, view_spatial_state);
         }
 
         self.primitives.recalculate_bounding_box();

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
@@ -30,6 +30,7 @@ impl ScenePart for Arrows3DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Arrows3DPart");
 
@@ -192,6 +193,7 @@ impl ScenePart for Arrows3DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Points2DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
@@ -31,6 +31,7 @@ impl ScenePart for Boxes2DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Boxes2DPartClassic");
 
@@ -178,6 +179,7 @@ impl ScenePart for Boxes2DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Boxes2DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
@@ -31,6 +31,7 @@ impl ScenePart for Boxes3DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Boxes3DPartClassic");
 
@@ -188,6 +189,7 @@ impl ScenePart for Boxes3DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Boxes3DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -31,6 +31,7 @@ impl ScenePart for CamerasPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("CamerasPartClassic");
 
@@ -69,6 +70,7 @@ impl ScenePart for CamerasPartClassic {
                 pinhole,
                 view_coordinates,
                 object_highlight,
+                view_spatial_state,
             );
         }
     }
@@ -117,6 +119,7 @@ impl CamerasPart {
         pinhole: Pinhole,
         view_coordinates: ViewCoordinates,
         object_highlight: OptionalSpaceViewObjectHighlight<'_>,
+        view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         // The transform *at* this object path already has the pinhole transformation we got passed in!
         // This makes sense, since if there's an image logged here one would expect that the transform applies.
@@ -141,9 +144,6 @@ impl CamerasPart {
         // Actual primitives are generated later.
         // Currently, we need information about viewport to display it correctly.
         // TODO(andreas): Would be great if we add all the lines etc. right away!
-        //                  Let's attempt this as part of
-        //                  https://github.com/rerun-io/rerun/issues/681 (Improve camera frustum length heuristic & editability)
-        //                  and https://github.com/rerun-io/rerun/issues/686 (Replace camera mesh with expressive camera gizmo (extension of current frustum)
         scene.space_cameras.push(SpaceCamera3D {
             obj_path: obj_path.clone(),
             instance: instance_hash,
@@ -152,7 +152,8 @@ impl CamerasPart {
             pinhole: Some(pinhole),
         });
 
-        let frustum_length = props.pinhole_image_plane_distance(&pinhole);
+        let frustum_length =
+            props.pinhole_image_plane_distance(&view_spatial_state.scene_bbox_accum);
 
         // TODO(andreas): FOV fallback doesn't make much sense. What does pinhole without fov mean?
         let fov_y = pinhole.fov_y().unwrap_or(std::f32::consts::FRAC_PI_2);
@@ -231,6 +232,7 @@ impl ScenePart for CamerasPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("CamerasPart");
 
@@ -273,6 +275,7 @@ impl ScenePart for CamerasPart {
                         pinhole,
                         view_coordinates,
                         object_highlight,
+                        view_spatial_state,
                     );
                 })
             }) {

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -74,6 +74,7 @@ impl ScenePart for ImagesPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("ImagesPartClassic");
 
@@ -312,6 +313,7 @@ impl ScenePart for ImagesPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("ImagesPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
@@ -90,6 +90,7 @@ impl ScenePart for Lines2DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Lines2DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
@@ -33,6 +33,7 @@ impl ScenePart for Lines3DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Lines3DPart");
 
@@ -181,6 +182,7 @@ impl ScenePart for Lines3DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Lines3DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -33,6 +33,7 @@ impl ScenePart for MeshPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("MeshPartClassic");
 
@@ -161,6 +162,7 @@ impl ScenePart for MeshPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("MeshPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
@@ -39,5 +39,6 @@ pub trait ScenePart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     );
 }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
@@ -34,6 +34,7 @@ impl ScenePart for Points2DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Points2DPartClassic");
 
@@ -255,6 +256,7 @@ impl ScenePart for Points2DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Points2DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
@@ -40,6 +40,7 @@ impl ScenePart for Points3DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Points3DPartClassic");
 
@@ -342,6 +343,7 @@ impl ScenePart for Points3DPart {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("Points3DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/segments2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/segments2d.rs
@@ -24,6 +24,7 @@ impl ScenePart for LineSegments2DPartClassic {
         query: &SceneQuery<'_>,
         transforms: &TransformCache,
         highlights: &SpaceViewHighlights,
+        _view_spatial_state: &crate::ui::view_spatial::ViewSpatialState,
     ) {
         crate::profile_scope!("LineSegments2DPart");
 

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -54,6 +54,7 @@ pub struct ViewSpatialState {
     /// Specify default explicitly, otherwise it will be a box at 0.0 after deserialization.
     #[serde(skip, default = "default_scene_bbox_accum")]
     pub scene_bbox_accum: BoundingBox,
+
     /// Estimated number of primitives last frame. Used to inform some heuristics.
     #[serde(skip)]
     pub scene_num_primitives: usize,

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -26,6 +26,8 @@ use super::{
 
 // ----------------------------------------------------------------------------
 
+/// Fills the scene, but doesn't care about visual flair like
+/// highlights or the sizes of camera frustums etc.
 fn query_scene_spatial(
     ctx: &mut ViewerContext<'_>,
     obj_paths: &nohash_hasher::IntSet<ObjPath>,
@@ -40,7 +42,13 @@ fn query_scene_spatial(
         obj_props: &Default::default(), // all visible
     };
     let mut scene = SceneSpatial::default();
-    scene.load_objects(ctx, &query, transforms, &SpaceViewHighlights::default());
+    scene.load_objects(
+        ctx,
+        &query,
+        transforms,
+        &SpaceViewHighlights::default(),
+        &Default::default(),
+    );
     scene
 }
 
@@ -107,6 +115,7 @@ impl Viewport {
                 spaces_info,
                 space_info,
                 &ObjectsProperties::default(),
+                &macaw::BoundingBox::nothing(),
             );
 
             for (category, obj_paths) in
@@ -399,6 +408,7 @@ impl Viewport {
             spaces_info,
             space_info,
             &ObjectsProperties::default(),
+            &macaw::BoundingBox::nothing(),
         );
         for (category, obj_paths) in
             SpaceView::default_queried_objects_by_category(ctx, space_info, &transforms)
@@ -553,6 +563,7 @@ impl Viewport {
                     spaces_info,
                     space_info,
                     &ObjectsProperties::default(),
+                    &macaw::BoundingBox::nothing(),
                 );
 
                 for category in all_categories {
@@ -572,12 +583,6 @@ impl Viewport {
                         .clicked()
                     {
                         ui.close_menu();
-
-                        let transforms = TransformCache::determine_transforms(
-                            spaces_info,
-                            space_info,
-                            &ObjectsProperties::default(),
-                        );
 
                         let scene_spatial = query_scene_spatial(ctx, &obj_paths, &transforms);
                         let new_space_view_id = self.add_space_view(SpaceView::new(


### PR DESCRIPTION
Base in on the latest known scene size.

Closes https://github.com/rerun-io/rerun/issues/681

I'm not super-happy with how we need to pipe the scene bbox around to accomplish this.

An alternative would be to computer it last, that is: populate the scene with a dummy distance, then compute the final distance after the scene is complete, like we do for point radii. The problem with this is that we also need the projection distance for the transform hieararchy for projecting 2D stuff onto the plane.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
