### PR TITLE
Versioned log streams streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,6 +3965,7 @@ dependencies = [
  "num-traits",
  "puffin",
  "rand",
+ "re_build_info",
  "re_format",
  "re_log",
  "re_string_interner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ rust-version = "1.67"
 version = "0.2.0"
 
 [workspace.dependencies]
+# When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
+# This is because we treat alpha-releases as incompatible, but semver doesn't.
+# In particular: if we compile rerun 0.3.0-alpha.0 we only want it to use
+# re_log_types 0.3.0-alpha.0, NOT 0.3.0-alpha.4 even though it is newer and semver-compatible.
 re_analytics = { path = "crates/re_analytics", version = "0.2.0" }
 re_arrow_store = { path = "crates/re_arrow_store", version = "0.2.0" }
 re_build_build_info = { path = "crates/re_build_build_info", version = "0.2.0" }

--- a/crates/re_build_info/src/buid_info.rs
+++ b/crates/re_build_info/src/buid_info.rs
@@ -1,0 +1,75 @@
+/// Information about the build of a Rust crate.
+///
+/// Create this with [`build_info`].
+///
+/// The `git_` fields are all empty on failure. Most likely git fails because we're not in a git repository
+/// to begin with, which happens because we've imported the published crate from crates.io.
+///
+/// There are a few other cases though, like
+/// - `git` is not installed
+/// - the user downloaded rerun as a tarball and then imported via a `path = ...` import
+/// - others?
+#[derive(Copy, Clone, Debug)]
+pub struct BuildInfo {
+    /// `CARGO_PKG_NAME`
+    pub crate_name: &'static str,
+
+    /// Parsed `CARGO_PKG_VERSION`
+    pub version: super::RustVersion,
+
+    /// Git commit hash, or empty string.
+    pub git_hash: &'static str,
+
+    /// Current git branch, or empty string.
+    pub git_branch: &'static str,
+
+    /// Target architecture and OS
+    ///
+    /// Example: `xaarch64-apple-darwin`
+    pub target_triple: &'static str,
+
+    /// ISO 8601 / RFC 3339 build time.
+    ///
+    /// Example: `"2023-02-23T19:33:26Z"`
+    pub datetime: &'static str,
+}
+
+impl BuildInfo {
+    pub fn git_hash_or_tag(&self) -> String {
+        if self.git_hash.is_empty() {
+            format!("v{}", self.version)
+        } else {
+            self.git_hash.to_owned()
+        }
+    }
+}
+
+/// For use with e.g. `--version`
+impl std::fmt::Display for BuildInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            crate_name,
+            version,
+            git_hash,
+            git_branch,
+            target_triple,
+            datetime,
+        } = self;
+
+        write!(f, "{crate_name} {version}")?;
+
+        write!(f, " {target_triple}")?;
+
+        if !git_branch.is_empty() {
+            write!(f, " {git_branch}")?;
+        }
+        if !git_hash.is_empty() {
+            let git_hash: String = git_hash.chars().take(7).collect(); // shorten
+            write!(f, " {git_hash}")?;
+        }
+
+        write!(f, ", built {datetime}")?;
+
+        Ok(())
+    }
+}

--- a/crates/re_build_info/src/buid_info.rs
+++ b/crates/re_build_info/src/buid_info.rs
@@ -1,6 +1,6 @@
 /// Information about the build of a Rust crate.
 ///
-/// Create this with [`build_info`].
+/// Create this with [`crate::build_info`].
 ///
 /// The `git_` fields are all empty on failure. Most likely git fails because we're not in a git repository
 /// to begin with, which happens because we've imported the published crate from crates.io.

--- a/crates/re_build_info/src/lib.rs
+++ b/crates/re_build_info/src/lib.rs
@@ -2,81 +2,11 @@
 //!
 //! To use this you also need to call `re_build_build_info::export_env_vars()` from your build.rs.
 
