### PR TITLE
Use Selection color from design token

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -106,8 +106,9 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
         egui_style.visuals.widgets.open.expansion = 2.0;
     }
 
-    egui_style.visuals.selection.bg_fill = get_aliased_color(&json, "{Alias.Color.Highlight.Default.value}");
-            
+    egui_style.visuals.selection.bg_fill =
+        get_aliased_color(&json, "{Alias.Color.Highlight.Default.value}");
+
     egui_style.visuals.widgets.noninteractive.bg_stroke.color = Color32::from_gray(30); // from figma. separator lines, panel lines, etc
 
     let subudued = get_aliased_color(&json, "{Alias.Color.Text.Subdued.value}");


### PR DESCRIPTION
I set out to apply various other design tokens, but after having a closer look at how not all our design sketches use the exact same colors and the existing struggle in design_tokens.rs, I did only this one impactful one
![image](https://user-images.githubusercontent.com/1220815/216760778-208b46da-d0ab-4488-9b9b-b79a0a262ea0.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
