### PR TITLE
Speed up convesions for color arrays

### DIFF
--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -16,7 +16,7 @@ __all__ = [
 class ColorRGBAArray(pa.ExtensionArray):  # type: ignore[misc]
     def from_numpy(array: npt.NDArray[np.uint8]) -> ColorRGBAArray:
         """Build a `ColorRGBAArray` from an numpy array."""
-        storage = pa.array([u8_array_to_rgba(c) for c in array], type=ColorRGBAType.storage_type)
+        storage = pa.array(u8_array_to_rgba(array), type=ColorRGBAType.storage_type)
         # TODO(john) enable extension type wrapper
         # return cast(ColorRGBAArray, pa.ExtensionArray.from_storage(ColorRGBAType(), storage))
         return storage  # type: ignore[no-any-return]


### PR DESCRIPTION
Resolves: https://github.com/rerun-io/rerun/issues/1424

Uses column-wise numpy operations for re-packing bytes for color arrays.

On colmap this brings the per-cloud color conversion from 9ms -> 100us.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
