### PR TITLE
fix timeline switch edge case

### DIFF
--- a/crates/re_viewer/src/misc/time_control.rs
+++ b/crates/re_viewer/src/misc/time_control.rs
@@ -127,9 +127,13 @@ impl TimeControl {
                 // then the user decides to switch timelines.
                 // When they do so, it might be the case that they switch to a timeline they've
                 // never interacted with before, in which case we don't even have a time state yet.
-                self.states
-                    .entry(self.timeline)
-                    .or_insert_with(|| TimeState::new(full_range.max));
+                self.states.entry(self.timeline).or_insert_with(|| {
+                    TimeState::new(if self.following {
+                        full_range.max
+                    } else {
+                        full_range.min
+                    })
+                });
             }
             PlayState::Playing => {
                 let dt = egui_ctx.input(|i| i.stable_dt).at_most(0.1) * self.speed;


### PR DESCRIPTION
Fixes https://github.com/rerun-io/rerun/issues/1259

[Kooha-2023-02-14-15-39-41.webm](https://user-images.githubusercontent.com/2910679/218770099-766f6daa-06ce-4f3b-9cd6-bc9603a72a68.webm)



Checklist:
- [x] reported `colmap` edge case now works
   - [x] switching during playback while live
   - [x] switching during playback while paused
   - [x] switching at end of playback