### PR TITLE
Fix sign error on rects logged with XCYCWH

### DIFF
--- a/crates/re_log_types/src/component_types/rect.rs
+++ b/crates/re_log_types/src/component_types/rect.rs
@@ -57,8 +57,8 @@ impl Rect2D {
             Rect2D::YXHW(Vec4D([y, x, _h, _w])) => [*x, *y],
             Rect2D::XYXY(Vec4D([x0, y0, _x1, _y1])) => [*x0, *y0],
             Rect2D::YXYX(Vec4D([y0, x0, _y1, _x1])) => [*x0, *y0],
-            Rect2D::XCYCWH(Vec4D([x_cen, y_cen, w, h])) => [x_cen - (w / 2.0), y_cen + (h / 2.0)],
-            Rect2D::XCYCW2H2(Vec4D([x_cen, y_cen, w_2, h_2])) => [x_cen - w_2, y_cen + h_2],
+            Rect2D::XCYCWH(Vec4D([x_cen, y_cen, w, h])) => [x_cen - (w / 2.0), y_cen - (h / 2.0)],
+            Rect2D::XCYCW2H2(Vec4D([x_cen, y_cen, w_2, h_2])) => [x_cen - w_2, y_cen - h_2],
         }
     }
 


### PR DESCRIPTION
Makes this trick work nicely.
```
        rr.log_rect(
            "camera/image/rgb/overscan",
            [camera.width / 2, camera.height / 2, camera.width * 1.2, camera.height * 1.2],
            rect_format=RectFormat.XCYCWH,
        )
```

![image](https://user-images.githubusercontent.com/3312232/218266573-1c946e79-3f47-4f72-bc5f-2747d8efefba.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
