### PR TITLE
Serve a `serve_wasm` analytics event when serving a .wasm file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,6 +4299,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hyper",
+ "re_analytics",
  "re_log",
  "tokio",
 ]

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -19,6 +19,9 @@ all-features = true
 [features]
 default = ["demo", "glam", "image", "re_viewer"]
 
+## Enable telemetry using our analytics SDK.
+analytics = ["re_web_server?/analytics", "re_viewer?/analytics"]
+
 ## Enable the `demo` module (helpers for Rerun examples).
 demo = []
 

--- a/crates/re_web_server/Cargo.toml
+++ b/crates/re_web_server/Cargo.toml
@@ -31,6 +31,9 @@ all-features = true
 ## will crash if you rey to run it!
 __ci = []
 
+## Enable telemetry using our analytics SDK.
+analytics = ["dep:re_analytics"]
+
 
 [dependencies]
 re_log.workspace = true
@@ -43,6 +46,10 @@ tokio = { workspace = true, default-features = false, features = [
   "macros",
   "rt-multi-thread",
 ] }
+
+# Optional dependencies:
+re_analytics = { workspace = true, optional = true }
+
 
 [build-dependencies]
 glob = "0.3.0"

--- a/crates/re_web_server/src/lib.rs
+++ b/crates/re_web_server/src/lib.rs
@@ -11,11 +11,40 @@
 use std::task::{Context, Poll};
 
 use futures_util::future;
-use hyper::{server::conn::AddrIncoming, service::Service};
-use hyper::{Body, Request, Response};
+use hyper::{server::conn::AddrIncoming, service::Service, Body, Request, Response};
 
-#[derive(Debug)]
-struct Svc;
+struct Svc {
+    // NOTE: Optional because it is possible to have the `analytics` feature flag enabled
+    // while at the same time opting-out of analytics at run-time.
+    #[cfg(feature = "analytics")]
+    analytics: Option<re_analytics::Analytics>,
+}
+
+impl Svc {
+    #[cfg(feature = "analytics")]
+    fn new() -> Self {
+        let analytics = match re_analytics::Analytics::new(std::time::Duration::from_secs(2)) {
+            Ok(analytics) => Some(analytics),
+            Err(err) => {
+                re_log::error!(%err, "failed to initialize analytics SDK");
+                None
+            }
+        };
+        Self { analytics }
+    }
+
+    #[cfg(not(feature = "analytics"))]
+    fn new() -> Self {
+        Self {}
+    }
+
+    #[cfg(feature = "analytics")]
+    fn on_serve_wasm(&self) {
+        if let Some(analytics) = &self.analytics {
+            analytics.record(re_analytics::Event::append("serve_wasm".into()));
+        }
+    }
+}
 
 impl Service<Request<Body>> for Svc {
     type Response = Response<Body>;
@@ -39,8 +68,12 @@ impl Service<Request<Body>> for Svc {
             "/" | "/index.html" => &include_bytes!("../web_viewer/index.html")[..],
             "/favicon.ico" => &include_bytes!("../web_viewer/favicon.ico")[..],
             "/sw.js" => &include_bytes!("../web_viewer/sw.js")[..],
-            "/re_viewer_bg.wasm" => &include_bytes!("../web_viewer/re_viewer_bg.wasm")[..],
             "/re_viewer.js" => &include_bytes!("../web_viewer/re_viewer.js")[..],
+            "/re_viewer_bg.wasm" => {
+                #[cfg(feature = "analytics")]
+                self.on_serve_wasm();
+                &include_bytes!("../web_viewer/re_viewer_bg.wasm")[..]
+            }
             _ => {
                 re_log::warn!("404 path: {}", req.uri().path());
                 let body = Body::from(Vec::new());
@@ -67,7 +100,7 @@ impl<T> Service<T> for MakeSvc {
     }
 
     fn call(&mut self, _: T) -> Self::Future {
-        future::ok(Svc)
+        future::ok(Svc::new())
     }
 }
 

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -22,7 +22,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 default = ["analytics", "glam", "image", "server", "sdk"]
 
 ## Enable telemetry using our analytics SDK.
-analytics = ["dep:re_analytics", "re_viewer/analytics"]
+analytics = ["dep:re_analytics", "re_viewer/analytics", "re_sdk?/analytics"]
 
 ## Add support for some math operations using [`glam`](https://crates.io/crates/glam/).
 ## Only relevant if feature `sdk` is enabled.


### PR DESCRIPTION
Can be tested with `cargo r -p objectron -- --serve`

It's extremely bare-bones, but will give us a hint of how popular this feature is:

![image](https://user-images.githubusercontent.com/1148717/220684912-0bcfe480-a4ec-48ee-96e9-f218246bd1da.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
