### PR TITLE
Fix web-viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,6 +4996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
+ "js-sys",
  "serde",
  "time-core",
  "time-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ polars-lazy = "0.27.1"
 polars-ops = "0.27.1"
 puffin = "0.14"
 thiserror = "1.0"
-time = "0.3"
+time = { version = "0.3", features = ["wasm-bindgen"] }
 tokio = "1.24"
 wgpu = { version = "0.15", default-features = false }
 wgpu-core = { version = "0.15", default-features = false }

--- a/crates/re_analytics/Cargo.toml
+++ b/crates/re_analytics/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror.workspace = true
-time = { version = "0.3", features = ["serde", "formatting", "parsing"] }
+time = { workspace = true, features = ["serde", "formatting", "parsing"] }
 uuid = { version = "1.1", features = ["serde", "v4", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
The web-viewer accidentally broke in https://github.com/rerun-io/rerun/pull/1408

We should be able to catch this on CI if we compile the wasm and then check it for any references to forbidden functions, like `env::time`, using some tool in <https://github.com/WebAssembly/wabt>.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
