### PR TITLE
Run cargo check after patching pre-release

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -123,7 +123,12 @@ jobs:
 
       - name: Patch Cargo.toml for Pre-Release
         if: github.ref == 'refs/heads/main'
-        run: python scripts/patch_prerelease_version.py
+        # After patching the pre-release version, run cargo check
+        # this updates the cargo.lock file with the new version numbers
+        # and keeps the wheel build from failing
+        run: |
+          python scripts/patch_prerelease_version.py
+          cargo check
 
       - name: Build and install rerun
         run: pip install rerun_py/


### PR DESCRIPTION
Without this we get an error when building the wheel:
```
2023-02-10T18:31:48.5580500Z   × Preparing metadata (pyproject.toml) did not run successfully.
2023-02-10T18:31:48.5680000Z   │ exit code: 1
2023-02-10T18:31:48.5781790Z   ╰─> [13 lines of output]
2023-02-10T18:31:48.5883080Z           Updating git repository `https://github.com/rerun-io/arrow2`
2023-02-10T18:31:48.5983070Z           Updating git submodule `https://github.com/apache/arrow-testing`
2023-02-10T18:31:48.6083950Z           Updating git submodule `https://github.com/apache/parquet-testing`
2023-02-10T18:31:48.6185010Z           Updating git repository `https://github.com/rerun-io/arrow2-convert`
2023-02-10T18:31:48.6281610Z           Updating crates.io index
2023-02-10T18:31:48.6282970Z       error: the lock file /Users/runner/work/rerun/rerun/Cargo.lock needs to be updated but --locked was passed to prevent this
2023-02-10T18:31:48.6284080Z       If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
