### PR TITLE
Use outlines for mesh selections instead of highlight colors

### DIFF
--- a/crates/re_renderer/examples/outlines.rs
+++ b/crates/re_renderer/examples/outlines.rs
@@ -79,11 +79,11 @@ impl framework::Example for Outlines {
             .unwrap();
 
         let outline_mask_large_mesh = match ((seconds_since_startup * 0.5) as u64) % 5 {
-            0 => OutlineMaskPreference::None,
-            1 => Some([1, 0]), // Same as the the y spinning mesh.
-            2 => Some([2, 0]), // Different than both meshes, outline A.
-            3 => Some([0, 1]), // Same as the the x spinning mesh.
-            4 => Some([0, 2]), // Different than both meshes, outline B.
+            0 => OutlineMaskPreference::NONE,
+            1 => OutlineMaskPreference::some(1, 0), // Same as the the y spinning mesh.
+            2 => OutlineMaskPreference::some(2, 0), // Different than both meshes, outline A.
+            3 => OutlineMaskPreference::some(0, 1), // Same as the the x spinning mesh.
+            4 => OutlineMaskPreference::some(0, 2), // Different than both meshes, outline B.
             _ => unreachable!(),
         };
 
@@ -94,12 +94,12 @@ impl framework::Example for Outlines {
                 rotation: glam::Quat::IDENTITY,
             },
             MeshProperties {
-                outline_mask: Some([1, 0]),
+                outline_mask: OutlineMaskPreference::some(1, 0),
                 position: glam::vec3(2.0, 0.0, -3.0),
                 rotation: glam::Quat::from_rotation_y(seconds_since_startup),
             },
             MeshProperties {
-                outline_mask: Some([0, 1]),
+                outline_mask: OutlineMaskPreference::some(0, 1),
                 position: glam::vec3(-2.0, 1.0, 3.0),
                 rotation: glam::Quat::from_rotation_x(seconds_since_startup),
             },

--- a/crates/re_renderer/shader/outlines/outlines_from_voronoi.wgsl
+++ b/crates/re_renderer/shader/outlines/outlines_from_voronoi.wgsl
@@ -19,21 +19,22 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
     let resolution = Vec2(textureDimensions(voronoi_texture).xy);
     let pixel_coordinates = resolution * in.texcoord;
     let closest_positions = textureSample(voronoi_texture, nearest_sampler, in.texcoord);
-    let to_closest_a_and_b = (closest_positions - pixel_coordinates.xyxy);
-    let distance_pixel_a = length(to_closest_a_and_b.xy);
-    let distance_pixel_b = length(to_closest_a_and_b.zw);
+
+    let distance_pixel_a = distance(pixel_coordinates, closest_positions.xy);
+    let distance_pixel_b = distance(pixel_coordinates, closest_positions.zw);
 
     let sharpness = 1.0; // Fun to play around with, but not exposed yet.
     let outline_a = saturate((uniforms.outline_radius_pixel - distance_pixel_a) * sharpness);
     let outline_b = saturate((uniforms.outline_radius_pixel - distance_pixel_b) * sharpness);
 
-    // We're going directly to an srgb-gamma target without automatic conversion.
-    let color_a = srgba_from_linear(outline_a * uniforms.color_layer_a);
-    let color_b = srgba_from_linear(outline_b * uniforms.color_layer_b);
+    let color_a = outline_a * uniforms.color_layer_a;
+    let color_b = outline_b * uniforms.color_layer_b;
 
     // Blend B over A.
     let color = color_a * (1.0 - color_b.a) + color_b;
-    return color;
+
+    // We're going directly to an srgb-gamma target without automatic conversion.
+    return srgba_from_linear(color);
 
     // Show only the outline. Useful for debugging.
     //return Vec4(color.rgb, 1.0);

--- a/crates/re_renderer/shader/outlines/outlines_from_voronoi.wgsl
+++ b/crates/re_renderer/shader/outlines/outlines_from_voronoi.wgsl
@@ -27,12 +27,13 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
     let outline_a = saturate((uniforms.outline_radius_pixel - distance_pixel_a) * sharpness);
     let outline_b = saturate((uniforms.outline_radius_pixel - distance_pixel_b) * sharpness);
 
-    let color_a = outline_a * uniforms.color_layer_a;
-    let color_b = outline_b * uniforms.color_layer_b;
+    // We're going directly to an srgb-gamma target without automatic conversion.
+    let color_a = srgba_from_linear(outline_a * uniforms.color_layer_a);
+    let color_b = srgba_from_linear(outline_b * uniforms.color_layer_b);
 
     // Blend B over A.
     let color = color_a * (1.0 - color_b.a) + color_b;
-    return srgba_from_linear(color);
+    return color;
 
     // Show only the outline. Useful for debugging.
     //return Vec4(color.rgb, 1.0);

--- a/crates/re_renderer/shader/outlines/outlines_from_voronoi.wgsl
+++ b/crates/re_renderer/shader/outlines/outlines_from_voronoi.wgsl
@@ -1,6 +1,7 @@
 #import <../types.wgsl>
 #import <../global_bindings.wgsl>
 #import <../screen_triangle_vertex.wgsl>
+#import <../utils/srgb.wgsl>
 
 @group(1) @binding(0)
 var voronoi_texture: texture_2d<f32>;
@@ -31,7 +32,7 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
 
     // Blend B over A.
     let color = color_a * (1.0 - color_b.a) + color_b;
-    return color;
+    return srgba_from_linear(color);
 
     // Show only the outline. Useful for debugging.
     //return Vec4(color.rgb, 1.0);

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -130,7 +130,7 @@ impl Default for MeshInstance {
             mesh: None,
             world_from_mesh: macaw::Affine3A::IDENTITY,
             additive_tint: Color32::TRANSPARENT,
-            outline_mask: None,
+            outline_mask: OutlineMaskPreference::NONE,
         }
     }
 }
