### PR TITLE
analytics: streamlining host vs. recorder python/rust versions

### DIFF
--- a/crates/re_analytics/src/lib.rs
+++ b/crates/re_analytics/src/lib.rs
@@ -220,6 +220,11 @@ impl Analytics {
         self.default_append_props.insert(name.into(), prop.into());
     }
 
+    /// Deregister a property.
+    pub fn deregister_append_property(&mut self, name: &'static str) {
+        self.default_append_props.remove(name);
+    }
+
     /// Record an event.
     ///
     /// It will be extended with an `event_id` and, if this is an [`EventKind::Append`],

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -170,9 +170,9 @@ fn test_encode_decode() {
             recording_id: crate::RecordingId::random(),
             is_official_example: true,
             started: Time::now(),
-            recording_source: crate::RecordingSource::RustSdk(
-                env!("CARGO_PKG_RUST_VERSION").into(),
-            ),
+            recording_source: crate::RecordingSource::RustSdk {
+                rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
+            },
         },
     })];
 

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -170,7 +170,9 @@ fn test_encode_decode() {
             recording_id: crate::RecordingId::random(),
             is_official_example: true,
             started: Time::now(),
-            recording_source: crate::RecordingSource::RustSdk,
+            recording_source: crate::RecordingSource::RustSdk(
+                env!("CARGO_PKG_RUST_VERSION").into(),
+            ),
         },
     })];
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -240,7 +240,7 @@ impl std::fmt::Display for PythonVersion {
             patch,
             suffix,
         } = self;
-        write!(f, "{}.{}.{}{}", major, minor, patch, suffix)
+        write!(f, "{major}.{minor}.{patch}{suffix}")
     }
 }
 
