### PR TITLE
Delete the prerelease before creating the new one

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -270,6 +270,18 @@ jobs:
           name: wheels
           path: dist
 
+      # First delete the old prerelease. If we don't do this, we don't get things like
+      # proper source-archives and changelog info.
+      # https://github.com/dev-drprasad/delete-tag-and-release
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          tag_name: prerelease
+          delete_release: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Re-tag the prerelease with the commit from this build
+      # https://github.com/richardsimko/update-tag
       - name: Update prerelease tag
         uses: richardsimko/update-tag@v1
         with:
@@ -277,19 +289,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Create the actual prerelease
+      # https://github.com/softprops/action-gh-release
       - name: GitHub Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: softprops/action-gh-release@v0.1.15
         with:
+          name: "Development Build"
           body: ${{ env.PRE_RELEASE_INSTRUCTIONS }}
           prerelease: true
-          artifacts: dist/*
-          name: "Development Build"
-          tag: "prerelease"
+          tag_name: prerelease
+          files: dist/*
           token: ${{ secrets.GITHUB_TOKEN }}
-          generateReleaseNotes: true
-          allowUpdates: true
-          removeArtifacts: true
-          replacesArtifacts: true
+          generate_release_notes: true
 
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Updating simply doesn't work the way we want. We know we get the behavior we want when the release is created, so just delete the old one and make a new one.

Switch back to using the same gh-action for prereleases as for main releases for consistency.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
