### PR TITLE
Fix combining outline mask for selection & hover

### DIFF
--- a/crates/re_renderer/src/renderer/outlines.rs
+++ b/crates/re_renderer/src/renderer/outlines.rs
@@ -66,8 +66,8 @@ use smallvec::smallvec;
 /// Each channel can distinguish up 255 different objects, each getting their own outline.
 ///
 /// Object index 0 is special: It is the default background of each outline channel, thus rendering with it
-/// is a form of "active no outline", effectively subtracting from the outline channel.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+/// is a form of "active no outline", effectively subtracting from any outline channel.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
 pub struct OutlineMaskPreference(pub Option<[u8; 2]>);
 
 impl OutlineMaskPreference {
@@ -86,6 +86,22 @@ impl OutlineMaskPreference {
     #[inline]
     pub fn is_none(self) -> bool {
         self.0.is_none()
+    }
+
+    #[inline]
+    pub fn combine(self, other: Self) -> Self {
+        if let Some([a, b]) = self.0 {
+            if let Some([other_a, other_b]) = other.0 {
+                OutlineMaskPreference::some(
+                    if a == 0 { other_a } else { a },
+                    if b == 0 { other_b } else { b },
+                )
+            } else {
+                self
+            }
+        } else {
+            other
+        }
     }
 }
 

--- a/crates/re_renderer/src/renderer/outlines.rs
+++ b/crates/re_renderer/src/renderer/outlines.rs
@@ -88,8 +88,9 @@ impl OutlineMaskPreference {
         self.0.is_none()
     }
 
+    /// Uses current outline and falls back to `other` if current is `None` or has a zero on any channel.
     #[inline]
-    pub fn combine(self, other: Self) -> Self {
+    pub fn with_fallback_to(self, other: Self) -> Self {
         if let Some([a, b]) = self.0 {
             if let Some([other_a, other_b]) = other.0 {
                 OutlineMaskPreference::some(

--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -155,7 +155,7 @@ impl<'a> OptionalSpaceViewOutlineMask<'a> {
                     .get(&instance_key)
                     .cloned()
                     .unwrap_or_default()
-                    .combine(entity_outline_mask.overall)
+                    .with_fallback_to(entity_outline_mask.overall)
             })
     }
 
@@ -400,7 +400,7 @@ impl SelectionState {
                                     let outline_mask =
                                         outlines_masks.entry(entity_path.hash()).or_default();
                                     outline_mask.overall =
-                                        outline_mask.overall.combine(selection_mask);
+                                        selection_mask.with_fallback_to(outline_mask.overall);
                                     outline_mask.any_selection_highlight = true;
                                 },
                             );
@@ -444,7 +444,8 @@ impl SelectionState {
                         } else {
                             &mut outline_mask.overall
                         };
-                        *outline_mask_target = outline_mask_target.combine(next_selection_mask());
+                        *outline_mask_target =
+                            next_selection_mask().with_fallback_to(*outline_mask_target);
                     }
                 }
             };
@@ -472,7 +473,7 @@ impl SelectionState {
                                         .hover = HoverHighlight::Hovered;
                                     let mask =
                                         outlines_masks.entry(entity_path.hash()).or_default();
-                                    mask.overall = mask.overall.combine(hover_mask);
+                                    mask.overall = hover_mask.with_fallback_to(mask.overall);
                                 },
                             );
                         }
@@ -509,7 +510,8 @@ impl SelectionState {
                         } else {
                             &mut outlined_entity.overall
                         };
-                        *outline_mask_target = outline_mask_target.combine(next_hover_mask());
+                        *outline_mask_target =
+                            next_hover_mask().with_fallback_to(*outline_mask_target);
                     }
                 }
             };

--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -155,7 +155,7 @@ impl<'a> OptionalSpaceViewOutlineMask<'a> {
                     .get(&instance_key)
                     .cloned()
                     .unwrap_or_default()
-                    .max(entity_outline_mask.overall)
+                    .combine(entity_outline_mask.overall)
             })
     }
 
