### PR TITLE
Add a test of memory use when logging a lot of big images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5111,6 +5111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_image_memory"
+version = "0.2.0"
+dependencies = [
+ "mimalloc",
+ "re_format",
+ "rerun",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "2"
-members = ["crates/*", "examples/rust/*", "rerun_py", "run_wasm"]
+members = [
+  "crates/*",
+  "examples/rust/*",
+  "rerun_py",
+  "run_wasm",
+  "tests/rust/*",
+]
 
 [workspace.package]
 authors = ["rerun.io <opensource@rerun.io>"]
@@ -55,6 +61,7 @@ half = "2.0"
 image = "0.24"
 lazy_static = "1.4"
 macaw = "0.18"
+mimalloc = "0.1.29"
 ndarray = "0.15"
 polars-core = "0.27.1"
 polars-lazy = "0.27.1"

--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -71,7 +71,7 @@ polars-ops = { workspace = true, optional = true, features = [
 
 [dev-dependencies]
 criterion = "0.4"
-mimalloc = "0.1"
+mimalloc.workspace = true
 polars-core = { workspace = true, features = [
   "diagonal_concat",
   "dtype-date",

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -46,7 +46,7 @@ puffin.workspace = true
 
 [dev-dependencies]
 criterion = "0.4"
-mimalloc = "0.1"
+mimalloc.workspace = true
 rand = "0.8"
 
 [lib]

--- a/crates/re_int_histogram/Cargo.toml
+++ b/crates/re_int_histogram/Cargo.toml
@@ -24,7 +24,7 @@ static_assertions = "1.1"
 [dev-dependencies]
 criterion = "0.4"
 insta = "1.23"
-mimalloc = "0.1"
+mimalloc.workspace = true
 
 
 [lib]

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -104,7 +104,7 @@ ruzstd = { version = "0.3.0", optional = true } # works on wasm
 
 [dev-dependencies]
 criterion = "0.4"
-mimalloc = "0.1"
+mimalloc.workspace = true
 serde_test = { version = "1" }
 arrow2 = { workspace = true, features = [
   "io_ipc",

--- a/crates/re_query/Cargo.toml
+++ b/crates/re_query/Cargo.toml
@@ -55,7 +55,7 @@ polars-core = { workspace = true, optional = true, features = [
 [dev-dependencies]
 criterion = "0.4"
 itertools = "0.10"
-mimalloc = "0.1"
+mimalloc.workspace = true
 polars-core = { workspace = true, features = [
   "dtype-date",
   "dtype-time",

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -63,7 +63,7 @@ pub mod external {
     pub use re_memory;
     pub use re_sdk_comms;
 
-    #[cfg(feature = "viewer")]
+    #[cfg(feature = "re_viewer")]
     pub use re_viewer;
 
     #[cfg(feature = "glam")]

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -63,7 +63,7 @@ pub mod external {
     pub use re_memory;
     pub use re_sdk_comms;
 
-    #[cfg(feature = "glam")]
+    #[cfg(feature = "viewer")]
     pub use re_viewer;
 
     #[cfg(feature = "glam")]

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -64,6 +64,9 @@ pub mod external {
     pub use re_sdk_comms;
 
     #[cfg(feature = "glam")]
+    pub use re_viewer;
+
+    #[cfg(feature = "glam")]
     pub use re_log_types::external::glam;
 
     #[cfg(feature = "image")]

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -357,11 +357,15 @@ impl MemoryPanel {
 
 fn summarize_callstack(callstack: &str) -> String {
     let patterns = [
+        ("MsgSender", "MsgSender"),
+        ("App::receive_messages", "App::receive_messages"),
+        ("DataStore>::insert", "DataStore"),
         ("LogDb", "LogDb"),
         ("EntityDb", "EntityDb"),
         ("EntityTree", "EntityTree"),
         ("::LogMsg>::deserialize", "LogMsg"),
         ("::TimePoint>::deserialize", "TimePoint"),
+        ("ImageCache", "ImageCache"),
         ("gltf", "gltf"),
         ("image::image", "image"),
         // -----

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -359,6 +359,7 @@ fn summarize_callstack(callstack: &str) -> String {
     let patterns = [
         ("MsgSender", "MsgSender"),
         ("App::receive_messages", "App::receive_messages"),
+        ("w_store::store::ComponentBucket>::archive", "archive"),
         ("DataStore>::insert", "DataStore"),
         ("LogDb", "LogDb"),
         ("EntityDb", "EntityDb"),

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -78,7 +78,7 @@ webbrowser = { version = "0.8", optional = true }
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { workspace = true, features = ["derive"] }
-mimalloc = "0.1.29"
+mimalloc.workspace = true
 puffin_http = "0.11"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -5,6 +5,8 @@ use re_smart_channel::Receiver;
 use anyhow::Context as _;
 use clap::Subcommand;
 
+// Note the extra blank lines between the point-lists below: it is required by `clap`.
+
 /// The Rerun Viewer and Server
 ///
 /// Features:

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -13,5 +13,5 @@ anyhow.workspace = true
 bytes = "1.3"
 clap = { workspace = true, features = ["derive"] }
 gltf.workspace = true
-mimalloc = "0.1"
+mimalloc.workspace = true
 reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -59,7 +59,7 @@ image = { version = "0.24", default-features = false, features = [
 ] }
 itertools = "0.10"
 macaw.workspace = true
-mimalloc = { version = "0.1.29", features = ["local_dynamic_tls"] }
+mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 numpy = { version = "0.18.0", features = ["half"] }
 pyo3 = { version = "0.18.0", features = ["abi3-py38"] }
 rand = { version = "0.8", features = ["std_rng"] }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,1 @@
+Uses of the rerun SDK designed to test different things.

--- a/tests/rust/test_image_memory/Cargo.toml
+++ b/tests/rust/test_image_memory/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_image_memory"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+rerun.workspace = true
+re_format.workspace = true
+
+mimalloc.workspace = true

--- a/tests/rust/test_image_memory/src/main.rs
+++ b/tests/rust/test_image_memory/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         re_viewer::env_vars::RERUN_TRACK_ALLOCATIONS,
     );
 
-    let session = rerun::Session::init("minimal_rs", true);
+    let session = rerun::Session::init("test_image_memory_rs", true);
 
     session.spawn(|mut session| {
         log_images(&mut session).unwrap();

--- a/tests/rust/test_image_memory/src/main.rs
+++ b/tests/rust/test_image_memory/src/main.rs
@@ -1,0 +1,56 @@
+//! Logs a bunch of big images to test Rerun memory usage.
+
+use mimalloc::MiMalloc;
+use re_memory::AccountingAllocator;
+use rerun::external::{image, re_memory, re_viewer};
+
+#[global_allocator]
+static GLOBAL: AccountingAllocator<MiMalloc> = AccountingAllocator::new(MiMalloc);
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    re_memory::accounting_allocator::turn_on_tracking_if_env_var(
+        re_viewer::env_vars::RERUN_TRACK_ALLOCATIONS,
+    );
+
+    let session = rerun::Session::init("minimal_rs", true);
+
+    session.spawn(|mut session| {
+        log_images(&mut session).unwrap();
+    })?;
+
+    Ok(())
+}
+
+fn log_images(session: &mut rerun::Session) -> Result<(), Box<dyn std::error::Error>> {
+    let (w, h) = (2048, 1024);
+    let n = 100;
+
+    let image = image::RgbaImage::from_fn(w, h, |x, y| {
+        if (x + y) % 2 == 0 {
+            image::Rgba([0, 0, 0, 255])
+        } else {
+            image::Rgba([255, 255, 255, 255])
+        }
+    });
+    let tensor = rerun::components::Tensor::from_image(image)?;
+
+    for _ in 0..n {
+        rerun::MsgSender::new("image")
+            .with_component(&[tensor.clone()])?
+            .send(session)?;
+    }
+
+    eprintln!(
+        "Logged {n} {w}x{h} RGBA images = {}",
+        re_format::format_bytes((n * w * h * 4) as _)
+    );
+
+    // Give viewer time to load it:
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    if let Some(allocs) = re_memory::accounting_allocator::global_allocs() {
+        eprintln!("{} RAM used", re_format::format_bytes(allocs.size as _));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Investigating https://github.com/rerun-io/rerun/issues/1242

`RERUN_TRACK_ALLOCATIONS=1 cargo r -p test_image_memory`

It turns out that when we log normal RGBA images we store the data once in the `ArrowMsg`, and then that data is deep-cloned when put in the store. I think it is because of this:

```rust
#[derive(Clone, Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
#[arrow_field(type = "dense")]
pub enum TensorData {
    U8(Vec<u8>),
    U16(Buffer<u16>),
    U32(Buffer<u32>),
    U64(Buffer<u64>),
    // ---
    I8(Buffer<i8>),
    I16(Buffer<i16>),
    I32(Buffer<i32>),
    I64(Buffer<i64>),
    // ---
    // TODO(#854): Native F16 support for arrow tensors
    //F16(Vec<arrow2::types::f16>),
    F32(Buffer<f32>),
    F64(Buffer<f64>),
    JPEG(Vec<u8>),
}
```

We use the ref-counted `Buffer` for everything except for 8-bit tensors (most images) and for jpegs.

We have a similar problem for the `Mesh3D` component.