### PR TITLE
Python SDK: Add a decorator to all out logging function to early-out

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log/annotation.py
+++ b/rerun_py/rerun_sdk/rerun/log/annotation.py
@@ -3,6 +3,7 @@ from typing import Iterable, Optional, Sequence, Tuple, Union
 
 from rerun import bindings
 from rerun.log import Color, _normalize_colors
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "AnnotationInfo",
@@ -72,6 +73,7 @@ def coerce_class_descriptor_like(arg: ClassDescriptionLike) -> ClassDescription:
         return ClassDescription(info=arg)  # type: ignore[arg-type]
 
 
+@log_decorator
 def log_annotation_context(
     entity_path: str,
     class_descriptions: Union[ClassDescriptionLike, Iterable[ClassDescriptionLike]],
@@ -113,9 +115,6 @@ def log_annotation_context(
         If true, the annotation context will be timeless (default: True).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     if not isinstance(class_descriptions, Iterable):
         class_descriptions = [class_descriptions]

--- a/rerun_py/rerun_sdk/rerun/log/arrow.py
+++ b/rerun_py/rerun_sdk/rerun/log/arrow.py
@@ -11,12 +11,14 @@ from rerun.components.label import LabelArray
 from rerun.components.radius import RadiusArray
 from rerun.log import _normalize_colors, _normalize_radii
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_arrow",
 ]
 
 
+@log_decorator
 def log_arrow(
     entity_path: str,
     origin: Optional[npt.ArrayLike],
@@ -57,9 +59,6 @@ def log_arrow(
         The entity is not time-dependent, and will be visible at any time point.
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     instanced: Dict[str, Any] = {}
     splats: Dict[str, Any] = {}

--- a/rerun_py/rerun_sdk/rerun/log/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log/bounding_box.py
@@ -14,12 +14,14 @@ from rerun.components.radius import RadiusArray
 from rerun.components.vec import Vec3DArray
 from rerun.log import _normalize_colors, _normalize_ids, _normalize_radii
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_obb",
 ]
 
 
+@log_decorator
 def log_obb(
     entity_path: str,
     half_size: Optional[npt.ArrayLike],
@@ -65,9 +67,6 @@ def log_obb(
         If true, the bounding box will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     instanced: Dict[str, Any] = {}
     splats: Dict[str, Any] = {}

--- a/rerun_py/rerun_sdk/rerun/log/camera.py
+++ b/rerun_py/rerun_sdk/rerun/log/camera.py
@@ -2,12 +2,14 @@ import numpy as np
 import numpy.typing as npt
 
 from rerun import bindings
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_pinhole",
 ]
 
 
+@log_decorator
 def log_pinhole(
     entity_path: str,
     *,
@@ -58,9 +60,6 @@ def log_pinhole(
         If true, the camera will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     # Transform arrow handling happens inside the python bridge
     bindings.log_pinhole(

--- a/rerun_py/rerun_sdk/rerun/log/extension_components.py
+++ b/rerun_py/rerun_sdk/rerun/log/extension_components.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import rerun.log.error_utils
 from rerun import bindings
 from rerun.components.instance import InstanceArray
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "_add_extension_components",
@@ -61,6 +62,7 @@ def _add_extension_components(
             instanced[name] = pa_value
 
 
+@log_decorator
 def log_extension_components(
     entity_path: str,
     ext: Dict[str, Any],
@@ -108,9 +110,6 @@ def log_extension_components(
         If true, the components will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     identifiers_np = np.array((), dtype="uint64")
     if identifiers:

--- a/rerun_py/rerun_sdk/rerun/log/file.py
+++ b/rerun_py/rerun_sdk/rerun/log/file.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.typing as npt
 
 from rerun import bindings
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "MeshFormat",
@@ -39,6 +40,7 @@ class ImageFormat(Enum):
     """JPEG format."""
 
 
+@log_decorator
 def log_mesh_file(
     entity_path: str,
     mesh_format: MeshFormat,
@@ -77,9 +79,6 @@ def log_mesh_file(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     if transform is None:
         transform = np.empty(shape=(0, 0), dtype=np.float32)
     else:
@@ -89,6 +88,7 @@ def log_mesh_file(
     bindings.log_mesh_file(entity_path, mesh_format.value, mesh_file, transform, timeless)
 
 
+@log_decorator
 def log_image_file(
     entity_path: str,
     *,
@@ -120,9 +120,6 @@ def log_image_file(
         If true, the image will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     img_format = getattr(img_format, "value", None)
 

--- a/rerun_py/rerun_sdk/rerun/log/image.py
+++ b/rerun_py/rerun_sdk/rerun/log/image.py
@@ -5,6 +5,7 @@ import numpy.typing as npt
 
 from rerun import bindings
 from rerun.log.error_utils import _send_warning
+from rerun.log.log_decorator import log_decorator
 from rerun.log.tensor import Tensor, _log_tensor, _to_numpy
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
 ]
 
 
+@log_decorator
 def log_image(
     entity_path: str,
     image: Tensor,
@@ -47,9 +49,6 @@ def log_image(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     image = _to_numpy(image)
 
     shape = image.shape
@@ -77,6 +76,7 @@ def log_image(
     _log_tensor(entity_path, image, ext=ext, timeless=timeless)
 
 
+@log_decorator
 def log_depth_image(
     entity_path: str,
     image: Tensor,
@@ -111,9 +111,6 @@ def log_depth_image(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     image = _to_numpy(image)
 
     # TODO(#635): Remove when issue with displaying f64 depth images is fixed.
@@ -142,6 +139,7 @@ def log_depth_image(
         )
 
 
+@log_decorator
 def log_segmentation_image(
     entity_path: str,
     image: npt.ArrayLike,
@@ -173,9 +171,6 @@ def log_segmentation_image(
         If true, the image will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     image = np.array(image, copy=False)
     if image.dtype not in (np.dtype("uint8"), np.dtype("uint16")):

--- a/rerun_py/rerun_sdk/rerun/log/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log/lines.py
@@ -11,6 +11,7 @@ from rerun.components.linestrip import LineStrip2DArray, LineStrip3DArray
 from rerun.components.radius import RadiusArray
 from rerun.log import _normalize_colors, _normalize_radii
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_path",
@@ -29,11 +30,10 @@ def log_path(
     ext: Optional[Dict[str, Any]] = None,
     timeless: bool = False,
 ) -> None:
-    if not bindings.is_enabled():
-        return
     log_line_strip(entity_path, positions, stroke_width=stroke_width, color=color, ext=ext, timeless=timeless)
 
 
+@log_decorator
 def log_line_strip(
     entity_path: str,
     positions: Optional[npt.ArrayLike],
@@ -73,9 +73,6 @@ def log_line_strip(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     if positions is not None:
         positions = np.require(positions, dtype="float32")
 
@@ -111,6 +108,7 @@ def log_line_strip(
         bindings.log_arrow_msg(entity_path, components=instanced, timeless=timeless)
 
 
+@log_decorator
 def log_line_segments(
     entity_path: str,
     positions: npt.ArrayLike,
@@ -148,9 +146,6 @@ def log_line_segments(
         If true, the line segments will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     if positions is None:
         positions = np.require([], dtype="float32")

--- a/rerun_py/rerun_sdk/rerun/log/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log/log_decorator.py
@@ -1,0 +1,21 @@
+import functools
+from typing import Any, Callable, TypeVar, cast
+
+from rerun import bindings
+
+_TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
+
+
+def log_decorator(func: _TFunc) -> _TFunc:
+    """
+    A decorator we add to all our logging function.
+
+    It early-outs if logging is disabled.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if bindings.is_enabled():
+            return func(*args, **kwargs)
+
+    return cast(_TFunc, wrapper)

--- a/rerun_py/rerun_sdk/rerun/log/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log/mesh.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.typing as npt
 
 from rerun import bindings
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_mesh",
@@ -11,6 +12,7 @@ __all__ = [
 ]
 
 
+@log_decorator
 def log_mesh(
     entity_path: str,
     positions: npt.ArrayLike,
@@ -72,9 +74,6 @@ def log_mesh(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     positions = np.asarray(positions, dtype=np.float32).flatten()
 
     if indices is not None:
@@ -88,6 +87,7 @@ def log_mesh(
     bindings.log_meshes(entity_path, [positions.flatten()], [indices], [normals], [albedo_factor], timeless)
 
 
+@log_decorator
 def log_meshes(
     entity_path: str,
     position_buffers: Sequence[npt.ArrayLike],
@@ -123,9 +123,6 @@ def log_meshes(
         If true, the mesh will be timeless (default: False)
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     position_buffers = [np.asarray(p, dtype=np.float32).flatten() for p in position_buffers]
     if index_buffers is not None:

--- a/rerun_py/rerun_sdk/rerun/log/points.py
+++ b/rerun_py/rerun_sdk/rerun/log/points.py
@@ -22,6 +22,7 @@ from rerun.log import (
 )
 from rerun.log.error_utils import _send_warning
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_point",
@@ -29,6 +30,7 @@ __all__ = [
 ]
 
 
+@log_decorator
 def log_point(
     entity_path: str,
     position: Optional[npt.ArrayLike] = None,
@@ -85,9 +87,6 @@ def log_point(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     if keypoint_id is not None and class_id is None:
         class_id = 0
     if position is not None:
@@ -131,6 +130,7 @@ def log_point(
         bindings.log_arrow_msg(entity_path, components=instanced, timeless=timeless)
 
 
+@log_decorator
 def log_points(
     entity_path: str,
     positions: Optional[npt.ArrayLike] = None,
@@ -190,9 +190,6 @@ def log_points(
         If true, the points will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     if keypoint_ids is not None and class_ids is None:
         class_ids = 0

--- a/rerun_py/rerun_sdk/rerun/log/rects.py
+++ b/rerun_py/rerun_sdk/rerun/log/rects.py
@@ -19,6 +19,7 @@ from rerun.log import (
 )
 from rerun.log.error_utils import _send_warning
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "RectFormat",
@@ -27,6 +28,7 @@ __all__ = [
 ]
 
 
+@log_decorator
 def log_rect(
     entity_path: str,
     rect: Optional[npt.ArrayLike],
@@ -64,9 +66,6 @@ def log_rect(
 
     """
 
-    if not bindings.is_enabled():
-        return
-
     if np.any(rect):  # type: ignore[arg-type]
         rects = np.asarray([rect], dtype="float32")
     else:
@@ -101,6 +100,7 @@ def log_rect(
         bindings.log_arrow_msg(entity_path, components=instanced, timeless=timeless)
 
 
+@log_decorator
 def log_rects(
     entity_path: str,
     rects: Optional[npt.ArrayLike],
@@ -152,9 +152,6 @@ def log_rects(
             If true, the rects will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     # Treat None the same as []
     if np.any(rects):  # type: ignore[arg-type]

--- a/rerun_py/rerun_sdk/rerun/log/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/log/scalar.py
@@ -10,12 +10,14 @@ from rerun.components.radius import RadiusArray
 from rerun.components.scalar import ScalarArray, ScalarPlotPropsArray
 from rerun.log import _normalize_colors
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_scalar",
 ]
 
 
+@log_decorator
 def log_scalar(
     entity_path: str,
     scalar: float,
@@ -109,9 +111,6 @@ def log_scalar(
         Optional dictionary of extension components. See [rerun.log_extension_components][]
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     instanced: Dict[str, Any] = {}
     splats: Dict[str, Any] = {}

--- a/rerun_py/rerun_sdk/rerun/log/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log/tensor.py
@@ -8,6 +8,7 @@ from rerun.components.instance import InstanceArray
 from rerun.components.tensor import TensorArray
 from rerun.log.error_utils import _send_warning
 from rerun.log.extension_components import _add_extension_components
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_tensor",
@@ -37,6 +38,7 @@ def _to_numpy(tensor: Tensor) -> npt.NDArray[Any]:
         return np.array(tensor, copy=False)
 
 
+@log_decorator
 def log_tensor(
     entity_path: str,
     tensor: npt.ArrayLike,
@@ -85,9 +87,6 @@ def _log_tensor(
     timeless: bool = False,
 ) -> None:
     """Log a general tensor, perhaps with named dimensions."""
-
-    if not bindings.is_enabled():
-        return
 
     if names is not None:
         names = list(names)

--- a/rerun_py/rerun_sdk/rerun/log/text.py
+++ b/rerun_py/rerun_sdk/rerun/log/text.py
@@ -9,6 +9,7 @@ from rerun.components.color import ColorRGBAArray
 from rerun.components.instance import InstanceArray
 from rerun.components.text_entry import TextEntryArray
 from rerun.log import _normalize_colors
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "LogLevel",
@@ -92,6 +93,7 @@ class LoggingHandler(logging.Handler):
         log_text_entry(objpath, record.getMessage(), level=level)
 
 
+@log_decorator
 def log_text_entry(
     entity_path: str,
     text: str,
@@ -122,9 +124,6 @@ def log_text_entry(
         Whether the text entry should be timeless.
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     instanced: Dict[str, Any] = {}
     splats: Dict[str, Any] = {}

--- a/rerun_py/rerun_sdk/rerun/log/transform.py
+++ b/rerun_py/rerun_sdk/rerun/log/transform.py
@@ -10,6 +10,7 @@ import numpy.typing as npt
 from rerun import bindings
 from rerun.log import _to_sequence
 from rerun.log.error_utils import _send_warning
+from rerun.log.log_decorator import log_decorator
 
 __all__ = [
     "log_view_coordinates",
@@ -18,6 +19,7 @@ __all__ = [
 ]
 
 
+@log_decorator
 def log_view_coordinates(
     entity_path: str,
     *,
@@ -91,15 +93,14 @@ def log_view_coordinates(
         bindings.log_view_coordinates_up_handedness(entity_path, up, right_handed, timeless)
 
 
+@log_decorator
 def log_unknown_transform(entity_path: str, timeless: bool = False) -> None:
     """Log that this entity is NOT in the same space as the parent, but you do not (yet) know how they relate."""
-
-    if not bindings.is_enabled():
-        return
 
     bindings.log_unknown_transform(entity_path, timeless=timeless)
 
 
+@log_decorator
 def log_rigid3(
     entity_path: str,
     *,
@@ -147,9 +148,6 @@ def log_rigid3(
         If true, the transform will be timeless (default: False).
 
     """
-
-    if not bindings.is_enabled():
-        return
 
     if parent_from_child and child_from_parent:
         _send_warning("Set either parent_from_child or child_from_parent, but not both. Ignoring log.", 1)


### PR DESCRIPTION
This replaces explicit checks with a decorator.

This decorator declaration preserves type information in Python 3.8 in my VSCode, which was a problem with previous attempts (https://github.com/rerun-io/rerun/pull/549).

In a follow-up PR we can add a try-catch to the decorator to prevent errors from bubbling up to the user (https://github.com/rerun-io/rerun/pull/549).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
