### PR TITLE
Proper rustc & LLVM versions

### DIFF
--- a/crates/re_analytics/src/lib.rs
+++ b/crates/re_analytics/src/lib.rs
@@ -106,13 +106,27 @@ impl Event {
 
     /// Adds Rerun version, git hash, build date and similar as properties to the event.
     pub fn with_build_info(self, build_info: &re_build_info::BuildInfo) -> Event {
-        self.with_prop("rerun_version", build_info.version.to_string())
-            .with_prop("target", build_info.target_triple)
+        let re_build_info::BuildInfo {
+            crate_name: _,
+            version,
+            rustc_version,
+            llvm_version,
+            git_hash: _,
+            git_branch,
+            is_in_rerun_workspace,
+            target_triple,
+            datetime,
+        } = build_info;
+
+        self.with_prop("rerun_version", version.to_string())
+            .with_prop("rust_version", (*rustc_version).to_owned())
+            .with_prop("llvm_version", (*llvm_version).to_owned())
+            .with_prop("target", *target_triple)
             .with_prop("git_hash", build_info.git_hash_or_tag())
-            .with_prop("git_branch", build_info.git_branch)
-            .with_prop("build_date", build_info.datetime)
+            .with_prop("git_branch", *git_branch)
+            .with_prop("build_date", *datetime)
             .with_prop("debug", cfg!(debug_assertions)) // debug-build?
-            .with_prop("rerun_workspace", build_info.is_in_rerun_workspace)
+            .with_prop("rerun_workspace", *is_in_rerun_workspace)
     }
 }
 

