### PR TITLE
Gracefully log an error if there are too many points or lines

### DIFF
--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -269,8 +269,8 @@ pub enum LineDrawDataError {
 
 // Textures are 2D since 1D textures are very limited in size (8k typically).
 // Need to keep these values in sync with lines.wgsl!
-const POSITION_TEXTURE_SIZE: u32 = 512; // 512 x 512 x vec4<f32> == 4mb, 262144 PositionDatas
-const LINE_STRIP_TEXTURE_SIZE: u32 = 256; // 256 x 256 x vec2<u32> == 0.5mb, 65536 line strips
+const POSITION_TEXTURE_SIZE: u32 = 512; // 512 x 512 x vec4<f32> == 4MiB, 262144 PositionDatas
+const LINE_STRIP_TEXTURE_SIZE: u32 = 256; // 256 x 256 x vec2<u32> == 0.5MiB, 65536 line strips
 
 impl LineDrawData {
     /// Total maximum number of line vertices per [`LineDrawData`].

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -133,7 +133,7 @@ pub enum PointCloudDrawDataError {
 
 /// Textures are 2D since 1D textures are very limited in size (8k typically).
 /// Need to keep this value in sync with `point_cloud.wgsl`!
-const DATA_TEXTURE_SIZE: u32 = 1024; // 1024 x 1024 x (vec4<f32> + [u8;4]) == 20mb, ~1mio points
+const DATA_TEXTURE_SIZE: u32 = 1024; // 1024 x 1024 x (vec4<f32> + [u8;4]) == 20 MiB, ~1M points
 
 impl PointCloudDrawData {
     /// Maximum number of vertices per [`PointCloudDrawData`].
@@ -205,8 +205,8 @@ impl PointCloudDrawData {
                 vertices.len()
             );
             (
-                &vertices[..Self::MAX_NUM_POINTS - 1],
-                &colors[..Self::MAX_NUM_POINTS - 1],
+                &vertices[..Self::MAX_NUM_POINTS],
+                &colors[..Self::MAX_NUM_POINTS],
             )
         } else {
             (vertices, colors)


### PR DESCRIPTION
Instead of crashing/going black etc. we're now logging an error and clamp down the number of lines-strips/line-vertices or points when we have too many.

Fixes #951
New issue for lifting the restriction: https://github.com/rerun-io/rerun/issues/957

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
