### PR TITLE
Fix "open source and free" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Some shortcomings:
 
 
 ## Business model
-Rerun uses an open core model. Everything in this repository will stay open source and free (as in beer), forever. In the future, Rerun will offer a commercial product that builds on top of the core free project.
+Rerun uses an open core model. Everything in this repository will stay open source and free (as in freedom), forever. In the future, Rerun will offer a commercial product that builds on top of the core free project.
 
 The Rerun open source project targets the needs of individual developers. The commercial product targets the needs specific to teams that build and run computer vision and robotics products.
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Gratis_versus_libre

![image](https://user-images.githubusercontent.com/105541061/221048452-ec76504b-c3f2-444c-b355-8c07a79d701c.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [o] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

Anything in this repo as licensed under MIT/Apache2 should be considered free (as in freedom) and not free (as in beer), so I fixed the typo.
