### PR TITLE
Don't use non-ISO transforms for updating bounds

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
@@ -74,6 +74,7 @@ impl SceneSpatialPrimitives {
         for (batch, vertex_iter) in self.points.iter_vertices_by_batch() {
             // Only use points which are an IsoTransform to update the bounding box
             // This prevents crazy bounds-increases when projecting 3d to 2d
+            // See: https://github.com/rerun-io/rerun/issues/1203
             if let Some(transform) = macaw::IsoTransform::from_mat4(&batch.world_from_obj) {
                 let batch_bb = macaw::BoundingBox::from_points(vertex_iter.map(|v| v.position));
                 self.bounding_box = self
@@ -84,6 +85,7 @@ impl SceneSpatialPrimitives {
         for (batch, vertex_iter) in self.line_strips.iter_vertices_by_batch() {
             // Only use points which are an IsoTransform to update the bounding box
             // This prevents crazy bounds-increases when projecting 3d to 2d
+            // See: https://github.com/rerun-io/rerun/issues/1203
             if let Some(transform) = macaw::IsoTransform::from_mat4(&batch.world_from_obj) {
                 let batch_bb = macaw::BoundingBox::from_points(vertex_iter.map(|v| v.position));
                 self.bounding_box = self


### PR DESCRIPTION
Much simpler solution than https://github.com/rerun-io/rerun/pull/1192 with better results.

Just don't incorporate these points when computing the bounding box at all. We could consider adding some optional margin to accommodate cases like this, but this behavior is a big net win for the current examples.

![image](https://user-images.githubusercontent.com/3312232/218232090-3d7c279d-72a0-4bcd-af6d-8045333e1019.png)

Resolves: https://github.com/rerun-io/rerun/issues/1203

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
