### PR TITLE
Set prerelease to true even for version-tagged CI job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       force_build_wheel:
-        description: 'Build python wheels'
+        description: "Build python wheels"
         required: true
         default: false
         type: boolean
@@ -314,7 +314,7 @@ jobs:
       - name: GitHub Release
         uses: ncipollo/release-action@v1.12.0
         with:
-          prerelease: false
+          prerelease: true
           artifacts: dist/*
           token: ${{ secrets.GITHUB_TOKEN }}
           generateReleaseNotes: true
@@ -394,7 +394,6 @@ jobs:
           git checkout --orphan gh-pages-orphan
           git commit -m "Update docs for ${GITHUB_SHA}"
           git push origin gh-pages-orphan:gh-pages -f
-
 
       # Mike will incrementally update the existing gh-pages branch
       # We then check it out, and reset it to a new orphaned branch, which we force-push to origin


### PR DESCRIPTION
Builds such as `0.3.0-alpha` should still be considered pre-releases. Rather than try to match on a tag, just always set the pre-release tag. Once the release is actually ready we can go in and manually promote the pre-release to the latest release through the github UI.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
