### PR TITLE
Install web dependencies before running cargo check

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -121,15 +121,6 @@ jobs:
           cache: "pip"
           cache-dependency-path: "rerun_py/requirements-build.txt"
 
-      - name: Patch Cargo.toml for Pre-Release
-        if: github.ref == 'refs/heads/main'
-        # After patching the pre-release version, run cargo check
-        # this updates the cargo.lock file with the new version numbers
-        # and keeps the wheel build from failing
-        run: |
-          python scripts/patch_prerelease_version.py
-          cargo check
-
       - name: Install prerequisites for building the web-viewer Wasm
         shell: bash
         continue-on-error: true
@@ -144,6 +135,16 @@ jobs:
           name: "wasm-opt.exe"
           url: "https://github.com/WebAssembly/binaryen/releases/download/version_111/binaryen-version_111-x86_64-windows.tar.gz"
           pathInArchive: "binaryen-version_111/bin/wasm-opt.exe"
+
+      - name: Patch Cargo.toml for Pre-Release
+        if: github.ref == 'refs/heads/main'
+        # After patching the pre-release version, run cargo check
+        # this updates the cargo.lock file with the new version numbers
+        # and keeps the wheel build from failing
+        run: |
+          python scripts/patch_prerelease_version.py
+          cargo check
+
 
       - name: Build and install rerun
         run: pip install rerun_py/


### PR DESCRIPTION
Not sure why CI didn't catch this. Maybe a merge ordering issue?  Mainline builds are still hitting this issue:
https://github.com/rerun-io/rerun/actions/runs/4149883478/jobs/7179165544
```
      Finished dev [optimized + debuginfo] target(s) in 2m 04s
  compile status: exit status: 0
  compile stderr: 
  wasm-bindgen cmd: "wasm-bindgen" "/home/runner/work/rerun/rerun/target_wasm/wasm32-unknown-unknown/debug/re_viewer.wasm" "--out-dir" "/home/runner/work/rerun/rerun/crates/re_web_server/../../web_viewer" "--no-modules" "--no-typescript"
  thread 'main' panicked at 'Failed to generate JS bindings: No such file or directory (os error 2). target_path: "/home/runner/work/rerun/rerun/target_wasm/wasm32-unknown-unknown/debug/re_viewer.wasm", build_dir: /home/runner/work/rerun/rerun/crates/re_web_server/../../web_viewer', crates/re_web_server/build.rs:181:31
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

During cargo check. I think we just need to make sure the web deps are installed first.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
