### PR TITLE
Increase image cache max size to 5 GB

### DIFF
--- a/crates/re_viewer/src/misc/caches/mod.rs
+++ b/crates/re_viewer/src/misc/caches/mod.rs
@@ -19,7 +19,9 @@ pub struct Caches {
 impl Caches {
     /// Call once per frame to potentially flush the cache(s).
     pub fn new_frame(&mut self) {
-        let max_image_cache_use = 5_000_000_000; // TODO(emilk): make configurable, and maybe a function of available+free RAM
+        // TODO(emilk): make max_image_cache_use configurable, and maybe a function of available VRAM
+        // Beware that a lof of people have very little VRAM: https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam
+        let max_image_cache_use = 2_000_000_000;
         self.image.new_frame(max_image_cache_use);
     }
 

--- a/crates/re_viewer/src/misc/caches/mod.rs
+++ b/crates/re_viewer/src/misc/caches/mod.rs
@@ -19,7 +19,7 @@ pub struct Caches {
 impl Caches {
     /// Call once per frame to potentially flush the cache(s).
     pub fn new_frame(&mut self) {
-        let max_image_cache_use = 1_000_000_000;
+        let max_image_cache_use = 5_000_000_000; // TODO(emilk): make configurable, and maybe a function of available+free RAM
         self.image.new_frame(max_image_cache_use);
     }
 


### PR DESCRIPTION
EDIT: I went to just 2GB.

# IGNORE THIS

This is just enough to fit default colmap images in cache :)

This means that opening colmap and hitting loop will stutter first play-through, then run smooth as butter.

Here's the memory use when looping colmap:

![image](https://user-images.githubusercontent.com/1148717/218753694-dd6dcb79-012e-4f20-9f35-2720360174d3.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
