### PR TITLE
ui: use the crosshair for zoom previews everywhere

### DIFF
--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -128,7 +128,7 @@ fn show_zoomed_image_region_tooltip(
     meter: Option<f32>,
 ) -> egui::Response {
     response
-        .on_hover_cursor(egui::CursorIcon::ZoomIn)
+        .on_hover_cursor(egui::CursorIcon::Crosshair)
         .on_hover_ui_at_pointer(|ui| {
             ui.set_max_width(320.0);
             ui.horizontal(|ui| {

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -384,7 +384,7 @@ fn view_2d_scrollable(
                 }
 
                 response
-                    .on_hover_cursor(egui::CursorIcon::ZoomIn)
+                    .on_hover_cursor(egui::CursorIcon::Crosshair)
                     .on_hover_ui_at_pointer(|ui| {
                         ui.set_max_width(320.0);
 

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -310,7 +310,7 @@ pub fn view_3d(
             };
             response = if let Some((image, uv)) = picked_image_with_uv {
                 response
-                    .on_hover_cursor(egui::CursorIcon::ZoomIn)
+                    .on_hover_cursor(egui::CursorIcon::Crosshair)
                     .on_hover_ui_at_pointer(|ui| {
                         ui.set_max_width(320.0);
 


### PR DESCRIPTION
This replaces the cursor used for zoom previews, using a "crosshair" rather than "magnifying glass with a + sign".

The reason is two-fold:
- "magnifying glass with a + sign" comes with expectations (i.e. clicking actually zooms in)
- this nicely parallels the behaviour of plots, which already use the crosshair for this (in fact `egui` docs describe the crosshair cursor as `For precision work`!)

Before:

https://user-images.githubusercontent.com/2910679/216556009-49a63cf8-2fd4-4b32-ae10-fabcec52c64e.mp4

After:

https://user-images.githubusercontent.com/2910679/216556212-90e56c24-bc92-41bf-be8a-0de4f0d919f2.mp4

