### PR TITLE
Make the native viewer an optional dependency of rerun, re_sdk, rerun_py

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,7 +4456,6 @@ dependencies = [
  "re_sdk",
  "re_sdk_comms",
  "re_smart_channel",
- "re_viewer",
  "re_web_server",
  "re_ws_comms",
  "tokio",

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -41,7 +41,7 @@ native_viewer = ["image", "dep:re_viewer"]
 ##
 ## You also need to install some additional tools, which you can do by running
 ## [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
-web = ["dep:re_ws_comms", "dep:re_web_server", "dep:webbrowser"]
+web_viewer = ["dep:re_ws_comms", "dep:re_web_server", "dep:webbrowser"]
 
 
 [dependencies]

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 
 
 [features]
-default = ["demo", "glam", "image", "re_viewer"]
+default = ["demo", "glam", "image", "native_viewer"]
 
 ## Enable telemetry using our analytics SDK.
 analytics = ["re_web_server?/analytics", "re_viewer?/analytics"]
@@ -31,8 +31,8 @@ glam = ["re_log_types/glam"]
 ## Integration with the [`image`](https://crates.io/crates/image/) crate.
 image = ["re_log_types/image"]
 
-## Support for the viewer.
-re_viewer = ["image", "dep:re_viewer"]
+## Support for the native viewer.
+native_viewer = ["image", "dep:re_viewer"]
 
 ## Support serving a web viewer over HTTP.
 ##

--- a/crates/re_sdk/src/clap.rs
+++ b/crates/re_sdk/src/clap.rs
@@ -8,7 +8,7 @@ use std::{net::SocketAddr, path::PathBuf};
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RerunBehavior {
     Save(PathBuf),
-    #[cfg(feature = "web")]
+    #[cfg(feature = "web_viewer")]
     Serve,
     Connect(SocketAddr),
     Spawn,
@@ -51,7 +51,7 @@ pub struct RerunArgs {
     connect: Option<Option<SocketAddr>>,
 
     /// Connects and sends the logged data to a web-based Rerun viewer.
-    #[cfg(feature = "web")]
+    #[cfg(feature = "web_viewer")]
     #[clap(long)]
     serve: bool,
 }
@@ -62,7 +62,7 @@ impl RerunArgs {
         match self.to_behavior() {
             RerunBehavior::Connect(addr) => session.connect(addr),
             RerunBehavior::Spawn => return true,
-            #[cfg(feature = "web")]
+            #[cfg(feature = "web_viewer")]
             RerunBehavior::Serve => session.serve(true),
             RerunBehavior::Save(_) => {}
         }
@@ -74,7 +74,7 @@ impl RerunArgs {
     pub fn on_teardown(&self, session: &mut Session) -> anyhow::Result<()> {
         let behavior = self.to_behavior();
 
-        #[cfg(feature = "web")]
+        #[cfg(feature = "web_viewer")]
         if behavior == RerunBehavior::Serve {
             eprintln!("Sleeping while serving the web viewer. Abort with Ctrl-C");
             std::thread::sleep(std::time::Duration::from_secs(1_000_000));
@@ -92,7 +92,7 @@ impl RerunArgs {
             return RerunBehavior::Save(path.clone());
         }
 
-        #[cfg(feature = "web")]
+        #[cfg(feature = "web_viewer")]
         if self.serve {
             return RerunBehavior::Serve;
         }

--- a/crates/re_sdk/src/demo_util.rs
+++ b/crates/re_sdk/src/demo_util.rs
@@ -67,10 +67,10 @@ pub fn grid(from: glam::Vec3, to: glam::Vec3, n: usize) -> impl Iterator<Item = 
 ///
 /// * `num_points`: Total number of points.
 /// * `radius`: The radius of the spiral.
-/// * `angular_step`: The factor applied between each step along the trigonemetric circle.
-/// * `angular_offset`: Offsets the starting position on the trigonemetric circle.
+/// * `angular_step`: The factor applied between each step along the trigonometric circle.
+/// * `angular_offset`: Offsets the starting position on the trigonometric circle.
 /// * `z_step`: The factor applied between between each step along the Z axis.
-#[cfg(all(feature = "glam", feature = "re_viewer"))]
+#[cfg(all(feature = "glam", feature = "native_viewer"))]
 pub fn color_spiral(
     num_points: usize,
     radius: f32,

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -63,7 +63,7 @@ pub mod external {
     pub use re_memory;
     pub use re_sdk_comms;
 
-    #[cfg(feature = "re_viewer")]
+    #[cfg(feature = "native_viewer")]
     pub use re_viewer;
 
     #[cfg(feature = "glam")]

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -16,7 +16,7 @@ pub struct Session {
 
     recording_source: RecordingSource,
 
-    #[cfg(feature = "web")]
+    #[cfg(feature = "web_viewer")]
     tokio_rt: tokio::runtime::Runtime,
 
     sender: Sender,
@@ -107,7 +107,7 @@ impl Session {
                 rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
             },
 
-            #[cfg(feature = "web")]
+            #[cfg(feature = "web_viewer")]
             tokio_rt: tokio::runtime::Runtime::new().unwrap(),
 
             sender: Default::default(),
@@ -197,7 +197,7 @@ impl Session {
             #[cfg(feature = "native_viewer")]
             Sender::NativeViewer(_) => {}
 
-            #[cfg(feature = "web")]
+            #[cfg(feature = "web_viewer")]
             Sender::WebViewer(web_server, _) => {
                 re_log::info!("Shutting down web server.");
                 web_server.abort();
@@ -210,7 +210,7 @@ impl Session {
     ///
     /// If the `open_browser` argument is set, your default browser
     /// will be opened to show the viewer.
-    #[cfg(feature = "web")]
+    #[cfg(feature = "web_viewer")]
     pub fn serve(&mut self, open_browser: bool) {
         if !self.enabled {
             re_log::debug!("Rerun disabled - call to serve() ignored");
@@ -294,7 +294,7 @@ impl Session {
             #[cfg(feature = "native_viewer")]
             Sender::NativeViewer(_) => vec![],
 
-            #[cfg(feature = "web")]
+            #[cfg(feature = "web_viewer")]
             Sender::WebViewer(_, _) => vec![],
         }
     }
@@ -486,7 +486,7 @@ enum Sender {
     NativeViewer(re_smart_channel::Sender<LogMsg>),
 
     /// Send it to the web viewer over WebSockets
-    #[cfg(feature = "web")]
+    #[cfg(feature = "web_viewer")]
     WebViewer(
         tokio::task::JoinHandle<()>,
         re_smart_channel::Sender<LogMsg>,
@@ -512,7 +512,7 @@ impl Sender {
                 }
             }
 
-            #[cfg(feature = "web")]
+            #[cfg(feature = "web_viewer")]
             Self::WebViewer(_, sender) => {
                 if let Err(err) = sender.send(msg) {
                     re_log::error_once!("Failed to send log message to web server: {err}");

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -194,7 +194,7 @@ impl Session {
                 self.sender = Sender::Remote(client);
             }
 
-            #[cfg(feature = "re_viewer")]
+            #[cfg(feature = "native_viewer")]
             Sender::NativeViewer(_) => {}
 
             #[cfg(feature = "web")]
@@ -249,7 +249,7 @@ impl Session {
     }
 
     /// Disconnect the streaming TCP connection, if any.
-    #[cfg(feature = "re_viewer")]
+    #[cfg(feature = "native_viewer")]
     #[allow(unused)] // only used with "re_viewer" feature
     pub fn disconnect(&mut self) {
         if !matches!(&self.sender, &Sender::Buffered(_)) {
@@ -291,7 +291,7 @@ impl Session {
 
             Sender::Buffered(log_messages) => std::mem::take(log_messages),
 
-            #[cfg(feature = "re_viewer")]
+            #[cfg(feature = "native_viewer")]
             Sender::NativeViewer(_) => vec![],
 
             #[cfg(feature = "web")]
@@ -394,7 +394,7 @@ impl Session {
     }
 }
 
-#[cfg(feature = "re_viewer")]
+#[cfg(feature = "native_viewer")]
 impl Session {
     fn app_env(&self) -> re_viewer::AppEnvironment {
         match &self.recording_source {
@@ -479,10 +479,10 @@ impl Session {
 enum Sender {
     Remote(re_sdk_comms::Client),
 
-    #[allow(unused)] // only used with `#[cfg(feature = "re_viewer")]`
+    #[allow(unused)] // only used with `#[cfg(feature = "native_viewer")]`
     Buffered(Vec<LogMsg>),
 
-    #[cfg(feature = "re_viewer")]
+    #[cfg(feature = "native_viewer")]
     NativeViewer(re_smart_channel::Sender<LogMsg>),
 
     /// Send it to the web viewer over WebSockets
@@ -505,7 +505,7 @@ impl Sender {
             Self::Remote(client) => client.send(msg),
             Self::Buffered(buffer) => buffer.push(msg),
 
-            #[cfg(feature = "re_viewer")]
+            #[cfg(feature = "native_viewer")]
             Self::NativeViewer(sender) => {
                 if let Err(err) = sender.send(msg) {
                     re_log::error_once!("Failed to send log message to viewer: {err}");

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -152,7 +152,7 @@ pub(crate) fn customize_eframe(cc: &eframe::CreationContext<'_>) -> re_ui::ReUi 
 // ---------------------------------------------------------------------------
 
 /// This wakes up the ui thread each time we receive a new message.
-#[cfg(not(feature = "web"))]
+#[cfg(not(feature = "web_viewer"))]
 #[cfg(not(target_arch = "wasm32"))]
 pub fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
     rx: re_smart_channel::Receiver<T>,

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -71,7 +71,7 @@ impl ViewerAnalytics {
             AppEnvironment::PythonSdk(_) => "python_sdk",
             AppEnvironment::RustSdk { rust_version: _ } => "rust_sdk",
             AppEnvironment::RerunCli { rust_version: _ } => "rerun_cli",
-            AppEnvironment::Web => "web",
+            AppEnvironment::Web => "web_viewer",
         };
         self.register("app_env", app_env_str.to_owned());
 

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -48,9 +48,9 @@ sdk = ["dep:re_sdk"]
 #
 # You also need to install some additional tools, which you can do by running
 # [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
-web = [
+web_viewer = [
   "re_ws_comms/server",
-  "re_sdk?/web",
+  "re_sdk?/web_viewer",
   "dep:re_web_server",
   "dep:webbrowser",
 ]

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -19,10 +19,10 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
 [features]
-default = ["analytics", "glam", "image", "server", "sdk"]
+default = ["analytics", "glam", "image", "native_viewer", "server", "sdk"]
 
 ## Enable telemetry using our analytics SDK.
-analytics = ["dep:re_analytics", "re_viewer/analytics", "re_sdk?/analytics"]
+analytics = ["dep:re_analytics", "re_sdk?/analytics"]
 
 ## Add support for some math operations using [`glam`](https://crates.io/crates/glam/).
 ## Only relevant if feature `sdk` is enabled.
@@ -31,19 +31,23 @@ glam = ["re_sdk?/glam"]
 ## Integration with the [`image`](https://crates.io/crates/image/) crate.
 image = ["re_log_types/image"]
 
-## Embed the Rerun SDK and re-export all of its public symbols.
-sdk = ["dep:re_sdk", "re_sdk?/re_viewer"]
+## Support a native viewer
+native_viewer = ["re_sdk?/native_viewer"]
 
 ## Support for running a HTTP server that listens to incoming log messages from a Rerun SDK.
 server = ["re_sdk_comms/server"]
 
+## Embed the Rerun SDK and re-export all of its public symbols.
+sdk = ["dep:re_sdk"]
+
 ## Support serving a web viewer over HTTP.
 ##
-## Enabling this adds quite a bit to the compile time and binary size,
-## since it requires compiling and bundling the viewer as wasm.
-##
-## You also need to install some additional tools, which you can do by running
-## [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
+## Enabling this inflates the binary size quite a bit, since it embeds the viewer wasm.
+# When building from source (in the repository), this feature adds quite a bit
+# to the compile time since it requires compiling and bundling the viewer as wasm.
+#
+# You also need to install some additional tools, which you can do by running
+# [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
 web = [
   "re_ws_comms/server",
   "re_sdk?/web",
@@ -54,11 +58,10 @@ web = [
 [dependencies]
 re_error.workspace = true
 re_format.workspace = true
-re_log_types.workspace = true
+re_log_types = { workspace = true, features = ["load"] }
 re_log.workspace = true
 re_memory.workspace = true
 re_smart_channel.workspace = true
-re_viewer = { workspace = true, default-features = false }
 re_ws_comms = { workspace = true, features = ["client"] }
 
 anyhow.workspace = true

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -248,7 +248,7 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
                 #[cfg(not(feature = "native_viewer"))]
                 {
                     _ = call_source;
-                    anyhow::bail!("rerun compiled without the 'native_viewer' feature");
+                    anyhow::bail!("Can't start viewer - rerun was compiled without the 'native_viewer' feature");
                 }
             }
         }
@@ -316,7 +316,9 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
         #[cfg(not(feature = "native_viewer"))]
         {
             _ = (call_source, rx);
-            anyhow::bail!("rerun compiled without the 'native_viewer' feature");
+            anyhow::bail!(
+                "Can't start viewer - rerun was compiled without the 'native_viewer' feature"
+            );
         }
     }
 }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -271,7 +271,7 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
     // Now what do we do with the data?
 
     if args.web_viewer {
-        #[cfg(feature = "web")]
+        #[cfg(feature = "web_viewer")]
         {
             #[cfg(feature = "server")]
             if args.url_or_path.is_none() && args.port == re_ws_comms::DEFAULT_WS_SERVER_PORT {
@@ -292,7 +292,7 @@ async fn run_impl(call_source: CallSource, args: Args) -> anyhow::Result<()> {
             return server_handle.await?;
         }
 
-        #[cfg(not(feature = "web"))]
+        #[cfg(not(feature = "web_viewer"))]
         {
             _ = (call_source, rx);
             anyhow::bail!("Can't host web-viewer - rerun was not compiled with the 'web' feature");
@@ -366,7 +366,7 @@ fn load_file_to_channel(path: &std::path::Path) -> anyhow::Result<Receiver<LogMs
     Ok(rx)
 }
 
-#[cfg(feature = "web")]
+#[cfg(feature = "web_viewer")]
 async fn host_web_viewer(rerun_ws_server_url: String) -> anyhow::Result<()> {
     let web_port = 9090;
     let viewer_url = format!("http://127.0.0.1:{web_port}?url={rerun_ws_server_url}");
@@ -384,7 +384,7 @@ async fn host_web_viewer(rerun_ws_server_url: String) -> anyhow::Result<()> {
     web_server_handle.await?
 }
 
-#[cfg(not(feature = "web"))]
+#[cfg(not(feature = "web_viewer"))]
 async fn host_web_viewer(_rerun_ws_server_url: String) -> anyhow::Result<()> {
     panic!("Can't host web-viewer - rerun was not compiled with the 'web' feature");
 }

--- a/examples/rust/api_demo/Cargo.toml
+++ b/examples/rust/api_demo/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-rerun = { workspace = true, features = ["web"] }
+rerun = { workspace = true, features = ["web_viewer"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -4,13 +4,13 @@ use std::f32::consts::TAU;
 
 use itertools::Itertools as _;
 
-use rerun::components::{
-    ColorRGBA, LineStrip3D, Point3D, Quaternion, Radius, Rigid3, Transform, Vec3D,
+use rerun::{
+    components::{ColorRGBA, LineStrip3D, Point3D, Quaternion, Radius, Rigid3, Transform, Vec3D},
+    demo_util::{bounce_lerp, color_spiral},
+    external::glam,
+    time::{Time, TimeType, Timeline},
+    MsgSender, MsgSenderError, Session,
 };
-use rerun::demo_util::{bounce_lerp, color_spiral};
-use rerun::external::glam;
-use rerun::time::{Time, TimeType, Timeline};
-use rerun::{MsgSender, MsgSenderError, Session};
 
 const NUM_POINTS: usize = 100;
 

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-rerun = { workspace = true, features = ["web"] }
+rerun = { workspace = true, features = ["web_viewer"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-rerun = { workspace = true, features = ["web"] }
+rerun = { workspace = true, features = ["web_viewer"] }
 
 anyhow.workspace = true
 bytes = "1.3"

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -12,10 +12,10 @@ name = "rerun_bindings" # name of the .so library that the Python module will im
 
 
 [features]
-default = ["extension-module"]
+default = ["extension-module", "native_viewer"]
 
 ## The features we turn on when building the PyPi package.
-pypi = ["extension-module", "web"]
+pypi = ["extension-module", "native_viewer", "web"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
@@ -23,6 +23,9 @@ pypi = ["extension-module", "web"]
 ## * <https://pyo3.rs/latest/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror>
 ## * <https://pyo3.rs/latest/building_and_distribution.html#building-python-extension-modules>
 extension-module = ["pyo3/extension-module"]
+
+## Support a native viewer
+native_viewer = ["rerun/native_viewer"]
 
 ## Support serving a web viewer over HTTP.
 ##

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -15,7 +15,7 @@ name = "rerun_bindings" # name of the .so library that the Python module will im
 default = ["extension-module", "native_viewer"]
 
 ## The features we turn on when building the PyPi package.
-pypi = ["extension-module", "native_viewer", "web"]
+pypi = ["extension-module", "native_viewer", "web_viewer"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
@@ -34,7 +34,7 @@ native_viewer = ["rerun/native_viewer"]
 ##
 ## You also need to install some additional tools, which you can do by running
 ## [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
-web = ["rerun/web"]
+web_viewer = ["rerun/web_viewer"]
 
 [dependencies]
 re_error.workspace = true

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -344,23 +344,9 @@ fn disconnect() {
 #[cfg(feature = "native_viewer")]
 #[pyfunction]
 fn show() -> PyResult<()> {
-    let mut session = global_session();
-    if session.is_connected() {
-        return Err(PyRuntimeError::new_err(
-            "Can't show the log messages: Rerun was configured to send the data to a server!",
-        ));
-    }
-
-    let log_messages = session.drain_log_messages_buffer();
-    drop(session);
-
-    if log_messages.is_empty() {
-        re_log::info!("Nothing logged, so nothing to show");
-        Ok(())
-    } else {
-        rerun_sdk::viewer::show(log_messages)
-            .map_err(|err| PyRuntimeError::new_err(format!("Failed to show Rerun Viewer: {err}")))
-    }
+    global_session()
+        .show()
+        .map_err(|err| PyRuntimeError::new_err(format!("Failed to show Rerun Viewer: {err}")))
 }
 
 #[pyfunction]

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -118,7 +118,7 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(is_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(set_enabled, m)?)?;
 
-    #[cfg(feature = "re_viewer")]
+    #[cfg(feature = "native_viewer")]
     {
         m.add_function(wrap_pyfunction!(disconnect, m)?)?;
         m.add_function(wrap_pyfunction!(show, m)?)?;
@@ -329,7 +329,7 @@ fn set_enabled(enabled: bool) {
 ///
 /// Subsequent log messages will be buffered and either sent on the next call to `connect`,
 /// or shown with `show`.
-#[cfg(feature = "re_viewer")]
+#[cfg(feature = "native_viewer")]
 #[pyfunction]
 fn disconnect() {
     global_session().disconnect();
@@ -341,7 +341,7 @@ fn disconnect() {
 /// Calling this function more than once is undefined behavior.
 /// We will try to fix this in the future.
 /// Blocked on <https://github.com/emilk/egui/issues/1918>.
-#[cfg(feature = "re_viewer")]
+#[cfg(feature = "native_viewer")]
 #[pyfunction]
 fn show() -> PyResult<()> {
     let mut session = global_session();

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -282,13 +282,13 @@ fn connect(addr: Option<String>) -> PyResult<()> {
 #[allow(clippy::unnecessary_wraps)] // False positive
 #[pyfunction]
 fn serve(open_browser: bool) -> PyResult<()> {
-    #[cfg(feature = "web")]
+    #[cfg(feature = "web_viewer")]
     {
         global_session().serve(open_browser);
         Ok(())
     }
 
-    #[cfg(not(feature = "web"))]
+    #[cfg(not(feature = "web_viewer"))]
     {
         _ = open_browser;
         Err(PyRuntimeError::new_err(


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1384

This adds a new `native_viewer` feature-flag to `rerun_py`, `rerun` and `re_sdk`.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
