### PR TITLE
Texture & buffer call now `destroy` on removal from pool

### DIFF
--- a/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
@@ -185,7 +185,7 @@ impl GpuBindGroupPool {
         _buffers: &mut GpuBufferPool,
         _samplers: &mut GpuSamplerPool,
     ) {
-        self.pool.frame_maintenance(frame_index);
+        self.pool.frame_maintenance(frame_index, |_res| {});
         // TODO(andreas): Update usage counter on dependent resources.
     }
 

--- a/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
@@ -56,7 +56,8 @@ impl GpuBufferPool {
 
     /// Called by `RenderContext` every frame. Updates statistics and may free unused buffers.
     pub fn frame_maintenance(&mut self, frame_index: u64) {
-        self.pool.frame_maintenance(frame_index);
+        self.pool
+            .frame_maintenance(frame_index, |res| res.destroy());
     }
 
     /// Takes strong buffer handle to ensure the user is still holding on to the buffer.

--- a/crates/re_renderer/src/wgpu_resources/texture_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/texture_pool.rs
@@ -99,7 +99,8 @@ impl GpuTexturePool {
 
     /// Called by `RenderContext` every frame. Updates statistics and may free unused textures.
     pub fn frame_maintenance(&mut self, frame_index: u64) {
-        self.pool.frame_maintenance(frame_index);
+        self.pool
+            .frame_maintenance(frame_index, |res| res.texture.destroy());
     }
 
     /// Takes strong texture handle to ensure the user is still holding on to the texture.


### PR DESCRIPTION
From WebGPU Spec:

>An application that no longer requires a [GPUTexture](https://www.w3.org/TR/webgpu/#gputexture) can choose to lose access to it before garbage collection by calling [destroy()](https://www.w3.org/TR/webgpu/#dom-gputexture-destroy).
Note: This allows the user agent to reclaim the GPU memory associated with the [GPUTexture](https://www.w3.org/TR/webgpu/#gputexture) once all previously submitted operations using it are complete.

(https://www.w3.org/TR/webgpu/#dom-gputexture-destroy)
(similiar for Buffer https://www.w3.org/TR/webgpu/#buffer-destruction)


Fixes #592

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)