-/// Information about the build of a Rust crate.
-///
-/// Create this with [`build_info`].
-///
-/// The `git_` fields are all empty on failure. Most likely git fails because we're not in a git repository
-/// to begin with, which happens because we've imported the published crate from crates.io.
-///
-/// There are a few other cases though, like
-/// - `git` is not installed
-/// - the user downloaded rerun as a tarball and then imported via a `path = ...` import
-/// - others?
-#[derive(Copy, Clone, Debug)]
-pub struct BuildInfo {
-    /// `CARGO_PKG_NAME`
-    pub crate_name: &'static str,
+mod buid_info;
+mod rust_version;
 
-    /// `CARGO_PKG_VERSION`
-    pub version: &'static str,
-
-    /// Git commit hash, or empty string.
-    pub git_hash: &'static str,
-
-    /// Current git branch, or empty string.
-    pub git_branch: &'static str,
-
-    /// Target architecture and OS
-    ///
-    /// Example: `xaarch64-apple-darwin`
-    pub target_triple: &'static str,
-
-    /// ISO 8601 / RFC 3339 build time.
-    ///
-    /// Example: `"2023-02-23T19:33:26Z"`
-    pub datetime: &'static str,
-}
-
-impl BuildInfo {
-    pub fn git_hash_or_tag(&self) -> String {
-        if self.git_hash.is_empty() {
-            format!("v{}", self.version)
-        } else {
-            self.git_hash.to_owned()
-        }
-    }
-}
-
-/// For use with e.g. `--version`
-impl std::fmt::Display for BuildInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            crate_name,
-            version,
-            git_hash,
-            git_branch,
-            target_triple,
-            datetime,
-        } = self;
-
-        write!(f, "{crate_name} {version}")?;
-
-        write!(f, " {target_triple}")?;
-
-        if !git_branch.is_empty() {
-            write!(f, " {git_branch}")?;
-        }
-        if !git_hash.is_empty() {
-            let git_hash: String = git_hash.chars().take(7).collect(); // shorten
-            write!(f, " {git_hash}")?;
-        }
-
-        write!(f, ", built {datetime}")?;
-
-        Ok(())
-    }
-}
+pub use buid_info::BuildInfo;
+pub use rust_version::RustVersion;
 
 /// Create a [`BuildInfo`] at compile-time using environment variables exported by
 /// calling `re_build_build_info::export_env_vars()` from your build.rs.
