### PR TITLE
Put all analytics to one bucket

### DIFF
--- a/crates/re_analytics/src/sink_native.rs
+++ b/crates/re_analytics/src/sink_native.rs
@@ -11,9 +11,6 @@ use crate::{Event, Property};
 // TODO(cmc): abstract away the concept of a `Sink` behind an actual trait when comes the time to
 // support more than just PostHog.
 
-#[cfg(debug_assertions)]
-const PUBLIC_POSTHOG_PROJECT_KEY: &str = "phc_XD1QbqTGdPJbzdVCbvbA9zGOG38wJFTl8RAwqMwBvTY";
-#[cfg(not(debug_assertions))]
 const PUBLIC_POSTHOG_PROJECT_KEY: &str = "phc_sgKidIE4WYYFSJHd8LEYY1UZqASpnfQKeMqlJfSXwqg";
 
 // ---

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -84,7 +84,10 @@ impl ViewerAnalytics {
             let mut event = Event::update("update_metadata".into())
                 .with_prop("rerun_version".into(), rerun_version.to_owned())
                 .with_prop("target".into(), target.to_owned())
-                .with_prop("git_hash".into(), git_hash.to_owned());
+                .with_prop("git_hash".into(), git_hash.to_owned())
+                .with_prop("debug".into(), cfg!(debug_assertions).to_owned()) // debug-build?
+                .with_prop("workspace".into(), std::env::var("IS_IN_RERUN_WORKSPACE").is_ok()) // proxy for "user checked out the project and built it from source"
+                ;
 
             // If we happen to know the Python or Rust version used on the _host machine_, i.e. the
             // machine running the viewer, then add it to the permanent user profile.

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -86,7 +86,7 @@ impl ViewerAnalytics {
                 .with_prop("target".into(), target.to_owned())
                 .with_prop("git_hash".into(), git_hash.to_owned())
                 .with_prop("debug".into(), cfg!(debug_assertions).to_owned()) // debug-build?
-                .with_prop("workspace".into(), std::env::var("IS_IN_RERUN_WORKSPACE").is_ok()) // proxy for "user checked out the project and built it from source"
+                .with_prop("rerun_workspace".into(), std::env::var("IS_IN_RERUN_WORKSPACE").is_ok()) // proxy for "user checked out the project and built it from source"
                 ;
 
             // If we happen to know the Python or Rust version used on the _host machine_, i.e. the


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1389

This puts all analytics events in the same bucket (our prod-bucket) to make it easy to see if the same user switches from using a published package to building from source.

It also adds two new propertis:

* `debug` - built with `debug_assertions` enabled
* `rerun_workspace`, a proxy for "user checked out the project and built it from source"

Perhaps we can come up with better names for these that are both descriptive and accurate? `from_repository`?