@@ -253,7 +253,7 @@ pub enum RecordingSource {
     PythonSdk(PythonVersion),
 
     /// The official Rerun Rust Logging SDK
-    RustSdk,
+    RustSdk(String),
 
     /// Perhaps from some manual data ingestion?
     Other(String),
@@ -264,7 +264,7 @@ impl std::fmt::Display for RecordingSource {
         match self {
             Self::Unknown => "Unknown".fmt(f),
             Self::PythonSdk(version) => write!(f, "Python {version} SDK"),
-            Self::RustSdk => "Rust SDK".fmt(f),
+            Self::RustSdk(version) => write!(f, "Rust {version} SDK"),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes
         }
     }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -253,7 +253,9 @@ pub enum RecordingSource {
     PythonSdk(PythonVersion),
 
     /// The official Rerun Rust Logging SDK
-    RustSdk(String),
+    RustSdk {
+        rust_version: String,
+    },
 
     /// Perhaps from some manual data ingestion?
     Other(String),
@@ -264,7 +266,7 @@ impl std::fmt::Display for RecordingSource {
         match self {
             Self::Unknown => "Unknown".fmt(f),
             Self::PythonSdk(version) => write!(f, "Python {version} SDK"),
-            Self::RustSdk(version) => write!(f, "Rust {version} SDK"),
+            Self::RustSdk { rust_version } => write!(f, "Rust {rust_version} SDK"),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes
         }
     }

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -103,7 +103,9 @@ impl Session {
         Self {
             enabled,
 
-            recording_source: RecordingSource::RustSdk(env!("CARGO_PKG_RUST_VERSION").into()),
+            recording_source: RecordingSource::RustSdk {
+                rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
+            },
 
             #[cfg(feature = "web")]
             tokio_rt: tokio::runtime::Runtime::new().unwrap(),
@@ -399,11 +401,13 @@ impl Session {
             RecordingSource::PythonSdk(python_version) => {
                 re_viewer::AppEnvironment::PythonSdk(python_version.clone())
             }
-            RecordingSource::RustSdk(rust_version) => {
-                re_viewer::AppEnvironment::RustSdk(rust_version.clone())
-            }
+            RecordingSource::RustSdk { rust_version } => re_viewer::AppEnvironment::RustSdk {
+                rust_version: rust_version.clone(),
+            },
             RecordingSource::Unknown | RecordingSource::Other(_) => {
-                re_viewer::AppEnvironment::RustSdk("unknown".into())
+                re_viewer::AppEnvironment::RustSdk {
+                    rust_version: "unknown".into(),
+                }
             }
         }
     }

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -103,9 +103,7 @@ impl Session {
         Self {
             enabled,
 
-            recording_source: RecordingSource::RustSdk(
-                env!("CARGO_PKG_RUST_VERSION").into(),
-            ),
+            recording_source: RecordingSource::RustSdk(env!("CARGO_PKG_RUST_VERSION").into()),
 
             #[cfg(feature = "web")]
             tokio_rt: tokio::runtime::Runtime::new().unwrap(),
@@ -404,7 +402,7 @@ impl Session {
             RecordingSource::RustSdk(rust_version) => {
                 re_viewer::AppEnvironment::RustSdk(rust_version.clone())
             }
-            RecordingSource::Unknown |  RecordingSource::Other(_) => {
+            RecordingSource::Unknown | RecordingSource::Other(_) => {
                 re_viewer::AppEnvironment::RustSdk("unknown".into())
             }
         }

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -103,7 +103,9 @@ impl Session {
         Self {
             enabled,
 
-            recording_source: RecordingSource::RustSdk,
+            recording_source: RecordingSource::RustSdk(
+                env!("CARGO_PKG_RUST_VERSION").into(),
+            ),
 
             #[cfg(feature = "web")]
             tokio_rt: tokio::runtime::Runtime::new().unwrap(),
@@ -399,8 +401,11 @@ impl Session {
             RecordingSource::PythonSdk(python_version) => {
                 re_viewer::AppEnvironment::PythonSdk(python_version.clone())
             }
-            RecordingSource::Unknown | RecordingSource::RustSdk | RecordingSource::Other(_) => {
-                re_viewer::AppEnvironment::RustSdk
+            RecordingSource::RustSdk(rust_version) => {
+                re_viewer::AppEnvironment::RustSdk(rust_version.clone())
+            }
+            RecordingSource::Unknown |  RecordingSource::Other(_) => {
+                re_viewer::AppEnvironment::RustSdk("unknown".into())
             }
         }
     }

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -76,7 +76,7 @@ pub enum AppEnvironment {
     PythonSdk(PythonVersion),
 
     /// Created from the Rerun Rust SDK.
-    RustSdk,
+    RustSdk(String),
 
     /// Running the Rust `rerun` binary from the CLI.
     RerunCli,

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -76,7 +76,7 @@ pub enum AppEnvironment {
     PythonSdk(PythonVersion),
 
     /// Created from the Rerun Rust SDK.
-    RustSdk(String),
+    RustSdk { rust_version: String },
 
     /// Running the Rust `rerun` binary from the CLI.
     RerunCli,

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -79,7 +79,7 @@ pub enum AppEnvironment {
     RustSdk { rust_version: String },
 
     /// Running the Rust `rerun` binary from the CLI.
-    RerunCli,
+    RerunCli { rust_version: String },
 
     /// We are a web-viewer running in a browser as Wasm.
     Web,

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -69,7 +69,7 @@ impl ViewerAnalytics {
         use crate::AppEnvironment;
         let app_env_str = match app_env {
             AppEnvironment::PythonSdk(_) => "python_sdk",
-            AppEnvironment::RustSdk(_) => "rust_sdk",
+            AppEnvironment::RustSdk { rust_version: _ } => "rust_sdk",
             AppEnvironment::RerunCli => "rerun_cli",
             AppEnvironment::Web => "web",
         };
@@ -91,8 +91,8 @@ impl ViewerAnalytics {
             //
             // The Python/Rust versions appearing in user profiles always apply to the host
             // environment, _not_ the environment in which the data logging is taking place!
-            if let AppEnvironment::RustSdk(version) = &app_env {
-                event = event.with_prop("rust_version".into(), version.clone());
+            if let AppEnvironment::RustSdk { rust_version } = &app_env {
+                event = event.with_prop("rust_version".into(), rust_version.clone());
             } else {
                 event = event.with_prop(
                     "rust_version".into(),
@@ -143,7 +143,7 @@ impl ViewerAnalytics {
             let recording_source = match &rec_info.recording_source {
                 RecordingSource::Unknown => "unknown".to_owned(),
                 RecordingSource::PythonSdk(_version) => "python_sdk".to_owned(),
-                RecordingSource::RustSdk(_version) => "rust_sdk".to_owned(),
+                RecordingSource::RustSdk { rust_version: _ } => "rust_sdk".to_owned(),
                 RecordingSource::Other(other) => other.clone(),
             };
 
@@ -152,8 +152,8 @@ impl ViewerAnalytics {
             //
             // The Python/Rust versions appearing in events always apply to the recording
             // environment, _not_ the environment in which the viewer is running!
-            if let RecordingSource::RustSdk(version) = &rec_info.recording_source {
-                self.register("rust_version", version.to_string());
+            if let RecordingSource::RustSdk { rust_version } = &rec_info.recording_source {
+                self.register("rust_version", rust_version.to_string());
                 self.deregister("python_version"); // can't be both!
             }
             if let RecordingSource::PythonSdk(version) = &rec_info.recording_source {

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -70,7 +70,7 @@ impl ViewerAnalytics {
         let app_env_str = match app_env {
             AppEnvironment::PythonSdk(_) => "python_sdk",
             AppEnvironment::RustSdk { rust_version: _ } => "rust_sdk",
-            AppEnvironment::RerunCli => "rerun_cli",
+            AppEnvironment::RerunCli { rust_version: _ } => "rerun_cli",
             AppEnvironment::Web => "web",
         };
         self.register("app_env", app_env_str.to_owned());
@@ -91,13 +91,12 @@ impl ViewerAnalytics {
             //
             // The Python/Rust versions appearing in user profiles always apply to the host
             // environment, _not_ the environment in which the data logging is taking place!
-            if let AppEnvironment::RustSdk { rust_version } = &app_env {
-                event = event.with_prop("rust_version".into(), rust_version.clone());
-            } else {
-                event = event.with_prop(
-                    "rust_version".into(),
-                    env!("CARGO_PKG_RUST_VERSION").to_owned(),
-                );
+            match &app_env {
+                AppEnvironment::RustSdk { rust_version }
+                | AppEnvironment::RerunCli { rust_version } => {
+                    event = event.with_prop("rust_version".into(), rust_version.clone());
+                }
+                _ => {}
             }
             if let AppEnvironment::PythonSdk(version) = app_env {
                 event = event.with_prop("python_version".into(), version.to_string());

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -49,6 +49,14 @@ impl ViewerAnalytics {
             analytics.register_append_property(name, property);
         }
     }
+
+    /// Deregister a property.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
+    fn deregister(&mut self, name: &'static str) {
+        if let Some(analytics) = &mut self.analytics {
+            analytics.deregister_append_property(name);
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -146,9 +154,11 @@ impl ViewerAnalytics {
             // environment, _not_ the environment in which the viewer is running!
             if let RecordingSource::RustSdk(version) = &rec_info.recording_source {
                 self.register("rust_version", version.to_string());
+                self.deregister("python_version"); // can't be both!
             }
             if let RecordingSource::PythonSdk(version) = &rec_info.recording_source {
                 self.register("python_version", version.to_string());
+                self.deregister("rust_version"); // can't be both!
             }
 
             self.register("recording_source", recording_source);

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -122,7 +122,7 @@ impl CallSource {
 
     fn app_env(&self) -> re_viewer::AppEnvironment {
         match self {
-            CallSource::Cli => re_viewer::AppEnvironment::RerunCli{
+            CallSource::Cli => re_viewer::AppEnvironment::RerunCli {
                 rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
             },
             CallSource::Python(python_version) => {

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -122,7 +122,9 @@ impl CallSource {
 
     fn app_env(&self) -> re_viewer::AppEnvironment {
         match self {
-            CallSource::Cli => re_viewer::AppEnvironment::RerunCli,
+            CallSource::Cli => re_viewer::AppEnvironment::RerunCli{
+                rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
+            },
             CallSource::Python(python_version) => {
                 re_viewer::AppEnvironment::PythonSdk(python_version.clone())
             }


### PR DESCRIPTION
> We can actually avoid this issue entirely: the python version that corresponds to the machine the user is running on (i.e. the machine that hosts the viewer) should never be included in events, it should only be part of the user profile (along with the rust version that's already there) i.e. `update_metadata`.
> 
> The `viewer_started` event then only keeps track of the app environment, while the `open_recording` event always keeps track of the `python_version` that corresponds to the machine doing the recording, never the host. We can also put the rust version of the machine doing the recording in there, for consistency.
> 
> That way everything becomes consistent and relatively straightforward to reason about:
> 
>     * The python & rust versions seen in user profiles (`update_metadata`) are those of the host machine (the one hosting the viewer).
> 
>     * The python & rust versions seen in events correspond to the machine doing the recording.