### PR TITLE
Set default_enabled correctly in python init

### DIFF
--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -133,6 +133,12 @@ impl Session {
         self.enabled = enabled;
     }
 
+    /// Set whether or not logging is enabled by default.
+    /// This will be overridden by the `RERUN` environment variable, if found.
+    pub fn set_default_enabled(&mut self, default_enabled: bool) {
+        self.enabled = crate::decide_logging_enabled(default_enabled);
+    }
+
     /// Set the [`ApplicationId`] to use for the following stream of log messages.
     ///
     /// This should be called once before anything else.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -263,7 +263,7 @@ fn init(application_id: String, application_path: Option<PathBuf>, default_enabl
     // HOTFIX: Currently, the session is already fetched when initializing the bindings, and so
     // `default_enabled` has already been set... we need to overwrite it if the user calls `init`
     // manually.
-    session.set_enabled(default_enabled);
+    session.set_default_enabled(default_enabled);
 
     session.set_application_id(ApplicationId(application_id), is_official_example);
 }


### PR DESCRIPTION
The fix in https://github.com/rerun-io/rerun/pull/1516/files was incomplete and causes the environment variables to be ignored.

Ironically https://github.com/rerun-io/rerun/pull/1507 also contained a fix for this issue.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
