### PR TITLE
Revert "Fix python bridge preventing logging transforms to root child"

### DIFF
--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -443,8 +443,9 @@ fn log_transform(
     timeless: bool,
 ) -> PyResult<()> {
     let entity_path = parse_entity_path(entity_path)?;
-    if entity_path.is_root() {
-        return Err(PyTypeError::new_err("Transforms are between a child entity and its parent, so the root cannot have a transform"));
+    if entity_path.len() == 1 {
+        // Stop people from logging a transform to a root-entity, such as "world" (which doesn't have a parent).
+        return Err(PyTypeError::new_err("Transforms are between a child entity and its parent, so root entities cannot have transforms"));
     }
     let mut session = global_session();
     let time_point = time(timeless);


### PR DESCRIPTION
This actually segfaulted for me when I tried using it on colmap with no useful logs:

`zsh: segmentation fault  RUST_LOG=debug python -m rerun`