### PR TITLE
Some small tweaks to the colmap example.

### DIFF
--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -140,8 +140,11 @@ def read_and_log_sparse_reconstruction(
 
         points = [point.xyz for point in visible_xyzs]
         point_colors = [point.rgb for point in visible_xyzs]
+        point_errors = [point.error for point in visible_xyzs]
 
-        rr.log_points("points", points, colors=point_colors)
+        rr.log_scalar("plot/average_reprojection_error", np.mean(point_errors), color=[240, 45, 58])
+
+        rr.log_points("points", points, colors=point_colors, ext={"error": point_errors})
 
         rr.log_rigid3(
             "camera",
@@ -165,7 +168,7 @@ def read_and_log_sparse_reconstruction(
         else:
             rr.log_image_file("camera/image", img_path=dataset_path / "images" / image.name)
 
-        rr.log_points("camera/image/keypoints", visible_xys, colors=point_colors)
+        rr.log_points("camera/image/keypoints", visible_xys, colors=[34, 138, 167])
 
 
 def main() -> None:


### PR DESCRIPTION
* Add user-component for error
* Make all 2d-keypoints a uniform color
* Add a plot of average reprojection error.

This gives us 3 space views with very reasonable default behavior for the viewer before we launch into making or editing space views.

![image](https://user-images.githubusercontent.com/3312232/218324674-a92200a7-74ec-4b04-b2f9-b0d256088f48.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
