### PR TITLE
Faster stable diffusion

### DIFF
--- a/examples/python/stable_diffusion/main.py
+++ b/examples/python/stable_diffusion/main.py
@@ -101,7 +101,7 @@ usually at the expense of lower image quality.
     parser.add_argument(
         "--num_inference_steps",
         type=int,
-        default=50,
+        default=10,
         help="""
 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
 expense of slower inference. This parameter will be modulated by `strength`.

--- a/examples/python/stable_diffusion/main.py
+++ b/examples/python/stable_diffusion/main.py
@@ -54,9 +54,9 @@ def run_stable_diffusion(
     pipe(
         prompt=prompt,
         strength=strength,
-        guidance_scale=11,
+        guidance_scale=guidance_scale,
         negative_prompt=n_prompt,
-        num_inference_steps=70,
+        num_inference_steps=num_inference_steps,
         image=image,
     )
 
@@ -118,7 +118,7 @@ be maximum and the denoising process will run for the full number of iterations 
     parser.add_argument(
         "--guidance_scale",
         type=float,
-        default=8,
+        default=11,
         help="""
 Guidance scale as defined in [Classifier-Free Diffusion Guidance](https://arxiv.org/abs/2207.12598).
 `guidance_scale` is defined as `w` of equation 2. of [Imagen


### PR DESCRIPTION
The `stable_diffusion` example had a bug that caused two parameters to be hard-coded (`guidance_scale` and `num_inference_steps`, even though there were arguments to ostensibly set these.

`num_inference_steps` was hard-coded to 70, which means the example takes a looooong time to run on the CPU. This in-particular would grind `just py-run-all` to a half during testing.

I fixed the bugs, simplified the code, and lowered `num_inference_steps` to 10. The result is quite noisy, but serviceable, and users can (now) control it with `--num_inference_steps`.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
