### PR TITLE
Better time axis on plot view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Rerun changelog
 
+
+## Unreleased
+
+* 2023-02-19: Improve display of date-times in plots [#1356](https://github.com/rerun-io/rerun/pull/1356).
+
+
+## Pre-release
+
 A rough time-line of major user-facing things added, removed and changed. Newest on top.
 
 * 2023-02-10: Add the ability to globally override logging-enabled with new env-var RERUN. [#1186](https://github.com/rerun-io/rerun/pull/1186).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4235,6 +4235,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "bytemuck",
+ "chrono",
  "cocoa",
  "console_error_panic_hook",
  "ctrlc",

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -64,6 +64,7 @@ re_analytics = { workspace = true, optional = true }
 ahash = "0.8"
 anyhow.workspace = true
 bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
+chrono = "0.4"
 eframe = { workspace = true, default-features = false, features = [
   "default_fonts",
   "persistence",

--- a/crates/re_viewer/src/ui/view_time_series/scene.rs
+++ b/crates/re_viewer/src/ui/view_time_series/scene.rs
@@ -118,13 +118,15 @@ impl SceneTimeSeries {
                             .color(color.map(|c| c.to_array()).as_ref(), default_color);
                         let label = annotation_info.label(label.map(|l| l.into()).as_ref());
 
+                        const DEFAULT_RADIUS: f32 = 0.75;
+
                         points.push(PlotPoint {
                             time: time.unwrap().as_i64(), // scalars cannot be timeless
                             value: scalar.into(),
                             attrs: PlotPointAttrs {
                                 label,
                                 color,
-                                radius: radius.map_or(1.0, |r| r.into()),
+                                radius: radius.map_or(DEFAULT_RADIUS, |r| r.into()),
                                 scattered: props.map_or(false, |props| props.scattered),
                             },
                         });
@@ -169,7 +171,7 @@ impl SceneTimeSeries {
         let mut line: PlotSeries = PlotSeries {
             label: line_label.to_owned(),
             color: attrs.color,
-            width: attrs.radius,
+            width: 2.0 * attrs.radius,
             kind: if attrs.scattered {
                 PlotSeriesKind::Scatter
             } else {
@@ -199,7 +201,7 @@ impl SceneTimeSeries {
                     PlotSeries {
                         label: line_label.to_owned(),
                         color: attrs.color,
-                        width: attrs.radius,
+                        width: 2.0 * attrs.radius,
                         kind,
                         points: Vec::with_capacity(num_points - i),
                     },

--- a/crates/re_viewer/src/ui/view_time_series/ui.rs
+++ b/crates/re_viewer/src/ui/view_time_series/ui.rs
@@ -162,7 +162,7 @@ fn format_time(time_type: TimeType, time_int: i64) -> String {
                     } else if is_whole_second {
                         return datetime.time().format("%H:%M:%SZ").to_string();
                     } else {
-                        return datetime.time().format("%H:%M:%S.3fZ").to_string();
+                        return datetime.time().format("%H:%M:%S%.3fZ").to_string();
                     }
                 }
             }


### PR DESCRIPTION
This introduces proper grid spacing for time-series, with tick-marks every:

* 24h 
* 12h
* 1h
* 10m
* 1m
* 10s
* 1s

and then using 10x factor above and below that.

It also formats the datetimes better, showing only the date at midnight, and only the time elsewhere. It also cuts out seconds and milliseconds intelligently.

### Before:
![image](https://user-images.githubusercontent.com/1148717/219937989-3852173e-2c72-49a0-9592-ceec99c6affe.png)

### After:
![image](https://user-images.githubusercontent.com/1148717/219938737-8d57ea2f-2edd-4923-9c68-fdb1995ec6fb.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
