### PR TITLE
Revert "Disable picking in spatial scenes while dragging"

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -343,12 +343,7 @@ fn view_2d_scrollable(
 
     // Check if we're hovering any hover primitive.
     let mut depth_at_pointer = None;
-
-    // No hover effect when user is dragging something (e.g. rotating the camera)
-    let is_anything_being_dragged = parent_ui
-        .ctx()
-        .memory(|mem| mem.is_anything_being_dragged());
-    if let (false, Some(pointer_pos_ui)) = (is_anything_being_dragged, response.hover_pos()) {
+    if let Some(pointer_pos_ui) = response.hover_pos() {
         let pointer_pos_space = space_from_ui.transform_pos(pointer_pos_ui);
         let hover_radius = space_from_ui.scale().y * 5.0; // TODO(emilk): from egui?
         let picking_result = scene.picking(

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -296,9 +296,7 @@ pub fn view_3d(
     }
 
     // TODO(andreas): We're very close making the hover reaction of ui2d and ui3d the same. Finish the job!
-    // No hover effect when user is dragging something (e.g. rotating the camera)
-    let is_anything_being_dragged = ui.ctx().memory(|mem| mem.is_anything_being_dragged());
-    if let (false, Some(pointer_pos)) = (is_anything_being_dragged, response.hover_pos()) {
+    if let Some(pointer_pos) = response.hover_pos() {
         let picking_result =
             scene.picking(glam::vec2(pointer_pos.x, pointer_pos.y), &rect, &eye, 5.0);
 


### PR DESCRIPTION
This reverts commit 6900f9a22f04e6b9ed3de2af99ccd48202a7d739.
Re-opens https://github.com/rerun-io/rerun/issues/1185

Single click is already detected as drag. Filtering those out is not enough. Checking if camera pose has changed/was interacted with is also not great as it causes flickering

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