@@ -221,6 +221,7 @@ impl MeshDrawData {
                         additive_tint: instance.additive_tint,
                         outline_mask: instance
                             .outline_mask
+                            .0
                             .map_or([0, 0, 0, 0], |mask| [mask[0], mask[1], 0, 0]),
                     });
                 }

--- a/crates/re_renderer/src/renderer/outlines.rs
+++ b/crates/re_renderer/src/renderer/outlines.rs
@@ -67,7 +67,38 @@ use smallvec::smallvec;
 ///
 /// Object index 0 is special: It is the default background of each outline channel, thus rendering with it
 /// is a form of "active no outline", effectively subtracting from the outline channel.
-pub type OutlineMaskPreference = Option<[u8; 2]>;
+#[derive(Clone, Copy, Default)]
+pub struct OutlineMaskPreference(pub Option<[u8; 2]>);
+
+impl OutlineMaskPreference {
+    pub const NONE: OutlineMaskPreference = OutlineMaskPreference(None);
+
+    #[inline]
+    pub fn max(self, other: OutlineMaskPreference) -> Self {
+        match self.0 {
+            Some(self_val) => match other.0 {
+                Some(other_val) => OutlineMaskPreference(Some(self_val.max(other_val))),
+                None => self,
+            },
+            None => other,
+        }
+    }
+
+    #[inline]
+    pub fn some(channel_a: u8, channel_b: u8) -> Self {
+        OutlineMaskPreference(Some([channel_a, channel_b]))
+    }
+
+    #[inline]
+    pub fn is_some(self) -> bool {
+        self.0.is_some()
+    }
+
+    #[inline]
+    pub fn is_none(self) -> bool {
+        self.0.is_none()
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct OutlineConfig {

--- a/crates/re_renderer/src/renderer/outlines.rs
+++ b/crates/re_renderer/src/renderer/outlines.rs
@@ -67,22 +67,11 @@ use smallvec::smallvec;
 ///
 /// Object index 0 is special: It is the default background of each outline channel, thus rendering with it
 /// is a form of "active no outline", effectively subtracting from the outline channel.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OutlineMaskPreference(pub Option<[u8; 2]>);
 
 impl OutlineMaskPreference {
     pub const NONE: OutlineMaskPreference = OutlineMaskPreference(None);
-
-    #[inline]
-    pub fn max(self, other: OutlineMaskPreference) -> Self {
-        match self.0 {
-            Some(self_val) => match other.0 {
-                Some(other_val) => OutlineMaskPreference(Some(self_val.max(other_val))),
-                None => self,
-            },
-            None => other,
-        }
-    }
 
     #[inline]
     pub fn some(channel_a: u8, channel_b: u8) -> Self {

--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -444,7 +444,7 @@ impl SelectionState {
                         } else {
                             &mut outline_mask.overall
                         };
-                        *outline_mask_target = outline_mask_target
+                        *outline_mask_target = (*outline_mask_target)
                             .max(OutlineMaskPreference::some(next_selection_mask_index(), 0));
                     }
                 }
@@ -511,7 +511,7 @@ impl SelectionState {
                         } else {
                             &mut outlined_entity.overall
                         };
-                        *outline_mask_target = outline_mask_target
+                        *outline_mask_target = (*outline_mask_target)
                             .max(OutlineMaskPreference::some(0, next_selection_mask_index()));
                     }
                 }

--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -137,15 +137,15 @@ impl<'a> OptionalSpaceViewEntityHighlight<'a> {
 }
 
 #[derive(Default)]
-pub struct SpaceViewEntityOutlineMask {
+pub struct SpaceViewOutlineMasks {
     overall: OutlineMaskPreference,
     instances: ahash::HashMap<InstanceKey, OutlineMaskPreference>,
 }
 
 #[derive(Copy, Clone)]
-pub struct OptionalSpaceViewEntityOutlineMask<'a>(Option<&'a SpaceViewEntityOutlineMask>);
+pub struct OptionalSpaceViewOutlineMask<'a>(Option<&'a SpaceViewOutlineMasks>);
 
