### PR TITLE
Force the ouput of the color-conversion code to be unsigned

### DIFF
--- a/rerun_py/rerun/color_conversion.py
+++ b/rerun_py/rerun/color_conversion.py
@@ -5,13 +5,13 @@ import numpy as np
 import numpy.typing as npt
 
 
-def u8_array_to_rgba(arr: Sequence[int]) -> int:
+def u8_array_to_rgba(arr: Sequence[int]) -> np.uint32:
     """Convert an array[4] of uint8 values into a uint32."""
     red = arr[0]
     green = arr[1]
     blue = arr[2]
     alpha = arr[3] if len(arr) == 4 else 0xFF
-    return (red << 24) + (green << 16) + (blue << 8) + alpha
+    return np.uint32((red << 24) + (green << 16) + (blue << 8) + alpha)
 
 
 def linear_to_gamma_u8_value(linear: npt.NDArray[Union[np.float32, np.float64]]) -> npt.NDArray[np.uint8]:


### PR DESCRIPTION
No idea why this was an issue on windows. Maybe python-3.11 issue?

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
