### PR TITLE
Fix re_renderer file watcher watching the same file several times

### DIFF
--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -95,7 +95,7 @@ pub use self::file_server_impl::FileServer;
 
 #[cfg(all(not(target_arch = "wasm32"), debug_assertions))] // non-wasm + debug build
 mod file_server_impl {
-    use ahash::HashSet;
+    use ahash::{HashMap, HashSet};
     use anyhow::Context as _;
     use crossbeam::channel::Receiver;
     use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
@@ -112,6 +112,7 @@ mod file_server_impl {
     pub struct FileServer {
         watcher: RecommendedWatcher,
         events_rx: Receiver<Event>,
+        file_watch_count: HashMap<PathBuf, usize>,
     }
 
     // Private details
@@ -130,7 +131,11 @@ mod file_server_impl {
                 }
             })?;
 
-            Ok(Self { watcher, events_rx })
+            Ok(Self {
+                watcher,
+                events_rx,
+                file_watch_count: HashMap::default(),
+            })
         }
     }
 
@@ -183,6 +188,14 @@ mod file_server_impl {
         ) -> anyhow::Result<PathBuf> {
             let path = std::fs::canonicalize(path.as_ref())?;
 
+            match self.file_watch_count.entry(path.clone()) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    *entry.get_mut() += 1;
+                    return Ok(path);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => entry.insert(1),
+            };
+
             self.watcher
                 .watch(
                     path.as_ref(),
@@ -214,6 +227,19 @@ mod file_server_impl {
         /// Stops watching for file events at the given `path`.
         pub fn unwatch(&mut self, path: impl AsRef<Path>) -> anyhow::Result<()> {
             let path = std::fs::canonicalize(path.as_ref())?;
+
+            match self.file_watch_count.entry(path.clone()) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    *entry.get_mut() -= 1;
+                    if *entry.get() == 0 {
+                        entry.remove();
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(_) => {
+                    anyhow::bail!("The path {:?} was not or no longer watched", path);
+                }
+            };
+
             self.watcher
                 .unwatch(path.as_ref())
                 .with_context(|| format!("couldn't unwatch file at {path:?}"))

--- a/crates/re_sdk/src/file_writer.rs
+++ b/crates/re_sdk/src/file_writer.rs
@@ -25,7 +25,7 @@ impl FileWriter {
 
         re_log::debug!("Saving file to {path:?}…");
 
-        let file = std::fs::File::create(&path).with_context(|| format!("Path: {:?}", path))?;
+        let file = std::fs::File::create(&path).with_context(|| format!("Path: {path:?}"))?;
         let mut encoder = re_log_types::encoding::Encoder::new(file)?;
 
         let join_handle = std::thread::Builder::new()


### PR DESCRIPTION
Bad in general (we do suprisingly often include the same file several times for good reasons) and application killing if something creates a renderpipeline every frame (which due to pooling should be cheap!).

Via Slack discussion: It could be that this is only an issue on _some_ platforms. On my Mac this was game over but it could be that on Linux where these were tested more intensively this is fine.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
