### PR TITLE
Add 2d support for linestrips

### DIFF
--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -75,7 +75,20 @@ def run_segmentation() -> None:
     rr.log_text_entry("logs/seg_demo_log", "label1 disappears and everything with label3 is now default colored again")
 
 
-def run_points_3d() -> None:
+def run_2d_lines() -> None:
+    import numpy as np
+
+    T = np.linspace(0, 5, 100)
+    for n in range(2, len(T)):
+        rr.set_time_seconds("sim_time", T[n])
+        t = T[:n]
+        x = np.cos(t * 5) * t
+        y = np.sin(t * 5) * t
+        pts = np.vstack([x, y]).T
+        rr.log_line_strip("2d_lines/spiral", positions=pts)
+
+
+def run_3d_points() -> None:
     import random
 
     rr.set_time_seconds("sim_time", 1)
@@ -261,7 +274,8 @@ def run_extension_component() -> None:
 
 def main() -> None:
     demos = {
-        "3d_points": run_points_3d,
+        "2d_lines": run_2d_lines,
+        "3d_points": run_3d_points,
         "log_cleared": run_log_cleared,
         "rects": run_rects,
         "segmentation": run_segmentation,

--- a/rerun_py/rerun_sdk/rerun/log/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log/lines.py
@@ -44,7 +44,7 @@ def log_line_strip(
     timeless: bool = False,
 ) -> None:
     r"""
-    Log a line strip through 3D space.
+    Log a line strip through 2D or 3D space.
 
     A line strip is a list of points connected by line segments. It can be used to draw approximations of smooth curves.
 
@@ -61,7 +61,7 @@ def log_line_strip(
     entity_path:
         Path to the path in the space hierarchy
     positions:
-        A Nx3 array of points along the path.
+        An Nx2 or Nx3 array of points along the path.
     stroke_width:
         Optional width of the line.
     color:
@@ -83,7 +83,12 @@ def log_line_strip(
     splats: Dict[str, Any] = {}
 
     if positions is not None:
-        instanced["rerun.linestrip3d"] = LineStrip3DArray.from_numpy_arrays([positions])
+        if positions.shape[1] == 2:
+            instanced["rerun.linestrip2d"] = LineStrip2DArray.from_numpy_arrays([positions])
+        elif positions.shape[1] == 3:
+            instanced["rerun.linestrip3d"] = LineStrip3DArray.from_numpy_arrays([positions])
+        else:
+            raise TypeError("Positions should be either Nx2 or Nx3")
 
     if color:
         colors = _normalize_colors([color])
@@ -132,7 +137,7 @@ def log_line_segments(
     entity_path:
         Path to the line segments in the space hierarchy
     positions:
-        A Nx3 array of points along the path.
+        An Nx2 or Nx3 array of points. Even-odd pairs will be connected as segments.
     stroke_width:
         Optional width of the line.
     color:


### PR DESCRIPTION
```
python examples/python/api_demo/main.py --demo 2d_lines
```
![image](https://user-images.githubusercontent.com/3312232/221864045-0afc862e-0d70-49ff-9753-fa6bc29758a7.png)


Resolves: https://github.com/rerun-io/rerun/issues/361

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
