### PR TITLE
Switch release action to ncipollo

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -290,17 +290,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Create the actual prerelease
-      # https://github.com/softprops/action-gh-release
+      # https://github.com/ncipollo/release-action
       - name: GitHub Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: ncipollo/release-action@v1.12.0
         with:
-          name: "Development Build"
           body: ${{ env.PRE_RELEASE_INSTRUCTIONS }}
           prerelease: true
-          tag_name: prerelease
-          files: dist/*
+          artifacts: dist/*
+          name: "Development Build"
+          tag: "prerelease"
           token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true
+          generateReleaseNotes: true
+          allowUpdates: true
+          removeArtifacts: true
+          replacesArtifacts: true
 
   # ---------------------------------------------------------------------------
 
@@ -317,13 +320,14 @@ jobs:
           name: wheels
           path: dist
 
+      # https://github.com/ncipollo/release-action
       - name: GitHub Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: ncipollo/release-action@v1.12.0
         with:
           prerelease: false
-          files: dist/*
+          artifacts: dist/*
           token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true
+          generateReleaseNotes: true
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
This job did what I expected when we ran it earlier whereas softprops is incorrectly adding in *all* the previous PRs start at 1.

See: https://github.com/rerun-io/rerun/releases/tag/prerelease

Just switching to ncipollo.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
