### PR TITLE
[ci] Separate mac wheels & trigger wheel build from ui

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,8 @@ on:
     inputs:
       force_build_wheel:
         description: 'Build python wheels'
-        required: false
+        required: true
+        default: false
         type: boolean
 
 env:
@@ -65,7 +66,7 @@ jobs:
   matrix-setup:
     # Building all the wheels is expensive, so we only run this job when we push (to main or release tags),
     # or if the job was manually triggered with `force_build_wheel` set to true.
-    if: github.event_name == 'push' || ${{ inputs.force_build_wheel }}
+    if: github.event_name == 'push' || github.event.inputs.force_build_wheel
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,7 +18,7 @@ env:
   PYTHON_VERSION: "3.8"
   PRE_RELEASE_INSTRUCTIONS: |
     ## Installing the pre-release Python SDK
-    1. Download the correct `.whl`. For Mac M1/M2, grab the "universal2" `.whl`
+    1. Download the correct `.whl`.
     2. Run `pip install rerun_sdk<...>.whl` (replace `<...>` with the actual filename)
     3. Test it: `rerun --version`
   UBUNTU_REQUIRED_PKGS: libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libfontconfig1-dev libatk-bridge2.0 libfreetype6-dev libglib2.0-dev
@@ -80,22 +80,15 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
         run: echo "$JOB_CONTEXT"
-      # Sets TAGGED_OR_MAIN if this workflow is running on a tag or the main branch.
-      - name: Set TAGGED_OR_MAIN
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-        run: echo "TAGGED_OR_MAIN=1" >> $GITHUB_ENV
 
       - id: set-matrix
         shell: bash
         run: |
           matrix=()
-
-          if [[ $TAGGED_OR_MAIN ]]; then
-            # MacOS build is really slow (>30 mins); uses up a lot of CI minutes
-            matrix+=('{"platform": "macos", "runs_on": "macos-latest"},')
-          fi
-          matrix+=('{"platform": "windows", "runs_on": "windows-latest-8-cores"},')
-          matrix+=('{"platform": "linux", "runs_on": "ubuntu-latest-16-cores", container: {"image": "rerunio/ci_docker:0.5"}}')
+          matrix+=('{"platform": "macos", "target": "x86_64-apple-darwin", "runs_on": "macos-latest"},')
+          matrix+=('{"platform": "macos", "target": "aarch64-apple-darwin", "runs_on": "macos-latest"},')
+          matrix+=('{"platform": "windows", "target": "x86_64-pc-windows-msvc", "runs_on": "windows-latest-8-cores"},')
+          matrix+=('{"platform": "linux", "target": "x86_64-unknown-linux-gnu", "runs_on": "ubuntu-latest-16-cores", container: {"image": "rerunio/ci_docker:0.5"}}')
 
           echo "Matrix values: ${matrix[@]}"
 
@@ -209,9 +202,9 @@ jobs:
           args: |
             --manifest-path rerun_py/Cargo.toml
             --release
+            --target {{ matrix.target }}
             --no-default-features
             --features pypi
-            --universal2
             --out pre-dist
 
       - name: Install built wheel

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,12 +2,17 @@ name: CI (Python)
 
 on:
   pull_request:
-    types: [labeled, synchronize, opened]
   push:
     branches:
       - "main"
     tags:
       - "v*.*.*" # on release tag
+  workflow_dispatch:
+    inputs:
+      force_build_wheel:
+        description: 'Build python wheels'
+        required: false
+        type: boolean
 
 env:
   PYTHON_VERSION: "3.8"
@@ -59,8 +64,8 @@ jobs:
 
   matrix-setup:
     # Building all the wheels is expensive, so we only run this job when we push (to main or release tags),
-    # or if the PR has the 'build wheels' label for explicit testing of wheels.
-    if: github.event_name == 'push' || contains( github.event.pull_request.labels.*.name, '🛞 build wheels')
+    # or if the job was manually triggered with `force_build_wheel` set to true.
+    if: github.event_name == 'push' || ${{ inputs.force_build_wheel }}
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -203,7 +203,7 @@ jobs:
           args: |
             --manifest-path rerun_py/Cargo.toml
             --release
-            --target {{ matrix.target }}
+            --target ${{ matrix.target }}
             --no-default-features
             --features pypi
             --out pre-dist


### PR DESCRIPTION
* remove need for special python wheel tag and use `workflow_dispatch` for ui controlled wheel publishing instead.
* Build aarch64 and x64 wheels in parallel, not as a universal wheel

The ui only works once this lands in main, so this is pretty much untested :(
I ensured using `act` that the yml is at least not broken.

Might fix #1442 

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
