### PR TITLE
Python doc improvements

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -50,7 +50,12 @@ SECTION_TABLE: Final[List[Section]] = [
     Section(
         title="Initialization",
         module_summary=None,
-        func_list=["init", "set_recording_id", "connect", "spawn"],
+        func_list=["init", "connect", "disconnect", "spawn", "serve"],
+    ),
+    Section(
+        title="Viewer Control",
+        module_summary=None,
+        func_list=["set_recording_id", "save"],
     ),
     Section(
         title="Time",
@@ -101,7 +106,7 @@ SECTION_TABLE: Final[List[Section]] = [
     ),
     Section(
         title="Transforms",
-        module_summary=None,
+        module_summary="log.transform",
         func_list=["log_rigid3", "log_pinhole", "log_unknown_transform", "log_view_coordinates"],
     ),
     Section(
@@ -153,14 +158,12 @@ with mkdocs_gen_files.open(index_path, "w") as index_file:
 hide:
     - toc
 ---
-# Examples
-You can find examples on our GitHub [here](https://github.com/rerun-io/rerun/tree/latest/examples/python).
+# Getting Started
+* [Quick start](https://www.rerun.io/docs/getting-started/python)
+* [Tutorial](https://www.rerun.io/docs/getting-started/logging-python)
+* [Examples on Github](https://github.com/rerun-io/rerun/tree/latest/examples/python)
 
-# Troubleshooting
-You can set `RUST_LOG=debug` before running your Python script
-and/or `rerun` process to get some verbose logging output.
-
-# Common APIs
+# APIs
 """
     )
 
@@ -190,7 +193,19 @@ and/or `rerun` process to get some verbose logging output.
         for func_name in section.func_list:
             func = rerun_pkg[func_name]
             index_file.write(f"[`rerun.{func_name}()`]({md_name}#rerun.{func_name}) | {func.docstring.lines[0]}\n")
+
         index_file.write("\n")
+
+    index_file.write(
+        """
+# Troubleshooting
+You can set `RUST_LOG=debug` before running your Python script
+and/or `rerun` process to get some verbose logging output.
+
+If you run into any issues don't hesitate to [open a ticket](https://github.com/rerun-io/rerun/issues/new/choose)
+or [join our Discord](https://discord.gg/Gcm8BbTaAj).
+"""
+    )
 
 
 # Generate the SUMMARY.txt file

--- a/rerun_py/rerun_sdk/rerun/log/transform.py
+++ b/rerun_py/rerun_sdk/rerun/log/transform.py
@@ -1,3 +1,8 @@
+"""
+Methods for logging transforms on entity paths.
+
+Learn more about transforms [in the manual](https://www.rerun.io/docs/concepts/spaces-and-transforms)
+"""
 from typing import Optional, Tuple
 
 import numpy.typing as npt


### PR DESCRIPTION
missing functions from common_index, move troubleshoot section, add to it, more getting started links.

Wanted to add more docs like with `transform.py` but I'd need to move a few functions around for that and don't want to do that today, seems to be too risky to break stuff (at least links)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
