### PR TITLE
Analytics: register SDK language and data source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,6 +3943,7 @@ dependencies = [
  "re_arrow_store",
  "re_log",
  "re_log_types",
+ "re_smart_channel",
  "re_string_interner",
  "serde",
  "thiserror",

--- a/crates/re_analytics/src/config_web.rs
+++ b/crates/re_analytics/src/config_web.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::todo, clippy::unused_self)]
+
 use std::collections::HashMap;
 
 use uuid::Uuid;

--- a/crates/re_analytics/src/pipeline_web.rs
+++ b/crates/re_analytics/src/pipeline_web.rs
@@ -1,3 +1,9 @@
+#![allow(
+    clippy::needless_pass_by_value,
+    clippy::unnecessary_wraps,
+    clippy::unused_self
+)]
+
 use std::time::Duration;
 
 use crate::{Config, Event, PostHogSink};

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -27,6 +27,7 @@ serde = ["dep:serde", "re_log_types/serde"]
 re_arrow_store.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
+re_smart_channel.workspace = true
 re_string_interner.workspace = true
 
 ahash = "0.8"

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -163,6 +163,10 @@ pub struct LogDb {
     /// that are created after they were logged.
     timeless_message_ids: Vec<MsgId>,
 
+    /// Set by whomever created this [`LogDb`].
+    pub data_source: Option<re_smart_channel::Source>,
+
+    /// Comes in a special message, [`LogMsg::BeginRecordingMsg`].
     recording_info: Option<RecordingInfo>,
 
     /// Where we store the entities.
@@ -266,6 +270,7 @@ impl LogDb {
             chronological_message_ids,
             log_messages,
             timeless_message_ids,
+            data_source: _,
             recording_info: _,
             entity_db,
         } = self;

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -170,7 +170,7 @@ fn test_encode_decode() {
             recording_id: crate::RecordingId::random(),
             is_official_example: true,
             started: Time::now(),
-            recording_source: crate::RecordingSource::PythonSdk,
+            recording_source: crate::RecordingSource::RustSdk,
         },
     })];
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -219,8 +219,13 @@ pub struct RecordingInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RecordingSource {
+    Unknown,
+
     /// The official Rerun Python Logging SDK
     PythonSdk,
+
+    /// The official Rerun Rust Logging SDK
+    RustSdk,
 
     /// Perhaps from some manual data ingestion?
     Other(String),
@@ -229,7 +234,9 @@ pub enum RecordingSource {
 impl std::fmt::Display for RecordingSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Unknown => "Unknown".fmt(f),
             Self::PythonSdk => "Python SDK".fmt(f),
+            Self::RustSdk => "Rust SDK".fmt(f),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes
         }
     }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -218,11 +218,39 @@ pub struct RecordingInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct PythonVersion {
+    /// e.g. 3
+    pub major: u8,
+
+    /// e.g. 11
+    pub minor: u8,
+
+    /// e.g. 0
+    pub patch: u8,
+
+    /// e.g. `a0` for alpha releases.
+    pub suffix: String,
+}
+
+impl std::fmt::Display for PythonVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            major,
+            minor,
+            patch,
+            suffix,
+        } = self;
+        write!(f, "{}.{}.{}{}", major, minor, patch, suffix)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RecordingSource {
     Unknown,
 
     /// The official Rerun Python Logging SDK
-    PythonSdk,
+    PythonSdk(PythonVersion),
 
     /// The official Rerun Rust Logging SDK
     RustSdk,
@@ -235,7 +263,7 @@ impl std::fmt::Display for RecordingSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Unknown => "Unknown".fmt(f),
-            Self::PythonSdk => "Python SDK".fmt(f),
+            Self::PythonSdk(version) => write!(f, "Python {version} SDK"),
             Self::RustSdk => "Rust SDK".fmt(f),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes
         }

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -395,8 +395,10 @@ impl Session {
 #[cfg(feature = "re_viewer")]
 impl Session {
     fn app_env(&self) -> re_viewer::AppEnvironment {
-        match self.recording_source {
-            RecordingSource::PythonSdk => re_viewer::AppEnvironment::PythonSdk,
+        match &self.recording_source {
+            RecordingSource::PythonSdk(python_version) => {
+                re_viewer::AppEnvironment::PythonSdk(python_version.clone())
+            }
             RecordingSource::Unknown | RecordingSource::RustSdk | RecordingSource::Other(_) => {
                 re_viewer::AppEnvironment::RustSdk
             }

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 
 use re_log_types::{
-    ApplicationId, BeginRecordingMsg, LogMsg, MsgId, PathOp, RecordingId, RecordingInfo, Time,
-    TimePoint,
+    ApplicationId, BeginRecordingMsg, LogMsg, MsgId, PathOp, RecordingId, RecordingInfo,
+    RecordingSource, Time, TimePoint,
 };
 
 /// This is the main object you need to create to use the Rerun SDK.
@@ -13,6 +13,8 @@ pub struct Session {
     /// Is this session enabled?
     /// If not, all calls into it are ignored!
     enabled: bool,
+
+    recording_source: RecordingSource,
 
     #[cfg(feature = "web")]
     tokio_rt: tokio::runtime::Runtime,
@@ -101,6 +103,8 @@ impl Session {
         Self {
             enabled,
 
+            recording_source: RecordingSource::RustSdk,
+
             #[cfg(feature = "web")]
             tokio_rt: tokio::runtime::Runtime::new().unwrap(),
 
@@ -155,6 +159,12 @@ impl Session {
             self.recording_id = Some(recording_id);
             self.has_sent_begin_recording_msg = false;
         }
+    }
+
+    /// Set where the recording is coming from.
+    /// The default is [`RecordingSource::RustSdk`].
+    pub fn set_recording_source(&mut self, recording_source: RecordingSource) {
+        self.recording_source = recording_source;
     }
 
     /// Send log data to a remote server.
@@ -317,7 +327,7 @@ impl Session {
                             recording_id,
                             is_official_example: self.is_official_example.unwrap_or_default(),
                             started: Time::now(),
-                            recording_source: re_log_types::RecordingSource::PythonSdk,
+                            recording_source: self.recording_source.clone(),
                         },
                     }
                     .into(),

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -100,16 +100,6 @@ impl App {
         storage: Option<&dyn eframe::Storage>,
         rx: Receiver<LogMsg>,
     ) -> Self {
-        Self::new(startup_options, re_ui, storage, rx, Default::default())
-    }
-
-    fn new(
-        startup_options: StartupOptions,
-        re_ui: re_ui::ReUi,
-        storage: Option<&dyn eframe::Storage>,
-        rx: Receiver<LogMsg>,
-        log_db: LogDb,
-    ) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         let ctrl_c = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -128,15 +118,9 @@ impl App {
             .expect("Error setting Ctrl-C handler");
         }
 
-        let mut state: AppState = storage
+        let state: AppState = storage
             .and_then(|storage| eframe::get_value(storage, eframe::APP_KEY))
             .unwrap_or_default();
-
-        let mut log_dbs = IntMap::default();
-        if !log_db.is_empty() {
-            state.selected_rec_id = log_db.recording_id();
-            log_dbs.insert(log_db.recording_id(), log_db);
-        }
 
         let analytics = ViewerAnalytics::new();
         analytics.on_viewer_started();
@@ -147,7 +131,7 @@ impl App {
             re_ui,
             component_ui_registry: Default::default(),
             rx,
-            log_dbs,
+            log_dbs: Default::default(),
             state,
             #[cfg(not(target_arch = "wasm32"))]
             ctrl_c,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -95,6 +95,7 @@ pub struct App {
 impl App {
     /// Create a viewer that receives new log messages over time
     pub fn from_receiver(
+        app_env: crate::AppEnvironment,
         startup_options: StartupOptions,
         re_ui: re_ui::ReUi,
         storage: Option<&dyn eframe::Storage>,
@@ -122,8 +123,8 @@ impl App {
             .and_then(|storage| eframe::get_value(storage, eframe::APP_KEY))
             .unwrap_or_default();
 
-        let analytics = ViewerAnalytics::new();
-        analytics.on_viewer_started();
+        let mut analytics = ViewerAnalytics::new();
+        analytics.on_viewer_started(app_env);
 
         Self {
             startup_options,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -597,8 +597,7 @@ impl App {
             if let LogMsg::BeginRecordingMsg(msg) = &msg {
                 re_log::debug!("Opening a new recording: {:?}", msg.info);
                 self.state.selected_rec_id = msg.info.recording_id;
-
-                self.analytics.on_open_recording(msg);
+                self.analytics.on_open_recording(&msg.info);
             }
 
             let log_db = self.log_dbs.entry(self.state.selected_rec_id).or_default();
@@ -732,6 +731,9 @@ impl App {
 
     fn show_log_db(&mut self, source: &re_smart_channel::Source, log_db: LogDb) {
         self.analytics.on_new_data_source(source);
+        if let Some(recording_info) = log_db.recording_info() {
+            self.analytics.on_open_recording(recording_info);
+        }
         self.state.selected_rec_id = log_db.recording_id();
         self.log_dbs.insert(log_db.recording_id(), log_db);
     }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -595,10 +595,10 @@ impl App {
 
         while let Ok(msg) = self.rx.try_recv() {
             if let LogMsg::BeginRecordingMsg(msg) = &msg {
-                re_log::debug!("Beginning a new recording: {:?}", msg.info);
+                re_log::debug!("Opening a new recording: {:?}", msg.info);
                 self.state.selected_rec_id = msg.info.recording_id;
 
-                self.analytics.on_new_recording(msg);
+                self.analytics.on_open_recording(msg);
             }
 
             let log_db = self.log_dbs.entry(self.state.selected_rec_id).or_default();

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -68,6 +68,21 @@ macro_rules! profile_scope {
 
 // ---------------------------------------------------------------------------
 
+/// Where is this App running in?
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AppEnvironment {
+    /// Created from the Rerun Python SDK.
+    PythonSdk,
+
+    /// Created from the Rerun Rust SDK.
+    RustSdk,
+
+    /// Running the Rust `rerun` binary from the CLI.
+    RerunCli,
+}
+
+// ---------------------------------------------------------------------------
+
 #[allow(dead_code)]
 const APPLICATION_NAME: &str = "Rerun Viewer";
 

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -13,6 +13,7 @@ mod viewer_analytics;
 
 pub use self::misc::color_map;
 pub(crate) use misc::{mesh_loader, Item, TimeControl, TimeView, ViewerContext};
+use re_log_types::PythonVersion;
 pub(crate) use ui::{event_log_view, memory_panel, selection_panel, time_panel, UiVerbosity};
 
 pub use app::{App, StartupOptions};
@@ -69,10 +70,10 @@ macro_rules! profile_scope {
 // ---------------------------------------------------------------------------
 
 /// Where is this App running in?
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AppEnvironment {
     /// Created from the Rerun Python SDK.
-    PythonSdk,
+    PythonSdk(PythonVersion),
 
     /// Created from the Rerun Rust SDK.
     RustSdk,

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -79,6 +79,9 @@ pub enum AppEnvironment {
 
     /// Running the Rust `rerun` binary from the CLI.
     RerunCli,
+
+    /// We are a web-viewer running in a browser as Wasm.
+    Web,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -40,6 +40,7 @@ pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
 }
 
 pub fn run_native_viewer_with_messages(
+    app_env: crate::AppEnvironment,
     startup_options: crate::StartupOptions,
     log_messages: Vec<LogMsg>,
 ) -> eframe::Result<()> {
@@ -49,6 +50,7 @@ pub fn run_native_viewer_with_messages(
     }
     run_native_app(Box::new(move |cc, re_ui| {
         Box::new(crate::App::from_receiver(
+            app_env,
             startup_options,
             re_ui,
             cc.storage,

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -60,7 +60,7 @@ impl RemoteViewerApp {
             .unwrap(); // TODO(emilk): handle error
 
         let app = crate::App::from_receiver(
-            self.app_env,
+            self.app_env.clone(),
             self.startup_options,
             self.re_ui.clone(),
             storage,

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -2,6 +2,7 @@ use crate::App;
 
 /// Connects to a server over `WebSockets`.
 pub struct RemoteViewerApp {
+    app_env: crate::AppEnvironment,
     startup_options: crate::StartupOptions,
     re_ui: re_ui::ReUi,
     /// The url of the remote server.
@@ -12,12 +13,14 @@ pub struct RemoteViewerApp {
 impl RemoteViewerApp {
     /// url to rerun server
     pub fn new(
+        app_env: crate::AppEnvironment,
         startup_options: crate::StartupOptions,
         re_ui: re_ui::ReUi,
         storage: Option<&dyn eframe::Storage>,
         url: String,
     ) -> Self {
         let mut slf = Self {
+            app_env,
             startup_options,
             re_ui,
             url,
@@ -56,7 +59,13 @@ impl RemoteViewerApp {
             })
             .unwrap(); // TODO(emilk): handle error
 
-        let app = crate::App::from_receiver(self.startup_options, self.re_ui.clone(), storage, rx);
+        let app = crate::App::from_receiver(
+            self.app_env,
+            self.startup_options,
+            self.re_ui.clone(),
+            storage,
+            rx,
+        );
 
         self.app = Some((connection, app));
     }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -97,28 +97,28 @@ impl ViewerAnalytics {
     }
 
     /// When we have loaded the start of a new recording.
-    pub fn on_open_recording(&mut self, msg: &re_log_types::BeginRecordingMsg) {
+    pub fn on_open_recording(&mut self, rec_info: &re_log_types::RecordingInfo) {
         // We hash the application_id and recording_id unless this is an official example.
         // That's because we want to be able to track which are the popular examples,
         // but we don't want to collect actual application ids.
         self.register("application_id", {
-            let prop = Property::from(msg.info.application_id.0.clone());
-            if msg.info.is_official_example {
+            let prop = Property::from(rec_info.application_id.0.clone());
+            if rec_info.is_official_example {
                 prop
             } else {
                 prop.hashed()
             }
         });
         self.register("recording_id", {
-            let prop = Property::from(msg.info.recording_id.to_string());
-            if msg.info.is_official_example {
+            let prop = Property::from(rec_info.recording_id.to_string());
+            if rec_info.is_official_example {
                 prop
             } else {
                 prop.hashed()
             }
         });
-        self.register("recording_source", msg.info.recording_source.to_string());
-        self.register("is_official_example", msg.info.is_official_example);
+        self.register("recording_source", rec_info.recording_source.to_string());
+        self.register("is_official_example", rec_info.is_official_example);
         self.record(Event::append("open_recording".into()));
     }
 }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -62,7 +62,7 @@ impl ViewerAnalytics {
         let app_env_str = match app_env {
             AppEnvironment::PythonSdk(_) => "python_sdk",
             AppEnvironment::RustSdk => "rust_sdk",
-            AppEnvironment::RerunCli => "rust_cli",
+            AppEnvironment::RerunCli => "rerun_cli",
             AppEnvironment::Web => "web",
         };
         self.register("app_env", app_env_str.to_owned());

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -97,7 +97,7 @@ impl ViewerAnalytics {
     }
 
     /// When we have loaded the start of a new recording.
-    pub fn on_new_recording(&mut self, msg: &re_log_types::BeginRecordingMsg) {
+    pub fn on_open_recording(&mut self, msg: &re_log_types::BeginRecordingMsg) {
         // We hash the application_id and recording_id unless this is an official example.
         // That's because we want to be able to track which are the popular examples,
         // but we don't want to collect actual application ids.
@@ -119,7 +119,7 @@ impl ViewerAnalytics {
         });
         self.register("recording_source", msg.info.recording_source.to_string());
         self.register("is_official_example", msg.info.is_official_example);
-        self.record(Event::append("new_recording".into()));
+        self.record(Event::append("open_recording".into()));
     }
 }
 

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -9,8 +9,6 @@ use re_analytics::{Analytics, Event, Property};
 #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
 use re_log_types::RecordingSource;
 
-use crate::AppEnvironment;
-
 pub struct ViewerAnalytics {
     // NOTE: Optional because it is possible to have the `analytics` feature flag enabled
     // while at the same time opting-out of analytics at run-time.
@@ -60,6 +58,7 @@ impl ViewerAnalytics {
 impl ViewerAnalytics {
     /// When the viewer is first started
     pub fn on_viewer_started(&mut self, app_env: crate::AppEnvironment) {
+        use crate::AppEnvironment;
         let app_env_str = match app_env {
             AppEnvironment::PythonSdk(_) => "python_sdk",
             AppEnvironment::RustSdk => "rust_sdk",
@@ -161,6 +160,6 @@ impl ViewerAnalytics {
 // When analytics are disabled:
 #[cfg(not(all(not(target_arch = "wasm32"), feature = "analytics")))]
 impl ViewerAnalytics {
-    pub fn on_viewer_started(&self) {}
+    pub fn on_viewer_started(&mut self, _app_env: crate::AppEnvironment) {}
     pub fn on_open_recording(&mut self, _log_db: &re_data_store::LogDb) {}
 }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -61,6 +61,7 @@ impl ViewerAnalytics {
             AppEnvironment::PythonSdk => "python_sdk",
             AppEnvironment::RustSdk => "rust_sdk",
             AppEnvironment::RerunCli => "rust_cli",
+            AppEnvironment::Web => "web",
         };
         self.register("app_env", app_env.to_owned());
 

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -6,6 +6,7 @@
 #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
 use re_analytics::{Analytics, Event, Property};
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
 use re_log_types::RecordingSource;
 
 use crate::AppEnvironment;
@@ -161,6 +162,5 @@ impl ViewerAnalytics {
 #[cfg(not(all(not(target_arch = "wasm32"), feature = "analytics")))]
 impl ViewerAnalytics {
     pub fn on_viewer_started(&self) {}
-    pub fn on_new_recording(&self, _msg: &re_log_types::BeginRecordingMsg) {}
-    pub fn on_new_data_source(&self, _data_source: &re_smart_channel::Source) {}
+    pub fn on_open_recording(&mut self, _log_db: &re_data_store::LogDb) {}
 }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -57,13 +57,17 @@ impl ViewerAnalytics {
 impl ViewerAnalytics {
     /// When the viewer is first started
     pub fn on_viewer_started(&mut self, app_env: crate::AppEnvironment) {
-        let app_env = match app_env {
-            AppEnvironment::PythonSdk => "python_sdk",
+        let app_env_str = match app_env {
+            AppEnvironment::PythonSdk(_) => "python_sdk",
             AppEnvironment::RustSdk => "rust_sdk",
             AppEnvironment::RerunCli => "rust_cli",
             AppEnvironment::Web => "web",
         };
-        self.register("app_env", app_env.to_owned());
+        self.register("app_env", app_env_str.to_owned());
+
+        if let AppEnvironment::PythonSdk(version) = app_env {
+            self.register("python_version", version.to_string());
+        }
 
         #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
         if let Some(analytics) = &self.analytics {

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -6,6 +6,8 @@
 #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
 use re_analytics::{Analytics, Event, Property};
 
+use crate::AppEnvironment;
+
 pub struct ViewerAnalytics {
     // NOTE: Optional because it is possible to have the `analytics` feature flag enabled
     // while at the same time opting-out of analytics at run-time.
@@ -54,7 +56,14 @@ impl ViewerAnalytics {
 #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
 impl ViewerAnalytics {
     /// When the viewer is first started
-    pub fn on_viewer_started(&self) {
+    pub fn on_viewer_started(&mut self, app_env: crate::AppEnvironment) {
+        let app_env = match app_env {
+            AppEnvironment::PythonSdk => "python_sdk",
+            AppEnvironment::RustSdk => "rust_sdk",
+            AppEnvironment::RerunCli => "rust_cli",
+        };
+        self.register("app_env", app_env.to_owned());
+
         #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
         if let Some(analytics) = &self.analytics {
             let rerun_version = env!("CARGO_PKG_VERSION");

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -27,10 +27,11 @@ pub async fn start(canvas_id: &str) -> std::result::Result<(), eframe::wasm_bind
         canvas_id,
         web_options,
         Box::new(move |cc| {
+            let app_env = crate::AppEnvironment::Web;
             let startup_options = crate::StartupOptions::default();
             let re_ui = crate::customize_eframe(cc);
             let url = get_url(&cc.integration_info);
-            let app = crate::RemoteViewerApp::new(startup_options, re_ui, cc.storage, url);
+            let app = crate::RemoteViewerApp::new(app_env, startup_options, re_ui, cc.storage, url);
             Box::new(app)
         }),
     )

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -113,6 +113,15 @@ pub enum CallSource {
     Python,
 }
 
+impl CallSource {
+    fn app_env(&self) -> re_viewer::AppEnvironment {
+        match self {
+            CallSource::Cli => re_viewer::AppEnvironment::RerunCli,
+            CallSource::Python => re_viewer::AppEnvironment::PythonSdk,
+        }
+    }
+}
+
 /// Run the Rerun application and return an exit code.
 ///
 /// This is used by the `rerun` binary and the Rerun Python SDK via `python -m rerun [args...]`.
@@ -199,7 +208,14 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
             load_file_to_channel(&path).with_context(|| format!("{path:?}"))?
         } else {
             // We are connecting to a server at a websocket address:
-            return connect_to_ws_url(&args, startup_options, profiler, url_or_path.clone()).await;
+            return connect_to_ws_url(
+                &args,
+                call_source.app_env(),
+                startup_options,
+                profiler,
+                url_or_path.clone(),
+            )
+            .await;
         }
     } else {
         #[cfg(feature = "server")]
@@ -245,7 +261,13 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
     } else {
         re_viewer::run_native_app(Box::new(move |cc, re_ui| {
             let rx = re_viewer::wake_up_ui_thread_on_each_msg(rx, cc.egui_ctx.clone());
-            let mut app = re_viewer::App::from_receiver(startup_options, re_ui, cc.storage, rx);
+            let mut app = re_viewer::App::from_receiver(
+                call_source.app_env(),
+                startup_options,
+                re_ui,
+                cc.storage,
+                rx,
+            );
             app.set_profiler(profiler);
             Box::new(app)
         }))?;
@@ -255,6 +277,7 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
 
 async fn connect_to_ws_url(
     args: &Args,
+    app_env: re_viewer::AppEnvironment,
     startup_options: re_viewer::StartupOptions,
     profiler: re_viewer::Profiler,
     mut rerun_server_ws_url: String,
@@ -269,6 +292,7 @@ async fn connect_to_ws_url(
         // By using RemoteViewerApp we let the user change the server they are connected to.
         re_viewer::run_native_app(Box::new(move |cc, re_ui| {
             let mut app = re_viewer::RemoteViewerApp::new(
+                app_env,
                 startup_options,
                 re_ui,
                 cc.storage,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -79,6 +79,16 @@ impl ThreadInfo {
 
 // ----------------------------------------------------------------------------
 
+fn python_version(py: Python<'_>) -> re_log_types::PythonVersion {
+    let py_version = py.version_info();
+    re_log_types::PythonVersion {
+        major: py_version.major,
+        minor: py_version.minor,
+        patch: py_version.patch,
+        suffix: py_version.suffix.map(|s| s.to_owned()).unwrap_or_default(),
+    }
+}
+
 /// The python module is called "rerun_bindings".
 #[pymodule]
 fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -86,7 +96,8 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // called more than once.
     re_log::setup_native_logging();
 
-    global_session().set_recording_source(re_log_types::RecordingSource::PythonSdk);
+    global_session()
+        .set_recording_source(re_log_types::RecordingSource::PythonSdk(python_version(py)));
 
     // NOTE: We do this here because we want child processes to share the same recording-id,
     // whether the user has called `init` or not.
@@ -203,13 +214,15 @@ fn time(timeless: bool) -> TimePoint {
 }
 
 // ----------------------------------------------------------------------------
+
 #[pyfunction]
-fn main(argv: Vec<String>) -> PyResult<u8> {
+fn main(py: Python<'_>, argv: Vec<String>) -> PyResult<u8> {
+    let call_src = rerun::CallSource::Python(python_version(py));
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap()
-        .block_on(rerun::run(rerun::CallSource::Python, argv))
+        .block_on(rerun::run(call_src, argv))
         .map_err(|err| PyRuntimeError::new_err(re_error::format(err)))
 }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -86,6 +86,8 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // called more than once.
     re_log::setup_native_logging();
 
+    global_session().set_recording_source(re_log_types::RecordingSource::PythonSdk);
+
     // NOTE: We do this here because we want child processes to share the same recording-id,
     // whether the user has called `init` or not.
     // See `default_recording_id` for extra information.


### PR DESCRIPTION
Closes most of https://github.com/rerun-io/rerun/issues/396

Contains a bug fix for what SDK the log events originate from (we would before always set `Python SDK` as the source).

Adds a new field `data_source` which can be any of:

* `file` (.rrd)
* `sdk` (likely `show()`)
* `ws_client` (likely `spawn()`)
* `tcp_server` (likely `connect()`)

Adds a `app_env` field that be any of `python_sdk`, `rust_sdk`, `rust_cli`, `web` (the latter won't happen until we have analytics on web).

Also adds a `python_version` when applicable.

## Example
Starting `rerun` rust binary with CLI, then connecting to it from Python SDK:
![image](https://user-images.githubusercontent.com/1148717/220665998-6c1757ed-e594-4b07-b205-77c502122370.png)


## TODO
* [x] Add analytics for if the viewer was started from Rust or Python
* [x] Python version
* [x] Ensure we send events when loading a file from the viewer
* [x] Send `data_source` as part of the `open_recording` event
* [ ] ~Send an event when `serve()` is called (serving a web browser)~ separate PR

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
