### PR TITLE
fix official example detection

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -158,7 +158,7 @@ def init(application_id: str, spawn: bool = False) -> None:
         stack = inspect.stack()
         for frame in stack[:MAX_FRAMES]:
             filename = frame[FRAME_FILENAME_INDEX]
-            path = pathlib.Path(filename).resolve()  # normalize before comparison!
+            path = pathlib.Path(str(filename)).resolve()  # normalize before comparison!
             if "rerun/examples" in str(path):
                 app_path = path
     except Exception:


### PR DESCRIPTION
When we removed the boilerplate from the python examples, we also changed the location of the `init()` call, which broke the official example detection thing.

This PR fixes that and makes sure it doesn't happen again.