### PR TITLE
On M1/M2 recommend `split-debuginfo=unpacked` instead of `split-debuginfo=packed`

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -95,7 +95,7 @@ rustflags = [
     "-C",
     "link-arg=-fuse-ld=/usr/local/bin/zld",
     "-C",
-    "split-debuginfo=packed",
+    "split-debuginfo=unpacked",
 ]
 ```
 
@@ -106,7 +106,7 @@ rustflags = [
     "-C",
     "link-arg=-fuse-ld=/opt/homebrew/bin/zld",
     "-C",
-    "split-debuginfo=packed",
+    "split-debuginfo=unpacked",
 ]
 ```
 
@@ -146,6 +146,6 @@ rustup component add llvm-tools-preview
 linker = "rust-lld.exe"
 rustflags = [
     "-C",
-    "split-debuginfo=packed",
+    "split-debuginfo=unpacked",
 ]
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -83,7 +83,7 @@ These tools can configured through your `Cargo` configuration, available at `$HO
 
 ### macOS
 
-On macOS, use the [zld](https://github.com/michaeleisel/zld) linker and keep debuginfo in a single separate file.
+On x64 macOS, use the [zld](https://github.com/michaeleisel/zld) linker and keep debuginfo in a single separate file.
 
 Pre-requisites:
 - Install [zld](https://github.com/michaeleisel/zld): `brew install michaeleisel/zld/zld`.
@@ -95,16 +95,16 @@ rustflags = [
     "-C",
     "link-arg=-fuse-ld=/usr/local/bin/zld",
     "-C",
-    "split-debuginfo=unpacked",
+    "split-debuginfo=packed",
 ]
 ```
+
+On Apple-silicon Mac (M1, M2), the default settings are already pretty good. The default linker is just as good as `zld`. Do NOT set `split-debuginfo=packed`, as that will make linking a lot slower. You can set `split-debuginfo=unpacked` for a small improvement.
 
 `config.toml` (M1):
 ```toml
 [target.aarch64-apple-darwin]
 rustflags = [
-    "-C",
-    "link-arg=-fuse-ld=/opt/homebrew/bin/zld",
     "-C",
     "split-debuginfo=unpacked",
 ]
@@ -146,6 +146,6 @@ rustup component add llvm-tools-preview
 linker = "rust-lld.exe"
 rustflags = [
     "-C",
-    "split-debuginfo=unpacked",
+    "split-debuginfo=packed",
 ]
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -101,7 +101,7 @@ rustflags = [
 
 On Apple-silicon Mac (M1, M2), the default settings are already pretty good. The default linker is just as good as `zld`. Do NOT set `split-debuginfo=packed`, as that will make linking a lot slower. You can set `split-debuginfo=unpacked` for a small improvement.
 
-`config.toml` (M1):
+`config.toml` (M1, M2):
 ```toml
 [target.aarch64-apple-darwin]
 rustflags = [


### PR DESCRIPTION
On my aarch64 Mac:

* `zld` doesn't help at all, nor hurt
* `-C", "split-debuginfo=packed` makes things 3x SLOWER
* `-C", "split-debuginfo=unpacked` neither helps nor hurts

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
