### PR TITLE
Update `rayon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3704,20 +3704,19 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,9 +2355,6 @@ name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "js-sys"

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -86,7 +86,6 @@ ecolor = { workspace = true, optional = true }
 glam = { workspace = true, optional = true }
 image = { workspace = true, optional = true, default-features = false, features = [
   "jpeg",
-  # "jpeg_rayon", # TODO(emilk): when https://github.com/rayon-rs/rayon/pull/1019 is released
 ] }
 macaw = { workspace = true, optional = true }
 rand = { version = "0.8", optional = true }

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -83,7 +83,6 @@ glam = { workspace = true, features = [
 half.workspace = true
 image = { workspace = true, default-features = false, features = [
   "jpeg",
-  # "jpeg_rayon", # TODO(emilk): when https://github.com/rayon-rs/rayon/pull/1019 is released
   "png",
 ] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -58,9 +58,7 @@ crossbeam = "0.8"
 document-features = "0.2"
 glam.workspace = true
 half.workspace = true
-image = { workspace = true, default-features = false, features = [
-  "jpeg_rayon",
-] }
+image = { workspace = true, default-features = false, features = ["jpeg"] }
 itertools = "0.10"
 macaw.workspace = true
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }


### PR DESCRIPTION
This updates us to `rayon 1.7.0` which has a single-threaded fallback (https://github.com/rayon-rs/rayon/pull/1019) making it work on the web.

This means that we can now start using `rayon` in our code base where it makes sense.

I also tested out the rayon-enabled jpeg decoder, but on my mac, on the objectron dataset, it was actually _slower_ (15.5 ms -> 16.5 ms).

Luckily <https://github.com/etemesi254/zune-jpeg> is reportedly faster, so we'll put our hopes on that instead.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
