### PR TITLE
Remove the python job path filters so that wheels are always buildable

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,10 +2,6 @@ name: CI (Python)
 
 on:
   pull_request:
-    paths:
-      - "rerun_py/**"
-      - "examples/python/**"
-      - ".github/workflows/python.yml"
     types: [labeled, synchronize, opened]
   push:
     branches:


### PR DESCRIPTION
Resolves: https://github.com/rerun-io/rerun/issues/1451

I ran into this issue as part of https://github.com/rerun-io/rerun/pull/1402/files but never ended up landing it.

Just add that isolated fix.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
