### PR TITLE
SDK: stream to disk with `save` feature

### DIFF
--- a/crates/re_sdk/src/file_writer.rs
+++ b/crates/re_sdk/src/file_writer.rs
@@ -1,0 +1,57 @@
+use anyhow::Context as _;
+
+use re_log_types::LogMsg;
+
+pub struct FileWriter {
+    // None = quite
+    tx: std::sync::mpsc::Sender<Option<LogMsg>>,
+    join_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for FileWriter {
+    fn drop(&mut self) {
+        self.tx.send(None).ok();
+        if let Some(join_handle) = self.join_handle.take() {
+            join_handle.join().ok();
+        }
+    }
+}
+
+impl FileWriter {
+    pub fn new(path: impl Into<std::path::PathBuf>) -> anyhow::Result<Self> {
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let path = path.into();
+
+        re_log::debug!("Saving file to {path:?}…");
+
+        let file = std::fs::File::create(&path).with_context(|| format!("Path: {:?}", path))?;
+        let mut encoder = re_log_types::encoding::Encoder::new(file)?;
+
+        let join_handle = std::thread::Builder::new()
+            .name("file_writer".into())
+            .spawn(move || {
+                while let Ok(Some(log_msg)) = rx.recv() {
+                    if let Err(err) = encoder.append(&log_msg) {
+                        re_log::error!("Failed to save log stream to {path:?}: {err}");
+                        return;
+                    }
+                }
+                if let Err(err) = encoder.finish() {
+                    re_log::error!("Failed to save log stream to {path:?}: {err}");
+                } else {
+                    re_log::debug!("Log stream saved to {path:?}");
+                }
+            })
+            .context("Failed to spawn thread")?;
+
+        Ok(Self {
+            tx,
+            join_handle: Some(join_handle),
+        })
+    }
+
+    pub fn write(&self, msg: LogMsg) {
+        self.tx.send(Some(msg)).ok();
+    }
+}

--- a/crates/re_sdk/src/file_writer.rs
+++ b/crates/re_sdk/src/file_writer.rs
@@ -3,7 +3,7 @@ use anyhow::Context as _;
 use re_log_types::LogMsg;
 
 pub struct FileWriter {
-    // None = quite
+    // None = quit
     tx: std::sync::mpsc::Sender<Option<LogMsg>>,
     join_handle: Option<std::thread::JoinHandle<()>>,
 }

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -9,6 +9,7 @@
 // Send data to a rerun session
 mod global;
 mod msg_sender;
+mod remote_viewer_server;
 mod session;
 
 pub use self::global::{global_session, global_session_with_default_enabled};

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -11,7 +11,7 @@
 mod file_writer;
 mod global;
 mod msg_sender;
-#[cfg(feature = "web")]
+#[cfg(feature = "web_viewer")]
 mod remote_viewer_server;
 mod session;
 

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -7,8 +7,11 @@
 #![warn(missing_docs)] // Let's keep the this crate well-documented!
 
 // Send data to a rerun session
+#[cfg(not(target_arch = "wasm32"))]
+mod file_writer;
 mod global;
 mod msg_sender;
+#[cfg(feature = "web")]
 mod remote_viewer_server;
 mod session;
 

--- a/crates/re_sdk/src/remote_viewer_server.rs
+++ b/crates/re_sdk/src/remote_viewer_server.rs
@@ -1,0 +1,59 @@
+use re_log_types::LogMsg;
+
+/// Hosts two servers:
+/// * A web-server, serving the web-viewer
+/// * A `WebSocket` server, server [`LogMsg`]es to remote viewer(s).
+pub struct RemoteViewerServer {
+    web_server_join_handle: tokio::task::JoinHandle<()>,
+    sender: re_smart_channel::Sender<LogMsg>,
+}
+
+impl Drop for RemoteViewerServer {
+    fn drop(&mut self) {
+        re_log::info!("Shutting down web server.");
+        self.web_server_join_handle.abort();
+    }
+}
+
+impl RemoteViewerServer {
+    pub fn new(tokio_rt: &tokio::runtime::Runtime, open_browser: bool) -> Self {
+        let (rerun_tx, rerun_rx) = re_smart_channel::smart_channel(re_smart_channel::Source::Sdk);
+
+        let web_server_join_handle = tokio_rt.spawn(async move {
+            // This is the server which the web viewer will talk to:
+            let ws_server = re_ws_comms::Server::new(re_ws_comms::DEFAULT_WS_SERVER_PORT)
+                .await
+                .unwrap();
+            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx)); // TODO(emilk): use tokio_rt ?
+
+            // This is the server that serves the Wasm+HTML:
+            let web_port = 9090;
+            let web_server = re_web_server::WebServer::new(web_port);
+            let web_server_handle = tokio::spawn(async move {
+                web_server.serve().await.unwrap();
+            });
+
+            let ws_server_url = re_ws_comms::default_server_url();
+            let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
+            if open_browser {
+                webbrowser::open(&viewer_url).ok();
+            } else {
+                re_log::info!("Web server is running - view it at {viewer_url}");
+            }
+
+            ws_server_handle.await.unwrap().unwrap();
+            web_server_handle.await.unwrap();
+        });
+
+        Self {
+            web_server_join_handle,
+            sender: rerun_tx,
+        }
+    }
+
+    pub fn send(&self, msg: LogMsg) {
+        if let Err(err) = self.sender.send(msg) {
+            re_log::error_once!("Failed to send log message to web server: {err}");
+        }
+    }
+}

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -7,7 +7,7 @@ use re_log_types::{
 
 use crate::file_writer::FileWriter;
 
-#[cfg(feature = "web")]
+#[cfg(feature = "web_viewer")]
 use crate::remote_viewer_server::RemoteViewerServer;
 
 /// This is the main object you need to create to use the Rerun SDK.

--- a/examples/rust/api_demo/src/main.rs
+++ b/examples/rust/api_demo/src/main.rs
@@ -649,7 +649,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut session = rerun::Session::init("api_demo_rs", true);
 
-    let should_spawn = args.rerun.on_startup(&mut session);
+    let should_spawn = args.rerun.on_startup(&mut session)?;
     if should_spawn {
         return session
             .spawn(move |mut session| run(&mut session, &args))
@@ -658,7 +658,7 @@ fn main() -> anyhow::Result<()> {
 
     run(&mut session, &args)?;
 
-    args.rerun.on_teardown(&mut session)?;
+    args.rerun.on_teardown();
 
     Ok(())
 }

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -435,7 +435,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut session = Session::init("objectron_rs", true);
 
-    let should_spawn = args.rerun.on_startup(&mut session);
+    let should_spawn = args.rerun.on_startup(&mut session)?;
     if should_spawn {
         return session
             .spawn(move |mut session| run(&mut session, &args))
@@ -444,7 +444,7 @@ fn main() -> anyhow::Result<()> {
 
     run(&mut session, &args)?;
 
-    args.rerun.on_teardown(&mut session)?;
+    args.rerun.on_teardown();
 
     Ok(())
 }

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -196,7 +196,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut session = Session::init("raw_mesh_rs", true);
 
-    let should_spawn = args.rerun.on_startup(&mut session);
+    let should_spawn = args.rerun.on_startup(&mut session)?;
     if should_spawn {
         return session
             .spawn(move |mut session| run(&mut session, &args))
@@ -205,7 +205,7 @@ fn main() -> anyhow::Result<()> {
 
     run(&mut session, &args)?;
 
-    args.rerun.on_teardown(&mut session)?;
+    args.rerun.on_teardown();
 
     Ok(())
 }

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -76,7 +76,9 @@ def script_setup(
         # You can ommit the argument to connect to the default address,
         # which is `127.0.0.1:9876`.
         rr.connect(args.addr)
-    elif args.save is None and not args.headless:
+    elif args.save is not None:
+        rr.save(args.save)
+    elif not args.headless:
         rr.spawn()
 
 
@@ -94,5 +96,3 @@ def script_teardown(args: Namespace) -> None:
         print("Sleeping while serving the web viewer. Abort with Ctrl-C")
         with contextlib.suppress(Exception):
             sleep(100_000)
-    elif args.save is not None:
-        rr.save(args.save)


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1393

To save an `.rrd` file to disk we would previously buffer all the log messages and then write them all at once at shutdown.

Now we do it in a separate thread continuously as the logging program is running.

I also took the opportunity to refactor and simplify `Session`.

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
