### PR TITLE
Update to eframe 0.21.3 with fix for web text input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727210e58c22f55f8be8f0409871d2e91ab32f743c98b1efd6a964fe138695d8"
+checksum = "3df3ce60931e5f2d83bab4484d1a283908534d5308cc6b0c5c22c59cd15ee7cc"
 dependencies = [
  "bytemuck",
  "directories-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }
 derive_more = "0.99"
 ecolor = "0.21.0"
-eframe = { version = "0.21.2", default-features = false }
+eframe = { version = "0.21.3", default-features = false }
 egui = "0.21.0"
 egui_dock = "0.4"
 egui_extras = "0.21.0"


### PR DESCRIPTION
It has this fix for inputting the letter "P" on the web 🤦‍♂️: https://github.com/emilk/egui/pull/2740

This is a safe update - nothing else has happened since eframe 0.21.2: https://github.com/emilk/egui/commits/master

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
