### PR TITLE
Simplify bind group allocation call by passing pool collection object.

### DIFF
--- a/crates/re_renderer/src/global_bindings.rs
+++ b/crates/re_renderer/src/global_bindings.rs
@@ -131,6 +131,7 @@ impl GlobalBindings {
     ) -> GpuBindGroup {
         pools.bind_groups.alloc(
             device,
+            pools,
             // Needs to be kept in sync with `global_bindings.wgsl` / `self.layout`
             &BindGroupDesc {
                 label: "global bind group".into(),
@@ -141,10 +142,6 @@ impl GlobalBindings {
                 ],
                 layout: self.layout,
             },
-            &pools.bind_group_layouts,
-            &pools.textures,
-            &pools.buffers,
-            &pools.samplers,
         )
     }
 }

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -232,6 +232,7 @@ impl GpuMesh {
                 let texture = ctx.texture_manager_2d.get(&material.albedo)?;
                 let bind_group = pools.bind_groups.alloc(
                     device,
+                    pools,
                     &BindGroupDesc {
                         label: material.label.clone(),
                         entries: smallvec![
@@ -240,10 +241,6 @@ impl GpuMesh {
                         ],
                         layout: mesh_bind_group_layout,
                     },
-                    &pools.bind_group_layouts,
-                    &pools.textures,
-                    &pools.buffers,
-                    &pools.samplers,
                 );
 
                 materials.push(GpuMaterial {

--- a/crates/re_renderer/src/renderer/compositor.rs
+++ b/crates/re_renderer/src/renderer/compositor.rs
@@ -30,26 +30,22 @@ impl DrawData for CompositorDrawData {
 
 impl CompositorDrawData {
     pub fn new(ctx: &mut RenderContext, target: &GpuTexture) -> Self {
-        let pools = &mut ctx.gpu_resources;
         let mut renderers = ctx.renderers.write();
         let compositor = renderers.get_or_create::<_, Compositor>(
             &ctx.shared_renderer_data,
-            pools,
+            &mut ctx.gpu_resources,
             &ctx.device,
             &mut ctx.resolver,
         );
         CompositorDrawData {
-            bind_group: pools.bind_groups.alloc(
+            bind_group: ctx.gpu_resources.bind_groups.alloc(
                 &ctx.device,
+                &ctx.gpu_resources,
                 &BindGroupDesc {
                     label: "compositor".into(),
                     entries: smallvec![BindGroupEntry::DefaultTextureView(target.handle)],
                     layout: compositor.bind_group_layout,
                 },
-                &pools.bind_group_layouts,
-                &pools.textures,
-                &pools.buffers,
-                &pools.samplers,
             ),
         }
     }

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -480,6 +480,7 @@ impl LineDrawData {
 
         let bind_group_all_lines = ctx.gpu_resources.bind_groups.alloc(
             &ctx.device,
+            &ctx.gpu_resources,
             &BindGroupDesc {
                 label: "line draw data".into(),
                 entries: smallvec![
@@ -488,10 +489,6 @@ impl LineDrawData {
                 ],
                 layout: line_renderer.bind_group_layout_all_lines,
             },
-            &ctx.gpu_resources.bind_group_layouts,
-            &ctx.gpu_resources.textures,
-            &ctx.gpu_resources.buffers,
-            &ctx.gpu_resources.samplers,
         );
 
         // Process batches
@@ -517,15 +514,12 @@ impl LineDrawData {
                     .min(Self::MAX_NUM_VERTICES as u32);
                 let bind_group = ctx.gpu_resources.bind_groups.alloc(
                     &ctx.device,
+                    &ctx.gpu_resources,
                     &BindGroupDesc {
                         label: batch_info.label.clone(),
                         entries: smallvec![uniform_buffer_binding],
                         layout: line_renderer.bind_group_layout_batch,
                     },
-                    &ctx.gpu_resources.bind_group_layouts,
-                    &ctx.gpu_resources.textures,
-                    &ctx.gpu_resources.buffers,
-                    &ctx.gpu_resources.samplers,
                 );
 
                 batches_internal.push(LineStripBatch {

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -298,6 +298,7 @@ impl PointCloudDrawData {
 
         let bind_group_all_points = ctx.gpu_resources.bind_groups.alloc(
             &ctx.device,
+            &ctx.gpu_resources,
             &BindGroupDesc {
                 label: "line drawdata".into(),
                 entries: smallvec![
@@ -306,10 +307,6 @@ impl PointCloudDrawData {
                 ],
                 layout: point_renderer.bind_group_layout_all_points,
             },
-            &ctx.gpu_resources.bind_group_layouts,
-            &ctx.gpu_resources.textures,
-            &ctx.gpu_resources.buffers,
-            &ctx.gpu_resources.samplers,
         );
 
         // Process batches
@@ -333,15 +330,12 @@ impl PointCloudDrawData {
             {
                 let bind_group = ctx.gpu_resources.bind_groups.alloc(
                     &ctx.device,
+                    &ctx.gpu_resources,
                     &BindGroupDesc {
                         label: batch_info.label.clone(),
                         entries: smallvec![uniform_buffer_binding],
                         layout: point_renderer.bind_group_layout_batch,
                     },
-                    &ctx.gpu_resources.bind_group_layouts,
-                    &ctx.gpu_resources.textures,
-                    &ctx.gpu_resources.buffers,
-                    &ctx.gpu_resources.samplers,
                 );
 
                 let point_vertex_range_end = (start_point_for_next_batch + batch_info.point_count)

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -174,6 +174,7 @@ impl RectangleDrawData {
 
             bind_groups.push(ctx.gpu_resources.bind_groups.alloc(
                 &ctx.device,
+                &ctx.gpu_resources,
                 &BindGroupDesc {
                     label: "rectangle".into(),
                     entries: smallvec![
@@ -183,10 +184,6 @@ impl RectangleDrawData {
                     ],
                     layout: rectangle_renderer.bind_group_layout,
                 },
-                &ctx.gpu_resources.bind_group_layouts,
-                &ctx.gpu_resources.textures,
-                &ctx.gpu_resources.buffers,
-                &ctx.gpu_resources.samplers,
             ));
         }
 

--- a/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
@@ -5,11 +5,12 @@ use smallvec::SmallVec;
 use crate::debug_label::DebugLabel;
 
 use super::{
-    bind_group_layout_pool::{GpuBindGroupLayoutHandle, GpuBindGroupLayoutPool},
+    bind_group_layout_pool::GpuBindGroupLayoutHandle,
     buffer_pool::{GpuBuffer, GpuBufferHandle, GpuBufferPool},
     dynamic_resource_pool::{DynamicResource, DynamicResourcePool, DynamicResourcesDesc},
     sampler_pool::{GpuSamplerHandle, GpuSamplerPool},
     texture_pool::{GpuTexture, GpuTextureHandle, GpuTexturePool},
+    WgpuResourcePools,
 };
 
 slotmap::new_key_type! { pub struct GpuBindGroupHandle; }
@@ -104,11 +105,8 @@ impl GpuBindGroupPool {
     pub fn alloc(
         &self,
         device: &wgpu::Device,
+        pools: &WgpuResourcePools,
         desc: &BindGroupDesc,
-        bind_group_layouts: &GpuBindGroupLayoutPool,
-        textures: &GpuTexturePool,
-        buffers: &GpuBufferPool,
-        samplers: &GpuSamplerPool,
     ) -> GpuBindGroup {
         // Retrieve strong handles to buffers and textures.
         // This way, an owner of a bind group handle keeps buffers & textures alive!.
@@ -118,7 +116,8 @@ impl GpuBindGroupPool {
             .filter_map(|e| {
                 if let BindGroupEntry::Buffer { handle, .. } = e {
                     Some(
-                        buffers
+                        pools
+                            .buffers
                             .get_from_handle(*handle)
                             .expect("BindGroupDesc had an invalid buffer handle"),
                     )
@@ -134,7 +133,8 @@ impl GpuBindGroupPool {
             .filter_map(|e| {
                 if let BindGroupEntry::DefaultTextureView(handle) = e {
                     Some(
-                        textures
+                        pools
+                            .textures
                             .get_from_handle(*handle)
                             .expect("BindGroupDesc had an invalid texture handle"),
                     )
@@ -178,14 +178,15 @@ impl GpuBindGroupPool {
                                 res
                             }
                             BindGroupEntry::Sampler(handle) => wgpu::BindingResource::Sampler(
-                                samplers
+                                pools
+                                    .samplers
                                     .get_resource(*handle)
                                     .expect("BindGroupDesc had an sampler handle"),
                             ),
                         },
                     })
                     .collect::<Vec<_>>(),
-                layout: bind_group_layouts.get_resource(desc.layout).unwrap(),
+                layout: pools.bind_group_layouts.get_resource(desc.layout).unwrap(),
             })
         });
 


### PR DESCRIPTION
Got tired of all these parameters and since `BindGroupPool::alloc` recently became non-mut, this can be easily simplified.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
