### PR TITLE
Introduce `DeserializableComponent` trait and high-level `query_latest`

### DIFF
--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -119,7 +119,10 @@ impl ExtraQueryHistory {
 // ----------------------------------------------------------------------------
 
 /// Get the latest value for a given [`re_log_types::msg_bundle::Component`].
-pub fn query_latest<C: DeserializableComponent>(
+///
+/// This assumes that the row we get from the store only contains a single instance for this
+/// component; it will log a warning otherwise.
+pub fn query_latest_single<C: DeserializableComponent>(
     entity_db: &EntityDb,
     entity_path: &EntityPath,
     query: &LatestAtQuery,

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -131,7 +131,7 @@ where
 
     // Although it would be nice to use the `re_query` helpers for this, we would need to move
     // this out of re_data_store to avoid a circular dep. Since we don't need to do a join for
-    // transforms this is easy enough.
+    // single components this is easy enough.
     let data_store = &entity_db.data_store;
 
     let components = [C::name()];
@@ -143,11 +143,11 @@ where
 
     let mut iter = arrow_array_deserialize_iterator::<C>(arr).ok()?;
 
-    let transform = iter.next();
+    let component = iter.next();
 
     if iter.next().is_some() {
-        re_log::warn_once!("Unexpected batch for Transform at: {}", entity_path);
+        re_log::warn_once!("Unexpected batch for {} at: {}", C::name(), entity_path);
     }
 
-    transform
+    component
 }

--- a/crates/re_log_types/src/msg_bundle.rs
+++ b/crates/re_log_types/src/msg_bundle.rs
@@ -90,7 +90,7 @@ pub trait Component: ArrowField {
 }
 
 /// A [`Component`] that fulfils all the conditions required to be serialized as an Arrow payload.
-pub trait SerializableComponent
+pub trait SerializableComponent<ArrowFieldType = Self>
 where
     Self: Component + ArrowSerialize + ArrowField<Type = Self> + 'static,
 {
@@ -103,9 +103,17 @@ impl<C> SerializableComponent for C where
 
 /// A [`Component`] that fulfils all the conditions required to be deserialized from an Arrow
 /// payload.
-pub trait DeserializableComponent
+///
+/// Note that due to the use of HRTBs in `arrow2_convert` traits, you will still need an extra HRTB
+/// clause when marking a type as `DeserializableComponent`:
+/// ```ignore
+/// where
+///     T: SerializableComponent,
+///     for<'a> &'a T::ArrayType: IntoIterator,
+/// ```
+pub trait DeserializableComponent<ArrowFieldType = Self>
 where
-    Self: Component + ArrowDeserialize + ArrowField<Type = Self> + 'static,
+    Self: Component + ArrowDeserialize + ArrowField<Type = ArrowFieldType> + 'static,
     Self::ArrayType: ArrowArray,
     for<'b> &'b Self::ArrayType: IntoIterator,
 {

--- a/crates/re_log_types/src/msg_bundle.rs
+++ b/crates/re_log_types/src/msg_bundle.rs
@@ -27,6 +27,7 @@ use arrow2::{
     offset::Offsets,
 };
 use arrow2_convert::{
+    deserialize::{ArrowArray, ArrowDeserialize},
     field::ArrowField,
     serialize::{ArrowSerialize, TryIntoArrow},
 };
@@ -88,8 +89,7 @@ pub trait Component: ArrowField {
     }
 }
 
-/// A trait to identify any [`Component`] that is ready to be collected and subsequently serialized
-/// into an Arrow payload.
+/// A [`Component`] that fulfils all the conditions required to be serialized as an Arrow payload.
 pub trait SerializableComponent
 where
     Self: Component + ArrowSerialize + ArrowField<Type = Self> + 'static,
@@ -98,6 +98,25 @@ where
 
 impl<C> SerializableComponent for C where
     C: Component + ArrowSerialize + ArrowField<Type = C> + 'static
+{
+}
+
+/// A [`Component`] that fulfils all the conditions required to be deserialized from an Arrow
+/// payload.
+pub trait DeserializableComponent
+where
+    Self: Component + ArrowDeserialize + ArrowField<Type = Self> + 'static,
+    Self::ArrayType: ArrowArray,
+    for<'b> &'b Self::ArrayType: IntoIterator,
+{
+}
+
+impl<C> DeserializableComponent for C
+where
+    C: Component,
+    C: ArrowDeserialize + ArrowField<Type = C> + 'static,
+    C::ArrayType: ArrowArray,
+    for<'b> &'b C::ArrayType: IntoIterator,
 {
 }
 

--- a/crates/re_log_types/src/msg_bundle.rs
+++ b/crates/re_log_types/src/msg_bundle.rs
@@ -113,7 +113,8 @@ impl<C> SerializableComponent for C where
 /// ```
 pub trait DeserializableComponent<ArrowFieldType = Self>
 where
-    Self: Component + ArrowDeserialize + ArrowField<Type = ArrowFieldType> + 'static,
+    Self: Component,
+    Self: ArrowDeserialize + ArrowField<Type = ArrowFieldType> + 'static,
     Self::ArrayType: ArrowArray,
     for<'b> &'b Self::ArrayType: IntoIterator,
 {

--- a/crates/re_query/src/entity_view.rs
+++ b/crates/re_query/src/entity_view.rs
@@ -6,11 +6,9 @@ use re_format::arrow;
 use re_log_types::{
     component_types::InstanceKey,
     external::arrow2_convert::{
-        deserialize::{arrow_array_deserialize_iterator, ArrowArray, ArrowDeserialize},
-        field::ArrowField,
-        serialize::ArrowSerialize,
+        deserialize::arrow_array_deserialize_iterator, field::ArrowField, serialize::ArrowSerialize,
     },
-    msg_bundle::Component,
+    msg_bundle::{Component, DeserializableComponent},
     ComponentName,
 };
 
@@ -58,10 +56,10 @@ impl ComponentWithInstances {
     }
 
     /// Iterate over the values and convert them to a native `Component`
-    pub fn iter_values<C: Component>(&self) -> crate::Result<impl Iterator<Item = Option<C>> + '_>
+    pub fn iter_values<C: DeserializableComponent>(
+        &self,
+    ) -> crate::Result<impl Iterator<Item = Option<C>> + '_>
     where
-        C: ArrowDeserialize + ArrowField<Type = C> + 'static,
-        C::ArrayType: ArrowArray,
         for<'a> &'a C::ArrayType: IntoIterator,
     {
         if C::name() != self.name {
@@ -77,10 +75,8 @@ impl ComponentWithInstances {
     }
 
     /// Look up the value that corresponds to a given `InstanceKey` and convert to `Component`
-    pub fn lookup<C: Component>(&self, instance_key: &InstanceKey) -> crate::Result<C>
+    pub fn lookup<C: DeserializableComponent>(&self, instance_key: &InstanceKey) -> crate::Result<C>
     where
-        C: ArrowDeserialize + ArrowField<Type = C> + 'static,
-        C::ArrayType: ArrowArray,
         for<'a> &'a C::ArrayType: IntoIterator,
     {
         if C::name() != self.name {
@@ -296,10 +292,8 @@ where
     }
 }
 
-impl<Primary> EntityView<Primary>
+impl<Primary: DeserializableComponent + ArrowSerialize> EntityView<Primary>
 where
-    Primary: Component + ArrowSerialize + ArrowDeserialize + ArrowField<Type = Primary> + 'static,
-    Primary::ArrayType: ArrowArray,
     for<'a> &'a Primary::ArrayType: IntoIterator,
 {
     /// Iterate over the instance keys
@@ -332,12 +326,10 @@ where
     /// Iterate over the values of a `Component`.
     ///
     /// Always produces an iterator of length `self.primary.len()`
-    pub fn iter_component<C: Component>(
+    pub fn iter_component<C: DeserializableComponent + Clone>(
         &self,
     ) -> crate::Result<impl Iterator<Item = Option<C>> + '_>
     where
-        C: Clone + ArrowDeserialize + ArrowField<Type = C> + 'static,
-        C::ArrayType: ArrowArray,
         for<'b> &'b C::ArrayType: IntoIterator,
     {
         let component = self.components.get(&C::name());

--- a/crates/re_query/src/entity_view.rs
+++ b/crates/re_query/src/entity_view.rs
@@ -8,7 +8,7 @@ use re_log_types::{
     external::arrow2_convert::{
         deserialize::arrow_array_deserialize_iterator, field::ArrowField, serialize::ArrowSerialize,
     },
-    msg_bundle::{Component, DeserializableComponent},
+    msg_bundle::{Component, DeserializableComponent, SerializableComponent},
     ComponentName,
 };
 
@@ -128,14 +128,10 @@ impl ComponentWithInstances {
     }
 
     /// Produce a `ComponentWithInstances` from native component types
-    pub fn from_native<C>(
+    pub fn from_native<C: SerializableComponent>(
         instance_keys: Option<&Vec<InstanceKey>>,
         values: &Vec<C>,
-    ) -> crate::Result<ComponentWithInstances>
-    where
-        C: Component + 'static,
-        C: ArrowSerialize + ArrowField<Type = C>,
-    {
+    ) -> crate::Result<ComponentWithInstances> {
         use re_log_types::external::arrow2_convert::serialize::arrow_serialize_to_mutable_array;
 
         let instance_keys = if let Some(keys) = instance_keys {
@@ -292,7 +288,7 @@ where
     }
 }
 
-impl<Primary: DeserializableComponent + ArrowSerialize> EntityView<Primary>
+impl<Primary: SerializableComponent + DeserializableComponent> EntityView<Primary>
 where
     for<'a> &'a Primary::ArrayType: IntoIterator,
 {

--- a/crates/re_query/src/visit.rs
+++ b/crates/re_query/src/visit.rs
@@ -44,8 +44,7 @@
 
 use re_log_types::{
     component_types::InstanceKey,
-    external::arrow2_convert::serialize::ArrowSerialize,
-    msg_bundle::{Component, DeserializableComponent},
+    msg_bundle::{Component, DeserializableComponent, SerializableComponent},
 };
 
 use crate::EntityView;
@@ -93,7 +92,7 @@ macro_rules! create_visitor {
     );
 }
 
-impl<Primary: DeserializableComponent + ArrowSerialize> EntityView<Primary>
+impl<Primary: SerializableComponent + DeserializableComponent> EntityView<Primary>
 where
     for<'a> &'a Primary::ArrayType: IntoIterator,
 {

--- a/crates/re_query/src/visit.rs
+++ b/crates/re_query/src/visit.rs
@@ -44,12 +44,8 @@
 
 use re_log_types::{
     component_types::InstanceKey,
-    external::arrow2_convert::{
-        deserialize::{ArrowArray, ArrowDeserialize},
-        field::ArrowField,
-        serialize::ArrowSerialize,
-    },
-    msg_bundle::Component,
+    external::arrow2_convert::serialize::ArrowSerialize,
+    msg_bundle::{Component, DeserializableComponent},
 };
 
 use crate::EntityView;
@@ -72,8 +68,7 @@ macro_rules! create_visitor {
 
         ) -> crate::Result<()>
         where $(
-            $CC: Clone + ArrowDeserialize + ArrowField<Type = $CC> + 'static,
-            $CC::ArrayType: ArrowArray,
+            $CC: Clone + DeserializableComponent,
             for<'a> &'a $CC::ArrayType: IntoIterator,
         )*
         {
@@ -98,10 +93,8 @@ macro_rules! create_visitor {
     );
 }
 
-impl<Primary> EntityView<Primary>
+impl<Primary: DeserializableComponent + ArrowSerialize> EntityView<Primary>
 where
-    Primary: Component + ArrowSerialize + ArrowDeserialize + ArrowField<Type = Primary> + 'static,
-    Primary::ArrayType: ArrowArray,
     for<'a> &'a Primary::ArrayType: IntoIterator,
 {
     create_visitor! {visit1; ;}

--- a/crates/re_viewer/src/misc/space_info.rs
+++ b/crates/re_viewer/src/misc/space_info.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use nohash_hasher::IntSet;
 
 use re_arrow_store::{LatestAtQuery, TimeInt, Timeline};
-use re_data_store::{log_db::EntityDb, query_latest, EntityPath, EntityTree};
+use re_data_store::{log_db::EntityDb, query_latest_single, EntityPath, EntityTree};
 use re_log_types::{Transform, ViewCoordinates};
 use re_query::query_entity_with_primary;
 
@@ -112,7 +112,8 @@ impl SpaceInfoCollection {
             tree: &EntityTree,
             query: &LatestAtQuery,
         ) {
-            if let Some(transform) = query_latest::<Transform>(entity_db, &tree.path, query) {
+            if let Some(transform) = query_latest_single::<Transform>(entity_db, &tree.path, query)
+            {
                 // A set transform (likely non-identity) - create a new space.
                 parent_space
                     .child_spaces
@@ -156,7 +157,7 @@ impl SpaceInfoCollection {
         let mut spaces_info = Self::default();
 
         // Start at the root. The root is always part of the collection!
-        if query_latest::<Transform>(entity_db, &EntityPath::root(), &query).is_some() {
+        if query_latest_single::<Transform>(entity_db, &EntityPath::root(), &query).is_some() {
             re_log::warn_once!("The root entity has a 'transform' component! This will have no effect. Did you mean to apply the transform elsewhere?");
         }
         let mut root_space_info = SpaceInfo::new(EntityPath::root());

--- a/crates/re_viewer/src/misc/space_info.rs
+++ b/crates/re_viewer/src/misc/space_info.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use nohash_hasher::IntSet;
 
 use re_arrow_store::{LatestAtQuery, TimeInt, Timeline};
-use re_data_store::{log_db::EntityDb, query_transform, EntityPath, EntityTree};
+use re_data_store::{log_db::EntityDb, query_latest, EntityPath, EntityTree};
 use re_log_types::{Transform, ViewCoordinates};
 use re_query::query_entity_with_primary;
 
@@ -112,7 +112,7 @@ impl SpaceInfoCollection {
             tree: &EntityTree,
             query: &LatestAtQuery,
         ) {
-            if let Some(transform) = query_transform(entity_db, &tree.path, query) {
+            if let Some(transform) = query_latest::<Transform>(entity_db, &tree.path, query) {
                 // A set transform (likely non-identity) - create a new space.
                 parent_space
                     .child_spaces
@@ -156,7 +156,7 @@ impl SpaceInfoCollection {
         let mut spaces_info = Self::default();
 
         // Start at the root. The root is always part of the collection!
-        if query_transform(entity_db, &EntityPath::root(), &query).is_some() {
+        if query_latest::<Transform>(entity_db, &EntityPath::root(), &query).is_some() {
             re_log::warn_once!("The root entity has a 'transform' component! This will have no effect. Did you mean to apply the transform elsewhere?");
         }
         let mut root_space_info = SpaceInfo::new(EntityPath::root());

--- a/crates/re_viewer/src/misc/transform_cache.rs
+++ b/crates/re_viewer/src/misc/transform_cache.rs
@@ -1,6 +1,8 @@
 use nohash_hasher::IntMap;
 use re_arrow_store::LatestAtQuery;
-use re_data_store::{log_db::EntityDb, query_latest, EntityPath, EntityPropertyMap, EntityTree};
+use re_data_store::{
+    log_db::EntityDb, query_latest_single, EntityPath, EntityPropertyMap, EntityTree,
+};
 
 use crate::misc::TimeControl;
 
@@ -222,7 +224,7 @@ fn transform_at(
     query: &LatestAtQuery,
     encountered_pinhole: &mut bool,
 ) -> Result<Option<macaw::Mat4>, UnreachableTransform> {
-    if let Some(transform) = query_latest(entity_db, entity_path, query) {
+    if let Some(transform) = query_latest_single(entity_db, entity_path, query) {
         match transform {
             re_log_types::Transform::Rigid3(rigid) => Ok(Some(rigid.parent_from_child().to_mat4())),
             // If we're connected via 'unknown' it's not reachable
@@ -269,7 +271,7 @@ fn inverse_transform_at(
     query: &LatestAtQuery,
     encountered_pinhole: &mut bool,
 ) -> Result<Option<macaw::Mat4>, UnreachableTransform> {
-    if let Some(parent_transform) = query_latest(entity_db, entity_path, query) {
+    if let Some(parent_transform) = query_latest_single(entity_db, entity_path, query) {
         match parent_transform {
             re_log_types::Transform::Rigid3(rigid) => Ok(Some(rigid.child_from_parent().to_mat4())),
             // If we're connected via 'unknown', everything except whats under `parent_tree` is unreachable

--- a/crates/re_viewer/src/misc/transform_cache.rs
+++ b/crates/re_viewer/src/misc/transform_cache.rs
@@ -1,6 +1,6 @@
 use nohash_hasher::IntMap;
 use re_arrow_store::LatestAtQuery;
-use re_data_store::{log_db::EntityDb, query_transform, EntityPath, EntityPropertyMap, EntityTree};
+use re_data_store::{log_db::EntityDb, query_latest, EntityPath, EntityPropertyMap, EntityTree};
 
 use crate::misc::TimeControl;
 
@@ -222,7 +222,7 @@ fn transform_at(
     query: &LatestAtQuery,
     encountered_pinhole: &mut bool,
 ) -> Result<Option<macaw::Mat4>, UnreachableTransform> {
-    if let Some(transform) = query_transform(entity_db, entity_path, query) {
+    if let Some(transform) = query_latest(entity_db, entity_path, query) {
         match transform {
             re_log_types::Transform::Rigid3(rigid) => Ok(Some(rigid.parent_from_child().to_mat4())),
             // If we're connected via 'unknown' it's not reachable
@@ -269,7 +269,7 @@ fn inverse_transform_at(
     query: &LatestAtQuery,
     encountered_pinhole: &mut bool,
 ) -> Result<Option<macaw::Mat4>, UnreachableTransform> {
-    if let Some(parent_transform) = query_transform(entity_db, entity_path, query) {
+    if let Some(parent_transform) = query_latest(entity_db, entity_path, query) {
         match parent_transform {
             re_log_types::Transform::Rigid3(rigid) => Ok(Some(rigid.child_from_parent().to_mat4())),
             // If we're connected via 'unknown', everything except whats under `parent_tree` is unreachable

--- a/crates/re_viewer/src/ui/data_ui/component_ui_registry.rs
+++ b/crates/re_viewer/src/ui/data_ui/component_ui_registry.rs
@@ -4,11 +4,7 @@ use re_arrow_store::LatestAtQuery;
 use re_log_types::{
     component_types::InstanceKey,
     external::arrow2,
-    external::arrow2_convert::{
-        deserialize::{ArrowArray, ArrowDeserialize},
-        field::ArrowField,
-    },
-    msg_bundle::Component,
+    msg_bundle::{Component, DeserializableComponent},
     ComponentName,
 };
 use re_query::ComponentWithInstances;
@@ -74,10 +70,8 @@ impl Default for ComponentUiRegistry {
 }
 
 impl ComponentUiRegistry {
-    fn add<C>(&mut self)
+    fn add<C: DeserializableComponent + DataUi>(&mut self)
     where
-        C: Component + DataUi + ArrowDeserialize + ArrowField<Type = C> + 'static,
-        C::ArrayType: ArrowArray,
         for<'a> &'a C::ArrayType: IntoIterator,
     {
         self.components.insert(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,4 +1,4 @@
-use re_data_store::{query_latest, EntityPath, EntityProperties};
+use re_data_store::{query_latest_single, EntityPath, EntityProperties};
 use re_log_types::{TimeType, Transform};
 
 use crate::{
@@ -412,7 +412,7 @@ fn entity_props_ui(
                 if let Some(entity_path) = entity_path {
                     let query = ctx.current_query();
                     if let Some(re_log_types::Transform::Pinhole(pinhole)) =
-                        query_latest::<Transform>(&ctx.log_db.entity_db, entity_path, &query)
+                        query_latest_single::<Transform>(&ctx.log_db.entity_db, entity_path, &query)
                     {
                         ui.label("Image plane distance");
                         let mut distance = entity_props.pinhole_image_plane_distance(&pinhole);

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,5 +1,5 @@
-use re_data_store::{query_transform, EntityPath, EntityProperties};
-use re_log_types::TimeType;
+use re_data_store::{query_latest, EntityPath, EntityProperties};
+use re_log_types::{TimeType, Transform};
 
 use crate::{
     ui::{view_spatial::SpatialNavigationMode, Blueprint},
@@ -407,11 +407,12 @@ fn entity_props_ui(
             }
             ui.end_row();
 
+            // pinhole_image_plane_distance
             if view_state.state_spatial.nav_mode == SpatialNavigationMode::ThreeD {
                 if let Some(entity_path) = entity_path {
                     let query = ctx.current_query();
                     if let Some(re_log_types::Transform::Pinhole(pinhole)) =
-                        query_transform(&ctx.log_db.entity_db, entity_path, &query)
+                        query_latest::<Transform>(&ctx.log_db.entity_db, entity_path, &query)
                     {
                         ui.label("Image plane distance");
                         let mut distance = entity_props.pinhole_image_plane_distance(&pinhole);

--- a/crates/re_viewer/src/ui/space_view_heuristics.rs
+++ b/crates/re_viewer/src/ui/space_view_heuristics.rs
@@ -4,7 +4,7 @@ use ahash::HashMap;
 use itertools::Itertools;
 use nohash_hasher::IntSet;
 use re_arrow_store::{DataStore, LatestAtQuery, Timeline};
-use re_data_store::{log_db::EntityDb, query_latest, ComponentName, EntityPath};
+use re_data_store::{log_db::EntityDb, query_latest_single, ComponentName, EntityPath};
 use re_log_types::{
     component_types::{Tensor, TensorTrait},
     msg_bundle::Component,
@@ -100,7 +100,7 @@ fn is_interesting_space_view_not_at_root(
     //       .. an unknown transform, the children can't be shown otherwise
     //       .. an pinhole transform, we'd like to see the world from this camera's pov as well!
     if candidate.category == ViewCategory::Spatial {
-        if let Some(transform) = query_latest(entity_db, &candidate.space_path, query) {
+        if let Some(transform) = query_latest_single(entity_db, &candidate.space_path, query) {
             match transform {
                 re_log_types::Transform::Rigid3(_) => {}
                 re_log_types::Transform::Pinhole(_) | re_log_types::Transform::Unknown => {

--- a/crates/re_viewer/src/ui/space_view_heuristics.rs
+++ b/crates/re_viewer/src/ui/space_view_heuristics.rs
@@ -4,7 +4,7 @@ use ahash::HashMap;
 use itertools::Itertools;
 use nohash_hasher::IntSet;
 use re_arrow_store::{DataStore, LatestAtQuery, Timeline};
-use re_data_store::{log_db::EntityDb, query_transform, ComponentName, EntityPath};
+use re_data_store::{log_db::EntityDb, query_latest, ComponentName, EntityPath};
 use re_log_types::{
     component_types::{Tensor, TensorTrait},
     msg_bundle::Component,
@@ -100,7 +100,7 @@ fn is_interesting_space_view_not_at_root(
     //       .. an unknown transform, the children can't be shown otherwise
     //       .. an pinhole transform, we'd like to see the world from this camera's pov as well!
     if candidate.category == ViewCategory::Spatial {
-        if let Some(transform) = query_transform(entity_db, &candidate.space_path, query) {
+        if let Some(transform) = query_latest(entity_db, &candidate.space_path, query) {
             match transform {
                 re_log_types::Transform::Rigid3(_) => {}
                 re_log_types::Transform::Pinhole(_) | re_log_types::Transform::Unknown => {

--- a/crates/re_viewer/src/ui/view_category.rs
+++ b/crates/re_viewer/src/ui/view_category.rs
@@ -1,5 +1,5 @@
 use re_arrow_store::{LatestAtQuery, TimeInt};
-use re_data_store::{query_transform, EntityPath, LogDb, Timeline};
+use re_data_store::{query_latest, EntityPath, LogDb, Timeline};
 use re_log_types::{
     component_types::{
         Box3D, LineStrip2D, LineStrip3D, Point2D, Point3D, Rect2D, Scalar, Tensor, TensorTrait,
@@ -73,7 +73,7 @@ pub fn categorize_entity_path(
 
     // If it has a transform we might want to visualize it in space
     // (as of writing we do that only for projections, i.e. cameras, but visualizations for rigid transforms may be added)
-    if query_transform(
+    if query_latest::<Transform>(
         &log_db.entity_db,
         entity_path,
         &LatestAtQuery::new(timeline, TimeInt::MAX),

--- a/crates/re_viewer/src/ui/view_category.rs
+++ b/crates/re_viewer/src/ui/view_category.rs
@@ -1,5 +1,5 @@
 use re_arrow_store::{LatestAtQuery, TimeInt};
-use re_data_store::{query_latest, EntityPath, LogDb, Timeline};
+use re_data_store::{query_latest_single, EntityPath, LogDb, Timeline};
 use re_log_types::{
     component_types::{
         Box3D, LineStrip2D, LineStrip3D, Point2D, Point3D, Rect2D, Scalar, Tensor, TensorTrait,
@@ -73,7 +73,7 @@ pub fn categorize_entity_path(
 
     // If it has a transform we might want to visualize it in space
     // (as of writing we do that only for projections, i.e. cameras, but visualizations for rigid transforms may be added)
-    if query_latest::<Transform>(
+    if query_latest_single::<Transform>(
         &log_db.entity_db,
         entity_path,
         &LatestAtQuery::new(timeline, TimeInt::MAX),


### PR DESCRIPTION
This adds a `DeserializableComponent` trait (which does what you think it does and means what you think it means) and uses it everywhere it makes sense.
Also fixed a bunch of places where `SerializableComponent` wasn't used yet.

In addition to this, this generalizes the `query_transform` function (that we use in a bunch of places in the UI to fetch the latest transform of a given entity path) to any component.
We do so because I now have the need to fetch stuff other than transforms when displaying the selection panel.