### PR TITLE
Print detailed version/build info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,6 +1923,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glam"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +2446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2633,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.14.2+1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2668,18 @@ checksum = "04d1c67deb83e6b75fa4fe3309e09cfeade12e7721d95322af500d3814ea60c9"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3130,6 +3199,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4454,6 +4532,7 @@ dependencies = [
  "re_viewer",
  "re_web_server",
  "re_ws_comms",
+ "shadow-rs",
  "tokio",
  "webbrowser",
 ]
@@ -4799,6 +4878,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.20.0"
+source = "git+https://github.com/rerun-io/shadow-rs?branch=john/fix_gen_docs#003186582e463bcbafc5fbfa9e21327acb1ca2c4"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time 0.3.17",
+ "tzdb",
 ]
 
 [[package]]
@@ -5191,6 +5282,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -5497,6 +5590,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b882d864be6a5d7c3c916719944458b1e03c85f86dbc825ec98155117c4408"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5586,6 +5698,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,6 @@ debug = true
 # If that is not possible, patch to a branch that has a PR open on the upstream repo.
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
+
+# Upstream PR https://github.com/baoyachi/shadow-rs/pull/128
+shadow-rs = { git = "https://github.com/rerun-io/shadow-rs", branch = "john/fix_gen_docs" }

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -66,6 +66,7 @@ crossbeam = "0.8"
 document-features = "0.2"
 egui = { workspace = true, default-features = false }
 puffin.workspace = true
+shadow-rs = "0.20"
 
 # Optional dependencies:
 re_analytics = { workspace = true, optional = true }
@@ -81,3 +82,6 @@ clap = { workspace = true, features = ["derive"] }
 mimalloc = "0.1.29"
 puffin_http = "0.11"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[build-dependencies]
+shadow-rs = "0.20"

--- a/crates/rerun/build.rs
+++ b/crates/rerun/build.rs
@@ -1,0 +1,3 @@
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -90,3 +90,5 @@ pub use run::{run, CallSource};
 // NOTE: Have a look at `re_sdk/src/lib.rs` for an accurate listing of all these symbols.
 #[cfg(feature = "sdk")]
 pub use re_sdk::*;
+
+shadow_rs::shadow!(build);

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -19,7 +19,7 @@ use clap::Subcommand;
 ///
 /// * `RERUN_TRACK_ALLOCATIONS`: track all allocations in order to find memory leaks in the viewer. WARNING: slows down the viewer by a lot!
 #[derive(Debug, clap::Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = crate::build::CLAP_LONG_VERSION, about)]
 struct Args {
     /// Either a path to a `.rrd` file to load, or a websocket url to a Rerun Server from which to read data
     ///

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Scientific/Engineering :: Visualization",
 ]
-dependencies = ["deprecated", "numpy>=1.23", "pyarrow==10.0.1"]
+dependencies = ["deprecated", "numpy>=1.23", "pyarrow==10.0.1", "semver>=2.13"]
 description = "The Rerun Logging SDK"
 keywords = ["computer-vision", "logging", "rerun"]
 name = "rerun-sdk"

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -1,10 +1,10 @@
 """The Rerun Python SDK, which is a wrapper around the re_sdk crate."""
 
 import atexit
-import semver
 from typing import Optional
 
 import rerun_bindings as bindings  # type: ignore[attr-defined]
+import semver
 from rerun.log import log_cleared
 from rerun.log.annotation import log_annotation_context
 from rerun.log.arrow import log_arrow

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -1,6 +1,7 @@
 """The Rerun Python SDK, which is a wrapper around the re_sdk crate."""
 
 import atexit
+import semver
 from typing import Optional
 
 import rerun_bindings as bindings  # type: ignore[attr-defined]
@@ -71,6 +72,19 @@ def unregister_shutdown() -> None:
 
 
 # -----------------------------------------------------------------------------
+
+
+def get_version() -> semver.VersionInfo:
+    """
+    Get the version of the Rerun SDK.
+
+    Returns
+    -------
+    semver.VersionInfo
+        The version of the Rerun SDK.
+
+    """
+    return semver.parse_version_info(bindings.get_version())
 
 
 def get_recording_id() -> str:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -92,6 +92,7 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     global_session().set_recording_id(default_recording_id(py));
 
     m.add_function(wrap_pyfunction!(main, m)?)?;
+    m.add_function(wrap_pyfunction!(get_version, m)?)?;
 
     m.add_function(wrap_pyfunction!(get_registered_component_names, m)?)?;
 
@@ -209,6 +210,11 @@ fn main(argv: Vec<String>) -> PyResult<u8> {
         .unwrap()
         .block_on(rerun::run(rerun::CallSource::Python, argv))
         .map_err(|err| PyRuntimeError::new_err(re_error::format(err)))
+}
+
+#[pyfunction]
+fn get_version() -> &'static str {
+    rerun::build::PKG_VERSION
 }
 
 #[pyfunction]


### PR DESCRIPTION
* Output detailed version/build info with `--version` flag on entrypoints.
* Add `get_version()` Python API

```py
In [1]: import rerun as rr
DEV ENVIRONMENT DETECTED! Re-importing rerun from: /Users/john/Source/rerun/rerun_py/rerun_sdk

In [2]: rr.get_version()
Out[2]: VersionInfo(major=0, minor=2, patch=0, prerelease=None, build='3a03da72.1')
```

```sh
> rerun --version
rerun 0.2.0+3a03da72.1
branch:1310-add-commit-hash-and-date-to-version-numbers-add-both-to-gui
commit_hash:3a03da72
build_time:2023-02-15 11:59:35 +01:00
build_env:rustc 1.67.0 (fc594f156 2023-01-24),1.67-aarch64-apple-darwin
```

Upstream PR on `shadow-rs`: https://github.com/baoyachi/shadow-rs/pull/128

Closes #1310

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)