### PR TITLE
Fix type signature for tensor names

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log/tensor.py
@@ -41,7 +41,7 @@ def log_tensor(
     entity_path: str,
     tensor: npt.ArrayLike,
     *,
-    names: Optional[Iterable[str]] = None,
+    names: Optional[Iterable[str | None]] = None,
     meter: Optional[float] = None,
     ext: Optional[Dict[str, Any]] = None,
     timeless: bool = False,
@@ -78,7 +78,7 @@ def log_tensor(
 def _log_tensor(
     entity_path: str,
     tensor: npt.NDArray[Any],
-    names: Optional[Iterable[Optional[str]]] = None,
+    names: Optional[Iterable[str | None]] = None,
     meter: Optional[float] = None,
     meaning: bindings.TensorDataMeaning = None,
     ext: Optional[Dict[str, Any]] = None,

--- a/rerun_py/rerun_sdk/rerun/log/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log/tensor.py
@@ -41,7 +41,7 @@ def log_tensor(
     entity_path: str,
     tensor: npt.ArrayLike,
     *,
-    names: Optional[Iterable[str | None]] = None,
+    names: Optional[Iterable[Optional[str]]] = None,
     meter: Optional[float] = None,
     ext: Optional[Dict[str, Any]] = None,
     timeless: bool = False,
@@ -78,7 +78,7 @@ def log_tensor(
 def _log_tensor(
     entity_path: str,
     tensor: npt.NDArray[Any],
-    names: Optional[Iterable[str | None]] = None,
+    names: Optional[Iterable[Optional[str]]] = None,
     meter: Optional[float] = None,
     meaning: bindings.TensorDataMeaning = None,
     ext: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
Following up on https://github.com/rerun-io/rerun/issues/631 fixed the type signature.

All other handling seemed to be done already:
```
import rerun as rr
import numpy as np

rr.init("tensor_test", spawn=True)

T = np.random.rand(10, 10, 10)
rr.log_tensor("tensor_test", T, names=["foo", None, "bar"])
```

![image](https://user-images.githubusercontent.com/3312232/221904198-220ff404-dd79-4ed6-9280-30eb3482374e.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
