### PR TITLE
EditableAutoValue needs serde

### DIFF
--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -4,17 +4,22 @@ use re_log_types::{
     msg_bundle::DeserializableComponent, EntityPath,
 };
 
-use crate::{log_db::EntityDb, EditableAutoValue};
+use crate::log_db::EntityDb;
+
+#[cfg(feature = "serde")]
+use crate::EditableAutoValue;
 
 // ----------------------------------------------------------------------------
 
 /// Properties for a collection of entities.
+#[cfg(feature = "serde")]
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EntityPropertyMap {
     props: nohash_hasher::IntMap<EntityPath, EntityProperties>,
 }
 
+#[cfg(feature = "serde")]
 impl EntityPropertyMap {
     pub fn get(&self, entity_path: &EntityPath) -> EntityProperties {
         self.props.get(entity_path).cloned().unwrap_or_default()
@@ -31,6 +36,7 @@ impl EntityPropertyMap {
 
 // ----------------------------------------------------------------------------
 
+#[cfg(feature = "serde")]
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -42,9 +48,11 @@ pub struct EntityProperties {
     /// Distance of the projection plane (frustum far plane).
     ///
     /// Only applies to pinhole cameras when in a spatial view, using 3D navigation.
+    ///
     pub pinhole_image_plane_distance: EditableAutoValue<f32>,
 }
 
+#[cfg(feature = "serde")]
 impl EntityProperties {
     /// Multiply/and these together.
     pub fn with_child(&self, child: &Self) -> Self {
@@ -60,6 +68,7 @@ impl EntityProperties {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Default for EntityProperties {
     fn default() -> Self {
         Self {
@@ -87,6 +96,7 @@ pub struct ExtraQueryHistory {
 
 impl ExtraQueryHistory {
     /// Multiply/and these together.
+    #[allow(dead_code)]
     fn with_child(&self, child: &Self) -> Self {
         Self {
             nanos: self.nanos.max(child.nanos),

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc = document_features::document_features!()]
 //!
 
+#[cfg(feature = "serde")]
 mod editable_auto_value;
 pub mod entity_properties;
 pub mod entity_tree;
@@ -17,6 +18,7 @@ pub use log_db::LogDb;
 
 use re_log_types::msg_bundle;
 
+#[cfg(feature = "serde")]
 pub use editable_auto_value::EditableAutoValue;
 pub use re_log_types::{ComponentName, EntityPath, EntityPathPart, Index, TimeInt, Timeline};
 


### PR DESCRIPTION
serde is an optional dep for `re_data_store` so trying to run benches that depend on the data store without specifying the feature-list was resulting in compilation errors:
```
:~/rerun$ cargo bench -p re_query
   Compiling re_data_store v0.2.0 (/home/jleibs/rerun/crates/re_data_store)
error[E0433]: failed to resolve: use of undeclared crate or module `serde`
 --> crates/re_data_store/src/editable_auto_value.rs:2:24
  |
2 | #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, Eq, PartialEq)]
  |                        ^^^^^ use of undeclared crate or module `serde

...
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
