### PR TITLE
Less bright frustum

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -181,7 +181,7 @@ impl SceneSpatial {
     const HOVER_COLOR: Color32 = Color32::from_rgb(255, 200, 200);
     const SELECTION_COLOR: Color32 = Color32::from_rgb(255, 170, 170);
     const SIBLING_SELECTION_COLOR: Color32 = Color32::from_rgb(255, 140, 140);
-    const CAMERA_COLOR: Color32 = Color32::from_rgb(255, 128, 128);
+    const CAMERA_COLOR: Color32 = Color32::from_rgb(150, 150, 150);
 
     fn size_boost(size: Size) -> Size {
         if size.is_auto() {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1220815/215866210-dc6e5154-b0ff-4fef-bc03-a4091149f1e0.png)


After:

![image](https://user-images.githubusercontent.com/1220815/215865925-a2f6ab02-3e0f-478b-81c5-956dce168626.png)

After with hover:
![image](https://user-images.githubusercontent.com/1220815/215865982-8d78d4bc-1026-4c24-b7be-6dd498154760.png)

After with selection:
![image](https://user-images.githubusercontent.com/1220815/215866041-ed7d33f0-92f1-469d-81e2-b271f642e1df.png)


Fixes one of the issues in #880 

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
