### PR TITLE
Fetch before pushing docs & put python docs in sub-directories

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -53,7 +53,7 @@ jobs:
   create_rrd:
     name: Create example RRD files
     runs-on: ubuntu-latest-16-cores
-    needs: [ lint ]
+    needs: [lint]
     steps:
       - uses: actions/checkout@v3
 
@@ -102,7 +102,7 @@ jobs:
     runs-on: macos-latest
     # This build is really slow (>30 mins); uses up a lot of CI minutes
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-    needs: [ lint, create_rrd ]
+    needs: [lint, create_rrd]
     strategy:
       matrix:
         target: [x64, universal2]
@@ -183,7 +183,7 @@ jobs:
   windows:
     name: Build Python Wheels for Windows
     runs-on: windows-latest-8-cores
-    needs: [ lint, create_rrd ]
+    needs: [lint, create_rrd]
     strategy:
       matrix:
         target: [x64]
@@ -248,7 +248,7 @@ jobs:
   linux:
     name: Build Python Wheels for Linux
     runs-on: ubuntu-latest-16-cores
-    needs: [ lint, create_rrd ]
+    needs: [lint, create_rrd]
     steps:
       - uses: actions/checkout@v3
 
@@ -327,7 +327,7 @@ jobs:
   # See https://github.com/marvinpinto/action-automatic-releases#automatically-generate-a-pre-release-when-changes-land-on-master for details
   pre-release:
     name: Pre Release
-    needs: [ macos, windows, linux ]
+    needs: [macos, windows, linux]
     if: github.ref == 'refs/heads/main'
     runs-on: "ubuntu-latest"
     steps:
@@ -354,7 +354,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [ macos, windows, linux ]
+    needs: [macos, windows, linux]
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3
@@ -436,4 +436,5 @@ jobs:
 
       - name: Deploy via mike # https://github.com/jimporter/mike
         run: |
-          mike deploy -F rerun_py/mkdocs.yml -p --rebase -b gh-pages HEAD
+          git fetch
+          mike deploy -F rerun_py/mkdocs.yml -p --rebase -b gh-pages --deploy-prefix docs/python HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,5 @@ jobs:
 
       - name: Deploy via mike # https://github.com/jimporter/mike
         run: |
-          mike deploy -F rerun_py/mkdocs.yml -p --rebase -b gh-pages -u ${{github.ref_name}} latest
+          git fetch
+          mike deploy -F rerun_py/mkdocs.yml -p --rebase -b gh-pages --deploy-prefix docs/python -u ${{github.ref_name}} latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,7 +173,9 @@ jobs:
       # See: https://github.com/c-w/ghp-import
       - name: Deploy the docs
         if: ${{ github.event_name == 'push' }}
-        run: python3 -m ghp_import -n -p -x rust/head target/doc/ -m "Update the rust docs"
+        run: |
+          git fetch
+          python3 -m ghp_import -n -p -x docs/rust/head target/doc/ -m "Update the rust docs"
 
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Puts the respective docs sites `docs/python` and `docs/rust`.
Attempts to fetch before updating docs to reduce race-conditions that cause push failures.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
