### PR TITLE
use wasm target-dir for `bacon wasm`

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -22,6 +22,7 @@ command = [
   "cranky",
   "-p=re_viewer",
   "--target=wasm32-unknown-unknown",
+  "--target-dir=target_wasm",
   "--all-features",
   "--color=always",
 ]


### PR DESCRIPTION
`bacon wasm` is currently configured to use the native target directory, leading to unnecessary suffering when alternating between `bacon` & `bacon wasm` builds :sob: 