### PR TITLE
[re_renderer] fix bindgroup reuse regression

### DIFF
--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -279,8 +279,6 @@ impl RenderContext {
                 pipeline_layouts,
             );
 
-            // Bind group maintenance must come before texture/buffer maintenance since it
-            // registers texture/buffer use
             bind_groups.begin_frame(frame_index, textures, buffers, samplers);
 
             textures.begin_frame(frame_index);

--- a/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
@@ -204,7 +204,6 @@ impl GpuBindGroupPool {
         _samplers: &mut GpuSamplerPool,
     ) {
         self.pool.begin_frame(frame_index, |_res| {});
-        // TODO(andreas): Update usage counter on dependent resources.
     }
 
     pub fn num_resources(&self) -> usize {

--- a/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
@@ -75,8 +75,8 @@ impl GpuBufferPool {
         self.pool.begin_frame(frame_index, |res| res.destroy());
     }
 
-    /// Internal method to retrieve a resource from a weak handle (used by [`super::GpuBindGroupPool`])
-    pub(super) fn get_from_handle(&self, handle: GpuBufferHandle) -> Result<GpuBuffer, PoolError> {
+    /// Method to retrieve a resource from a weak handle (used by [`super::GpuBindGroupPool`])
+    pub fn get_from_handle(&self, handle: GpuBufferHandle) -> Result<GpuBuffer, PoolError> {
         self.pool.get_from_handle(handle)
     }
 

--- a/crates/re_renderer/src/wgpu_resources/texture_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/texture_pool.rs
@@ -108,11 +108,8 @@ impl GpuTexturePool {
             .begin_frame(frame_index, |res| res.texture.destroy());
     }
 
-    /// Internal method to retrieve a resource from a weak handle (used by [`super::GpuBindGroupPool`])
-    pub(super) fn get_from_handle(
-        &self,
-        handle: GpuTextureHandle,
-    ) -> Result<GpuTexture, PoolError> {
+    /// Method to retrieve a resource from a weak handle (used by [`super::GpuBindGroupPool`])
+    pub fn get_from_handle(&self, handle: GpuTextureHandle) -> Result<GpuTexture, PoolError> {
         self.pool.get_from_handle(handle)
     }
 


### PR DESCRIPTION
Caused a subtle bug in #1374 that made "weak" handles no longer stable accross intra-frame resource re-use. This in turn caused the BindGroupPool to fail to re-use bindgroups from previous frames as it stores weak handles in its descriptor.

In other words, `RUST_LOG=debug cargo run --example 2d` got very spammy, now it is nice and quiet again!

Added a test to prevent this from breaking again.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
