### PR TITLE
Tweak colors of Python docs

### DIFF
--- a/rerun_py/docs/css/mkdocstrings.css
+++ b/rerun_py/docs/css/mkdocstrings.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;425;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap");
 
 /* Indentation. */
@@ -35,8 +35,12 @@ body {
 .md-typeset h1,
 .md-typeset h2 {
   margin-bottom: 1rem;
-  font-weight: 600;
+  font-weight: 700;
   color: inherit;
+}
+
+.md-typeset p + h1 {
+  margin-top: 2rem;
 }
 
 header {


### PR DESCRIPTION
Adds Rerun's fonts and tweaks the colors.

We can be even more granular down the road, but this little hack has a lot of impact in very few lines of code.

<img width="2035" alt="Bildschirm­foto 2023-02-14 um 11 32 59" src="https://user-images.githubusercontent.com/875708/218710866-ca8ee670-5605-4e52-a6fb-898808e359f5.png">

<img width="2036" alt="image" src="https://user-images.githubusercontent.com/875708/218711347-bbb943e8-8bfe-4a05-90c2-e0a5ed88559a.png">

