### PR TITLE
OS independent Zoom factor & serialization thereof

### DIFF
--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -29,6 +29,12 @@ pub enum Command {
 
     #[cfg(not(target_arch = "wasm32"))]
     ToggleFullscreen,
+    #[cfg(not(target_arch = "wasm32"))]
+    ZoomIn,
+    #[cfg(not(target_arch = "wasm32"))]
+    ZoomOut,
+    #[cfg(not(target_arch = "wasm32"))]
+    ZoomReset,
 
     SelectionPrevious,
     SelectionNext,
@@ -91,6 +97,15 @@ impl Command {
                 "Toggle fullscreen",
                 "Toggle between windowed and fullscreen viewer",
             ),
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ZoomIn => ("Zoom In", "Increases the ui scaling factor"),
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ZoomOut => ("Zoom Out", "Decreases the ui scaling factor"),
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ZoomReset => (
+                "Reset Zoom",
+                "Resets ui scaling factor to the OS provided default",
+            ),
 
             Command::SelectionPrevious => ("Previous selection", "Go to previous selection"),
             Command::SelectionNext => ("Next selection", "Go to next selection"),
@@ -151,8 +166,16 @@ impl Command {
             Command::ToggleBlueprintPanel => Some(ctrl_shift(Key::B)),
             Command::ToggleSelectionPanel => Some(ctrl_shift(Key::S)),
             Command::ToggleTimePanel => Some(ctrl_shift(Key::T)),
+
             #[cfg(not(target_arch = "wasm32"))]
             Command::ToggleFullscreen => Some(key(Key::F11)),
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ZoomIn => Some(egui::gui_zoom::kb_shortcuts::ZOOM_IN),
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ZoomOut => Some(egui::gui_zoom::kb_shortcuts::ZOOM_OUT),
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ZoomReset => Some(egui::gui_zoom::kb_shortcuts::ZOOM_RESET),
+
             Command::SelectionPrevious => Some(ctrl_shift(Key::ArrowLeft)),
             Command::SelectionNext => Some(ctrl_shift(Key::ArrowRight)),
             Command::ToggleCommandPalette => Some(cmd(Key::P)),

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -49,7 +49,9 @@ pub struct StartupOptions {
 
 // ----------------------------------------------------------------------------
 
+#[cfg(not(target_arch = "wasm32"))]
 const MIN_ZOOM_FACTOR: f32 = 0.2;
+#[cfg(not(target_arch = "wasm32"))]
 const MAX_ZOOM_FACTOR: f32 = 4.0;
 
 /// The Rerun viewer as an [`eframe`] application.

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -897,6 +897,7 @@ impl Default for AppState {
             event_log_view: Default::default(),
             selection_panel: Default::default(),
             time_panel: Default::default(),
+            #[cfg(not(target_arch = "wasm32"))]
             profiler: Default::default(),
             zoom_factor: 1.0,
         }

--- a/crates/re_viewer/src/misc/app_options.rs
+++ b/crates/re_viewer/src/misc/app_options.rs
@@ -10,6 +10,15 @@ pub struct AppOptions {
     /// Show milliseconds, RAM usage, etc.
     #[serde(skip)] // restore to the default for the current mode (dev vs debug)
     pub show_metrics: bool,
+
+    /// Zoom factor, independent of OS points_per_pixel setting.
+    ///
+    /// At every frame we check the OS reported scaling (i.e. points_per_pixel)
+    /// and apply this zoom factor to determine the actual points_per_pixel.
+    /// This way, the zooming stays constant when switching between differently scaled screens.
+    /// (Since this is serialized, even between sessions!)
+    #[cfg(not(target_arch = "wasm32"))]
+    pub zoom_factor: f32,
 }
 
 impl Default for AppOptions {
@@ -21,6 +30,9 @@ impl Default for AppOptions {
             warn_latency: 0.200,
 
             show_metrics: cfg!(debug_assertions),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            zoom_factor: 1.0,
         }
     }
 }


### PR DESCRIPTION
* Command palette actions for zoom in/out/reset
* Zoom factor is now an OS scaling independent factor that is used every frame to determine `pixels_from_points`. This way users can move around the window and it keeps the zoom factor
* show zoom factor in the menu
* Zoom is now serialized out. Fixes #1351

![image](https://user-images.githubusercontent.com/1220815/221924122-1a1be7b3-7bd8-42d7-847e-a07a4ca1c716.png)

![image](https://user-images.githubusercontent.com/1220815/221924192-e689bfd7-38b9-4b7f-896e-c1c4f9527bdd.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)