### PR TITLE
bacon: work around infinite build loop

### DIFF
--- a/examples/objectron/build.rs
+++ b/examples/objectron/build.rs
@@ -32,9 +32,11 @@ fn main() -> Result<(), std::io::Error> {
     .flatten()
     .collect::<Vec<_>>();
 
-    // `prost-build` will try and rebuild even if nothing has changed in the .proto definitions,
-    // which will lead to infinite build loops with tools like `bacon` that watch the filesystem
-    // for any changes to the project's files.
+    // `cargo` has an implicit `rerun-if-changed=src/**` clause, which will act against us in this
+    // instance.
+    // Make sure to _not_ rewrite identical data, so as to avoid being stuck in an infinite build
+    // loop when using tools like e.g. `bacon` that watch the filesystem for any changes to the
+    // project's files.
     if let Ok(cur_bytes) = std::fs::read(&dst_path) {
         if bytes == cur_bytes {
             return Ok(());


### PR DESCRIPTION
~`prost-build` is a bit too liberal with its change detection.~

`cargo` has an implicit `rerun-if-changed=src/**` clause, which in turn retriggers a proto build, which retriggers `bacon`, which retriggers `cargo`...

The official solution is to use [`exclude`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields), though that would not do what we want in this case as we still want the file to be published.