### PR TITLE
Add options to create a cleaner UI for when doing screen recordings

### DIFF
--- a/crates/re_viewer/src/misc/app_options.rs
+++ b/crates/re_viewer/src/misc/app_options.rs
@@ -1,7 +1,7 @@
 /// Global options for the viewer.
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
-pub struct Options {
+pub struct AppOptions {
     pub show_camera_axes_in_3d: bool,
 
     pub low_latency: f32,
@@ -10,7 +10,7 @@ pub struct Options {
     pub debug: DebugOptions,
 }
 
-impl Default for Options {
+impl Default for AppOptions {
     fn default() -> Self {
         Self {
             show_camera_axes_in_3d: true,
@@ -23,7 +23,7 @@ impl Default for Options {
     }
 }
 
-impl Options {
+impl AppOptions {
     pub fn show_dev_controls(&self) -> bool {
         cfg!(debug_assertions) && !self.debug.extra_clean_ui
     }

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -1,7 +1,7 @@
+mod app_options;
 pub mod caches;
 pub(crate) mod color_map;
 pub(crate) mod mesh_loader;
-mod options;
 mod selection;
 mod selection_state;
 pub(crate) mod space_info;
@@ -25,15 +25,15 @@ pub(crate) mod profiler;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod clipboard;
 
+pub use transform_cache::{TransformCache, UnreachableTransform};
 pub use {
-    options::*,
+    app_options::*,
     selection::{MultiSelection, Selection},
     selection_state::{
         HoverHighlight, HoveredSpace, InteractionHighlight, OptionalSpaceViewObjectHighlight,
         SelectionHighlight, SelectionState, SpaceViewHighlights,
     },
 };
-pub use transform_cache::{TransformCache, UnreachableTransform};
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_viewer/src/misc/viewer_context.rs
+++ b/crates/re_viewer/src/misc/viewer_context.rs
@@ -11,7 +11,7 @@ use super::selection::{MultiSelection, Selection};
 /// Common things needed by many parts of the viewer.
 pub struct ViewerContext<'a> {
     /// Global options for the whole viewer.
-    pub options: &'a mut super::Options,
+    pub app_options: &'a mut super::AppOptions,
 
     /// Things that need caching.
     pub cache: &'a mut super::Caches,

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -325,7 +325,7 @@ pub fn view_3d(
 
     // TODO(andreas): This isn't part of the camera, but of the transform https://github.com/rerun-io/rerun/issues/753
     for camera in &scene.space_cameras {
-        if ctx.options.show_camera_axes_in_3d {
+        if ctx.app_options.show_camera_axes_in_3d {
             let transform = camera.world_from_cam();
             let axis_length =
                 eye.approx_pixel_world_size_at(transform.translation(), rect.size()) * 32.0;

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -343,7 +343,7 @@ impl Viewport {
                 .scope(|ui| space_view_ui(ctx, ui, spaces_info, space_view, &highlights))
                 .response;
 
-            if ctx.options.show_spaceview_controls() {
+            if ctx.app_options.show_spaceview_controls() {
                 let frame = ctx.re_ui.hovering_frame();
                 hovering_panel(ui, frame, response.rect, |ui| {
                     space_view_options_link(ctx, selection_panel_expanded, space_view.id, ui, "⛭");
@@ -362,7 +362,7 @@ impl Viewport {
                 .scope(|ui| space_view_ui(ctx, ui, spaces_info, space_view, &highlights))
                 .response;
 
-            if ctx.options.show_spaceview_controls() {
+            if ctx.app_options.show_spaceview_controls() {
                 let frame = ctx.re_ui.hovering_frame();
                 hovering_panel(ui, frame, response.rect, |ui| {
                     if ctx
@@ -653,7 +653,7 @@ impl<'a, 'b> egui_dock::TabViewer for TabViewer<'a, 'b> {
             .scope(|ui| space_view_ui(self.ctx, ui, self.spaces_info, space_view, &highlights))
             .response;
 
-        if self.ctx.options.show_spaceview_controls() {
+        if self.ctx.app_options.show_spaceview_controls() {
             // Show buttons for maximize and space view options:
             let frame = self.ctx.re_ui.hovering_frame();
             hovering_panel(ui, frame, response.rect, |ui| {


### PR DESCRIPTION
This options is currently only available in dev builds!

![clean-ui-option](https://user-images.githubusercontent.com/1148717/215070253-7892abbb-667b-4b2c-9b53-f9370329f36e.gif)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
