### PR TITLE
Use write belt for mesh data gpu upload

### DIFF
--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -70,14 +70,7 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod>(
         num_buffers as _,
     );
     staging_buffer.extend(content);
-    staging_buffer.copy_to_buffer(
-        ctx.active_frame
-            .frame_global_command_encoder
-            .lock()
-            .get_or_create(&ctx.device),
-        &buffer,
-        0,
-    );
+    staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(&ctx.device), &buffer, 0);
 
     (0..num_buffers)
         .into_iter()

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -70,7 +70,7 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod>(
         num_buffers as _,
     );
     staging_buffer.extend(content);
-    staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(&ctx.device), &buffer, 0);
+    staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(), &buffer, 0);
 
     (0..num_buffers)
         .into_iter()

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -86,12 +86,7 @@ pub fn load_gltf_from_buffer(
         meshes.insert(
             mesh.index(),
             (
-                ctx.mesh_manager.create(
-                    &mut ctx.gpu_resources,
-                    &ctx.texture_manager_2d,
-                    &re_mesh,
-                    lifetime,
-                )?,
+                ctx.mesh_manager.write().create(ctx, &re_mesh, lifetime)?,
                 Arc::new(re_mesh),
             ),
         );

--- a/crates/re_renderer/src/importer/obj.rs
+++ b/crates/re_renderer/src/importer/obj.rs
@@ -67,12 +67,8 @@ pub fn load_obj_from_buffer(
             };
             let gpu_mesh = ctx
                 .mesh_manager
-                .create(
-                    &mut ctx.gpu_resources,
-                    &ctx.texture_manager_2d,
-                    &mesh,
-                    lifetime,
-                )
+                .write()
+                .create(ctx, &mesh, lifetime)
                 .unwrap(); // TODO(andreas): Handle error
             MeshInstance {
                 gpu_mesh,

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -155,8 +155,9 @@ impl GpuMesh {
 
         // TODO(andreas): Have a variant that gets this from a stack allocator.
         let vertex_buffer_positions_size =
-            std::mem::size_of_val(data.vertex_positions.as_slice()) as u64;
-        let vertex_buffer_data_size = std::mem::size_of_val(data.vertex_data.as_slice()) as u64;
+            (data.vertex_positions.len() * std::mem::size_of::<glam::Vec3>()) as u64;
+        let vertex_buffer_data_size =
+            (data.vertex_data.len() * std::mem::size_of::<mesh_vertices::MeshVertexData>()) as u64;
         let vertex_buffer_combined_size = vertex_buffer_positions_size + vertex_buffer_data_size;
 
         let pools = &ctx.gpu_resources;

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -1,10 +1,10 @@
-use std::{num::NonZeroU64, ops::Range};
+use std::ops::Range;
 
 use ecolor::Rgba;
 use smallvec::{smallvec, SmallVec};
 
 use crate::{
-    context::uniform_buffer_allocation_size,
+    allocator::create_and_fill_uniform_buffer_batch,
     debug_label::DebugLabel,
     resource_managers::{GpuTexture2DHandle, ResourceManagerError},
     wgpu_resources::{
@@ -130,10 +130,11 @@ pub(crate) mod gpu_data {
     use crate::wgpu_buffer_types;
 
     /// Keep in sync with [`MaterialUniformBuffer`] in `instanced_mesh.wgsl`
-    #[repr(C)]
+    #[repr(C, align(256))]
     #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct MaterialUniformBuffer {
         pub albedo_multiplier: wgpu_buffer_types::Vec4,
+        pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 1],
     }
 }
 
@@ -152,15 +153,13 @@ impl GpuMesh {
             data.indices.len() / 3
         );
 
-        // TODO(andreas): Have a variant that gets this from a stack allocator.]
-        // TODO(andreas): Don't use a queue to upload
+        // TODO(andreas): Have a variant that gets this from a stack allocator.
         let vertex_buffer_positions_size =
             std::mem::size_of_val(data.vertex_positions.as_slice()) as u64;
         let vertex_buffer_data_size = std::mem::size_of_val(data.vertex_data.as_slice()) as u64;
         let vertex_buffer_combined_size = vertex_buffer_positions_size + vertex_buffer_data_size;
 
         let pools = &ctx.gpu_resources;
-        let queue = ctx.queue.clone();
         let device = &ctx.device;
 
         let vertex_buffer_combined = {
@@ -173,19 +172,19 @@ impl GpuMesh {
                     mapped_at_creation: false,
                 },
             );
-            let mut staging_buffer = queue
-                .write_buffer_with(
-                    &vertex_buffer_combined,
-                    0,
-                    vertex_buffer_combined_size.try_into().unwrap(),
-                )
-                .unwrap(); // Fails only if mapping is bigger than buffer size.
-            staging_buffer[..vertex_buffer_positions_size as usize]
-                .copy_from_slice(bytemuck::cast_slice(&data.vertex_positions));
-            staging_buffer
-                [vertex_buffer_positions_size as usize..vertex_buffer_combined_size as usize]
-                .copy_from_slice(bytemuck::cast_slice(&data.vertex_data));
-            drop(staging_buffer);
+
+            let mut staging_buffer = ctx.cpu_write_gpu_read_belt.lock().allocate::<u8>(
+                &ctx.device,
+                &ctx.gpu_resources.buffers,
+                vertex_buffer_combined_size as _,
+            );
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_positions));
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_data));
+            staging_buffer.copy_to_buffer(
+                ctx.active_frame.encoder.lock().get(&ctx.device),
+                &vertex_buffer_combined,
+                0,
+            );
             vertex_buffer_combined
         };
 
