### PR TITLE
Remove `show` from Python SDK

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -306,25 +306,8 @@ def serve(open_browser: bool = True) -> None:
 
 
 def disconnect() -> None:
-    """Disconnect from the remote rerun server (if any)."""
+    """Closes all TCP connections, servers, and files that have been opened with [`rerun.connect`], [`rerun.serve`], [`rerun.save`] or [`rerun.spawn`]."""
     bindings.disconnect()
-
-
-def show() -> None:
-    """
-    Show previously logged data.
-
-    This only works if you have not called `connect`.
-
-    NOTE: There is a bug which causes this function to only work once on some platforms.
-
-    """
-
-    if not bindings.is_enabled():
-        print("Rerun is disabled - show() call ignored")
-        return
-
-    bindings.show()
 
 
 def save(path: str) -> None:

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -306,7 +306,13 @@ def serve(open_browser: bool = True) -> None:
 
 
 def disconnect() -> None:
-    """Closes all TCP connections, servers, and files that have been opened with [`rerun.connect`], [`rerun.serve`], [`rerun.save`] or [`rerun.spawn`]."""
+    """
+    Closes all TCP connections, servers, and files.
+
+    Closes all TCP connections, servers, and files that have been opened with
+    [`rerun.connect`], [`rerun.serve`], [`rerun.save`] or [`rerun.spawn`].
+    """
+
     bindings.disconnect()
 
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -117,12 +117,7 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(shutdown, m)?)?;
     m.add_function(wrap_pyfunction!(is_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(set_enabled, m)?)?;
-
-    #[cfg(feature = "native_viewer")]
-    {
-        m.add_function(wrap_pyfunction!(disconnect, m)?)?;
-        m.add_function(wrap_pyfunction!(show, m)?)?;
-    }
+    m.add_function(wrap_pyfunction!(disconnect, m)?)?;
     m.add_function(wrap_pyfunction!(save, m)?)?;
 
     m.add_function(wrap_pyfunction!(set_time_sequence, m)?)?;
@@ -330,24 +325,9 @@ fn set_enabled(enabled: bool) {
 ///
 /// Subsequent log messages will be buffered and either sent on the next call to `connect`,
 /// or shown with `show`.
-#[cfg(feature = "native_viewer")]
 #[pyfunction]
 fn disconnect() {
     global_session().disconnect();
-}
-
-/// Show the buffered log data.
-///
-/// NOTE: currently this only works _once_.
-/// Calling this function more than once is undefined behavior.
-/// We will try to fix this in the future.
-/// Blocked on <https://github.com/emilk/egui/issues/1918>.
-#[cfg(feature = "native_viewer")]
-#[pyfunction]
-fn show() -> PyResult<()> {
-    global_session()
-        .show()
-        .map_err(|err| PyRuntimeError::new_err(format!("Failed to show Rerun Viewer: {err}")))
 }
 
 #[pyfunction]


### PR DESCRIPTION
We'll keep it for the Rust SDK for now, since `spawn` isn't that great yet.

Closes https://github.com/rerun-io/rerun/issues/895

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)