### PR TITLE
Shorten 'average_reprojection_error' to keep the blueprint manageable

### DIFF
--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -142,7 +142,7 @@ def read_and_log_sparse_reconstruction(
         point_colors = [point.rgb for point in visible_xyzs]
         point_errors = [point.error for point in visible_xyzs]
 
-        rr.log_scalar("plot/average_reprojection_error", np.mean(point_errors), color=[240, 45, 58])
+        rr.log_scalar("plot/avg_reproj_err", np.mean(point_errors), color=[240, 45, 58])
 
         rr.log_points("points", points, colors=point_colors, ext={"error": point_errors})
 


### PR DESCRIPTION
The long title makes for quite a wide blueprint panel which can't be reduced at the moment.

Before;
![image](https://user-images.githubusercontent.com/3312232/218335944-1ffc6169-bb71-40e1-b2cd-c30e689a7cbf.png)

After:
![image](https://user-images.githubusercontent.com/3312232/218335916-334bdbfc-62a4-415a-8e86-5ff66a4650dd.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
