### PR TITLE
Fix garbage collection

### DIFF
--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -37,11 +37,21 @@ impl Default for EntityDb {
             data_store: re_arrow_store::DataStore::new(
                 InstanceKey::name(),
                 DataStoreConfig {
-                    component_bucket_size_bytes: 1024 * 1024, // 1 MiB
+                    // Garbage collection of the datastore is currently driven by the `MsgId`
+                    // component column, as a workaround for the `MsgId` mismatch issue.
+                    //
+                    // Since this component is only a few bytes large, trying to trigger a GC
+                    // based on bucket size is a lost cause, so make sure to have a small enough
+                    // row limit.
+                    //
+                    // TODO(cmc): Reasses once the whole `MsgId` mismatch issue is resolved
+                    // (probably once batching is implemented).
+                    component_bucket_nb_rows: 128,
+                    component_bucket_size_bytes: 10 * 1024 * 1024, // 10 MiB
                     // We do not garbage collect index buckets at the moment, and so the size of
                     // individual index buckets is irrelevant, only their total number of rows
                     // matter.
-                    // See <pr-link> for details.
+                    // See https://github.com/rerun-io/rerun/pull/1558 for details.
                     //
                     // TODO(cmc): Bring back index GC once the whole `MsgId` mismatch issue is
                     // resolved (probably once batching is implemented).


### PR DESCRIPTION
Garbage collection is currently broken (since the port to Arrow) due to a configuration that has a hard time coexisting with the workarounds in place for the `MsgId` mismatch problem.

This is all very reminiscing of the issues faced in https://github.com/rerun-io/rerun/pull/1535 and https://github.com/rerun-io/rerun/pull/1558 and the reason for that is that this yet another manifestation of the same exact underlying problem: dealing `MsgId` mismatches when going across the viewer<>store boundary.

The short-term fix is again a configuration change; the long-term fix will be to eliminate the root problem while we design and implement batch support.

Closes https://github.com/rerun-io/rerun/issues/1539

---

`canny`, capped at `500MiB`:

https://user-images.githubusercontent.com/2910679/224371054-5f4c586a-d42c-49bc-9529-18dd82471528.mp4

---

`clock` running indefinitely as fast as my machine will allow it, capped at `500MiB`:

https://user-images.githubusercontent.com/2910679/224371721-be99baf4-b3c1-4207-a44e-09cb52dbda03.mp4

Notice that the memory taken by the index doesn't shrink, again this is very much related to https://github.com/rerun-io/rerun/pull/1558 and the mismatch issue.