### PR TITLE
Fix mesh creation failing to copy index data.

### DIFF
--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -189,7 +189,7 @@ impl GpuMesh {
             vertex_buffer_combined
         };
 
-        let index_buffer_size = std::mem::size_of_val(data.indices.as_slice()) as u64;
+        let index_buffer_size = (std::mem::size_of::<u32>() * data.indices.len()) as u64;
         let index_buffer = {
             let index_buffer = pools.buffers.alloc(
                 device,


### PR DESCRIPTION
* fix wrong index data size
* fix dubious `copy_to_buffer` copy size on `CpuWriteGpuReadBuffer`
 
Fixes #1467

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
