### PR TITLE
Rename all instances of `frame_maintenance` to `begin_frame`

### DIFF
--- a/crates/re_renderer/examples/framework.rs
+++ b/crates/re_renderer/examples/framework.rs
@@ -207,7 +207,7 @@ impl<E: Example + 'static> Application<E> {
                     self.window.request_redraw();
                 }
                 Event::RedrawRequested(_) => {
-                    self.re_ctx.frame_maintenance();
+                    self.re_ctx.begin_frame();
 
                     // native debug build
                     #[cfg(all(not(target_arch = "wasm32"), debug_assertions))]

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -161,11 +161,11 @@ impl RenderContext {
     /// Call this at the beginning of a new frame.
     ///
     /// Updates internal book-keeping, frame allocators and executes delayed events like shader reloading.
-    pub fn frame_maintenance(&mut self) {
+    pub fn begin_frame(&mut self) {
         self.frame_index += 1;
 
         // Tick the error tracker so that it knows when to reset!
-        // Note that we're ticking on frame_maintenance rather than raw frames, which
+        // Note that we're ticking on begin_frame rather than raw frames, which
         // makes a world of difference when we're in a poisoned state.
         #[cfg(all(not(target_arch = "wasm32"), debug_assertions))] // native debug build
         self.err_tracker.tick();
@@ -178,8 +178,8 @@ impl RenderContext {
             re_log::debug!(?modified_paths, "got some filesystem events");
         }
 
-        self.mesh_manager.frame_maintenance(self.frame_index);
-        self.texture_manager_2d.frame_maintenance(self.frame_index);
+        self.mesh_manager.begin_frame(self.frame_index);
+        self.texture_manager_2d.begin_frame(self.frame_index);
 
         {
             let WgpuResourcePools {
@@ -195,13 +195,13 @@ impl RenderContext {
 
             // Shader module maintenance must come before render pipelines because render pipeline
             // recompilation picks up all shaders that have been recompiled this frame.
-            shader_modules.frame_maintenance(
+            shader_modules.begin_frame(
                 &self.device,
                 &mut self.resolver,
                 self.frame_index,
                 &modified_paths,
             );
-            render_pipelines.frame_maintenance(
+            render_pipelines.begin_frame(
                 &self.device,
                 self.frame_index,
                 shader_modules,
@@ -210,14 +210,14 @@ impl RenderContext {
 
             // Bind group maintenance must come before texture/buffer maintenance since it
             // registers texture/buffer use
-            bind_groups.frame_maintenance(self.frame_index, textures, buffers, samplers);
+            bind_groups.begin_frame(self.frame_index, textures, buffers, samplers);
 
-            textures.frame_maintenance(self.frame_index);
-            buffers.frame_maintenance(self.frame_index);
+            textures.begin_frame(self.frame_index);
+            buffers.begin_frame(self.frame_index);
 
-            pipeline_layouts.frame_maintenance(self.frame_index);
-            bind_group_layouts.frame_maintenance(self.frame_index);
-            samplers.frame_maintenance(self.frame_index);
+            pipeline_layouts.begin_frame(self.frame_index);
+            bind_group_layouts.begin_frame(self.frame_index);
+            samplers.begin_frame(self.frame_index);
         }
     }
 }

--- a/crates/re_renderer/src/error_tracker.rs
+++ b/crates/re_renderer/src/error_tracker.rs
@@ -266,7 +266,7 @@ impl ErrorTracker {
     /// Logs a wgpu error, making sure to deduplicate them as needed.
     pub fn handle_error(&self, error: wgpu::Error) {
         // The pipeline is in a poisoned state, errors are still coming in: we won't be
-        // clearing the tracker until it had at least 2 complete frame_maintenance cycles
+        // clearing the tracker until it had at least 2 complete begin_frame cycles
         // without any errors (meaning the swapchain surface is stabilized).
         self.clear_countdown.store(3, Ordering::Relaxed);
 

--- a/crates/re_renderer/src/resource_managers/mesh_manager.rs
+++ b/crates/re_renderer/src/resource_managers/mesh_manager.rs
@@ -64,7 +64,7 @@ impl MeshManager {
         self.manager.get(handle)
     }
 
-    pub(crate) fn frame_maintenance(&mut self, frame_index: u64) {
-        self.manager.frame_maintenance(frame_index);
+    pub(crate) fn begin_frame(&mut self, frame_index: u64) {
+        self.manager.begin_frame(frame_index);
     }
 }

--- a/crates/re_renderer/src/resource_managers/resource_manager.rs
+++ b/crates/re_renderer/src/resource_managers/resource_manager.rs
@@ -153,7 +153,7 @@ where
         }
     }
 
-    pub(crate) fn frame_maintenance(&mut self, frame_index: u64) {
+    pub(crate) fn begin_frame(&mut self, frame_index: u64) {
         // Kill single frame resources.
         self.single_frame_resources.clear();
 

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -193,7 +193,7 @@ impl TextureManager2D {
     }
 
     #[allow(clippy::unused_self)]
-    pub(crate) fn frame_maintenance(&mut self, _frame_index: u64) {
+    pub(crate) fn begin_frame(&mut self, _frame_index: u64) {
         // no-op.
         // In the future we might add handling of background processing or introduce frame-lived textures.
     }

--- a/crates/re_renderer/src/wgpu_resources/bind_group_layout_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_layout_pool.rs
@@ -37,7 +37,7 @@ impl GpuBindGroupLayoutPool {
         self.pool.get_resource(handle)
     }
 
-    pub fn frame_maintenance(&mut self, frame_index: u64) {
+    pub fn begin_frame(&mut self, frame_index: u64) {
         self.pool.current_frame_index = frame_index;
     }
 

--- a/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
@@ -178,14 +178,14 @@ impl GpuBindGroupPool {
         }
     }
 
-    pub fn frame_maintenance(
+    pub fn begin_frame(
         &mut self,
         frame_index: u64,
         _textures: &mut GpuTexturePool,
         _buffers: &mut GpuBufferPool,
         _samplers: &mut GpuSamplerPool,
     ) {
-        self.pool.frame_maintenance(frame_index);
+        self.pool.begin_frame(frame_index);
         // TODO(andreas): Update usage counter on dependent resources.
     }
 

--- a/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
@@ -55,8 +55,8 @@ impl GpuBufferPool {
     }
 
     /// Called by `RenderContext` every frame. Updates statistics and may free unused buffers.
-    pub fn frame_maintenance(&mut self, frame_index: u64) {
-        self.pool.frame_maintenance(frame_index);
+    pub fn begin_frame(&mut self, frame_index: u64) {
+        self.pool.begin_frame(frame_index);
     }
 
     /// Takes strong buffer handle to ensure the user is still holding on to the buffer.

--- a/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
@@ -54,7 +54,7 @@ impl GpuPipelineLayoutPool {
         self.pool.get_resource(handle)
     }
 
-    pub fn frame_maintenance(&mut self, frame_index: u64) {
+    pub fn begin_frame(&mut self, frame_index: u64) {
         self.pool.current_frame_index = frame_index;
     }
 

--- a/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
@@ -154,7 +154,7 @@ impl GpuRenderPipelinePool {
         })
     }
 
-    pub fn frame_maintenance(
+    pub fn begin_frame(
         &mut self,
         device: &wgpu::Device,
         frame_index: u64,
@@ -179,7 +179,7 @@ impl GpuRenderPipelinePool {
             // The frame counter just got bumped by one. So any shader that has `frame_created`,
             // equal the current frame now, must have been recompiled since the user didn't have a
             // chance yet to add new shaders for this frame!
-            // (note that this assumes that shader `frame_maintenance` happens before pipeline `frame_maintenance`)
+            // (note that this assumes that shader `begin_frame` happens before pipeline `begin_frame`)
             if frame_created < frame_index {
                 return None;
             }

--- a/crates/re_renderer/src/wgpu_resources/sampler_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/sampler_pool.rs
@@ -69,7 +69,7 @@ impl GpuSamplerPool {
         self.pool.get_resource(handle)
     }
 
-    pub fn frame_maintenance(&mut self, frame_index: u64) {
+    pub fn begin_frame(&mut self, frame_index: u64) {
         self.pool.current_frame_index = frame_index;
     }
 

--- a/crates/re_renderer/src/wgpu_resources/shader_module_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/shader_module_pool.rs
@@ -80,7 +80,7 @@ impl GpuShaderModulePool {
             .get_or_create(desc, |desc| desc.create_shader_module(device, resolver))
     }
 
-    pub fn frame_maintenance<Fs: FileSystem>(
+    pub fn begin_frame<Fs: FileSystem>(
         &mut self,
         device: &wgpu::Device,
         resolver: &mut FileResolver<Fs>,

--- a/crates/re_renderer/src/wgpu_resources/texture_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/texture_pool.rs
@@ -98,8 +98,8 @@ impl GpuTexturePool {
     }
 
     /// Called by `RenderContext` every frame. Updates statistics and may free unused textures.
-    pub fn frame_maintenance(&mut self, frame_index: u64) {
-        self.pool.frame_maintenance(frame_index);
+    pub fn begin_frame(&mut self, frame_index: u64) {
+        self.pool.begin_frame(frame_index);
     }
 
     /// Takes strong texture handle to ensure the user is still holding on to the texture.

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -441,7 +441,7 @@ impl eframe::App for App {
                 .paint_callback_resources
                 .get::<re_renderer::RenderContext>()
                 .unwrap();
-            // Query statistics before frame_maintenance as this might be more accurate if there's resources that we recreate every frame.
+            // Query statistics before begin_frame as this might be more accurate if there's resources that we recreate every frame.
             render_ctx.gpu_resources.statistics()
         };
 
@@ -504,7 +504,7 @@ impl eframe::App for App {
                         .paint_callback_resources
                         .get_mut::<re_renderer::RenderContext>()
                         .unwrap();
-                    render_ctx.frame_maintenance();
+                    render_ctx.begin_frame();
 
                     if log_db.is_empty() {
                         wait_screen_ui(ui, &self.rx);


### PR DESCRIPTION
Comments already indicated that it should be called at the beginning of a frame!

This is a pure search & replace PR.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
