### PR TITLE
NOMERGE: Proof-of-concept: calculate 2d-bounding boxes differently

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -180,7 +180,7 @@ impl SceneSpatial {
             part.load(self, ctx, query, transforms, highlights);
         }
 
-        self.primitives.recalculate_bounding_box();
+        self.primitives.recalculate_bounding_boxes();
     }
 
     // TODO(andreas): Better ways to determine these?

--- a/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
@@ -160,7 +160,8 @@ pub fn picking(
     };
 
     let SceneSpatialPrimitives {
-        bounding_box: _,
+        bounding_box_2d: _,
+        bounding_box_3d: _,
         textured_rectangles,
         textured_rectangles_ids,
         line_strips,

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -283,15 +283,17 @@ impl ViewSpatialState {
         space_view_id: SpaceViewId,
         highlights: &SpaceViewHighlights,
     ) {
-        self.scene_bbox = scene.primitives.bounding_box();
         // If this is the first time the bounding box is set, (re-)determine the nav_mode.
         // TODO(andreas): Keep track of user edits
         if self.scene_bbox_accum.is_nothing() {
-            self.scene_bbox_accum = self.scene_bbox;
             self.nav_mode = scene.preferred_navigation_mode(space);
+            self.scene_bbox = scene.primitives.bounding_box(self.nav_mode);
+            self.scene_bbox_accum = self.scene_bbox;
         } else {
+            self.scene_bbox = scene.primitives.bounding_box(self.nav_mode);
             self.scene_bbox_accum = self.scene_bbox_accum.union(self.scene_bbox);
         }
+
         self.scene_num_primitives = scene.primitives.num_primitives();
 
         match self.nav_mode {


### PR DESCRIPTION
Putting this up for reference, but I don't think it's exactly the right fix.

1) There's probably a cleaner way to bound points that get close to the plane of projection? Seems like something maybe glam has builtin somewhere?
2) Need to do similar handling for things other than points.
3) Points that are way outside the FOV are still pretty useless.

See exa:

https://user-images.githubusercontent.com/3312232/218203772-e7755529-bd24-480e-aed2-40567c9946da.mov

I think on top of this we should probably still bound (or at least default) based on some margin around the FOV of the camera matrix, though I don't think we have access to that information in this context?

Basically if it's a purely 2D scene, we should aggregate as normal over 2D geometry, but if it's a 3D projection *into* a 2D scene that means we  have a defined camera matrix defined and then we should use a margin informed by the camera definition rather than worrying about the content at all.

### Checklist
* [ ] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