--- a/crates/re_build_info/src/build_info.rs
+++ b/crates/re_build_info/src/build_info.rs
@@ -17,6 +17,12 @@ pub struct BuildInfo {
     /// Crate version, parsed from `CARGO_PKG_VERSION`, ignoring any `+metadata` suffix.
     pub version: super::CrateVersion,
 
+    /// The raw version string of the Rust compiler used, or an empty string.
+    pub rustc_version: &'static str,
+
+    /// The raw version string of the LLVM toolchain used, or an empty string.
+    pub llvm_version: &'static str,
+
     /// Git commit hash, or empty string.
     pub git_hash: &'static str,
 
@@ -55,6 +61,8 @@ impl std::fmt::Display for BuildInfo {
         let Self {
             crate_name,
             version,
+            rustc_version,
+            llvm_version,
             git_hash,
             git_branch,
             is_in_rerun_workspace: _,
@@ -62,7 +70,18 @@ impl std::fmt::Display for BuildInfo {
             datetime,
         } = self;
 
+        let rustc_version = (!rustc_version.is_empty()).then(|| format!("rustc {rustc_version}"));
+        let llvm_version = (!llvm_version.is_empty()).then(|| format!("LLVM {llvm_version}"));
+
         write!(f, "{crate_name} {version}")?;
+
+        if let Some(rustc_version) = rustc_version {
+            write!(f, " [{rustc_version}")?;
+            if let Some(llvm_version) = llvm_version {
+                write!(f, ", {llvm_version}")?;
+            }
+            write!(f, "]")?;
+        }
 
         write!(f, " {target_triple}")?;
 

--- a/crates/re_build_info/src/lib.rs
+++ b/crates/re_build_info/src/lib.rs
@@ -20,6 +20,8 @@ macro_rules! build_info {
             llvm_version: env!("RE_BUILD_LLVM_VERSION"),
             git_hash: env!("RE_BUILD_GIT_HASH"),
             git_branch: env!("RE_BUILD_GIT_BRANCH"),
+            // TODO(cmc): `PartialEq` is not available in const contexts, so this won't actually
+            // build if you try to instantiate a BuildInfo in a constant.
             is_in_rerun_workspace: env!("RE_BUILD_IS_IN_RERUN_WORKSPACE") == "yes",
             target_triple: env!("RE_BUILD_TARGET_TRIPLE"),
             datetime: env!("RE_BUILD_DATETIME"),

--- a/crates/re_build_info/src/lib.rs
+++ b/crates/re_build_info/src/lib.rs
@@ -16,6 +16,8 @@ macro_rules! build_info {
         $crate::BuildInfo {
             crate_name: env!("CARGO_PKG_NAME"),
             version: $crate::CrateVersion::parse(env!("CARGO_PKG_VERSION")),
+            rustc_version: env!("RE_BUILD_RUSTC_VERSION"),
+            llvm_version: env!("RE_BUILD_LLVM_VERSION"),
             git_hash: env!("RE_BUILD_GIT_HASH"),
             git_branch: env!("RE_BUILD_GIT_BRANCH"),
             is_in_rerun_workspace: env!("RE_BUILD_IS_IN_RERUN_WORKSPACE") == "yes",

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -233,7 +233,8 @@ fn test_encode_decode() {
             is_official_example: true,
             started: Time::now(),
             recording_source: crate::RecordingSource::RustSdk {
-                rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
+                rustc_version: String::new(),
+                llvm_version: String::new(),
             },
         },
     })];

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -261,8 +261,8 @@ pub enum RecordingSource {
 
     /// The official Rerun Rust Logging SDK
     RustSdk {
-        /// `CARGO_PKG_RUST_VERSION` = the MSRV specified by out crate. TODO(#1509): remove or improve
-        rust_version: String,
+        rustc_version: String,
+        llvm_version: String,
     },
 
     /// Perhaps from some manual data ingestion?
@@ -274,7 +274,10 @@ impl std::fmt::Display for RecordingSource {
         match self {
             Self::Unknown => "Unknown".fmt(f),
             Self::PythonSdk(version) => write!(f, "Python {version} SDK"),
-            Self::RustSdk { rust_version } => write!(f, "Rust {rust_version} SDK"),
+            Self::RustSdk {
+                rustc_version: rust_version,
+                llvm_version: _,
+            } => write!(f, "Rust {rust_version} SDK"),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes
         }
     }

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -107,7 +107,8 @@ impl Session {
             enabled,
 
             recording_source: RecordingSource::RustSdk {
-                rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
+                rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
+                llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
             },
 
             #[cfg(all(feature = "tokio_runtime", not(target_arch = "wasm32")))]

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1119,6 +1119,8 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
     let re_build_info::BuildInfo {
         crate_name,
         version,
+        rustc_version,
+        llvm_version,
         git_hash: _,
         git_branch: _,
         is_in_rerun_workspace: _,
@@ -1128,10 +1130,24 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
 
     ui.style_mut().wrap = Some(false);
 
+    let rustc_version = if rustc_version.is_empty() {
+        "unknown"
+    } else {
+        rustc_version
+    };
+
+    let llvm_version = if llvm_version.is_empty() {
+        "unknown"
+    } else {
+        llvm_version
+    };
+
     ui.label(format!(
         "{crate_name} {version}\n\
         {target_triple}\n\
-        Built {datetime}"
+        rustc {rustc_version}\n\
+        LLVM {llvm_version}\n\
+        Built {datetime}",
     ));
 
     ui.add_space(12.0);

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -77,14 +77,14 @@ pub enum AppEnvironment {
 
     /// Created from the Rerun Rust SDK.
     RustSdk {
-        /// `CARGO_PKG_RUST_VERSION` = the MSRV specified by out crate. TODO(#1509): remove or improve
-        rust_version: String,
+        rustc_version: String,
+        llvm_version: String,
     },
 
     /// Running the Rust `rerun` binary from the CLI.
     RerunCli {
-        /// `CARGO_PKG_RUST_VERSION` = the MSRV specified by out crate. TODO(#1509): remove or improve
-        rust_version: String,
+        rustc_version: String,
+        llvm_version: String,
     },
 
     /// We are a web-viewer running in a browser as Wasm.
@@ -96,11 +96,16 @@ impl AppEnvironment {
         use re_log_types::RecordingSource;
         match source {
             RecordingSource::PythonSdk(python_version) => Self::PythonSdk(python_version.clone()),
-            RecordingSource::RustSdk { rust_version } => Self::RustSdk {
-                rust_version: rust_version.clone(),
+            RecordingSource::RustSdk {
+                rustc_version: rust_version,
+                llvm_version,
+            } => Self::RustSdk {
+                rustc_version: rust_version.clone(),
+                llvm_version: llvm_version.clone(),
             },
             RecordingSource::Unknown | RecordingSource::Other(_) => Self::RustSdk {
-                rust_version: "unknown".into(),
+                rustc_version: "unknown".into(),
+                llvm_version: "unknown".into(),
             },
         }
     }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -127,7 +127,8 @@ impl CallSource {
     fn app_env(&self) -> re_viewer::AppEnvironment {
         match self {
             CallSource::Cli => re_viewer::AppEnvironment::RerunCli {
-                rust_version: env!("CARGO_PKG_RUST_VERSION").into(),
+                rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
+                llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
             },
             CallSource::Python(python_version) => {
                 re_viewer::AppEnvironment::PythonSdk(python_version.clone())


### PR DESCRIPTION
Fixes #1509 

Also keeps track of LLVM version while we're at it, since we've already seen many lavapipe/llvmpipe related issues already...

---

```sh
$ rerun --version
rerun 0.2.0 [rustc 1.67.0 (fc594f156 2023-01-24), LLVM 15.0.6] x86_64-unknown-linux-gnu cmc/analytics/rust_version e52d606, built 2023-03-06T10:49:07Z
```

![image](https://user-images.githubusercontent.com/2910679/223090342-c57a5627-4b09-4625-b6ba-5fcade514763.png)