@@ -85,7 +15,7 @@ macro_rules! build_info {
     () => {
         $crate::BuildInfo {
             crate_name: env!("CARGO_PKG_NAME"),
-            version: env!("CARGO_PKG_VERSION"),
+            version: $crate::RustVersion::parse(env!("CARGO_PKG_VERSION")),
             git_hash: env!("RE_BUILD_GIT_HASH"),
             git_branch: env!("RE_BUILD_GIT_BRANCH"),
             target_triple: env!("RE_BUILD_TARGET_TRIPLE"),

--- a/crates/re_build_info/src/rust_version.rs
+++ b/crates/re_build_info/src/rust_version.rs
@@ -1,0 +1,143 @@
+const NO_ALPHA: u8 = 255;
+
+/// Sub-set of semver supporting major, minor, patch and an optional `-alpha.X` suffix.
+///
+/// Examples: `1.2.3` and `1.2.3-alpha.4`.
+///
+/// This `struct` is designed to be space-efficient (32-bit)
+/// so it can be used as a version string in file formats.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RustVersion {
+    major: u8,
+    minor: u8,
+    patch: u8,
+    alpha: u8,
+}
+
+impl RustVersion {
+    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            alpha: NO_ALPHA,
+        }
+    }
+
+    pub const fn new_alpha(major: u8, minor: u8, patch: u8, alpha: u8) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            alpha,
+        }
+    }
+
+    pub const fn parse(s: &str) -> Self {
+        // Note that this is a const function, which means we are extremely limited in what we can do!
+
+        const fn parse_u8(s: &[u8], begin: usize, end: usize) -> u8 {
+            assert!(begin < end);
+            assert!(
+                s[begin] != b'0' || begin + 1 == end,
+                "multi-digit number cannot start with zero"
+            );
+
+            let mut num = 0u64;
+            let mut i = begin;
+
+            while i < end {
+                let c = s[i];
+                assert!(
+                    b'0' <= c && c <= b'9',
+                    "Unexpected non-digit in version string"
+                );
+                let digit = c - b'0';
+                num = num * 10 + digit as u64;
+                i += 1;
+            }
+            assert!(num <= u8::MAX as u64);
+            num as _
+        }
+
+        let s = s.as_bytes();
+
+        let mut i = 0;
+        while s[i] != b'.' {
+            i += 1;
+        }
+        let major = parse_u8(s, 0, i);
+
+        i += 1;
+        let minor_start = i;
+        while s[i] != b'.' {
+            i += 1;
+        }
+        let minor = parse_u8(s, minor_start, i);
+
+        i += 1;
+        let patch_start = i;
+        while i < s.len() && s[i] != b'-' {
+            i += 1;
+        }
+        let patch = parse_u8(s, patch_start, i);
+
+        if i < s.len() {
+            // `-alpha.X` suffix
+            assert!(s[i] == b'-', "Expected `-alpha.X` suffix");
+            i += 1;
+            assert!(s[i] == b'a', "Expected `-alpha.X` suffix");
+            i += 1;
+            assert!(s[i] == b'l', "Expected `-alpha.X` suffix");
+            i += 1;
+            assert!(s[i] == b'p', "Expected `-alpha.X` suffix");
+            i += 1;
+            assert!(s[i] == b'h', "Expected `-alpha.X` suffix");
+            i += 1;
+            assert!(s[i] == b'a', "Expected `-alpha.X` suffix");
+            i += 1;
+            assert!(s[i] == b'.', "Expected `-alpha.X` suffix");
+            i += 1;
+            let alpha = parse_u8(s, i, s.len());
+            Self::new_alpha(major, minor, patch, alpha)
+        } else {
+            Self::new(major, minor, patch)
+        }
+    }
+}
+
+impl std::fmt::Display for RustVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            major,
+            minor,
+            patch,
+            alpha,
+        } = *self;
+        if alpha == NO_ALPHA {
+            write!(f, "{major}.{minor}.{patch}")
+        } else {
+            write!(f, "{major}.{minor}.{patch}-alpha.{alpha}")
+        }
+    }
+}
+
+#[test]
+fn test_parse_version() {
+    let parse = RustVersion::parse;
+    assert_eq!(parse("0.2.0"), RustVersion::new(0, 2, 0));
+    assert_eq!(parse("1.2.3"), RustVersion::new(1, 2, 3));
+    assert_eq!(parse("123.45.67"), RustVersion::new(123, 45, 67));
+    assert_eq!(
+        parse("123.45.67-alpha.89"),
+        RustVersion::new_alpha(123, 45, 67, 89)
+    );
+}
+
+#[test]
+fn test_format_parse_roundtrip() {
+    let parse = RustVersion::parse;
+    for version in ["0.2.0", "1.2.3", "123.45.67", "123.45.67-alpha.89"] {
+        assert_eq!(parse(version).to_string(), version);
+    }
+}

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -51,6 +51,7 @@ serde = [
 [dependencies]
 
 # Rerun
+re_build_info.workspace = true
 re_format.workspace = true
 re_log.workspace = true
 re_string_interner.workspace = true

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -91,7 +91,7 @@ fn warn_on_version_mismatch(encoded_version: [u8; 4]) {
     let local_version = RustVersion::parse(env!("CARGO_PKG_VERSION"));
 
     if !encoded_version.is_semver_compatible_with(local_version) {
-        re_log::warn!("Loading stream with incompatible Rerun version {encoded_version}. Local Rerun version is {local_version}. Will try to load it anyways, but it might fail in interesting ways.");
+        re_log::warn!("Found log stream with Rerun version {encoded_version}, which is incompatible with the local Rerun version {local_version}. Loading will try to continue, but might fail in subtle ways.");
     }
 }
 

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -21,8 +21,12 @@ mod encoder {
 
     impl<W: std::io::Write> Encoder<W> {
         pub fn new(mut write: W) -> anyhow::Result<Self> {
+            let rerun_version = re_build_info::RustVersion::parse(env!("CARGO_PKG_VERSION"));
+
             write.write_all(b"RRF0").context("header")?;
-            write.write_all(&[0, 0, 0, 0]).context("header")?; // reserved for future use
+            write
+                .write_all(&rerun_version.to_bytes())
+                .context("header")?;
 
             let level = 3;
             let zstd_encoder = zstd::stream::Encoder::new(write, level).context("zstd start")?;
@@ -73,6 +77,25 @@ mod encoder {
 pub use encoder::*;
 
 // ----------------------------------------------------------------------------
+
+fn warn_on_version_mismatch(encoded_version: [u8; 4]) {
+    use re_build_info::RustVersion;
+
+    // We used 0000 for all .rrd files up until 2023-02-27, post 0.2.0 release:
+    let encoded_version = if encoded_version == [0, 0, 0, 0] {
+        RustVersion::new(0, 2, 0)
+    } else {
+        RustVersion::from_bytes(encoded_version)
+    };
+
+    let local_version = RustVersion::parse(env!("CARGO_PKG_VERSION"));
+
+    if !encoded_version.is_semver_compatible_with(local_version) {
+        re_log::warn!("Loading stream with incompatible Rerun version {encoded_version}. Local Rerun version is {local_version}. Will try to load it anyways, but it might fail in interesting ways.");
+    }
+}
+
+// ----------------------------------------------------------------------------
 // native decode:
 
 #[cfg(feature = "load")]
@@ -93,7 +116,7 @@ impl<'r, R: std::io::Read> Decoder<'r, std::io::BufReader<R>> {
         read.read_exact(&mut header).context("missing header")?;
         anyhow::ensure!(&header == b"RRF0", "Not a rerun file");
         read.read_exact(&mut header).context("missing header")?;
-        anyhow::ensure!(header == [0, 0, 0, 0], "Incompatible rerun file format");
+        warn_on_version_mismatch(header);
 
         let zdecoder = zstd::stream::read::Decoder::new(read).context("zstd")?;
         Ok(Self {
@@ -154,7 +177,7 @@ impl<R: std::io::Read> Decoder<R> {
         read.read_exact(&mut header).context("missing header")?;
         anyhow::ensure!(&header == b"RRF0", "Not a rerun file");
         read.read_exact(&mut header).context("missing header")?;
-        anyhow::ensure!(header == [0, 0, 0, 0], "Incompatible rerun file format");
+        warn_on_version_mismatch(header);
 
         let zdecoder =
             ruzstd::StreamingDecoder::new(read).map_err(|err| anyhow::anyhow!("ruzstd: {err}"))?;

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -95,7 +95,7 @@ impl ViewerAnalytics {
             };
 
             let mut event = Event::update("update_metadata")
-                .with_prop("rerun_version", build_info.version)
+                .with_prop("rerun_version", build_info.version.to_string())
                 .with_prop("target", build_info.target_triple)
                 .with_prop("git_hash", git_hash)
                 .with_prop("debug", cfg!(debug_assertions)) // debug-build?


### PR DESCRIPTION
This encodes the full Rerun version in our log streams (networked and .rrd files). When loading a stream a warning will be logged if the versions are potentially incompatible.

This PR also constrains the Rerun version to always be on the pattern `X.Y.Z[-alpha.W]`. With (X,Y,Z,W)<255. This allows us to always encode the version in 32 bits.

Closes https://github.com/rerun-io/rerun/issues/873

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
