### PR TITLE
Remove sensitive data from analytics

### DIFF
--- a/crates/re_analytics/src/lib.rs
+++ b/crates/re_analytics/src/lib.rs
@@ -112,18 +112,19 @@ impl Event {
             rustc_version,
             llvm_version,
             git_hash: _,
-            git_branch,
+            git_branch: _,
             is_in_rerun_workspace,
             target_triple,
             datetime,
         } = build_info;
+
+        // We intentionally don't include the branch name, because it can contain sensitive user-stuff.
 
         self.with_prop("rerun_version", version.to_string())
             .with_prop("rust_version", (*rustc_version).to_owned())
             .with_prop("llvm_version", (*llvm_version).to_owned())
             .with_prop("target", *target_triple)
             .with_prop("git_hash", build_info.git_hash_or_tag())
-            .with_prop("git_branch", *git_branch)
             .with_prop("build_date", *datetime)
             .with_prop("debug", cfg!(debug_assertions)) // debug-build?
             .with_prop("rerun_workspace", *is_in_rerun_workspace)

--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -40,12 +40,15 @@ fn install_panic_hook(_build_info: BuildInfo) {
                     .with_build_info(&_build_info)
                     .with_prop("callstack", callstack);
 
-                // `panic_info.message` is unstable, so this is the recommended way of getting
-                // the panic message out. We need both the `&str` and `String` variants.
-                if let Some(msg) = panic_info.payload().downcast_ref::<&str>() {
-                    event = event.with_prop("message", *msg);
-                } else if let Some(msg) = panic_info.payload().downcast_ref::<String>() {
-                    event = event.with_prop("message", msg.clone());
+                let include_panic_message = false; // Don't include it, because it can contain sensitive information (`panic!("Couldn't read {file_path}")`)
+                if include_panic_message {
+                    // `panic_info.message` is unstable, so this is the recommended way of getting
+                    // the panic message out. We need both the `&str` and `String` variants.
+                    if let Some(msg) = panic_info.payload().downcast_ref::<&str>() {
+                        event = event.with_prop("message", *msg);
+                    } else if let Some(msg) = panic_info.payload().downcast_ref::<String>() {
+                        event = event.with_prop("message", msg.clone());
+                    }
                 }
 
                 if let Some(location) = panic_info.location() {

--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -40,10 +40,9 @@ fn install_panic_hook(_build_info: BuildInfo) {
                     .with_build_info(&_build_info)
                     .with_prop("callstack", callstack);
                 if let Some(location) = panic_info.location() {
-                    event = event.with_prop(
-                        "location",
-                        format!("{}:{}", location.file(), location.line()),
-                    );
+                    let file =
+                        anonymize_source_file_path(&std::path::PathBuf::from(location.file()));
+                    event = event.with_prop("location", format!("{file}:{}", location.line()));
                 }
                 analytics.record(event);
 

--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -40,6 +40,8 @@ fn install_panic_hook(_build_info: BuildInfo) {
                     .with_build_info(&_build_info)
                     .with_prop("callstack", callstack);
 
+                // `panic_info.message` is unstable, so this is the recommended way of getting
+                // the panic message out. We need both the `&str` and `String` variants.
                 if let Some(msg) = panic_info.payload().downcast_ref::<&str>() {
                     event = event.with_prop("message", *msg);
                 } else if let Some(msg) = panic_info.payload().downcast_ref::<String>() {


### PR DESCRIPTION
I forgot to anonymize the file path in the `file:line` location of panics, which means we are leaking full paths into our analytics, which is really bad.

We also had `git_branch` included, which can also contain sensitive stuff.

 We should do a patch-release as soon as this is merged.

We're looking into how to do delete all the affected log events.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
