### PR TITLE
heuristic for camera frustum length is now based on scene size

### DIFF
--- a/crates/re_data_store/src/editable_auto_value.rs
+++ b/crates/re_data_store/src/editable_auto_value.rs
@@ -1,0 +1,43 @@
+/// A value that is either determined automatically by some heuristic, or specified by the user.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, Eq, PartialEq)]
+#[serde(bound = "T: serde::Serialize, for<'de2> T: serde::Deserialize<'de2>")]
+pub enum EditableAutoValue<T>
+where
+    T: std::fmt::Debug + Eq + PartialEq + Clone + Default + serde::Serialize,
+    for<'de2> T: serde::Deserialize<'de2>,
+{
+    /// The user explicitly specified what they wanted
+    UserEdited(T),
+
+    /// The value is determined automatically.
+    ///
+    /// We may update this at any time or interpret the value stored here differently under certain circumstances.
+    Auto(T),
+}
+
+impl<T> Default for EditableAutoValue<T>
+where
+    T: std::fmt::Debug + Eq + PartialEq + Clone + Default + serde::Serialize,
+    for<'de2> T: serde::Deserialize<'de2>,
+{
+    fn default() -> Self {
+        EditableAutoValue::Auto(T::default())
+    }
+}
+
+impl<T> EditableAutoValue<T>
+where
+    T: std::fmt::Debug + Eq + PartialEq + Clone + Default + serde::Serialize,
+    for<'de2> T: serde::Deserialize<'de2>,
+{
+    pub fn is_auto(&self) -> bool {
+        matches!(self, EditableAutoValue::Auto(_))
+    }
+
+    /// Gets the value, disregarding if it was user edited or determined by a heuristic.
+    pub fn get(&self) -> &T {
+        match self {
+            EditableAutoValue::Auto(v) | EditableAutoValue::UserEdited(v) => v,
+        }
+    }
+}

--- a/crates/re_data_store/src/editable_auto_value.rs
+++ b/crates/re_data_store/src/editable_auto_value.rs
@@ -40,4 +40,13 @@ where
             EditableAutoValue::Auto(v) | EditableAutoValue::UserEdited(v) => v,
         }
     }
+
+    /// Returns other if self is auto, self otherwise.
+    pub fn or<'a>(&'a self, other: &'a EditableAutoValue<T>) -> &'a EditableAutoValue<T> {
+        if self.is_auto() {
+            other
+        } else {
+            self
+        }
+    }
 }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -4,7 +4,7 @@ use re_log_types::{
     msg_bundle::DeserializableComponent, EntityPath,
 };
 
-use crate::log_db::EntityDb;
+use crate::{log_db::EntityDb, EditableAutoValue};
 
 // ----------------------------------------------------------------------------
 
@@ -39,44 +39,21 @@ pub struct EntityProperties {
     pub visible_history: ExtraQueryHistory,
     pub interactive: bool,
 
-    /// Distance of the projection plane.
+    /// Distance of the projection plane (frustum far plane).
     ///
     /// Only applies to pinhole cameras when in a spatial view, using 3D navigation.
-    pinhole_image_plane_distance: Option<ordered_float::NotNan<f32>>,
+    pub pinhole_image_plane_distance: EditableAutoValue<ordered_float::NotNan<f32>>,
 }
 
 impl EntityProperties {
-    /// If this has a pinhole camera transform, how far away is the image plane.
-    ///
-    /// Scale relative to the respective space the pinhole camera is in.
-    /// None indicates the user never edited this field (should use a meaningful default then).
-    ///
-    /// Method returns a pinhole camera specific default if the value hasn't been set yet.
-    pub fn pinhole_image_plane_distance(&self, pinhole: &re_log_types::Pinhole) -> f32 {
-        self.pinhole_image_plane_distance
-            .unwrap_or_else(|| {
-                let distance = pinhole
-                    .focal_length()
-                    .unwrap_or_else(|| pinhole.focal_length_in_pixels().y());
-                ordered_float::NotNan::new(distance).unwrap_or_default()
-            })
-            .into()
-    }
-
-    /// see `pinhole_image_plane_distance()`
-    pub fn set_pinhole_image_plane_distance(&mut self, distance: f32) {
-        self.pinhole_image_plane_distance = ordered_float::NotNan::new(distance).ok();
-    }
-
     /// Multiply/and these together.
     pub fn with_child(&self, child: &Self) -> Self {
         Self {
             visible: self.visible && child.visible,
             visible_history: self.visible_history.with_child(&child.visible_history),
             interactive: self.interactive && child.interactive,
-            pinhole_image_plane_distance: child
-                .pinhole_image_plane_distance
-                .or(self.pinhole_image_plane_distance),
+            // TODO(andreas): Inheriting doesn't work properly since parents don't set this value usually
+            pinhole_image_plane_distance: child.pinhole_image_plane_distance.clone(),
         }
     }
 }
@@ -87,7 +64,7 @@ impl Default for EntityProperties {
             visible: true,
             visible_history: ExtraQueryHistory::default(),
             interactive: true,
-            pinhole_image_plane_distance: None,
+            pinhole_image_plane_distance: EditableAutoValue::default(),
         }
     }
 }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -52,8 +52,10 @@ impl EntityProperties {
             visible: self.visible && child.visible,
             visible_history: self.visible_history.with_child(&child.visible_history),
             interactive: self.interactive && child.interactive,
-            // TODO(andreas): Inheriting doesn't work properly since parents don't set this value usually
-            pinhole_image_plane_distance: child.pinhole_image_plane_distance.clone(),
+            pinhole_image_plane_distance: self
+                .pinhole_image_plane_distance
+                .or(&child.pinhole_image_plane_distance)
+                .clone(),
         }
     }
 }

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc = document_features::document_features!()]
 //!
 
