### PR TITLE
[re_renderer] Fix alignment crash on texture upload from depth_cloud

### DIFF
--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -240,7 +240,7 @@ fn create_and_upload_texture<T: bytemuck::Pod>(
 
     let format_info = depth_texture_desc.format.describe();
     let width_blocks = depth_cloud.depth_dimensions.x / format_info.block_dimensions.0 as u32;
-    let height_blocks = depth_cloud.depth_dimensions.y / format_info.block_dimensions.0 as u32;
+    let height_blocks = depth_cloud.depth_dimensions.y / format_info.block_dimensions.1 as u32;
     let bytes_per_row_unaligned = width_blocks * format_info.block_size as u32;
 
     // TODO(andreas): CpuGpuWriteBelt should make it easier to do this.


### PR DESCRIPTION
Fix depth_cloud not taking care of row alignment (TODO: Really the `CpuWriteGpuReadBuffer` should have a utility for this!) 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
