### PR TITLE
objectron: don't force `--connect` with `--run-forever`

### DIFF
--- a/examples/objectron/main.py
+++ b/examples/objectron/main.py
@@ -281,9 +281,6 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.run_forever:
-        assert args.connect, "If you run forever, you need to --connect"
-
     rr.init("objectron")
 
     if args.connect:


### PR DESCRIPTION
`--run-forever` now works out of the box thanks to `spawn_and_connect`, so don't force the user to manually spawn a viewer.