### PR TITLE
Fix expecting always Rgba8Unorm backbuffer on Web & Bgra8Unorm on native

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     "cSpell.words": [
         "andreas",
         "bbox",
+        "framebuffer",
         "hoverable",
         "Keypoint",
         "memoffset",
@@ -31,6 +32,7 @@
         "objectron",
         "Skybox",
         "smallvec",
+        "swapchain",
         "texcoords",
         "Tonemapper",
         "tonemapping",

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -129,18 +129,11 @@ pub(crate) fn customize_eframe(cc: &eframe::CreationContext<'_>) -> re_ui::ReUi 
 
         let paint_callback_resources = &mut render_state.renderer.write().paint_callback_resources;
 
-        // TODO(andreas): Query used surface format from eframe/renderer.
-        let output_format_color = if cfg!(target_arch = "wasm32") {
-            wgpu::TextureFormat::Rgba8Unorm
-        } else {
-            wgpu::TextureFormat::Bgra8Unorm
-        };
-
         paint_callback_resources.insert(RenderContext::new(
             render_state.device.clone(),
             render_state.queue.clone(),
             RenderContextConfig {
-                output_format_color,
+                output_format_color: render_state.target_format,
                 hardware_tier: crate::hardware_tier(),
             },
         ));


### PR DESCRIPTION
Fixes #1353 which was *not*  egui-wgpu bug after all but a straight forward issue in our code.

Tested re_renderer example and viewer on web & native, worked for me as before.
Not yet confirmed on a setup that crashed before, but I'm very confident this is fixed

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
