### PR TITLE
Always include the rerun_sdk in the python search path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,4 +56,7 @@
         "--message-format=json",
         "--all-targets"
     ],
+    "python.analysis.extraPaths": [
+        "rerun_py/rerun_sdk"
+    ],
 }


### PR DESCRIPTION
This is a partial solution for: https://github.com/rerun-io/rerun/issues/1243

Generally we always want intellisense for our own versions of the code within the editor, even if we've installed the rerun package into our pip environment.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
