### PR TITLE
Update arrow2, arrow2_convert and polars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "arrow2_convert"
 version = "0.4.0"
-source = "git+https://github.com/rerun-io/arrow2-convert?rev=ac65e04a517db0e3f15bc6a0036b7c371023da48#ac65e04a517db0e3f15bc6a0036b7c371023da48"
+source = "git+https://github.com/DataEngineeringLabs/arrow2-convert?rev=a270bb6da73afb20dba09f45ce27cd18ddf4838d#a270bb6da73afb20dba09f45ce27cd18ddf4838d"
 dependencies = [
  "arrow2",
  "arrow2_convert_derive",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "arrow2_convert_derive"
 version = "0.4.0"
-source = "git+https://github.com/rerun-io/arrow2-convert?rev=ac65e04a517db0e3f15bc6a0036b7c371023da48#ac65e04a517db0e3f15bc6a0036b7c371023da48"
+source = "git+https://github.com/DataEngineeringLabs/arrow2-convert?rev=a270bb6da73afb20dba09f45ce27cd18ddf4838d#a270bb6da73afb20dba09f45ce27cd18ddf4838d"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,5 +72,5 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-# https://github.com/DataEngineeringLabs/arrow2-convert/pull/98
-arrow2_convert = { git = "https://github.com/rerun-io/arrow2-convert", rev = "ac65e04a517db0e3f15bc6a0036b7c371023da48" }
+# From 2023-02-11, includes the merge of https://github.com/DataEngineeringLabs/arrow2-convert/pull/98
+arrow2_convert = { git = "https://github.com/DataEngineeringLabs/arrow2-convert", rev = "a270bb6da73afb20dba09f45ce27cd18ddf4838d" }


### PR DESCRIPTION
Part of #813 

Sadly we still need to patch `arrow2_convert`. Our previous patch was to this commit: https://github.com/DataEngineeringLabs/arrow2-convert/commit/7e63de5ce71741aaea3c36572d3e6831658ec3ed which wasn't part of any PR that got merged.

So, we patch `arrow2_convert` again, waiting for this  new PR to be merged, and hopefully released before Monday 😬 
* https://github.com/DataEngineeringLabs/arrow2-convert/pull/98


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
