### PR TITLE
Hack depth offset in order to make objects not disappear

### DIFF
--- a/crates/re_renderer/shader/utils/depth_offset.wgsl
+++ b/crates/re_renderer/shader/utils/depth_offset.wgsl
@@ -4,13 +4,19 @@
 fn apply_depth_offset(position: Vec4, offset: f32) -> Vec4 {
     // Z buffer z is computed using position.z/position.w,
     // Therefore, to affect the final output by a given offset we need to multiply it with position.w.
-    // (This also means that we're loosing some precision!)
+    // This also means though that we're loosing a lot of precision
     //
     // We're using inverse z, i.e. 0.0 is far, 1.0 is near.
     // We want a positive depth_offset_factor to move towards the viewer, so offset needs to be added.
+    //
+    // With this in place we still may cross over to 0.0 (the far plane) too early,
+    // making objects disappear into the far when they'd be otherwise stilil rendered.
+    // Since we're actually supposed to have an *infinite* far plane this should never happen!
+    // Therefore we simply dictacte a minimum z value.
+    // This ofc wrecks the depth offset and may cause z fighting with all very far away objects, but it's better than having things disappear!
     return Vec4(
         position.xy,
-        position.z + frame.depth_offset_factor * offset * position.w,
+        max(position.z + frame.depth_offset_factor * offset * position.w, f32eps),
         position.w
     );
 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -356,7 +356,7 @@ fn obj_props_ui(
                     if ui
                         .add(
                             egui::DragValue::new(&mut distance)
-                                .clamp_range(0.0..=f32::INFINITY)
+                                .clamp_range(0.0..=1.0e8)
                                 .speed(speed),
                         )
                         .on_hover_text("Controls how far away the image plane is.")


### PR DESCRIPTION
None of the things here is great, but it solves the problem at hand.
* smaller depth offset steps (experimented in tracking_hf & colmap with history on the image itself)
* bypass far z culling completely (far away layered images will "loose" more and more layers, but they won't disappear)
* limit image plane distance to not be too insane
* ensure use of f32 depth buffer for more consistency in this whole mess (precision was essentially unspecified so far)

Fix of one of the issues in #880 

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
