### PR TITLE
Internal log_text_entry_internal to break circular deps

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/log/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "scalar",
     "tensor",
     "text",
+    "text_internal",
     "transform",
     "ext",
 ]

--- a/rerun_py/rerun_sdk/rerun/log/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/log/error_utils.py
@@ -2,7 +2,6 @@ import inspect
 import logging
 
 import rerun
-from rerun import bindings
 from rerun.log.text_internal import LogLevel, log_text_entry_internal
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/log/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/log/error_utils.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 
 from rerun import bindings
-from rerun.log.text import LogLevel, log_text_entry
+from rerun.log.text_internal import LogLevel, log_text_entry_internal
 
 __all__ = [
     "_send_warning",
@@ -29,5 +29,5 @@ def _send_warning(message: str, depth_to_user_code: int) -> None:
 
     context_descriptor = _build_warning_context_string(skip_first=depth_to_user_code + 2)
     warning = f"{message}\n{context_descriptor}"
-    log_text_entry("rerun", warning, level=LogLevel.WARN)
+    log_text_entry_internal("rerun", warning, level=LogLevel.WARN)
     logging.warning(warning)

--- a/rerun_py/rerun_sdk/rerun/log/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/log/error_utils.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 
+import rerun
 from rerun import bindings
 from rerun.log.text_internal import LogLevel, log_text_entry_internal
 
@@ -24,7 +25,7 @@ def _send_warning(message: str, depth_to_user_code: int) -> None:
     or raise an exception and let the @log_decorator handle it instead.
     """
 
-    if bindings.strict_mode():
+    if rerun.strict_mode():
         raise TypeError(message)
 
     context_descriptor = _build_warning_context_string(skip_first=depth_to_user_code + 2)

--- a/rerun_py/rerun_sdk/rerun/log/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log/log_decorator.py
@@ -4,7 +4,7 @@ import traceback
 from typing import Any, Callable, TypeVar, cast
 
 from rerun import bindings
-from rerun.log.text import LogLevel, log_text_entry
+from rerun.log.text_internal import LogLevel, log_text_entry_internal
 
 _TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
 
@@ -34,7 +34,7 @@ def log_decorator(func: _TFunc) -> _TFunc:
                 return func(*args, **kwargs)
             except Exception as e:
                 warning = "".join(traceback.format_exception(e.__class__, e, e.__traceback__))
-                log_text_entry("rerun", warning, level=LogLevel.WARN)
+                log_text_entry_internal("rerun", warning, level=LogLevel.WARN)
                 logging.warning(f"Ignoring rerun log call: {warning}")
 
     return cast(_TFunc, wrapper)

--- a/rerun_py/rerun_sdk/rerun/log/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log/log_decorator.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 from typing import Any, Callable, TypeVar, cast
 
+import rerun
 from rerun import bindings
 from rerun.log.text_internal import LogLevel, log_text_entry_internal
 
@@ -26,7 +27,7 @@ def log_decorator(func: _TFunc) -> _TFunc:
         if not bindings.is_enabled():
             return
 
-        if bindings.strict_mode():
+        if rerun.strict_mode():
             # Pass on any exceptions to the caller
             return func(*args, **kwargs)
         else:

--- a/rerun_py/rerun_sdk/rerun/log/text.py
+++ b/rerun_py/rerun_sdk/rerun/log/text.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 from typing import Any, Dict, Final, Optional, Sequence
 
 # Fully qualified to avoid circular import

--- a/rerun_py/rerun_sdk/rerun/log/text.py
+++ b/rerun_py/rerun_sdk/rerun/log/text.py
@@ -10,40 +10,13 @@ from rerun.components.instance import InstanceArray
 from rerun.components.text_entry import TextEntryArray
 from rerun.log import _normalize_colors
 from rerun.log.log_decorator import log_decorator
+from rerun.log.text_internal import LogLevel
 
 __all__ = [
     "LogLevel",
     "LoggingHandler",
     "log_text_entry",
 ]
-
-
-@dataclass
-class LogLevel:
-    """
-    Represents the standard log levels.
-
-    This is a collection of constants rather than an enum because we do support
-    arbitrary strings as level (e.g. for user-defined levels).
-    """
-
-    CRITICAL: Final = "CRITICAL"
-    """ Designates catastrophic failures. """
-
-    ERROR: Final = "ERROR"
-    """ Designates very serious errors. """
-
-    WARN: Final = "WARN"
-    """ Designates hazardous situations. """
-
-    INFO: Final = "INFO"
-    """ Designates useful information. """
-
-    DEBUG: Final = "DEBUG"
-    """ Designates lower priority information. """
-
-    TRACE: Final = "TRACE"
-    """ Designates very low priority, often extremely verbose, information. """
 
 
 class LoggingHandler(logging.Handler):

--- a/rerun_py/rerun_sdk/rerun/log/text_internal.py
+++ b/rerun_py/rerun_sdk/rerun/log/text_internal.py
@@ -11,8 +11,7 @@ from rerun.log import _normalize_colors
 
 __all__ = [
     "LogLevel",
-    "LoggingHandler",
-    "log_text_entry",
+    "log_text_entry_internal",
 ]
 
 
@@ -42,8 +41,6 @@ class LogLevel:
 
     TRACE: Final = "TRACE"
     """ Designates very low priority, often extremely verbose, information. """
-
-
 
 
 def log_text_entry_internal(
@@ -88,9 +85,6 @@ def log_text_entry_internal(
     if color:
         colors = _normalize_colors([color])
         instanced["rerun.colorrgba"] = ColorRGBAArray.from_numpy(colors)
-
-    if ext:
-        rerun.log.extension_components._add_extension_components(instanced, splats, ext, None)
 
     if splats:
         splats["rerun.instance_key"] = InstanceArray.splat()

--- a/rerun_py/rerun_sdk/rerun/log/text_internal.py
+++ b/rerun_py/rerun_sdk/rerun/log/text_internal.py
@@ -1,0 +1,101 @@
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Final, Optional, Sequence
+
+# Fully qualified to avoid circular import
+from rerun import bindings
+from rerun.components.color import ColorRGBAArray
+from rerun.components.instance import InstanceArray
+from rerun.components.text_entry import TextEntryArray
+from rerun.log import _normalize_colors
+
+__all__ = [
+    "LogLevel",
+    "LoggingHandler",
+    "log_text_entry",
+]
+
+
+@dataclass
+class LogLevel:
+    """
+    Represents the standard log levels.
+
+    This is a collection of constants rather than an enum because we do support
+    arbitrary strings as level (e.g. for user-defined levels).
+    """
+
+    CRITICAL: Final = "CRITICAL"
+    """ Designates catastrophic failures. """
+
+    ERROR: Final = "ERROR"
+    """ Designates very serious errors. """
+
+    WARN: Final = "WARN"
+    """ Designates hazardous situations. """
+
+    INFO: Final = "INFO"
+    """ Designates useful information. """
+
+    DEBUG: Final = "DEBUG"
+    """ Designates lower priority information. """
+
+    TRACE: Final = "TRACE"
+    """ Designates very low priority, often extremely verbose, information. """
+
+
+
+
+def log_text_entry_internal(
+    entity_path: str,
+    text: str,
+    *,
+    level: Optional[str] = LogLevel.INFO,
+    color: Optional[Sequence[int]] = None,
+    timeless: bool = False,
+) -> None:
+    """
+    Internal API to log a text entry, with optional level.
+
+    This implementation doesn't support extension components, or the exception-capturing decorator
+    and is intended to be used from inside the other rerun log functions.
+
+    Parameters
+    ----------
+    entity_path:
+        The object path to log the text entry under.
+    text:
+        The text to log.
+    level:
+        The level of the text entry (default: `LogLevel.INFO`). Note this can technically
+        be an arbitrary string, but it's recommended to use one of the constants
+        from [LogLevel][rerun.log.text.LogLevel]
+    color:
+        Optional RGB or RGBA triplet in 0-255 sRGB.
+    timeless:
+        Whether the text entry should be timeless.
+
+    """
+
+    instanced: Dict[str, Any] = {}
+    splats: Dict[str, Any] = {}
+
+    if text:
+        instanced["rerun.text_entry"] = TextEntryArray.from_bodies_and_levels([(text, level)])
+    else:
+        logging.warning(f"Null  text entry in log_text_entry('{entity_path}') will be dropped.")
+
+    if color:
+        colors = _normalize_colors([color])
+        instanced["rerun.colorrgba"] = ColorRGBAArray.from_numpy(colors)
+
+    if ext:
+        rerun.log.extension_components._add_extension_components(instanced, splats, ext, None)
+
+    if splats:
+        splats["rerun.instance_key"] = InstanceArray.splat()
+        bindings.log_arrow_msg(entity_path, components=splats, timeless=timeless)
+
+    # Always the primary component last so range-based queries will include the other data. See(#1215)
+    if instanced:
+        bindings.log_arrow_msg(entity_path, components=instanced, timeless=timeless)


### PR DESCRIPTION
Importing `log_text_entry` from the decorator used to decorate the `log_text_entry` itself is problematic. Split text.py into the external-facing facing user API and a slimmed down internal version we can use from within our other API calls.

Also the calls checking strict_mode weren't valid. Not sure how this ever worked?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
