### PR TITLE
Fix precision issue when zooming in on the timeline

### DIFF
--- a/crates/re_log_types/src/time_range.rs
+++ b/crates/re_log_types/src/time_range.rs
@@ -91,16 +91,16 @@ impl TimeRangeF {
     /// Where in the range is this value? Returns 0-1 if within the range.
     ///
     /// Returns <0 if before and >1 if after.
-    pub fn inverse_lerp(&self, value: TimeReal) -> f32 {
+    pub fn inverse_lerp(&self, value: TimeReal) -> f64 {
         if self.min == self.max {
             0.5
         } else {
-            (value - self.min).as_f32() / (self.max - self.min).as_f32()
+            (value - self.min).as_f64() / (self.max - self.min).as_f64()
         }
     }
 
-    pub fn lerp(&self, t: f32) -> TimeReal {
-        self.min + (self.max - self.min) * t as f64
+    pub fn lerp(&self, t: f64) -> TimeReal {
+        self.min + (self.max - self.min) * t
     }
 
     #[inline]

--- a/crates/re_viewer/src/ui/time_panel/paint_ticks.rs
+++ b/crates/re_viewer/src/ui/time_panel/paint_ticks.rs
@@ -14,31 +14,34 @@ pub fn paint_time_ranges_and_ticks(
     time_type: TimeType,
 ) {
     let clip_rect = ui.clip_rect();
+    let clip_left = clip_rect.left() as f64;
+    let clip_right = clip_rect.right() as f64;
 
     for segment in &time_ranges_ui.segments {
         let mut x_range = segment.x.clone();
         let mut time_range = segment.time;
 
         // Cull:
-        if *x_range.end() < clip_rect.left() {
+        if *x_range.end() < clip_left {
             continue;
         }
-        if clip_rect.right() < *x_range.start() {
+        if clip_right < *x_range.start() {
             continue;
         }
 
         // Clamp segment to the visible portion to save CPU when zoomed in:
-        let left_t = egui::emath::inverse_lerp(x_range.clone(), clip_rect.left()).unwrap_or(0.5);
+        let left_t = egui::emath::inverse_lerp(x_range.clone(), clip_left).unwrap_or(0.5);
         if 0.0 < left_t && left_t < 1.0 {
-            x_range = clip_rect.left()..=*x_range.end();
+            x_range = clip_left..=*x_range.end();
             time_range = TimeRangeF::new(time_range.lerp(left_t), time_range.max);
         }
-        let right_t = egui::emath::inverse_lerp(x_range.clone(), clip_rect.right()).unwrap_or(0.5);
+        let right_t = egui::emath::inverse_lerp(x_range.clone(), clip_right).unwrap_or(0.5);
         if 0.0 < right_t && right_t < 1.0 {
-            x_range = *x_range.start()..=clip_rect.right();
+            x_range = *x_range.start()..=clip_right;
             time_range = TimeRangeF::new(time_range.min, time_range.lerp(right_t));
         }
 
+        let x_range = (*x_range.start() as f32)..=(*x_range.end() as f32);
         let rect = Rect::from_x_y_ranges(x_range, line_y_range.clone());
         time_area_painter
             .with_clip_rect(rect)

--- a/crates/re_viewer/src/ui/time_panel/time_selection_ui.rs
+++ b/crates/re_viewer/src/ui/time_panel/time_selection_ui.rs
@@ -53,7 +53,8 @@ pub fn loop_selection_ui(
 
         if let (Some(min_x), Some(max_x)) = (min_x, max_x) {
             // The top part only
-            let mut rect = Rect::from_x_y_ranges(min_x..=max_x, timeline_rect.y_range());
+            let mut rect =
+                Rect::from_x_y_ranges((min_x as f32)..=(max_x as f32), timeline_rect.y_range());
 
             // Make sure it is visible:
             if rect.width() < 2.0 {
@@ -151,7 +152,7 @@ pub fn loop_selection_ui(
             && !is_anything_being_dragged
             && ui.input(|i| i.pointer.primary_down() && i.modifiers.shift_only())
         {
-            if let Some(time) = time_ranges_ui.time_from_x(pointer_pos.x) {
+            if let Some(time) = time_ranges_ui.time_from_x_f32(pointer_pos.x) {
                 time_ctrl.set_loop_selection(TimeRangeF::point(time));
                 time_ctrl.set_looping(Looping::Selection);
                 ui.memory_mut(|mem| mem.set_dragged_id(right_edge_id));
@@ -214,8 +215,8 @@ fn drag_right_loop_selection_edge(
     let pointer_pos = ui.input(|i| i.pointer.hover_pos())?;
     let aim_radius = ui.input(|i| i.aim_radius());
 
-    let time_low = time_ranges_ui.time_from_x(pointer_pos.x - aim_radius)?;
-    let time_high = time_ranges_ui.time_from_x(pointer_pos.x + aim_radius)?;
+    let time_low = time_ranges_ui.time_from_x_f32(pointer_pos.x - aim_radius)?;
+    let time_high = time_ranges_ui.time_from_x_f32(pointer_pos.x + aim_radius)?;
 
     // TODO(emilk): snap to absolute time too
     let low_length = selected_range.max - time_low;
@@ -242,8 +243,8 @@ fn drag_left_loop_selection_edge(
     let pointer_pos = ui.input(|i| i.pointer.hover_pos())?;
     let aim_radius = ui.input(|i| i.aim_radius());
 
-    let time_low = time_ranges_ui.time_from_x(pointer_pos.x - aim_radius)?;
-    let time_high = time_ranges_ui.time_from_x(pointer_pos.x + aim_radius)?;
+    let time_low = time_ranges_ui.time_from_x_f32(pointer_pos.x - aim_radius)?;
+    let time_high = time_ranges_ui.time_from_x_f32(pointer_pos.x + aim_radius)?;
 
     // TODO(emilk): snap to absolute time too
     let low_length = time_low - selected_range.min;
@@ -267,11 +268,11 @@ fn on_drag_loop_selection(
 ) -> Option<()> {
     let pointer_delta = ui.input(|i| i.pointer.delta());
 
-    let min_x = time_ranges_ui.x_from_time(selected_range.min)? + pointer_delta.x;
-    let max_x = time_ranges_ui.x_from_time(selected_range.max)? + pointer_delta.x;
+    let min_x = time_ranges_ui.x_from_time_f32(selected_range.min)? + pointer_delta.x;
+    let max_x = time_ranges_ui.x_from_time_f32(selected_range.max)? + pointer_delta.x;
 
-    let min_time = time_ranges_ui.time_from_x(min_x)?;
-    let max_time = time_ranges_ui.time_from_x(max_x)?;
+    let min_time = time_ranges_ui.time_from_x_f32(min_x)?;
+    let max_time = time_ranges_ui.time_from_x_f32(max_x)?;
 
     let mut new_range = TimeRangeF::new(min_time, max_time);
 


### PR DESCRIPTION
Previously the view would become shaky and difficult to navigate as you zoomed closer and closer.

The fix: switch from f32 to f64.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
