### PR TITLE
Restore previous non-tracked camera pose on esc

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -239,6 +239,7 @@ pub const HELP_TEXT_3D: &str = "Drag to rotate.\n\
     CTRL slows down, SHIFT speeds up.\n\
     \n\
     Double-click an object to focus the view on it.\n\
+    For cameras, you can restore the view again with Escape.\n\
     \n\
     Double-click on empty space to reset the view.";
 


### PR DESCRIPTION
Allow the user to revert to the previous camera pose whenever a 3d camera is tracked.

https://user-images.githubusercontent.com/1220815/216840569-7412523e-14e8-4eb3-add0-ecb657d70e99.mov


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