-impl<'a> OptionalSpaceViewEntityOutlineMask<'a> {
+impl<'a> OptionalSpaceViewOutlineMask<'a> {
     pub fn index_outline_mask(&self, instance_key: InstanceKey) -> OutlineMaskPreference {
         self.0
             .map_or(OutlineMaskPreference::NONE, |entity_outline_mask| {
@@ -165,7 +165,7 @@ impl<'a> OptionalSpaceViewEntityOutlineMask<'a> {
 #[derive(Default)]
 pub struct SpaceViewHighlights {
     highlighted_entity_paths: IntMap<EntityPathHash, SpaceViewEntityHighlight>,
-    entity_outlines_masks: IntMap<EntityPathHash, SpaceViewEntityOutlineMask>,
+    outlines_masks: IntMap<EntityPathHash, SpaceViewOutlineMasks>,
 }
 
 impl SpaceViewHighlights {
@@ -179,8 +179,8 @@ impl SpaceViewHighlights {
     pub fn entity_outline_mask(
         &self,
         entity_path_hash: EntityPathHash,
-    ) -> OptionalSpaceViewEntityOutlineMask<'_> {
-        OptionalSpaceViewEntityOutlineMask(self.entity_outlines_masks.get(&entity_path_hash))
+    ) -> OptionalSpaceViewOutlineMask<'_> {
+        OptionalSpaceViewOutlineMask(self.outlines_masks.get(&entity_path_hash))
     }
 }
 
@@ -358,6 +358,20 @@ impl SelectionState {
 
         let mut highlighted_entity_paths =
             IntMap::<EntityPathHash, SpaceViewEntityHighlight>::default();
+        let mut outlines_masks = IntMap::<EntityPathHash, SpaceViewOutlineMasks>::default();
+
+        let mut selection_mask_index: u8 = 0;
+        let mut hover_mask_index: u8 = 0;
+        let mut next_selection_mask_index = || {
+            // We don't expect to overflow u8, but if we do, don't use the "background mask".
+            selection_mask_index = selection_mask_index.wrapping_add(1).at_least(1);
+            selection_mask_index
+        };
+        let mut next_hover_mask_index = || {
+            // We don't expect to overflow u8, but if we do, don't use the "background mask".
+            hover_mask_index = hover_mask_index.wrapping_add(1).at_least(1);
+            hover_mask_index
+        };
 
         for current_selection in self.selection.iter() {
             match current_selection {
@@ -366,6 +380,11 @@ impl SelectionState {
                 Item::DataBlueprintGroup(group_space_view_id, group_handle) => {
                     if *group_space_view_id == space_view_id {
                         if let Some(space_view) = space_views.get(group_space_view_id) {
+                            // Everything in the same group should receive the same selection outline.
+                            // (Due to the way outline masks work in re_renderer, we can't leave the hover channel empty)
+                            let selection_mask =
+                                OutlineMaskPreference::some(next_selection_mask_index(), 0);
+
                             space_view.data_blueprint.visit_group_entities_recursively(
                                 *group_handle,
                                 &mut |entity_path: &EntityPath| {
@@ -374,6 +393,10 @@ impl SelectionState {
                                         .or_default()
                                         .overall
                                         .selection = SelectionHighlight::SiblingSelection;
+                                    outlines_masks
+                                        .entry(entity_path.hash())
+                                        .or_default()
+                                        .overall = selection_mask;
                                 },
                             );
                         }
@@ -381,29 +404,43 @@ impl SelectionState {
                 }
 
                 Item::InstancePath(selected_space_view_context, selected_instance) => {
-                    let highlight = if *selected_space_view_context == Some(space_view_id) {
-                        SelectionHighlight::Selection
-                    } else {
-                        SelectionHighlight::SiblingSelection
-                    };
-
-                    let highlighted_entity = highlighted_entity_paths
-                        .entry(selected_instance.entity_path.hash())
-                        .or_default();
-
-                    let highlight_target = if let Some(selected_index) =
-                        selected_instance.instance_key.specific_index()
                     {
-                        &mut highlighted_entity
-                            .instances
-                            .entry(selected_index)
-                            .or_default()
-                            .selection
-                    } else {
-                        &mut highlighted_entity.overall.selection
-                    };
+                        let highlight = if *selected_space_view_context == Some(space_view_id) {
+                            SelectionHighlight::Selection
+                        } else {
+                            SelectionHighlight::SiblingSelection
+                        };
 
-                    *highlight_target = (*highlight_target).max(highlight);
+                        let highlighted_entity = highlighted_entity_paths
+                            .entry(selected_instance.entity_path.hash())
+                            .or_default();
+                        let highlight_target = if let Some(selected_index) =
+                            selected_instance.instance_key.specific_index()
+                        {
+                            &mut highlighted_entity
+                                .instances
+                                .entry(selected_index)
+                                .or_default()
+                                .selection
+                        } else {
+                            &mut highlighted_entity.overall.selection
+                        };
+                        *highlight_target = (*highlight_target).max(highlight);
+                    }
+                    {
+                        let outlined_entity = outlines_masks
+                            .entry(selected_instance.entity_path.hash())
+                            .or_default();
+                        let outline_mask_target = if let Some(selected_index) =
+                            selected_instance.instance_key.specific_index()
+                        {
+                            outlined_entity.instances.entry(selected_index).or_default()
+                        } else {
+                            &mut outlined_entity.overall
+                        };
+                        *outline_mask_target = outline_mask_target
+                            .max(OutlineMaskPreference::some(next_selection_mask_index(), 0));
+                    }
                 }
             };
         }
@@ -417,6 +454,10 @@ impl SelectionState {
                     // since they are truly local to a space view.
                     if *group_space_view_id == space_view_id {
                         if let Some(space_view) = space_views.get(group_space_view_id) {
+                            // Everything in the same group should receive the same selection outline.
+                            let hover_mask =
+                                OutlineMaskPreference::some(0, next_hover_mask_index());
+
                             space_view.data_blueprint.visit_group_entities_recursively(
                                 *group_handle,
                                 &mut |entity_path: &EntityPath| {
@@ -425,6 +466,9 @@ impl SelectionState {
                                         .or_default()
                                         .overall
                                         .hover = HoverHighlight::Hovered;
+                                    let mask =
+                                        outlines_masks.entry(entity_path.hash()).or_default();
+                                    mask.overall = mask.overall.max(hover_mask);
                                 },
                             );
                         }
@@ -432,73 +476,45 @@ impl SelectionState {
                 }
 
                 Item::InstancePath(_, selected_instance) => {
-                    let highlighted_entity = highlighted_entity_paths
-                        .entry(selected_instance.entity_path.hash())
-                        .or_default();
-
-                    let highlight_target = if let Some(selected_index) =
-                        selected_instance.instance_key.specific_index()
                     {
-                        &mut highlighted_entity
-                            .instances
-                            .entry(selected_index)
-                            .or_default()
-                            .hover
-                    } else {
-                        &mut highlighted_entity.overall.hover
-                    };
+                        let highlighted_entity = highlighted_entity_paths
+                            .entry(selected_instance.entity_path.hash())
+                            .or_default();
 
-                    *highlight_target = HoverHighlight::Hovered;
+                        let highlight_target = if let Some(selected_index) =
+                            selected_instance.instance_key.specific_index()
+                        {
+                            &mut highlighted_entity
+                                .instances
+                                .entry(selected_index)
+                                .or_default()
+                                .hover
+                        } else {
+                            &mut highlighted_entity.overall.hover
+                        };
+                        *highlight_target = HoverHighlight::Hovered;
+                    }
+                    {
+                        let outlined_entity = outlines_masks
+                            .entry(selected_instance.entity_path.hash())
+                            .or_default();
+                        let outline_mask_target = if let Some(selected_index) =
+                            selected_instance.instance_key.specific_index()
+                        {
+                            outlined_entity.instances.entry(selected_index).or_default()
+                        } else {
+                            &mut outlined_entity.overall
+                        };
+                        *outline_mask_target = outline_mask_target
+                            .max(OutlineMaskPreference::some(0, next_selection_mask_index()));
+                    }
                 }
             };
         }
 
-        // Compute outline masks from space view highlights.
-        let mut selection_mask_index: u8 = 0;
-        let mut hover_mask_index: u8 = 0;
-        let mut get_mask_preference = move |highlight: InteractionHighlight| {
-            if highlight.is_some() {
-                let a = if highlight.selection.is_some() {
-                    // We don't expect to overflow u8, but if we do, don't use the "background mask".
-                    selection_mask_index = selection_mask_index.wrapping_add(1).at_least(1);
-                    selection_mask_index
-                } else {
-                    0
-                };
-                let b = if highlight.hover.is_some() {
-                    // We don't expect to overflow u8, but if we do, don't use the "background mask".
-                    hover_mask_index = hover_mask_index.wrapping_add(1).at_least(1);
-                    hover_mask_index
-                } else {
-                    0
-                };
-                OutlineMaskPreference::some(a, b)
-            } else {
-                OutlineMaskPreference::NONE
-            }
-        };
-        let entity_outlines_masks = highlighted_entity_paths
-            .iter()
-            .map(|(entity, highlight)| {
-                (
-                    *entity,
-                    SpaceViewEntityOutlineMask {
-                        overall: get_mask_preference(highlight.overall),
-                        instances: highlight
-                            .instances
-                            .iter()
-                            .map(|(instance, highlight)| {
-                                (*instance, get_mask_preference(*highlight))
-                            })
-                            .collect(),
-                    },
-                )
-            })
-            .collect();
-
         SpaceViewHighlights {
             highlighted_entity_paths,
-            entity_outlines_masks,
+            outlines_masks,
         }
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -6,7 +6,7 @@ use re_log_types::{
     component_types::{ClassId, KeypointId, Tensor},
     MeshId,
 };
-use re_renderer::{Color32, Size};
+use re_renderer::{renderer::OutlineMaskPreference, Color32, Size};
 
 use super::{eye::Eye, SpaceCamera3D, SpatialNavigationMode};
 use crate::{
@@ -55,7 +55,7 @@ pub struct MeshSource {
     // TODO(andreas): Make this Conformal3 once glow is gone?
     pub world_from_mesh: macaw::Affine3A,
     pub mesh: Arc<LoadedMesh>,
-    pub additive_tint: Color32,
+    pub outline_mask: OutlineMaskPreference,
 }
 
 pub struct Image {

--- a/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
@@ -167,6 +167,7 @@ pub fn picking(
         points,
         meshes,
         depth_clouds: _, // no picking for depth clouds yet
+        any_outlines: _,
     } = primitives;
 
     picking_points(&context, &mut state, points);

--- a/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
@@ -27,6 +27,8 @@ pub struct SceneSpatialPrimitives {
 
     pub meshes: Vec<MeshSource>,
     pub depth_clouds: Vec<DepthCloud>,
+
+    pub any_outlines: bool,
 }
 
 const AXIS_COLOR_X: Color32 = Color32::from_rgb(255, 25, 25);
@@ -43,6 +45,7 @@ impl SceneSpatialPrimitives {
             points: PointCloudBuilder::new(re_ctx),
             meshes: Default::default(),
             depth_clouds: Default::default(),
+            any_outlines: false,
         }
     }
 
@@ -61,6 +64,7 @@ impl SceneSpatialPrimitives {
             points,
             meshes,
             depth_clouds,
+            any_outlines: _,
         } = &self;
 
         textured_rectangles.len()
@@ -81,6 +85,7 @@ impl SceneSpatialPrimitives {
             points,
             meshes,
             depth_clouds: _, // no bbox for depth clouds
+            any_outlines: _,
         } = self;
 
         *bounding_box = macaw::BoundingBox::nothing();

--- a/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
@@ -137,7 +137,7 @@ impl SceneSpatialPrimitives {
                     .map(move |mesh_instance| MeshInstance {
                         gpu_mesh: mesh_instance.gpu_mesh.clone(),
                         world_from_mesh: base_transform * mesh_instance.world_from_mesh,
-                        additive_tint: mesh.additive_tint,
+                        outline_mask: mesh.outline_mask,
                         ..Default::default()
                     })
             })

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
@@ -34,6 +34,7 @@ impl Arrows3DPart {
         let default_color = DefaultColor::EntityPath(ent_path);
 
         let entity_highlight = highlights.entity_highlight(ent_path.hash());
+        let any_part_selected = entity_highlight.any_selection_highlight();
 
         let mut line_batch = scene
             .primitives
@@ -51,7 +52,7 @@ impl Arrows3DPart {
                 instance_key,
                 entity_view,
                 props,
-                entity_highlight,
+                any_part_selected,
             );
 
             // TODO(andreas): support labels

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
@@ -125,7 +125,7 @@ impl ScenePart for Boxes2DPart {
                             instance_key,
                             &entity_view,
                             &props,
-                            entity_highlight,
+                            entity_highlight.any_selection_highlight(),
                         );
                         Self::visit_instance(
                             scene,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
@@ -34,6 +34,7 @@ impl Boxes3DPart {
 
         let annotations = scene.annotation_map.find(ent_path);
         let default_color = DefaultColor::EntityPath(ent_path);
+        let any_part_selected = entity_highlight.any_selection_highlight();
 
         let mut line_batch = scene
             .primitives
@@ -54,7 +55,7 @@ impl Boxes3DPart {
                 instance_key,
                 entity_view,
                 props,
-                entity_highlight,
+                any_part_selected,
             );
 
             let class_description = annotations.class_description(class_id);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -197,7 +197,7 @@ impl ScenePart for CamerasPart {
                         instance_key,
                         &entity_view,
                         &props,
-                        entity_highlight,
+                        entity_highlight.any_selection_highlight(),
                     );
 
                     let view_coordinates = determine_view_coordinates(

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -209,7 +209,7 @@ impl ImagesPart {
             instance_key,
             entity_view,
             properties,
-            entity_highlight,
+            entity_highlight.any_selection_highlight(),
         );
 
         let annotations = scene.annotation_map.find(ent_path);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
@@ -32,6 +32,7 @@ impl Lines2DPart {
 
         let annotations = scene.annotation_map.find(ent_path);
         let default_color = DefaultColor::EntityPath(ent_path);
+        let any_part_selected = entity_highlight.any_selection_highlight();
 
         let mut line_batch = scene
             .primitives
@@ -48,7 +49,7 @@ impl Lines2DPart {
                 instance_key,
                 entity_view,
                 props,
-                entity_highlight,
+                any_part_selected,
             );
 
             // TODO(andreas): support class ids for lines

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
@@ -32,6 +32,7 @@ impl Lines3DPart {
 
         let annotations = scene.annotation_map.find(ent_path);
         let default_color = DefaultColor::EntityPath(ent_path);
+        let any_part_selected = entity_highlight.any_selection_highlight();
 
         let mut line_batch = scene
             .primitives
@@ -48,7 +49,7 @@ impl Lines3DPart {
                 instance_key,
                 entity_view,
                 props,
-                entity_highlight,
+                any_part_selected,
             );
 
             let mut radius = radius.map_or(Size::AUTO, |r| Size::new_scene(r.0));

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -1,4 +1,3 @@
-use egui::Color32;
 use glam::Mat4;
 
 use re_data_store::{EntityPath, EntityProperties};
@@ -38,7 +37,8 @@ impl MeshPart {
 
         let _default_color = DefaultColor::EntityPath(ent_path);
         let world_from_obj_affine = glam::Affine3A::from_mat4(world_from_obj);
-        let entity_highlight = highlights.entity_highlight(ent_path.hash());
+        let entity_highlight = highlights.entity_highlight(ent_path.hash()); // TODO: remove this
+        let entity_outlines = highlights.entity_outline_mask(ent_path.hash());
 
         let visitor =
             |instance_key: InstanceKey, mesh: re_log_types::Mesh3D, _color: Option<ColorRGBA>| {
@@ -48,11 +48,6 @@ impl MeshPart {
                     entity_view,
                     props,
                     entity_highlight,
-                );
-
-                let additive_tint = SceneSpatial::apply_hover_and_selection_effect_color(
-                    Color32::TRANSPARENT,
-                    entity_highlight.index_highlight(instance_path_hash.instance_key),
                 );
 
                 if let Some(mesh) = ctx
@@ -67,7 +62,7 @@ impl MeshPart {
                         instance_path_hash,
                         world_from_mesh: world_from_obj_affine,
                         mesh: cpu_mesh,
-                        additive_tint,
+                        outline_mask: entity_outlines.index_outline_mask(instance_key),
                     })
                 {
                     scene.primitives.meshes.push(mesh);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -50,6 +50,9 @@ impl MeshPart {
                     entity_highlight,
                 );
 
+                let outline_mask = entity_outlines.index_outline_mask(instance_key);
+                scene.primitives.any_outlines |= outline_mask.is_some();
+
                 if let Some(mesh) = ctx
                     .cache
                     .mesh

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -37,7 +37,6 @@ impl MeshPart {
 
         let _default_color = DefaultColor::EntityPath(ent_path);
         let world_from_obj_affine = glam::Affine3A::from_mat4(world_from_obj);
-        let entity_highlight = highlights.entity_highlight(ent_path.hash()); // TODO: remove this
         let entity_outlines = highlights.entity_outline_mask(ent_path.hash());
 
         let visitor =
@@ -47,7 +46,7 @@ impl MeshPart {
                     instance_key,
                     entity_view,
                     props,
-                    entity_highlight,
+                    entity_outlines.any_selection_highlight(),
                 );
 
                 let outline_mask = entity_outlines.index_outline_mask(instance_key);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use points3d::Points3DPart;
 
 use super::SceneSpatial;
 use crate::{
-    misc::{OptionalSpaceViewEntityHighlight, SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, TransformCache, ViewerContext},
     ui::scene::SceneQuery,
 };
 use re_data_store::{EntityPath, EntityProperties, InstancePathHash};
@@ -48,10 +48,10 @@ pub fn instance_path_hash_for_picking<T: re_log_types::msg_bundle::Component>(
     instance_key: re_log_types::component_types::InstanceKey,
     entity_view: &re_query::EntityView<T>,
     props: &EntityProperties,
-    entity_highlight: OptionalSpaceViewEntityHighlight<'_>,
+    any_part_selected: bool,
 ) -> InstancePathHash {
     if props.interactive {
-        if entity_view.num_instances() == 1 || !entity_highlight.any_selection_highlight() {
+        if entity_view.num_instances() == 1 || !any_part_selected {
             InstancePathHash::entity_splat(ent_path)
         } else {
             InstancePathHash::instance(ent_path, instance_key)

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
@@ -39,6 +39,7 @@ impl Points2DPart {
 
         let annotations = scene.annotation_map.find(ent_path);
         let default_color = DefaultColor::EntityPath(ent_path);
+        let any_part_selected = entity_highlight.any_selection_highlight();
 
         // If keypoints ids show up we may need to connect them later!
         // We include time in the key, so that the "Visible history" (time range queries) feature works.
@@ -62,7 +63,7 @@ impl Points2DPart {
                 instance_key,
                 entity_view,
                 props,
-                entity_highlight,
+                any_part_selected,
             );
 
             let pos: glam::Vec2 = pos.into();

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
@@ -175,6 +175,7 @@ impl Points3DPart {
 
         let (annotation_infos, keypoints) =
             Self::process_annotations(query, entity_view, &annotations)?;
+        let any_part_selected = entity_highlight.any_selection_highlight();
         let instance_path_hashes = {
             crate::profile_scope!("instance_hashes");
             entity_view
@@ -185,7 +186,7 @@ impl Points3DPart {
                         instance_key,
                         entity_view,
                         properties,
-                        entity_highlight,
+                        any_part_selected,
                     )
                 })
                 .collect::<Vec<_>>()

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -5,6 +5,7 @@ use re_format::format_f32;
 use egui::{NumExt, WidgetText};
 use macaw::BoundingBox;
 use re_log_types::component_types::{Tensor, TensorData, TensorDataMeaning};
+use re_renderer::renderer::OutlineConfig;
 
 use crate::{
     misc::{
@@ -618,4 +619,18 @@ pub fn create_labels(
     }
 
     label_shapes
+}
+
+pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
+    // Brighten up our regular selection color a bit, otherwise it's too hard to see.
+    // (which would require us making the outlines *even* thicker)
+    let selection_outline_color =
+        re_renderer::Rgba::from(gui_ctx.style().visuals.selection.bg_fill) * 1.5;
+    let hover_outline_color = (selection_outline_color * 1.5).additive();
+
+    OutlineConfig {
+        outline_radius_pixel: (gui_ctx.pixels_per_point() * 2.5).at_least(1.0),
+        color_layer_a: selection_outline_color,
+        color_layer_b: hover_outline_color,
+    }
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -13,6 +13,7 @@ use crate::{
     ui::{
         data_ui::{self, DataUi},
         view_spatial::{
+            ui::outline_config,
             ui_renderer_bridge::{create_scene_paint_callback, get_viewport, ScreenBackground},
             SceneSpatial,
         },
@@ -490,7 +491,8 @@ fn setup_target_config(
             },
             pixels_from_point: pixels_from_points,
             auto_size_config,
-            ..Default::default()
+            // TODO: Should turn off the outline renderer if there's nothing is highlighted.
+            outline_config: Some(outline_config(painter.ctx())),
         }
     })
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -433,6 +433,9 @@ fn view_2d_scrollable(
             space_from_pixel,
             &space.to_string(),
             state.auto_size_config(response.rect.size()),
+            scene
+                .primitives
+                .any_outlines,
         ) else {
             return response;
         };
@@ -469,6 +472,7 @@ fn setup_target_config(
     space_from_pixel: f32,
     space_name: &str,
     auto_size_config: re_renderer::AutoSizeConfig,
+    any_outlines: bool,
 ) -> anyhow::Result<TargetConfiguration> {
     let pixels_from_points = painter.ctx().pixels_per_point();
     let resolution_in_pixel = get_viewport(painter.clip_rect(), pixels_from_points);
@@ -491,8 +495,7 @@ fn setup_target_config(
             },
             pixels_from_point: pixels_from_points,
             auto_size_config,
-            // TODO: Should turn off the outline renderer if there's nothing is highlighted.
-            outline_config: Some(outline_config(painter.ctx())),
+            outline_config: any_outlines.then(|| outline_config(painter.ctx())),
         }
     })
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -6,7 +6,6 @@ use macaw::{vec3, BoundingBox, Quat, Vec3};
 use re_data_store::{InstancePath, InstancePathHash};
 use re_log_types::{EntityPath, ViewCoordinates};
 use re_renderer::{
-    renderer::OutlineConfig,
     view_builder::{Projection, TargetConfiguration},
     RenderContext, Size,
 };
@@ -17,7 +16,7 @@ use crate::{
         data_ui::{self, DataUi},
         view_spatial::{
             scene::AdditionalPickingInfo,
-            ui::create_labels,
+            ui::{create_labels, outline_config},
             ui_renderer_bridge::{create_scene_paint_callback, get_viewport, ScreenBackground},
             SceneSpatial, SpaceCamera3D,
         },
@@ -517,9 +516,6 @@ fn paint_view(
         return;
     }
 
-    let selection_outline_color: re_renderer::Rgba = ui.visuals().selection.bg_fill.into();
-    let hover_outline_color = (selection_outline_color * 1.5).additive();
-
     let target_config = TargetConfiguration {
         name: name.into(),
 
@@ -534,11 +530,8 @@ fn paint_view(
         pixels_from_point,
         auto_size_config,
 
-        outline_config: Some(OutlineConfig {
-            outline_radius_pixel: pixels_from_point * 2.0,
-            color_layer_a: selection_outline_color,
-            color_layer_b: hover_outline_color,
-        }),
+        // TODO: Should turn off the outline renderer if there's nothing is highlighted.
+        outline_config: Some(outline_config(ui.ctx())),
     };
 
     let Ok(callback) = create_scene_paint_callback(

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -6,6 +6,7 @@ use macaw::{vec3, BoundingBox, Quat, Vec3};
 use re_data_store::{InstancePath, InstancePathHash};
 use re_log_types::{EntityPath, ViewCoordinates};
 use re_renderer::{
+    renderer::OutlineConfig,
     view_builder::{Projection, TargetConfiguration},
     RenderContext, Size,
 };
@@ -515,6 +516,10 @@ fn paint_view(
     if resolution_in_pixel[0] == 0 || resolution_in_pixel[1] == 0 {
         return;
     }
+
+    let selection_outline_color: re_renderer::Rgba = ui.visuals().selection.bg_fill.into();
+    let hover_outline_color = (selection_outline_color * 1.5).additive();
+
     let target_config = TargetConfiguration {
         name: name.into(),
 
@@ -529,7 +534,11 @@ fn paint_view(
         pixels_from_point,
         auto_size_config,
 
-        ..Default::default()
+        outline_config: Some(OutlineConfig {
+            outline_radius_pixel: pixels_from_point * 2.0,
+            color_layer_a: selection_outline_color,
+            color_layer_b: hover_outline_color,
+        }),
     };
 
     let Ok(callback) = create_scene_paint_callback(

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -530,8 +530,10 @@ fn paint_view(
         pixels_from_point,
         auto_size_config,
 
-        // TODO: Should turn off the outline renderer if there's nothing is highlighted.
-        outline_config: Some(outline_config(ui.ctx())),
+        outline_config: scene
+            .primitives
+            .any_outlines
+            .then(|| outline_config(ui.ctx())),
     };
 
     let Ok(callback) = create_scene_paint_callback(


### PR DESCRIPTION
Uses outlines for selection/hovering of meshes.

https://user-images.githubusercontent.com/1220815/223980840-1bd68ddc-e3be-43ad-b252-10b0a8d2f813.mov


Introduces a sibling data structure  to `SpaceViewEntityHighlight` in order to quickly get the desired grouping-aware outline mask indices, called `SpaceViewOutlineMasks`. `SpaceViewOutlineMasks` will likely fully replace `SpaceViewEntityHighlight`in the near future; in any case a bit more work in this area is needed; consider this a first quick-and-dirty step! 

Color choices etc. are not considered final, but a first step. We'll go over them again when everything is changed to outlines instead of highlights.

Copy pasting a few other notes I posted previously on the internal Slack:

*Previously, we distinguished “sibling selections”, i.e.  you select something in one space view and there is a different (!) highlight in another space view where the same object is visible. That’s gone now because I can only support 2 channels at the moment
* (hardly visible in video) when an object outline is “see through” is not always intuitive in particular in regards to hover highlights. This happens because the the outline mask texture uses the same depth buffer for both selection & hover (but then computes different distance/voronoi values for each). In my humble defense, Blender has the exact same issues if one pays a lot of attention (but they don’t have hover, alas though a primary vs secondary selection which)
* our selection color is awfully dark. I had to brighten it up a bit but it still feels to dark. This means I need to make the lines thicker than I want to (the outline impl is fairly good with large outlines, but I didn’t actually want those)
* I’m again not happy with the anti-aliasing quality on non-4k screen. To be revisited. Might also just hint at me being obsessed at this point
* giving the hover outline some additive transparency feels really nice
* oh my god this so much better, the bar was low tho

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

part of #889 