### PR TITLE
Slightly nicer tensor view

### DIFF
--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -722,6 +722,8 @@ fn image_ui(
             // .......... a
             // .......... r
 
+            // TODO(emilk): draw actual arrows behind the text instead of the ugly emoji arrows
+
             // Label for X axis:
             {
                 let text_background = painter.add(egui::Shape::Noop);


### PR DESCRIPTION
* shorter selector name label
* only show axes on hover
* longer slider

![tensor-ui-improvements](https://user-images.githubusercontent.com/1148717/216057860-d7a0a5f7-0e20-4c49-90d8-72c957ce872a.gif)


Moving the sliders below the tensor image is difficult in immediate mode. We could move them to the very bottom of the space view area, but I think that would be too far.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
