### PR TITLE
Detailed errors for `include_file!`

### DIFF
--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -22,7 +22,7 @@ macro_rules! include_file {
 
             use anyhow::Context as _;
             $crate::FileServer::get_mut(|fs| fs.watch(&mut resolver, &file_path, false))
-                .with_context(|| format!("include_file!({}) failed while trying to import physical path {file_path:?}", $path))
+                .with_context(|| format!("include_file!({}) (rooted at {:?}) failed while trying to import physical path {file_path:?}", $path, file!()))
                 .unwrap()
         }
 
@@ -65,7 +65,7 @@ macro_rules! include_file {
             // and canonicalize it.
             use anyhow::Context as _;
             $crate::get_filesystem().canonicalize(&path)
-                .with_context(|| format!("include_file!({}) failed while trying to import virtual path {path:?}", $path))
+                .with_context(|| format!("include_file!({}) (rooted at {:?}) failed while trying to import virtual path {path:?}", $path, file!()))
                 .unwrap()
         }
     }};

--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -20,7 +20,10 @@ macro_rules! include_file {
                 .unwrap()
                 .join($path);
 
-            $crate::FileServer::get_mut(|fs| fs.watch(&mut resolver, &file_path, false)).unwrap()
+            use anyhow::Context as _;
+            $crate::FileServer::get_mut(|fs| fs.watch(&mut resolver, &file_path, false))
+                .with_context(|| format!("include_file!({}) failed while trying to import physical path {file_path:?}", $path))
+                .unwrap()
         }
 
         #[cfg(not(all(not(target_arch = "wasm32"), debug_assertions)))] // otherwise
@@ -60,7 +63,9 @@ macro_rules! include_file {
             //
             // Therefore, the in-memory filesystem will actually be able to find this path,
             // and canonicalize it.
-            $crate::get_filesystem().canonicalize(&path).unwrap()
+            $crate::get_filesystem().canonicalize(&path)
+                .with_context(|| format!("include_file!({}) failed while trying to import virtual path {path:?}", $path))
+                .unwrap()
         }
     }};
 }

--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -63,6 +63,7 @@ macro_rules! include_file {
             //
             // Therefore, the in-memory filesystem will actually be able to find this path,
             // and canonicalize it.
+            use anyhow::Context as _;
             $crate::get_filesystem().canonicalize(&path)
                 .with_context(|| format!("include_file!({}) failed while trying to import virtual path {path:?}", $path))
                 .unwrap()


### PR DESCRIPTION
Fixes #1322.

Before:
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)', crates/re_renderer/src/renderer/mesh_renderer.rs:286:25
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
[...]
```

After:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: include_file!(../../shader/instanced_mesh.wgsl) (rooted at "crates/re_renderer/src/renderer/mesh_renderer.rs") failed while trying to import physical path "crates/re_renderer/src/renderer/../../shader/instanced_mesh.wgsl"

Caused by:
    No such file or directory (os error 2)', crates/re_renderer/src/renderer/mesh_renderer.rs:286:25
stack backtrace:
   0: rust_begin_unwind
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
[...]
```