### PR TITLE
Fix wrong image path in the colmap example

### DIFF
--- a/examples/colmap/main.py
+++ b/examples/colmap/main.py
@@ -165,7 +165,7 @@ def read_and_log_sparse_reconstruction(
             _, encimg = cv2.imencode(".jpg", img)
             rr.log_image_file("camera/image", img_bytes=encimg)
         else:
-            rr.log_image_file("camera/image/rgb", img_path=dataset_path / "images" / image.name)
+            rr.log_image_file("camera/image", img_path=dataset_path / "images" / image.name)
 
         rr.log_points("camera/image/keypoints", visible_xys, colors=point_colors)
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3312232/218271809-8a7e868e-cd87-4bcc-a212-c4276e825f87.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
