### PR TITLE
Allow controlling the graphics backend & power preference through standard wgpu env vars

### DIFF
--- a/crates/re_renderer/src/config.rs
+++ b/crates/re_renderer/src/config.rs
@@ -90,14 +90,22 @@ pub struct RenderContextConfig {
 ///
 /// Other backend might work as well, but lack of support isn't regarded as a bug.
 pub fn supported_backends() -> wgpu::Backends {
-    // Native - we primarily test Vulkan & Metal
-    // DX12 is added since as of writing some Windows VMs provide DX12 but no Vulkan drivers.
-    // We want to keep this list small in order to keep variance low!
+    // Native.
     #[cfg(not(target_arch = "wasm32"))]
     {
-        wgpu::Backends::VULKAN | wgpu::Backends::DX12 | wgpu::Backends::METAL
+        // We primarily test Vulkan & Metal!
+        // Ideally we'd only have these two in order to keep our variance low.
+        wgpu::Backends::VULKAN | wgpu::Backends::METAL |
+
+        // DX12 is added since, as of writing some Windows VMs provide DX12 but no Vulkan drivers.
+        // (this has been observed with Parallels on Apple Silicon)
+        // Having this in means that wgpu will pick DX12 over Vulkan.
+        wgpu::Backends::DX12 |
+
+        // Add GL as a fallback to try when there is something wrong with Vulkan.
+        wgpu::Backends::GL
     }
-    // Web - we support only WebGL right now!
+    // Web - we support only WebGL right now, WebGPU should work but hasn't been tested.
     #[cfg(target_arch = "wasm32")]
     {
         wgpu::Backends::GL

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -96,6 +96,8 @@ pub(crate) fn wgpu_options() -> egui_wgpu::WgpuConfiguration {
             }),
             backends: re_renderer::config::supported_backends(),
             device_descriptor: crate::hardware_tier().device_descriptor(),
+            // TODO(andreas): This should be the default for egui-wgpu.
+            power_preference: wgpu::util::power_preference_from_env().unwrap_or(wgpu::PowerPreference::HighPerformance),
             ..Default::default()
         }
 }


### PR DESCRIPTION
Didn't realize that these env-vars are opt-ins from `wgpu::util` (kinda makes sense thinking about it!)
This might help us with troubleshooting in tickets like #1324

Depicted is my Ubuntu vm running with GL - note how this completely meses up gamma handling -.-
![image](https://user-images.githubusercontent.com/1220815/219425135-d54ac33e-7967-43be-bd80-f97ba7796e1f.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
