### PR TITLE
Prevent wrap on 'Streams' text

### DIFF
--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -210,9 +210,8 @@ impl TimePanel {
 
             let size = egui::vec2(self.prev_col_width, 28.0);
             ui.allocate_ui_with_layout(size, egui::Layout::top_down(egui::Align::LEFT), |ui| {
-                // Make sure the size is at least 60 to accommodate the "Streams" text
-                // so it doesn't end up wrapping
-                ui.set_min_size(size.max(egui::vec2(60., 28.0)));
+                ui.set_min_size(size);
+                ui.style_mut().wrap = Some(false);
                 ui.add_space(4.0); // hack to vertically center the text
                 ui.strong("Streams");
             })


### PR DESCRIPTION
@emilk is there a better way of doing this?

In any case this seems to work:
![image](https://user-images.githubusercontent.com/3312232/218872134-d5189535-4610-4b47-99f4-51c5da16a797.png)

![image](https://user-images.githubusercontent.com/3312232/218872172-66ec18e9-0618-4f59-bf18-63473cb4d4ab.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
