### PR TITLE
Convert view_tensor to use the new native Tensors

### DIFF
--- a/crates/re_log_types/src/component_types/tensor.rs
+++ b/crates/re_log_types/src/component_types/tensor.rs
@@ -428,6 +428,11 @@ pub enum TensorCastError {
 
     #[error("ndarray Array is not contiguous and in standard order")]
     NotContiguousStdOrder,
+
+    #[error(
+        "tensors do not currently support f16 data (https://github.com/rerun-io/rerun/issues/854)"
+    )]
+    F16NotSupported,
 }
 
 impl From<&Tensor> for ClassicTensor {
@@ -569,6 +574,15 @@ tensor_type!(i64, I64);
 
 tensor_type!(f32, F32);
 tensor_type!(f64, F64);
+
+// TODO(#854) Switch back to `tensor_type!` once we have F16 tensors
+impl<'a> TryFrom<&'a Tensor> for ::ndarray::ArrayViewD<'a, half::f16> {
+    type Error = TensorCastError;
+
+    fn try_from(_: &'a Tensor) -> Result<Self, Self::Error> {
+        Err(TensorCastError::F16NotSupported)
+    }
+}
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_log_types/src/component_types/tensor.rs
+++ b/crates/re_log_types/src/component_types/tensor.rs
@@ -6,8 +6,8 @@ use arrow2_convert::deserialize::ArrowDeserialize;
 use arrow2_convert::field::ArrowField;
 use arrow2_convert::{serialize::ArrowSerialize, ArrowDeserialize, ArrowField, ArrowSerialize};
 
-use crate::TensorElement;
 use crate::{msg_bundle::Component, ClassicTensor, TensorDataStore};
+use crate::{TensorDataType, TensorElement};
 
 pub trait TensorTrait {
     fn id(&self) -> TensorId;
@@ -17,6 +17,7 @@ pub trait TensorTrait {
     fn is_vector(&self) -> bool;
     fn meaning(&self) -> TensorDataMeaning;
     fn get(&self, index: &[u64]) -> Option<TensorElement>;
+    fn dtype(&self) -> TensorDataType;
 }
 
 // ----------------------------------------------------------------------------
@@ -388,6 +389,21 @@ impl TensorTrait for Tensor {
             TensorData::F32(buf) => Some(TensorElement::F32(buf[offset])),
             TensorData::F64(buf) => Some(TensorElement::F64(buf[offset])),
             TensorData::JPEG(_) => None, // Too expensive to unpack here.
+        }
+    }
+
+    fn dtype(&self) -> TensorDataType {
+        match &self.data {
+            TensorData::U8(_) | TensorData::JPEG(_) => TensorDataType::U8,
+            TensorData::U16(_) => TensorDataType::U16,
+            TensorData::U32(_) => TensorDataType::U32,
+            TensorData::U64(_) => TensorDataType::U64,
+            TensorData::I8(_) => TensorDataType::I8,
+            TensorData::I16(_) => TensorDataType::I16,
+            TensorData::I32(_) => TensorDataType::I32,
+            TensorData::I64(_) => TensorDataType::I64,
+            TensorData::F32(_) => TensorDataType::F32,
+            TensorData::F64(_) => TensorDataType::F64,
         }
     }
 }

