### PR TITLE
Remove duplicated 'nix' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,12 +485,12 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf530afb40e45e14440701e5e996d7fd139e84a912a4d83a8d6a0fb3e58663"
+checksum = "595eb0438b3c6d262395fe30e6de9a61beb57ea56290b00a07f227fe6e20cbf2"
 dependencies = [
  "log",
- "nix 0.25.0",
+ "nix",
  "slotmap",
  "thiserror",
  "vec_map",
@@ -1043,11 +1043,11 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.3"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
+checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
 dependencies = [
- "nix 0.25.0",
+ "nix",
  "winapi",
 ]
 
@@ -2817,19 +2817,6 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
-dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
@@ -4703,7 +4690,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix 0.24.2",
+ "nix",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
@@ -5674,7 +5661,7 @@ dependencies = [
  "bitflags",
  "downcast-rs",
  "libc",
- "nix 0.24.2",
+ "nix",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -5687,7 +5674,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
- "nix 0.24.2",
+ "nix",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -5699,7 +5686,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
- "nix 0.24.2",
+ "nix",
  "wayland-client",
  "xcursor",
 ]
@@ -6169,7 +6156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
 dependencies = [
  "gethostname",
- "nix 0.24.2",
+ "nix",
  "winapi",
  "winapi-wsapoll",
  "x11rb-protocol",
@@ -6181,7 +6168,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
 dependencies = [
- "nix 0.24.2",
+ "nix",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -42,7 +42,6 @@ skip = [
   { name = "ahash" },     # Popular crate + fast release schedule = lots of crates still using old versions
   { name = "base64" },    # Too popular
   { name = "memoffset" }, # Small crate
-  { name = "nix" },       # Too many to protect against
   { name = "time" },      # Too popular
   { name = "windows" },   # wgpu and rfd are sometimes on different versions
 ]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -42,7 +42,7 @@ cargo doc --document-private-items --no-deps --all-features
 
 cargo deny --all-features --log-level error --target aarch64-apple-darwin check
 cargo deny --all-features --log-level error --target wasm32-unknown-unknown check
-cargo deny --all-features --log-level error --target x86_64-pc-windows-msvc
+cargo deny --all-features --log-level error --target x86_64-pc-windows-msvc check
 cargo deny --all-features --log-level error --target x86_64-unknown-linux-musl check
 
 echo "All checks passed!"


### PR DESCRIPTION
```
❯ cargo update -p calloop --precise 0.10.2
    Updating calloop v0.10.3 -> v0.10.2

❯ cargo update -p ctrlc --precise 3.2.2
    Updating ctrlc v3.2.3 -> v3.2.2
    Removing nix v0.25.0
```

`ctrlc` diff: https://github.com/Detegr/rust-ctrlc/compare/3.2.2...3.2.3
`calloop` diff: https://github.com/Smithay/calloop/compare/v0.10.2...v0.10.3


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
