### PR TITLE
Remove derive_more dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,12 +851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,19 +1155,6 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn",
 ]
 
@@ -3883,7 +3864,6 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "crossbeam",
- "derive_more",
  "directories-next",
  "glob",
  "once_cell",
@@ -3962,7 +3942,6 @@ version = "0.2.0"
 dependencies = [
  "arrow2",
  "comfy-table 6.1.4",
- "derive_more",
 ]
 
 [[package]]
@@ -3998,7 +3977,6 @@ dependencies = [
  "bytemuck",
  "chrono",
  "criterion",
- "derive_more",
  "document-features",
  "ecolor",
  "fixed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ arrow2 = "0.16"
 arrow2_convert = "0.4.2"
 clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }
-derive_more = "0.99"
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = "0.21.0"

--- a/crates/re_analytics/Cargo.toml
+++ b/crates/re_analytics/Cargo.toml
@@ -23,7 +23,6 @@ re_log.workspace = true
 # External dependencies:
 anyhow.workspace = true
 crossbeam = "0.8"
-derive_more.workspace = true
 once_cell = "1.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/re_analytics/src/lib.rs
+++ b/crates/re_analytics/src/lib.rs
@@ -112,12 +112,12 @@ impl Event {
     }
 }
 
-#[derive(Debug, Clone, derive_more::From, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Property {
+    Bool(bool),
     Integer(i64),
     Float(f64),
     String(String),
-    Bool(bool),
 }
 
 impl Property {
@@ -131,12 +131,40 @@ impl Property {
         let mut hasher = sha2::Sha256::default();
         hasher.update(SALT);
         match self {
+            Property::Bool(data) => hasher.update([*data as u8]),
             Property::Integer(data) => hasher.update(data.to_le_bytes()),
             Property::Float(data) => hasher.update(data.to_le_bytes()),
             Property::String(data) => hasher.update(data),
-            Property::Bool(data) => hasher.update([*data as u8]),
         }
-        format!("{:x}", hasher.finalize()).into()
+        Self::String(format!("{:x}", hasher.finalize()))
+    }
+}
+
+impl From<bool> for Property {
+    #[inline]
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<i64> for Property {
+    #[inline]
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<f64> for Property {
+    #[inline]
+    fn from(value: f64) -> Self {
+        Self::Float(value)
+    }
+}
+
+impl From<String> for Property {
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::String(value)
     }
 }
 

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -19,4 +19,3 @@ all-features = true
 [dependencies]
 arrow2.workspace = true
 comfy-table.workspace = true
-derive_more.workspace = true

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -40,7 +40,6 @@ impl std::fmt::Display for DisplayIntervalUnit {
 }
 
 //TODO(john) move this and the Display impl upstream into arrow2
-#[derive(derive_more::From, derive_more::Into)]
 #[repr(transparent)]
 pub struct DisplayDataType(DataType);
 

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -66,7 +66,6 @@ chrono = { version = "0.4", features = [
   "js-sys",
   "wasmbind",
 ] } # TODO(emilk): replace `chrono` with `time` crate
-derive_more.workspace = true
 document-features = "0.2"
 fixed = { version = "1.17", default-features = false, features = ["serde"] }
 half = { workspace = true, features = ["bytemuck"] }

--- a/crates/re_log_types/src/component_types/color.rs
+++ b/crates/re_log_types/src/component_types/color.rs
@@ -11,18 +11,7 @@ use crate::msg_bundle::Component;
 ///
 /// assert_eq!(ColorRGBA::data_type(), DataType::UInt32);
 /// ```
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    derive_more::From,
-    derive_more::Into,
-    ArrowField,
-    ArrowSerialize,
-    ArrowDeserialize,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ArrowField, ArrowSerialize, ArrowDeserialize)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[arrow_field(transparent)]
 pub struct ColorRGBA(pub u32);

--- a/crates/re_log_types/src/component_types/label.rs
+++ b/crates/re_log_types/src/component_types/label.rs
@@ -11,17 +11,7 @@ use crate::msg_bundle::Component;
 ///
 /// assert_eq!(Label::data_type(), DataType::Utf8);
 /// ```
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    derive_more::From,
-    derive_more::Into,
-    ArrowField,
-    ArrowSerialize,
-    ArrowDeserialize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, ArrowField, ArrowSerialize, ArrowDeserialize)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[arrow_field(transparent)]
 pub struct Label(pub String);
