### PR TITLE
Fix our continuous pre-releases

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -44,12 +44,14 @@ disallowed-types = [
 
 # Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
 doc-valid-idents = [
+  "GitHub",
   "GLB",
   "GLTF",
   "iOS",
   "macOS",
   "NaN",
   "OBJ",
+  "PyPI",
   "sRGB",
   "sRGBA",
   "WebGL",

--- a/crates/re_build_info/src/buid_info.rs
+++ b/crates/re_build_info/src/buid_info.rs
@@ -14,8 +14,8 @@ pub struct BuildInfo {
     /// `CARGO_PKG_NAME`
     pub crate_name: &'static str,
 
-    /// Parsed `CARGO_PKG_VERSION`
-    pub version: super::RustVersion,
+    /// Crate version, parsed from `CARGO_PKG_VERSION`, ignoring any `+metadata` suffix.
+    pub version: super::CrateVersion,
 
     /// Git commit hash, or empty string.
     pub git_hash: &'static str,

--- a/crates/re_build_info/src/crate_version.rs
+++ b/crates/re_build_info/src/crate_version.rs
@@ -5,7 +5,9 @@ const MAX_NUM: u8 = 31;
 
 const IS_ALPHA_BIT: u8 = 1 << 7;
 
-/// Sub-set of semver supporting `major.minor.patch`, an optional `-alpha.X`.
+/// The version of a Rerun crate.
+///
+/// Sub-set of semver supporting `major.minor.patch` plus an optional `-alpha.X`.
 ///
 /// When parsing, any `+metadata` suffix is ignored.
 ///
@@ -20,14 +22,14 @@ const IS_ALPHA_BIT: u8 = 1 << 7;
 /// This limited subset it chosen so that we can encode the version in 32 bits
 /// in our `.rrd` files and on the wire.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct RustVersion {
+pub struct CrateVersion {
     major: u8,
     minor: u8,
     patch: u8,
     alpha: Option<u8>,
 }
 
-impl RustVersion {
+impl CrateVersion {
     pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
         assert!(
             major <= MAX_NUM && minor <= MAX_NUM && patch <= MAX_NUM,
@@ -72,7 +74,7 @@ impl RustVersion {
         [major, minor, patch, suffix_byte]
     }
 
-    pub fn is_semver_compatible_with(self, other: RustVersion) -> bool {
+    pub fn is_semver_compatible_with(self, other: CrateVersion) -> bool {
         if self.alpha != other.alpha {
             return false; // Alphas can contain breaking changes
         }
@@ -178,7 +180,7 @@ impl RustVersion {
     }
 }
 
-impl std::fmt::Display for RustVersion {
+impl std::fmt::Display for CrateVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             major,
@@ -197,13 +199,13 @@ impl std::fmt::Display for RustVersion {
 
 #[test]
 fn test_parse_version() {
-    let parse = RustVersion::parse;
-    assert_eq!(parse("0.2.0"), RustVersion::new(0, 2, 0));
-    assert_eq!(parse("1.2.3"), RustVersion::new(1, 2, 3));
-    assert_eq!(parse("12.23.24"), RustVersion::new(12, 23, 24));
+    let parse = CrateVersion::parse;
+    assert_eq!(parse("0.2.0"), CrateVersion::new(0, 2, 0));
+    assert_eq!(parse("1.2.3"), CrateVersion::new(1, 2, 3));
+    assert_eq!(parse("12.23.24"), CrateVersion::new(12, 23, 24));
     assert_eq!(
         parse("12.23.24-alpha.31"),
-        RustVersion {
+        CrateVersion {
             major: 12,
             minor: 23,
             patch: 24,
@@ -212,7 +214,7 @@ fn test_parse_version() {
     );
     assert_eq!(
         parse("12.23.24+foo"),
-        RustVersion {
+        CrateVersion {
             major: 12,
             minor: 23,
             patch: 24,
@@ -221,7 +223,7 @@ fn test_parse_version() {
     );
     assert_eq!(
         parse("12.23.24-alpha.31+bar"),
-        RustVersion {
+        CrateVersion {
             major: 12,
             minor: 23,
             patch: 24,
@@ -232,7 +234,7 @@ fn test_parse_version() {
 
 #[test]
 fn test_format_parse_roundtrip() {
-    let parse = RustVersion::parse;
+    let parse = CrateVersion::parse;
     for version in [
         "0.2.0",
         "1.2.3",
@@ -249,7 +251,7 @@ fn test_format_parse_roundtrip() {
 #[test]
 fn test_compatibility() {
     fn are_compatible(a: &str, b: &str) -> bool {
-        RustVersion::parse(a).is_semver_compatible_with(RustVersion::parse(b))
+        CrateVersion::parse(a).is_semver_compatible_with(CrateVersion::parse(b))
     }
 
     assert!(are_compatible("0.2.0", "0.2.0"));

--- a/crates/re_build_info/src/crate_version.rs
+++ b/crates/re_build_info/src/crate_version.rs
@@ -74,7 +74,7 @@ impl CrateVersion {
         [major, minor, patch, suffix_byte]
     }
 
-    pub fn is_semver_compatible_with(self, other: CrateVersion) -> bool {
+    pub fn is_compatible_with(self, other: CrateVersion) -> bool {
         if self.alpha != other.alpha {
             return false; // Alphas can contain breaking changes
         }
@@ -88,6 +88,7 @@ impl CrateVersion {
         }
     }
 
+    /// Parse a semver version string, ignoring any trailing `+metadata`.
     pub const fn parse(version_string: &str) -> Self {
         // Note that this is a const function, which means we are extremely limited in what we can do!
 
@@ -251,7 +252,7 @@ fn test_format_parse_roundtrip() {
 #[test]
 fn test_compatibility() {
     fn are_compatible(a: &str, b: &str) -> bool {
-        CrateVersion::parse(a).is_semver_compatible_with(CrateVersion::parse(b))
+        CrateVersion::parse(a).is_compatible_with(CrateVersion::parse(b))
     }
 
     assert!(are_compatible("0.2.0", "0.2.0"));

--- a/crates/re_build_info/src/lib.rs
+++ b/crates/re_build_info/src/lib.rs
@@ -3,10 +3,10 @@
 //! To use this you also need to call `re_build_build_info::export_env_vars()` from your build.rs.
 
 mod buid_info;
-mod rust_version;
+mod crate_version;
 
 pub use buid_info::BuildInfo;
-pub use rust_version::RustVersion;
+pub use crate_version::CrateVersion;
 
 /// Create a [`BuildInfo`] at compile-time using environment variables exported by
 /// calling `re_build_build_info::export_env_vars()` from your build.rs.
@@ -15,7 +15,7 @@ macro_rules! build_info {
     () => {
         $crate::BuildInfo {
             crate_name: env!("CARGO_PKG_NAME"),
-            version: $crate::RustVersion::parse(env!("CARGO_PKG_VERSION")),
+            version: $crate::CrateVersion::parse(env!("CARGO_PKG_VERSION")),
             git_hash: env!("RE_BUILD_GIT_HASH"),
             git_branch: env!("RE_BUILD_GIT_BRANCH"),
             target_triple: env!("RE_BUILD_TARGET_TRIPLE"),

--- a/crates/re_build_info/src/rust_version.rs
+++ b/crates/re_build_info/src/rust_version.rs
@@ -30,7 +30,7 @@ pub struct RustVersion {
 }
 
 impl RustVersion {
-    const fn new(major: u8, minor: u8, patch: u8) -> Self {
+    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
         assert!(
             major <= MAX_NUM && minor <= MAX_NUM && patch <= MAX_NUM,
             "Too large number in version string"

--- a/crates/re_build_info/src/rust_version.rs
+++ b/crates/re_build_info/src/rust_version.rs
@@ -10,11 +10,12 @@ const IS_PRERELEASE_BIT: u8 = 1 << 6;
 ///
 /// Examples: `1.2.3`, `1.2.3-alpha.4`, `1.2.3+prerelease`, `1.2.3-alpha.7+prerelease`
 ///
-/// We use `-alpha.X` when we publish to crates.io and PyPI.
+/// We use `-alpha.X` when we publish pre-releases to crates.io and PyPI.
 ///
-/// We use `+prerelease` for pre-releases that you can download from our GitHub.
+/// We use `+prerelease` for continuous pre-releases that you can download from our GitHub.
 /// Two pre-releases of the same rust version aren't distinguished by their version string,
 /// but you can still see their git commit hash if you run `rerun --version`.
+/// See also `scripts/version_util.py`.
 ///
 /// The version numbers aren't allowed to be very large (current max: 31).
 /// This limited subset it chosen so that we can encode the version in 32 bits

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -21,7 +21,7 @@ mod encoder {
 
     impl<W: std::io::Write> Encoder<W> {
         pub fn new(mut write: W) -> anyhow::Result<Self> {
-            let rerun_version = re_build_info::RustVersion::parse(env!("CARGO_PKG_VERSION"));
+            let rerun_version = re_build_info::CrateVersion::parse(env!("CARGO_PKG_VERSION"));
 
             write.write_all(b"RRF0").context("header")?;
             write
@@ -79,16 +79,16 @@ pub use encoder::*;
 // ----------------------------------------------------------------------------
 
 fn warn_on_version_mismatch(encoded_version: [u8; 4]) {
-    use re_build_info::RustVersion;
+    use re_build_info::CrateVersion;
 
     // We used 0000 for all .rrd files up until 2023-02-27, post 0.2.0 release:
     let encoded_version = if encoded_version == [0, 0, 0, 0] {
-        RustVersion::new(0, 2, 0)
+        CrateVersion::new(0, 2, 0)
     } else {
-        RustVersion::from_bytes(encoded_version)
+        CrateVersion::from_bytes(encoded_version)
     };
 
-    let local_version = RustVersion::parse(env!("CARGO_PKG_VERSION"));
+    let local_version = CrateVersion::parse(env!("CARGO_PKG_VERSION"));
 
     if !encoded_version.is_semver_compatible_with(local_version) {
         re_log::warn!("Found log stream with Rerun version {encoded_version}, which is incompatible with the local Rerun version {local_version}. Loading will try to continue, but might fail in subtle ways.");

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -90,7 +90,7 @@ fn warn_on_version_mismatch(encoded_version: [u8; 4]) {
 
     let local_version = CrateVersion::parse(env!("CARGO_PKG_VERSION"));
 
-    if !encoded_version.is_semver_compatible_with(local_version) {
+    if !encoded_version.is_compatible_with(local_version) {
         re_log::warn!("Found log stream with Rerun version {encoded_version}, which is incompatible with the local Rerun version {local_version}. Loading will try to continue, but might fail in subtle ways.");
     }
 }

--- a/scripts/version_util.py
+++ b/scripts/version_util.py
@@ -4,17 +4,18 @@
 Script should only be called by the CI system.
 
 This script accepts one argument:
-    --patch_prerelease: This will patch the version in rerun/Cargo.toml with the current git sha. This is intended to
-    create a prerelease version for continuous releases.
+    --patch_prerelease: This will patch the version in rerun/Cargo.toml with a `+prerelease` suffix.
+    This is intended to create a prerelease version for continuous releases.
 
     --check_version: This will check that the version in rerun/Cargo.toml matches the version in the tag name from
     `GITHUB_REF_NAME`. This is intended to be used to check that the version number in Cargo.toml is correct before
     creating a release on PyPI. If the versions don't match, an exception will be raised.
 """
 
+# See also crates/re_build_info/src/rust_version.rs
+
 import os
 import re
-import subprocess
 import sys
 from typing import Final
 
@@ -36,11 +37,6 @@ def get_cargo_version(cargo_toml: str) -> semver.VersionInfo:
         raise Exception("Could not find valid base version number in Cargo.toml")
 
     return semver.parse_version_info(match.groups()[0])
-
-
-def get_git_sha() -> str:
-    """Return the git short sha of the current commit."""
-    return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
 
 
 def get_ref_name_version() -> semver.VersionInfo:
@@ -90,8 +86,7 @@ def main() -> None:
     cargo_version = get_cargo_version(cargo_toml)
 
     if sys.argv[1] == "--patch_prerelease":
-        git_sha = get_git_sha()
-        new_version = cargo_version.bump_build(git_sha)
+        new_version = f"{cargo_version}+prerelease"
         new_cargo_toml = patch_cargo_version(cargo_toml, new_version)
 
         # Write the patched Cargo.toml back to disk


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1457

## Summary
Ignore the `+{$GITHASH}` suffix (that we use for our continuous releases) when parsing rust crate version.

## Details

We use `-alpha.X`-suffixes when we do intentional pre-releases, published to `crates.io` and `PyPI`.

We also do continuous releases of wheel on each merge to `main`. These are distinguished by suffixing our version string with `+{$GITHASH}`.

This caused issues when trying to parse the crate versions (at compile time). With this PR, we now ignore that suffix.

## Why not parse it?
The `+build-metadata` suffixes of semver are not part of the actual version. It is metadata.

We use the crate version to version our .rrd files, and so we should ignore metadata for that anyway.

We still show the git hash with `rerun --version`, and include it in our analytics.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)