### PR TITLE
Hotfix for `default_enabled` in Python SDK

### DIFF
--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -260,6 +260,11 @@ fn init(application_id: String, application_path: Option<PathBuf>, default_enabl
 
     let mut session = rerun::global_session_with_default_enabled(default_enabled);
 
+    // HOTFIX: Currently, the session is already fetched when initalizing the bindings, and so
+    // `default_enabled` has already been set... we need to overwrite it if the user calls `init`
+    // manually.
+    session.set_enabled(default_enabled);
+
     session.set_application_id(ApplicationId(application_id), is_official_example);
 }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -260,7 +260,7 @@ fn init(application_id: String, application_path: Option<PathBuf>, default_enabl
 
     let mut session = rerun::global_session_with_default_enabled(default_enabled);
 
-    // HOTFIX: Currently, the session is already fetched when initalizing the bindings, and so
+    // HOTFIX: Currently, the session is already fetched when initializing the bindings, and so
     // `default_enabled` has already been set... we need to overwrite it if the user calls `init`
     // manually.
     session.set_enabled(default_enabled);


### PR DESCRIPTION
Currently broken, as reported by @Erol444 in #1511.

The diff tells the whole story.