### PR TITLE
Fix windows rebuilding without any changes

### DIFF
--- a/crates/re_renderer/build.rs
+++ b/crates/re_renderer/build.rs
@@ -20,9 +20,10 @@ use walkdir::{DirEntry, WalkDir};
 // Mapping to cargo:rerun-if-changed with glob support
 fn rerun_if_changed(path: &str) {
     // Workaround for windows verbatim paths not working with glob.
-    // https://github.com/rust-lang/glob/issues/111
+    // Issue: https://github.com/rust-lang/glob/issues/111
+    // Fix: https://github.com/rust-lang/glob/pull/112
     // Fixed on upstream, but no release containing the fix as of writing.
-    let path = path.trim_start_matches("\\\\?\\");
+    let path = path.trim_start_matches(r"\\?\");
 
     for path in glob::glob(path).unwrap() {
         println!("cargo:rerun-if-changed={}", path.unwrap().to_string_lossy());

--- a/crates/re_web_server/build.rs
+++ b/crates/re_web_server/build.rs
@@ -11,9 +11,10 @@ use std::{
 // Mapping to cargo:rerun-if-changed with glob support
 fn rerun_if_changed(path: &str) {
     // Workaround for windows verbatim paths not working with glob.
-    // https://github.com/rust-lang/glob/issues/111
+    // Issue: https://github.com/rust-lang/glob/issues/111
+    // Fix: https://github.com/rust-lang/glob/pull/112
     // Fixed on upstream, but no release containing the fix as of writing.
-    let path = path.trim_start_matches("\\\\?\\");
+    let path = path.trim_start_matches(r"\\?\");
 
     for path in glob::glob(path).unwrap() {
         println!("cargo:rerun-if-changed={}", path.unwrap().to_string_lossy());


### PR DESCRIPTION
This is caused by `glob` not supporting verbatim windows paths. This PR works around this by "de-verbatizing" paths with a hack.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