--- a/crates/re_log_types/src/data.rs
+++ b/crates/re_log_types/src/data.rs
@@ -365,6 +365,11 @@ impl component_types::TensorTrait for ClassicTensor {
     fn get(&self, index: &[u64]) -> Option<TensorElement> {
         self.get(index)
     }
+
+    #[inline]
+    fn dtype(&self) -> TensorDataType {
+        self.dtype
+    }
 }
 
 impl ClassicTensor {
@@ -392,11 +397,6 @@ impl ClassicTensor {
     #[inline]
     pub fn shape(&self) -> &[component_types::TensorDimension] {
         self.shape.as_slice()
-    }
-
-    #[inline]
-    pub fn dtype(&self) -> TensorDataType {
-        self.dtype
     }
 
     #[inline]

--- a/crates/re_tensor_ops/src/lib.rs
+++ b/crates/re_tensor_ops/src/lib.rs
@@ -4,7 +4,10 @@
 //! This is particularly helpful for performing slice-operations for
 //! dimensionality reduction.
 
-use re_log_types::{component_types, ClassicTensor, TensorDataStore, TensorDataTypeTrait};
+use re_log_types::{
+    component_types::{self, TensorTrait},
+    ClassicTensor, TensorDataStore, TensorDataTypeTrait,
+};
 
 pub mod dimension_mapping;
 

--- a/crates/re_viewer/src/misc/caches/mod.rs
+++ b/crates/re_viewer/src/misc/caches/mod.rs
@@ -46,6 +46,8 @@ pub struct TensorStats {
 
 impl TensorStats {
     fn new(tensor: &re_log_types::component_types::Tensor) -> Self {
+        use half::f16;
+        use ndarray::ArrayViewD;
         use re_log_types::TensorDataType;
 
         macro_rules! declare_tensor_range_int {
@@ -89,8 +91,6 @@ impl TensorStats {
         declare_tensor_range_float!(tensor_range_f32, f32);
         declare_tensor_range_float!(tensor_range_f64, f64);
 
-        // TODO(854) re-enable once we have F16 tensors
-        /*
         #[allow(clippy::needless_pass_by_value)]
         fn tensor_range_f16(tensor: ndarray::ArrayViewD<'_, f16>) -> (f64, f64) {
             crate::profile_function!();
@@ -100,50 +100,22 @@ impl TensorStats {
                 });
             (min.to_f64(), max.to_f64())
         }
-        */
 
         let range = match tensor.dtype() {
-            TensorDataType::U8 => ndarray::ArrayViewD::<u8>::try_from(tensor)
-                .ok()
-                .map(tensor_range_u8),
-            TensorDataType::U16 => ndarray::ArrayViewD::<u16>::try_from(tensor)
-                .ok()
-                .map(tensor_range_u16),
-            TensorDataType::U32 => ndarray::ArrayViewD::<u32>::try_from(tensor)
-                .ok()
-                .map(tensor_range_u32),
-            TensorDataType::U64 => ndarray::ArrayViewD::<u64>::try_from(tensor)
-                .ok()
-                .map(tensor_range_u64),
+            TensorDataType::U8 => ArrayViewD::<u8>::try_from(tensor).map(tensor_range_u8),
+            TensorDataType::U16 => ArrayViewD::<u16>::try_from(tensor).map(tensor_range_u16),
+            TensorDataType::U32 => ArrayViewD::<u32>::try_from(tensor).map(tensor_range_u32),
+            TensorDataType::U64 => ArrayViewD::<u64>::try_from(tensor).map(tensor_range_u64),
 
-            TensorDataType::I8 => ndarray::ArrayViewD::<i8>::try_from(tensor)
-                .ok()
-                .map(tensor_range_i8),
-            TensorDataType::I16 => ndarray::ArrayViewD::<i16>::try_from(tensor)
-                .ok()
-                .map(tensor_range_i16),
-            TensorDataType::I32 => ndarray::ArrayViewD::<i32>::try_from(tensor)
-                .ok()
-                .map(tensor_range_i32),
-            TensorDataType::I64 => ndarray::ArrayViewD::<i64>::try_from(tensor)
-                .ok()
-                .map(tensor_range_i64),
-
-            // TODO(854) re-enable once we have F16 tensors
-            /*
-            TensorDataType::F16 => ndarray::ArrayViewD::<f16>::try_from(tensor)
-            .ok()
-            .map(tensor_range_f16),
-            */
-            TensorDataType::F16 => None,
-            TensorDataType::F32 => ndarray::ArrayViewD::<f32>::try_from(tensor)
-                .ok()
-                .map(tensor_range_f32),
-            TensorDataType::F64 => ndarray::ArrayViewD::<f64>::try_from(tensor)
-                .ok()
-                .map(tensor_range_f64),
+            TensorDataType::I8 => ArrayViewD::<i8>::try_from(tensor).map(tensor_range_i8),
+            TensorDataType::I16 => ArrayViewD::<i16>::try_from(tensor).map(tensor_range_i16),
+            TensorDataType::I32 => ArrayViewD::<i32>::try_from(tensor).map(tensor_range_i32),
+            TensorDataType::I64 => ArrayViewD::<i64>::try_from(tensor).map(tensor_range_i64),
+            TensorDataType::F16 => ArrayViewD::<f16>::try_from(tensor).map(tensor_range_f16),
+            TensorDataType::F32 => ArrayViewD::<f32>::try_from(tensor).map(tensor_range_f32),
+            TensorDataType::F64 => ArrayViewD::<f64>::try_from(tensor).map(tensor_range_f64),
         };
 
-        Self { range }
+        Self { range: range.ok() }
     }
 }

--- a/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
+++ b/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
@@ -4,7 +4,7 @@ use egui::{Color32, ColorImage};
 use egui_extras::RetainedImage;
 use image::DynamicImage;
 use re_log_types::{
-    component_types::{self, ClassId, TensorDataMeaning},
+    component_types::{self, ClassId, TensorDataMeaning, TensorTrait},
     ClassicTensor, MsgId, TensorDataStore, TensorDataType,
 };
 use re_renderer::{

--- a/crates/re_viewer/src/ui/view_tensor/scene.rs
+++ b/crates/re_viewer/src/ui/view_tensor/scene.rs
@@ -1,9 +1,6 @@
 use re_arrow_store::LatestAtQuery;
 use re_data_store::{EntityPath, EntityProperties, InstancePath};
-use re_log_types::{
-    component_types::{InstanceKey, Tensor},
-    ClassicTensor,
-};
+use re_log_types::component_types::{InstanceKey, Tensor, TensorTrait};
 use re_query::{query_entity_with_primary, EntityView, QueryError};
 
 use crate::{misc::ViewerContext, ui::SceneQuery};
@@ -13,7 +10,7 @@ use crate::{misc::ViewerContext, ui::SceneQuery};
 /// A tensor scene, with everything needed to render it.
 #[derive(Default)]
 pub struct SceneTensor {
-    pub tensors: std::collections::BTreeMap<InstancePath, ClassicTensor>,
+    pub tensors: std::collections::BTreeMap<InstancePath, Tensor>,
 }
 
 impl SceneTensor {
@@ -47,7 +44,6 @@ impl SceneTensor {
         entity_view: &EntityView<Tensor>,
     ) -> Result<(), QueryError> {
         entity_view.visit1(|instance_key: InstanceKey, tensor: Tensor| {
-            let tensor = ClassicTensor::from(&tensor);
             if !tensor.is_shaped_like_an_image() {
                 let instance_path = InstancePath::instance(ent_path.clone(), instance_key);
                 self.tensors.insert(instance_path, tensor);


### PR DESCRIPTION
Converting to ClassicTensor was incurring an unnecessary copy.

![image](https://user-images.githubusercontent.com/3312232/221896793-dc8fe9b4-8a8a-461b-a351-63a17363744b.png)


Resolves: https://github.com/rerun-io/rerun/issues/1434

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
