### PR TITLE
datastore: early exit missing components at table level

### DIFF
--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -657,6 +657,11 @@ impl IndexTable {
     ) -> Option<[Option<RowIndex>; N]> {
         crate::profile_function!();
 
+        // Early-exit if this entire table is unaware of this component.
+        if !self.all_components.contains(&primary) {
+            return None;
+        }
+
         let timeline = self.timeline;
 
         // The time we're looking for gives us an upper bound: all components must be indexed


### PR DESCRIPTION
This is a partial fix for #1545: it takes care of the `O(n)` backward walk when querying for non-existing components, but it doesn't explain why there are that many buckets in the first place when running the `clocks` example (that's another problem for another PR).

Bench:
![image](https://user-images.githubusercontent.com/2910679/224278674-8987a4da-7f5b-45fa-abdc-712066efb91e.png)

`clocks` in debug:
![image](https://user-images.githubusercontent.com/2910679/224278370-9f71bed7-9b77-4b38-b202-8269402b9079.png)