+mod editable_auto_value;
 pub mod entity_properties;
 pub mod entity_tree;
 mod instance_path;
@@ -16,6 +17,7 @@ pub use log_db::LogDb;
 
 use re_log_types::msg_bundle;
 
+pub use editable_auto_value::EditableAutoValue;
 pub use re_log_types::{ComponentName, EntityPath, EntityPathPart, Index, TimeInt, Timeline};
 
 // ----------------------------------------------------------------------------

--- a/crates/re_viewer/src/misc/transform_cache.rs
+++ b/crates/re_viewer/src/misc/transform_cache.rs
@@ -240,7 +240,7 @@ fn transform_at(
                     // Images are spanned in their local x/y space.
                     // Center it and move it along z, scaling the further we move.
                     let props = entity_properties.get(entity_path);
-                    let distance: f32 = (*props.pinhole_image_plane_distance.get()).into();
+                    let distance: f32 = props.pinhole_image_plane_distance.get().into_inner();
 
                     let focal_length = pinhole.focal_length_in_pixels();
                     let focal_length = glam::vec2(focal_length.x(), focal_length.y());

--- a/crates/re_viewer/src/misc/transform_cache.rs
+++ b/crates/re_viewer/src/misc/transform_cache.rs
@@ -239,10 +239,8 @@ fn transform_at(
                     // A pinhole camera means that we're looking at an image.
                     // Images are spanned in their local x/y space.
                     // Center it and move it along z, scaling the further we move.
-
-                    let distance = entity_properties
-                        .get(entity_path)
-                        .pinhole_image_plane_distance(&pinhole);
+                    let props = entity_properties.get(entity_path);
+                    let distance: f32 = (*props.pinhole_image_plane_distance.get()).into();
 
                     let focal_length = pinhole.focal_length_in_pixels();
                     let focal_length = glam::vec2(focal_length.x(), focal_length.y());

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -416,7 +416,7 @@ fn entity_props_ui(
                     {
                         ui.label("Image plane distance");
                         let mut distance: f32 =
-                            (*entity_props.pinhole_image_plane_distance.get()).into();
+                            entity_props.pinhole_image_plane_distance.get().into_inner();
                         let speed = (distance * 0.05).at_least(0.01);
                         if ui
                             .add(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,4 +1,4 @@
-use re_data_store::{query_latest_single, EntityPath, EntityProperties};
+use re_data_store::{query_latest_single, EditableAutoValue, EntityPath, EntityProperties};
 use re_log_types::{TimeType, Transform};
 
 use crate::{
@@ -411,11 +411,12 @@ fn entity_props_ui(
             if view_state.state_spatial.nav_mode == SpatialNavigationMode::ThreeD {
                 if let Some(entity_path) = entity_path {
                     let query = ctx.current_query();
-                    if let Some(re_log_types::Transform::Pinhole(pinhole)) =
+                    if let Some(re_log_types::Transform::Pinhole(_)) =
                         query_latest_single::<Transform>(&ctx.log_db.entity_db, entity_path, &query)
                     {
                         ui.label("Image plane distance");
-                        let mut distance = entity_props.pinhole_image_plane_distance(&pinhole);
+                        let mut distance: f32 =
+                            (*entity_props.pinhole_image_plane_distance.get()).into();
                         let speed = (distance * 0.05).at_least(0.01);
                         if ui
                             .add(
@@ -426,7 +427,10 @@ fn entity_props_ui(
                             .on_hover_text("Controls how far away the image plane is.")
                             .changed()
                         {
-                            entity_props.set_pinhole_image_plane_distance(distance);
+                            entity_props.pinhole_image_plane_distance =
+                                EditableAutoValue::UserEdited(
+                                    ordered_float::NotNan::new(distance).unwrap(),
+                                );
                         }
                         ui.end_row();
                     }

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -179,6 +179,9 @@ impl SpaceView {
                 let mut scene = view_spatial::SceneSpatial::new(ctx.render_ctx);
                 scene.load(ctx, &query, &transforms, highlights);
                 self.view_state
+                    .state_spatial
+                    .update_object_property_heuristics(ctx, &mut self.data_blueprint);
+                self.view_state
                     .ui_spatial(ctx, ui, &self.space_path, scene, self.id, highlights);
             }
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -86,7 +86,7 @@ impl CamerasPart {
             return;
         };
 
-        let frustum_length: f32 = (*props.pinhole_image_plane_distance.get()).into();
+        let frustum_length: f32 = props.pinhole_image_plane_distance.get().into_inner();
 
         scene.space_cameras.push(SpaceCamera3D {
             entity_path: entity_path.clone(),

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -86,7 +86,7 @@ impl CamerasPart {
             return;
         };
 
-        let frustum_length = props.pinhole_image_plane_distance(&pinhole);
+        let frustum_length: f32 = (*props.pinhole_image_plane_distance.get()).into();
 
         scene.space_cameras.push(SpaceCamera3D {
             entity_path: entity_path.clone(),


### PR DESCRIPTION
Introduces `EditableAutoValue` and per-frame heuristic updates on properties. In the future we can build more properties on top of this and update them in a central place like done here

Replaces #916
Fixes #681

### Checklist
* [x] I have read and agree to [Contributor Guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I've added a line to `CHANGELOG.md` (if this is a big enough change to warrant it)

<!--
Add any improvements to the branch as new commits, to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
