### PR TITLE
Implement outlines for rectangles & use them for select & hover of image primitives in Viewer

### DIFF
--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -328,6 +328,7 @@ impl framework::Example for RenderDepthClouds {
                 texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
                 multiplicative_tint: Rgba::from_white_alpha(0.5),
                 depth_offset: -1,
+                ..Default::default()
             }],
         )
         .unwrap();

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -12,6 +12,7 @@ struct UniformBuffer {
     depth_offset: f32,
     /// Tint multiplied with the texture color.
     multiplicative_tint: Vec4,
+    outline_mask: UVec2,
 };
 @group(1) @binding(0)
 var<uniform> rect_info: UniformBuffer;
@@ -45,4 +46,9 @@ fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {
 fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     let texture_color = textureSample(texture, texture_sampler, in.texcoord);
     return texture_color * rect_info.multiplicative_tint;
+}
+
+@fragment
+fn fs_main_outline_mask(in: VertexOut) -> @location(0) UVec2 {
+    return rect_info.outline_mask;
 }


### PR DESCRIPTION
back in the habit! Part of #889 

Showing some 2D things for a change - the inward extending outline actually saves us here.
https://user-images.githubusercontent.com/1220815/224327611-72238bf5-86f7-4e20-8eaf-06465bc2d534.mov

And some "artificial" 3D (everywhere else we have camera lines around it, stealing the show)
<img width="617" alt="image" src="https://user-images.githubusercontent.com/1220815/224328181-fdca4ca2-65db-4b80-afe5-61f90ffc5f44.png">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