@@ -367,15 +367,15 @@ impl SelectionState {
 
         let mut selection_mask_index: u8 = 0;
         let mut hover_mask_index: u8 = 0;
-        let mut next_selection_mask_index = || {
+        let mut next_selection_mask = || {
             // We don't expect to overflow u8, but if we do, don't use the "background mask".
             selection_mask_index = selection_mask_index.wrapping_add(1).at_least(1);
-            selection_mask_index
+            OutlineMaskPreference::some(selection_mask_index, 0)
         };
-        let mut next_hover_mask_index = || {
+        let mut next_hover_mask = || {
             // We don't expect to overflow u8, but if we do, don't use the "background mask".
             hover_mask_index = hover_mask_index.wrapping_add(1).at_least(1);
-            hover_mask_index
+            OutlineMaskPreference::some(0, hover_mask_index)
         };
 
         for current_selection in self.selection.iter() {
@@ -387,8 +387,7 @@ impl SelectionState {
                         if let Some(space_view) = space_views.get(group_space_view_id) {
                             // Everything in the same group should receive the same selection outline.
                             // (Due to the way outline masks work in re_renderer, we can't leave the hover channel empty)
-                            let selection_mask =
-                                OutlineMaskPreference::some(next_selection_mask_index(), 0);
+                            let selection_mask = next_selection_mask();
 
                             space_view.data_blueprint.visit_group_entities_recursively(
                                 *group_handle,
@@ -400,7 +399,8 @@ impl SelectionState {
                                         .selection = SelectionHighlight::SiblingSelection;
                                     let outline_mask =
                                         outlines_masks.entry(entity_path.hash()).or_default();
-                                    outline_mask.overall = outline_mask.overall.max(selection_mask);
+                                    outline_mask.overall =
+                                        outline_mask.overall.combine(selection_mask);
                                     outline_mask.any_selection_highlight = true;
                                 },
                             );
@@ -444,8 +444,7 @@ impl SelectionState {
                         } else {
                             &mut outline_mask.overall
                         };
-                        *outline_mask_target = (*outline_mask_target)
-                            .max(OutlineMaskPreference::some(next_selection_mask_index(), 0));
+                        *outline_mask_target = outline_mask_target.combine(next_selection_mask());
                     }
                 }
             };
@@ -461,8 +460,7 @@ impl SelectionState {
                     if *group_space_view_id == space_view_id {
                         if let Some(space_view) = space_views.get(group_space_view_id) {
                             // Everything in the same group should receive the same selection outline.
-                            let hover_mask =
-                                OutlineMaskPreference::some(0, next_hover_mask_index());
+                            let hover_mask = next_hover_mask();
 
                             space_view.data_blueprint.visit_group_entities_recursively(
                                 *group_handle,
@@ -474,7 +472,7 @@ impl SelectionState {
                                         .hover = HoverHighlight::Hovered;
                                     let mask =
                                         outlines_masks.entry(entity_path.hash()).or_default();
-                                    mask.overall = mask.overall.max(hover_mask);
+                                    mask.overall = mask.overall.combine(hover_mask);
                                 },
                             );
                         }
@@ -511,8 +509,7 @@ impl SelectionState {
                         } else {
                             &mut outlined_entity.overall
                         };
-                        *outline_mask_target = (*outline_mask_target)
-                            .max(OutlineMaskPreference::some(0, next_selection_mask_index()));
+                        *outline_mask_target = outline_mask_target.combine(next_hover_mask());
                     }
                 }
             };

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -37,19 +37,19 @@ impl MeshPart {
 
         let _default_color = DefaultColor::EntityPath(ent_path);
         let world_from_obj_affine = glam::Affine3A::from_mat4(world_from_obj);
-        let entity_outlines = highlights.entity_outline_mask(ent_path.hash());
+        let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
         let visitor =
             |instance_key: InstanceKey, mesh: re_log_types::Mesh3D, _color: Option<ColorRGBA>| {
-                let instance_path_hash = instance_path_hash_for_picking(
+                let picking_instance_hash = instance_path_hash_for_picking(
                     ent_path,
                     instance_key,
                     entity_view,
                     props,
-                    entity_outlines.any_selection_highlight(),
+                    entity_highlight.any_selection_highlight(),
                 );
 
-                let outline_mask = entity_outlines.index_outline_mask(instance_key);
+                let outline_mask = entity_highlight.index_outline_mask(instance_key);
                 scene.primitives.any_outlines |= outline_mask.is_some();
 
                 if let Some(mesh) = ctx
@@ -61,10 +61,10 @@ impl MeshPart {
                         ctx.render_ctx,
                     )
                     .map(|cpu_mesh| MeshSource {
-                        instance_path_hash,
+                        instance_path_hash: picking_instance_hash,
                         world_from_mesh: world_from_obj_affine,
                         mesh: cpu_mesh,
-                        outline_mask: entity_outlines.index_outline_mask(instance_key),
+                        outline_mask,
                     })
                 {
                     scene.primitives.meshes.push(mesh);


### PR DESCRIPTION
When hovering a an entity of an already selected group:

Before:
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/1220815/224264227-b279e9e9-78f0-4998-82a0-ce020e52d5ce.png">
nothing happens!

After:
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/1220815/224263798-6c9d3b67-cebd-48f3-8dda-45bfd55bdba6.png">
Get expected "internal" hover highlight!


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
