### PR TITLE
On push sync the docs to gh-pages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,7 +152,7 @@ jobs:
           args: --all-targets --all-features
 
       - name: Set up git author
-        #if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config --global user.name "${GITHUB_ACTOR}"
@@ -161,18 +161,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up ghp-import
-        #if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: pip install ghp-import
 
       - name: Patch in a redirect page
-        #if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: echo "<meta http-equiv=\"refresh\" content=\"0; url=${REDIRECT_CRATE}\">" > target/doc/index.html
         env:
           REDIRECT_CRATE: rerun_sdk
 
       # See: https://github.com/c-w/ghp-import
       - name: Deploy the docs
-        #if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: python3 -m ghp_import -n -p -x rust/head target/doc/ -m "Update the rust docs"
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
On push to main we will update the latest docs:
 - https://rerun-io.github.io/rerun/rust/head

By default we redirect to the `rerun_sdk` crate.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
