### PR TITLE
EntityPath::from_str must parse the given string

### DIFF
--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::{hash::Hash128, path::entity_path_impl::EntityPathImpl, EntityPathPart};
+use crate::{
+    hash::Hash128, parse_entity_path, path::entity_path_impl::EntityPathImpl, EntityPathPart,
+};
 
 // ----------------------------------------------------------------------------
 
@@ -162,17 +164,18 @@ impl From<&[EntityPathPart]> for EntityPath {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<&str> for EntityPath {
     #[inline]
-    fn from(component: &str) -> Self {
-        Self::from(vec![EntityPathPart::from(component)])
+    fn from(path: &str) -> Self {
+        Self::from(parse_entity_path(path).unwrap())
     }
 }
 
 impl From<String> for EntityPath {
     #[inline]
-    fn from(component: String) -> Self {
-        Self::from(vec![EntityPathPart::from(component)])
+    fn from(path: String) -> Self {
+        Self::from(path.as_str())
     }
 }
 


### PR DESCRIPTION
This is a very dangerous and hard to track footgun:
```rust
    let a = EntityPath::from("null_demo/rect/0");
    let b = EntityPath::from(
        rerun::external::re_log_types::parse_entity_path("null_demo/rect/0").unwrap(),
    );
    dbg!(&a);
    dbg!(&b);
    dbg!(a == b);
```
```
[examples/api_demo/src/main.rs:158] &a = EntityPath(null_demo/rect/0)
[examples/api_demo/src/main.rs:159] &b = EntityPath(null_demo/rect/0)
[examples/api_demo/src/main.rs:160] a == b = false
```

It is made even more dangerous by the fact that some API will just take the `EntityPath` you give them as-is (e.g. `send_path_op`) while some will re-parse it behind the scene (e.g. `log_arrow`).
Consequently, the following will never work, even though everything looks like it's in the right place:
```rust
    // sim_time = 1
    MsgSender::new("null_demo/rect/0")
        .with_timepoint(sim_time(1 as _))
        .with_component(&[Rect2D::from_xywh(5.0, 5.0, 4.0, 4.0)])?
        .with_component(&[ColorRGBA::from([255, 0, 0, 255])])?
        .with_component(&[Label("Rect1".into())])?
        .send(session)?;
    MsgSender::new("null_demo/rect/1")
        .with_timepoint(sim_time(1 as _))
        .with_component(&[Rect2D::from_xywh(10.0, 5.0, 4.0, 4.0)])?
        .with_component(&[ColorRGBA::from([0, 255, 0, 255])])?
        .with_component(&[Label("Rect2".into())])?
        .send(session)?;

    // sim_time = 2
    log_cleared(session, &sim_time(2 as _), "null_demo/rect/0", false);

    // sim_time = 3
    log_cleared(session, &sim_time(3 as _), "null_demo/rect", true);
```

The event log looks right, except it just doesn't work:
![image](https://user-images.githubusercontent.com/2910679/217041814-9b0029b6-b7cb-456b-996c-f9d1fbfea3d5.png)