@@ -200,51 +199,39 @@ impl GpuMesh {
                     mapped_at_creation: false,
                 },
             );
-            let mut staging_buffer = queue
-                .write_buffer_with(&index_buffer, 0, index_buffer_size.try_into().unwrap())
-                .unwrap(); // Fails only if mapping is bigger than buffer size.
-            staging_buffer[..index_buffer_size as usize]
-                .copy_from_slice(bytemuck::cast_slice(&data.indices));
-            drop(staging_buffer);
+
+            let mut staging_buffer = ctx.cpu_write_gpu_read_belt.lock().allocate::<u32>(
+                &ctx.device,
+                &ctx.gpu_resources.buffers,
+                data.indices.len(),
+            );
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.indices));
+            staging_buffer.copy_to_buffer(
+                ctx.active_frame.encoder.lock().get(&ctx.device),
+                &index_buffer,
+                0,
+            );
             index_buffer
         };
 
         let materials = {
-            // Buffer for *all* materials
-            let allocation_size_per_uniform_buffer =
-                uniform_buffer_allocation_size::<gpu_data::MaterialUniformBuffer>(device);
-            let combined_buffers_size =
-                allocation_size_per_uniform_buffer * data.materials.len() as u64;
-            let material_uniform_buffers = pools.buffers.alloc(
-                device,
-                &BufferDesc {
-                    label: data.label.clone().push_str(" - material uniforms"),
-                    size: combined_buffers_size,
-                    usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
-                    mapped_at_creation: false,
-                },
+            let uniform_buffer_bindings = create_and_fill_uniform_buffer_batch(
+                ctx,
+                data.label.clone().push_str(" - material uniforms"),
+                data.materials
+                    .iter()
+                    .map(|material| gpu_data::MaterialUniformBuffer {
+                        albedo_multiplier: material.albedo_multiplier.into(),
+                        end_padding: Default::default(),
+                    }),
             );
 
-            let mut materials_staging_buffer = queue
-                .write_buffer_with(
-                    &material_uniform_buffers,
-                    0,
-                    NonZeroU64::new(combined_buffers_size).unwrap(),
-                )
-                .unwrap(); // Fails only if mapping is bigger than buffer size.
-
             let mut materials = SmallVec::with_capacity(data.materials.len());
-            for (i, material) in data.materials.iter().enumerate() {
-                // CAREFUL: Memory from `write_buffer_with` may not be aligned, causing bytemuck to fail at runtime if we use it to cast the memory to a slice!
-                let material_buffer_range_start = i * allocation_size_per_uniform_buffer as usize;
-                let material_buffer_range_end = material_buffer_range_start
-                    + std::mem::size_of::<gpu_data::MaterialUniformBuffer>();
-
-                materials_staging_buffer[material_buffer_range_start..material_buffer_range_end]
-                    .copy_from_slice(bytemuck::bytes_of(&gpu_data::MaterialUniformBuffer {
-                        albedo_multiplier: material.albedo_multiplier.into(),
-                    }));
-
+            for (material, uniform_buffer_binding) in data
+                .materials
+                .iter()
+                .zip(uniform_buffer_bindings.into_iter())
+            {
                 let texture = ctx.texture_manager_2d.get(&material.albedo)?;
                 let bind_group = pools.bind_groups.alloc(
                     device,
@@ -252,13 +239,7 @@ impl GpuMesh {
                         label: material.label.clone(),
                         entries: smallvec![
                             BindGroupEntry::DefaultTextureView(texture.handle),
-                            BindGroupEntry::Buffer {
-                                handle: material_uniform_buffers.handle,
-                                offset: material_buffer_range_start as _,
-                                size: NonZeroU64::new(std::mem::size_of::<
-                                    gpu_data::MaterialUniformBuffer,
-                                >() as u64)
-                            }
+                            uniform_buffer_binding
                         ],
                         layout: mesh_bind_group_layout,
                     },

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -181,7 +181,7 @@ impl GpuMesh {
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_positions));
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_data));
             staging_buffer.copy_to_buffer(
-                ctx.active_frame.encoder.lock().get(&ctx.device),
+                ctx.active_frame.encoder.lock().get(),
                 &vertex_buffer_combined,
                 0,
             );
@@ -206,11 +206,7 @@ impl GpuMesh {
                 data.indices.len(),
             );
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.indices));
-            staging_buffer.copy_to_buffer(
-                ctx.active_frame.encoder.lock().get(&ctx.device),
-                &index_buffer,
-                0,
-            );
+            staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(), &index_buffer, 0);
             index_buffer
         };
 

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -207,10 +207,13 @@ impl MeshDrawData {
         let batches: Result<Vec<_>, _> = mesh_runs
             .into_iter()
             .map(|(mesh_handle, count)| {
-                ctx.mesh_manager.get(mesh_handle).map(|mesh| MeshBatch {
-                    mesh: mesh.clone(),
-                    count,
-                })
+                ctx.mesh_manager
+                    .read()
+                    .get(mesh_handle)
+                    .map(|mesh| MeshBatch {
+                        mesh: mesh.clone(),
+                        count,
+                    })
             })
             .collect();
 

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -284,7 +284,7 @@ impl PointCloudDrawData {
         }
 
         builder.color_buffer.copy_to_texture(
-            ctx.active_frame.encoder.lock().get(&ctx.device),
+            ctx.active_frame.encoder.lock().get(),
             wgpu::ImageCopyTexture {
                 texture: &color_texture.texture,
                 mip_level: 0,

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -284,10 +284,7 @@ impl PointCloudDrawData {
         }
 
         builder.color_buffer.copy_to_texture(
-            ctx.active_frame
-                .frame_global_command_encoder
-                .lock()
-                .get_or_create(&ctx.device),
+            ctx.active_frame.encoder.lock().get(&ctx.device),
             wgpu::ImageCopyTexture {
                 texture: &color_texture.texture,
                 mip_level: 0,

--- a/crates/re_viewer/src/misc/mesh_loader.rs
+++ b/crates/re_viewer/src/misc/mesh_loader.rs
@@ -139,9 +139,8 @@ impl LoadedMesh {
         let bbox = macaw::BoundingBox::from_points(positions.iter().copied());
 
         let mesh_instances = vec![re_renderer::renderer::MeshInstance {
-            gpu_mesh: render_ctx.mesh_manager.create(
-                &mut render_ctx.gpu_resources,
-                &render_ctx.texture_manager_2d,
+            gpu_mesh: render_ctx.mesh_manager.write().create(
+                render_ctx,
                 &re_renderer::mesh::Mesh {
                     label: name.clone().into(),
                     indices,


### PR DESCRIPTION
With that all uniform buffer creation runs by the new utility from #1400.
Mesh creation now passes immutable ctx (needed a little bit more `RwLock` for that).
Simplified `FrameGlobalCommandEncoder` a and made it have a more strictly checked usage pattern.

Part of https://github.com/rerun-io/rerun/issues/1398

tested raw_mesh example and re_renderer multiview to confirm things still work

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
