### PR TITLE
LogDb: dont split on index bucket size

### DIFF
--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -38,7 +38,15 @@ impl Default for EntityDb {
                 InstanceKey::name(),
                 DataStoreConfig {
                     component_bucket_size_bytes: 1024 * 1024, // 1 MiB
-                    index_bucket_size_bytes: 1024,            // 1KiB
+                    // We do not garbage collect index buckets at the moment, and so the size of
+                    // individual index buckets is irrelevant, only their total number of rows
+                    // matter.
+                    // See <pr-link> for details.
+                    //
+                    // TODO(cmc): Bring back index GC once the whole `MsgId` mismatch issue is
+                    // resolved (probably once batching is implemented).
+                    index_bucket_size_bytes: u64::MAX,
+                    index_bucket_nb_rows: 2048,
                     ..Default::default()
                 },
             ),


### PR DESCRIPTION
This disables index size limits when instantiating datastores in `LogDb`, which can result in a lot of bucket splits for literally no benefits.

The complete rationale is explained in https://github.com/rerun-io/rerun/issues/1545#issuecomment-1463673273.
Here's the most important excerpt from it:

> Now, when it comes to index buckets, row limits are what actually matters as they put an upper bound on the cost of sorting the bucket.
> 
> Size limits don't matter at all OTOH, since we don't even GC index buckets anymore at the moment (because of the `MsgId` mismatch problem, which is the exact same issue described in https://github.com/rerun-io/rerun/pull/1535 and is generally the root of all our issues of that nature).
> 
> The fix here should be to remove the index data size limit.

Closes https://github.com/rerun-io/rerun/issues/1545