@@ -30,5 +20,18 @@ impl Component for Label {
     #[inline]
     fn name() -> crate::ComponentName {
         "rerun.label".into()
+    }
+}
+
+impl From<String> for Label {
+    #[inline]
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Label> for String {
+    fn from(value: Label) -> Self {
+        value.0
     }
 }

--- a/crates/re_log_types/src/component_types/label.rs
+++ b/crates/re_log_types/src/component_types/label.rs
@@ -31,6 +31,7 @@ impl From<String> for Label {
 }
 
 impl From<Label> for String {
+    #[inline]
     fn from(value: Label) -> Self {
         value.0
     }

--- a/crates/re_log_types/src/component_types/radius.rs
+++ b/crates/re_log_types/src/component_types/radius.rs
@@ -12,16 +12,7 @@ use crate::msg_bundle::Component;
 /// # use arrow2::datatypes::{DataType, Field};
 /// assert_eq!(Radius::data_type(), DataType::Float32);
 /// ```
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    derive_more::From,
-    derive_more::Into,
-    ArrowField,
-    ArrowSerialize,
-    ArrowDeserialize,
-)]
+#[derive(Debug, Clone, Copy, ArrowField, ArrowSerialize, ArrowDeserialize)]
 #[arrow_field(transparent)]
 pub struct Radius(pub f32);
 

--- a/crates/re_log_types/src/component_types/scalar.rs
+++ b/crates/re_log_types/src/component_types/scalar.rs
@@ -33,6 +33,7 @@ impl From<f64> for Scalar {
 }
 
 impl From<Scalar> for f64 {
+    #[inline]
     fn from(value: Scalar) -> Self {
         value.0
     }

--- a/crates/re_log_types/src/component_types/scalar.rs
+++ b/crates/re_log_types/src/component_types/scalar.rs
@@ -14,16 +14,7 @@ use crate::msg_bundle::Component;
 /// # use arrow2::datatypes::{DataType, Field};
 /// assert_eq!(Scalar::data_type(), DataType::Float64);
 /// ```
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    derive_more::From,
-    derive_more::Into,
-    ArrowField,
-    ArrowSerialize,
-    ArrowDeserialize,
-)]
+#[derive(Debug, Clone, Copy, ArrowField, ArrowSerialize, ArrowDeserialize)]
 #[arrow_field(transparent)]
 pub struct Scalar(pub f64);
 
@@ -31,6 +22,19 @@ impl Component for Scalar {
     #[inline]
     fn name() -> crate::ComponentName {
         "rerun.scalar".into()
+    }
+}
+
+impl From<f64> for Scalar {
+    #[inline]
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Scalar> for f64 {
+    fn from(value: Scalar) -> Self {
+        value.0
     }
 }
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -121,7 +121,7 @@ impl std::str::FromStr for RecordingId {
 /// The user-chosen name of the application doing the logging.
 ///
 /// Used to categorize recordings.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Display)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ApplicationId(pub String);
 
@@ -143,6 +143,13 @@ impl ApplicationId {
     /// Currently: `"unknown_app_id"`.
     pub fn unknown() -> Self {
         Self("unknown_app_id".to_owned())
+    }
+}
+
+impl std::fmt::Display for ApplicationId {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/crates/re_viewer/src/ui/view_time_series/scene.rs
+++ b/crates/re_viewer/src/ui/view_time_series/scene.rs
@@ -126,7 +126,7 @@ impl SceneTimeSeries {
                             attrs: PlotPointAttrs {
                                 label,
                                 color,
-                                radius: radius.map_or(DEFAULT_RADIUS, |r| r.into()),
+                                radius: radius.map_or(DEFAULT_RADIUS, |r| r.0),
                                 scattered: props.map_or(false, |props| props.scattered),
                             },
                         });

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,7 @@ wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny
 deny = [
   { name = "cgmath" },      # We use glam
   { name = "cmake" },       # Never again
+  { name = "derive_more" }, # Is very slow to compile; see https://github.com/rerun-io/rerun/issues/1316
   { name = "egui_glow" },   # We use wgpu
   { name = "openssl-sys" }, # We prefer rustls
   { name = "openssl" },     # We prefer rustls


### PR DESCRIPTION
Part of https://github.com/rerun-io/rerun/issues/1316

`derive_more` took a whopping 32s to compile (!). We don't need it!