### PR TITLE
Log static re_renderer resource generation

### DIFF
--- a/crates/re_renderer/src/wgpu_resources/bind_group_layout_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_layout_pool.rs
@@ -4,7 +4,7 @@ use super::{resource::PoolError, static_resource_pool::StaticResourcePool};
 
 slotmap::new_key_type! { pub struct GpuBindGroupLayoutHandle; }
 
-#[derive(Clone, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 pub struct BindGroupLayoutDesc {
     /// Debug label of the bind group layout. This will show up in graphics debuggers for easy identification.
     pub label: DebugLabel,

--- a/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
@@ -12,7 +12,7 @@ pub struct GpuPipelineLayout {
     pub layout: wgpu::PipelineLayout,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct PipelineLayoutDesc {
     /// Debug label of the pipeline layout. This will show up in graphics debuggers for easy identification.
     pub label: DebugLabel,

--- a/crates/re_renderer/src/wgpu_resources/sampler_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/sampler_pool.rs
@@ -5,7 +5,7 @@ use crate::debug_label::DebugLabel;
 
 slotmap::new_key_type! { pub struct GpuSamplerHandle; }
 
-#[derive(Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct SamplerDesc {
     /// Debug label of the sampler. This will show up in graphics debuggers for easy identification.
     pub label: DebugLabel,

--- a/crates/re_renderer/src/wgpu_resources/static_resource_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/static_resource_pool.rs
@@ -33,7 +33,7 @@ impl<Handle: Key, Desc, Res> Default for StaticResourcePool<Handle, Desc, Res> {
 impl<Handle, Desc, Res> StaticResourcePool<Handle, Desc, Res>
 where
     Handle: Key,
-    Desc: Clone + Eq + Hash,
+    Desc: std::fmt::Debug + Clone + Eq + Hash,
 {
     fn to_pool_error<T>(get_result: Option<T>, handle: Handle) -> Result<T, PoolError> {
         get_result.ok_or_else(|| {
@@ -51,6 +51,7 @@ where
         creation_func: F,
     ) -> Handle {
         *self.lookup.entry(desc.clone()).or_insert_with(|| {
+            re_log::debug!(?desc, "Created new resource");
             let resource = creation_func(desc);
             self.resources.insert(StoredResource {
                 resource,

--- a/crates/re_renderer/src/wgpu_resources/texture_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/texture_pool.rs
@@ -46,6 +46,15 @@ pub struct TextureDesc {
     pub usage: wgpu::TextureUsages,
 }
 
+impl TextureDesc {
+    /// Copies the desc but changes the label.
+    pub fn with_label(&self, label: DebugLabel) -> Self {
+        let mut new = self.clone();
+        new.label = label;
+        new
+    }
+}
+
 impl DynamicResourcesDesc for TextureDesc {
     /// Number of bytes this texture is expected to take.
     ///


### PR DESCRIPTION
Had a situation where I needed to check whether the resource pool does it job (it did) and then noticed that unlike the dynamic resource pool, the static doesn't log resource creation!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
