### PR TITLE
Let the release job take care of creating the prerelease tag

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -279,15 +279,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Re-tag the prerelease with the commit from this build
-      # https://github.com/richardsimko/update-tag
-      - name: Update prerelease tag
-        uses: richardsimko/update-tag@v1
-        with:
-          tag_name: prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       # Create the actual prerelease
       # https://github.com/ncipollo/release-action
       - name: GitHub Release


### PR DESCRIPTION
This hits a slightly different code-path when creating release notes. I'm hoping this will restore the correct behavior for "auto" release notes. If it doesn't, we might have to just write our own python script to wrangle the github APIs ourselves.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
