### PR TITLE
Implement outlines for points 2d/3d/depth & use them for select & hover in Viewer

### DIFF
--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -179,6 +179,7 @@ impl RenderDepthClouds {
                 depth_dimensions: depth.dimensions,
                 depth_data: depth.data.clone(),
                 colormap: re_renderer::ColorMap::ColorMapTurbo,
+                outline_mask_id: Default::default(),
             }],
         )
         .unwrap();

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -106,23 +106,9 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) Vec4 {
-    // There's easier ways to compute anti-aliasing for when we are in ortho mode since it's
-    // just circles.
-    // But it's very nice to have mostly the same code path and this gives us the sphere world
-    // position along the way.
-    let ray_in_world = camera_ray_to_world_pos(in.pos_in_world);
-
-    // Sphere intersection with anti-aliasing as described by Iq here
-    // https://www.shadertoy.com/view/MsSSWV
-    // (but rearranged and labeled to it's easier to understand!)
-    let d = ray_sphere_distance(ray_in_world, in.point_pos_in_world, in.point_radius);
-    let smallest_distance_to_sphere = d.x;
-    let closest_ray_dist = d.y;
-    let pixel_world_size = approx_pixel_world_size_at(closest_ray_dist);
-    if smallest_distance_to_sphere > pixel_world_size {
+    let coverage = sphere_quad_coverage(in.pos_in_world, in.point_radius, in.point_pos_in_world);
+    if coverage < 0.001 {
         discard;
     }
-    let coverage = 1.0 - saturate(smallest_distance_to_sphere / pixel_world_size);
-
     return vec4(in.point_color.rgb, coverage);
 }

--- a/crates/re_renderer/shader/lines.wgsl
+++ b/crates/re_renderer/shader/lines.wgsl
@@ -223,7 +223,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
     return out;
 }
 
-fn compute_coverage(in: VertexOut) -> f32{
+fn compute_coverage(in: VertexOut) -> f32 {
     var coverage = 1.0;
     if has_any_flag(in.currently_active_flags, CAP_START_ROUND | CAP_END_ROUND) {
         let distance_to_skeleton = length(in.position_world - in.closest_strip_position);
@@ -241,7 +241,7 @@ fn compute_coverage(in: VertexOut) -> f32{
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     var coverage = compute_coverage(in);
-    if coverage < 0.00001 {
+    if coverage < 0.001 {
         discard;
     }
 

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -13,6 +13,8 @@ var color_texture: texture_2d<f32>;
 struct BatchUniformBuffer {
     world_from_obj: Mat4,
     flags: u32,
+    _padding: UVec2, // UVec3 would take its own 4xf32 row, UVec2 is on the same as flags
+    outline_mask_ids: UVec2,
 };
 @group(2) @binding(0)
 var<uniform> batch: BatchUniformBuffer;
@@ -101,4 +103,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
         shading = max(0.4, sqrt(1.2 - distance(in.point_center, in.world_position) / in.radius)); // quick and dirty coloring
     }
     return vec4(in.color.rgb * shading, coverage);
+}
+
+@fragment
+fn fs_main_outline_mask(in: VertexOut) -> @location(0) UVec2 {
+    // TODO: Coverage
+    return batch.outline_mask_ids;
 }

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -14,7 +14,7 @@ struct BatchUniformBuffer {
     world_from_obj: Mat4,
     flags: u32,
     _padding: UVec2, // UVec3 would take its own 4xf32 row, UVec2 is on the same as flags
-    outline_mask_ids: UVec2,
+    outline_mask: UVec2,
 };
 @group(2) @binding(0)
 var<uniform> batch: BatchUniformBuffer;
@@ -78,24 +78,12 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) Vec4 {
-    // There's easier ways to compute anti-aliasing for when we are in ortho mode since it's just circles.
-    // But it's very nice to have mostly the same code path and this gives us the sphere world position along the way.
-    let ray = camera_ray_to_world_pos(in.world_position);
-
-    // Sphere intersection with anti-aliasing as described by Iq here
-    // https://www.shadertoy.com/view/MsSSWV
-    // (but rearranged and labeled to it's easier to understand!)
-    let d = ray_sphere_distance(ray, in.point_center, in.radius);
-    let smallest_distance_to_sphere = d.x;
-    let closest_ray_dist = d.y;
-    let pixel_world_size = approx_pixel_world_size_at(closest_ray_dist);
-    if smallest_distance_to_sphere > pixel_world_size {
+    let coverage = sphere_quad_coverage(in.world_position, in.radius, in.point_center);
+    if coverage < 0.001 {
         discard;
     }
-    let coverage = 1.0 - saturate(smallest_distance_to_sphere / pixel_world_size);
 
     // TODO(andreas): Do we want manipulate the depth buffer depth to actually render spheres?
-
     // TODO(andreas): Proper shading
     // TODO(andreas): This doesn't even use the sphere's world position for shading, the world position used here is flat!
     var shading = 1.0;
@@ -107,6 +95,12 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
 
 @fragment
 fn fs_main_outline_mask(in: VertexOut) -> @location(0) UVec2 {
-    // TODO: Coverage
-    return batch.outline_mask_ids;
+    // Output is an integer target, can't use coverage therefore.
+    // But we still want to discard fragments where coverage is low.
+    // Since the outline extends a bit, a very low cut off tends to look better.
+    let coverage = sphere_quad_coverage(in.world_position, in.radius, in.point_center);
+    if coverage < 1.0 {
+        discard;
+    }
+    return batch.outline_mask;
 }

--- a/crates/re_renderer/shader/utils/sphere_quad.wgsl
+++ b/crates/re_renderer/shader/utils/sphere_quad.wgsl
@@ -89,3 +89,19 @@ fn sphere_quad_span(vertex_idx: u32, point_pos: Vec3, point_unresolved_radius: f
 
     return SphereQuadData(pos, radius);
 }
+
+fn sphere_quad_coverage(world_position: Vec3, radius: f32, point_center: Vec3) -> f32 {
+    // There's easier ways to compute anti-aliasing for when we are in ortho mode since it's just circles.
+    // But it's very nice to have mostly the same code path and this gives us the sphere world position along the way.
+    let ray = camera_ray_to_world_pos(world_position);
+
+    // Sphere intersection with anti-aliasing as described by Iq here
+    // https://www.shadertoy.com/view/MsSSWV
+    // (but rearranged and labeled to it's easier to understand!)
+    let d = ray_sphere_distance(ray, point_center, radius);
+    let smallest_distance_to_sphere = d.x;
+    let closest_ray_dist = d.y;
+    let pixel_world_size = approx_pixel_world_size_at(closest_ray_dist);
+
+    return 1.0 - saturate(smallest_distance_to_sphere / pixel_world_size);
+}

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -52,6 +52,7 @@ where
             flags: PointCloudBatchFlags::ENABLE_SHADING,
             point_count: 0,
             overall_outline_mask_ids: OutlineMaskPreference::NONE,
+            additional_outline_mask_ids_vertex_ranges: Vec::new(),
         });
 
         PointCloudBatchBuilder(self)
@@ -223,6 +224,13 @@ where
             max_points,
             colors: &mut self.0.color_buffer,
             user_data: &mut self.0.user_data,
+            additional_outline_mask_ids: &mut self
+                .0
+                .batches
+                .last_mut()
+                .unwrap()
+                .additional_outline_mask_ids_vertex_ranges, // TODO: less weird borrows?
+            start_vertex_index: old_size as _,
         }
     }
 
@@ -307,12 +315,11 @@ where
 pub struct PointsBuilder<'a, PerPointUserData> {
     // Vertices is a slice, which radii will update
     vertices: &'a mut [PointCloudVertex],
-
-    // Colors and user-data are the Vec we append
-    // the data to if provided.
     max_points: usize,
     colors: &'a mut CpuWriteGpuReadBuffer<Color32>,
     user_data: &'a mut Vec<PerPointUserData>,
+    additional_outline_mask_ids: &'a mut Vec<(std::ops::Range<u32>, OutlineMaskPreference)>,
+    start_vertex_index: u32,
 }
 
 impl<'a, PerPointUserData> PointsBuilder<'a, PerPointUserData>
@@ -360,6 +367,23 @@ where
         crate::profile_function!();
         self.user_data
             .extend(data.take(self.max_points - self.user_data.len()));
+        self
+    }
+
+    /// Pushes additional outline mask ids for a specific range of points.
+    /// The range is relative to this builder's range, not the entire batch.
+    ///
+    /// Prefer the `overall_outline_mask_ids` setting to set the outline mask ids for the entire batch whenever possible!
+    #[inline]
+    pub fn push_additional_outline_mask_ids_for_range(
+        self,
+        range: std::ops::Range<u32>,
+        ids: OutlineMaskPreference,
+    ) -> Self {
+        self.additional_outline_mask_ids.push((
+            (range.start + self.start_vertex_index)..(range.end + self.start_vertex_index),
+            ids,
+        ));
         self
     }
 }

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -229,7 +229,7 @@ where
                 .batches
                 .last_mut()
                 .unwrap()
-                .additional_outline_mask_ids_vertex_ranges, // TODO: less weird borrows?
+                .additional_outline_mask_ids_vertex_ranges,
             start_vertex_index: old_size as _,
         }
     }
@@ -259,7 +259,7 @@ where
                 .batches
                 .last_mut()
                 .unwrap()
-                .additional_outline_mask_ids_vertex_ranges, // TODO: less weird borrows?
+                .additional_outline_mask_ids_vertex_ranges,
             outline_mask_id: OutlineMaskPreference::NONE,
         }
     }

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -1,8 +1,8 @@
 use crate::{
     allocator::CpuWriteGpuReadBuffer,
     renderer::{
-        PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudDrawDataError,
-        PointCloudVertex,
+        OutlineMaskPreference, PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData,
+        PointCloudDrawDataError, PointCloudVertex,
     },
     Color32, DebugLabel, RenderContext, Size,
 };
@@ -51,6 +51,7 @@ where
             world_from_obj: glam::Mat4::IDENTITY,
             flags: PointCloudBatchFlags::ENABLE_SHADING,
             point_count: 0,
+            overall_outline_mask_ids: OutlineMaskPreference::NONE,
         });
 
         PointCloudBatchBuilder(self)
@@ -147,6 +148,13 @@ where
     #[inline]
     pub fn world_from_obj(mut self, world_from_obj: glam::Mat4) -> Self {
         self.batch_mut().world_from_obj = world_from_obj;
+        self
+    }
+
+    /// Sets an outline mask for every element in the batch.
+    #[inline]
+    pub fn outline_mask_ids(mut self, outline_mask_ids: OutlineMaskPreference) -> Self {
+        self.batch_mut().overall_outline_mask_ids = outline_mask_ids;
         self
     }
 

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -17,6 +17,7 @@ use std::num::NonZeroU32;
 use crate::{
     allocator::create_and_fill_uniform_buffer_batch,
     include_file,
+    renderer::OutlineMaskProcessor,
     resource_managers::ResourceManagerError,
     view_builder::ViewBuilder,
     wgpu_resources::{
@@ -28,8 +29,8 @@ use crate::{
 };
 
 use super::{
-    DrawData, DrawPhase, FileResolver, FileSystem, RenderContext, Renderer, SharedRendererData,
-    WgpuResourcePools,
+    DrawData, DrawPhase, FileResolver, FileSystem, OutlineMaskPreference, RenderContext, Renderer,
+    SharedRendererData, WgpuResourcePools,
 };
 
 // ---
@@ -42,10 +43,12 @@ mod gpu_data {
     pub struct DepthCloudInfoUBO {
         pub depth_camera_extrinsics: crate::wgpu_buffer_types::Mat4,
         pub depth_camera_intrinsics: crate::wgpu_buffer_types::Mat3,
-        pub radius_scale: crate::wgpu_buffer_types::F32RowPadded,
-        pub colormap: crate::wgpu_buffer_types::U32RowPadded,
 
-        pub end_padding: [crate::wgpu_buffer_types::PaddingRow; 16 - 9],
+        pub radius_scale: f32,
+        pub colormap: u32,
+        pub outline_mask_id: crate::wgpu_buffer_types::UVec2,
+
+        pub end_padding: [crate::wgpu_buffer_types::PaddingRow; 16 - 8],
     }
 }
 
@@ -94,6 +97,9 @@ pub struct DepthCloud {
 
     /// Configures color mapping mode.
     pub colormap: ColorMap,
+
+    /// Option outline mask id preference.
+    pub outline_mask_id: OutlineMaskPreference,
 }
 
 impl Default for DepthCloud {
@@ -105,14 +111,21 @@ impl Default for DepthCloud {
             depth_dimensions: glam::UVec2::ZERO,
             depth_data: DepthCloudDepthData::default(),
             colormap: ColorMap::ColorMapTurbo,
+            outline_mask_id: OutlineMaskPreference::NONE,
         }
     }
 }
 
 #[derive(Clone)]
+struct DepthCloudDrawInstance {
+    bind_group: GpuBindGroup,
+    num_points: u32,
+    render_outline_mask: bool,
+}
+
+#[derive(Clone)]
 pub struct DepthCloudDrawData {
-    // Every single point clouds and their respective total number of points.
-    bind_groups: Vec<(u32, GpuBindGroup)>,
+    instances: Vec<DepthCloudDrawInstance>,
 }
 
 impl DrawData for DepthCloudDrawData {
@@ -139,7 +152,7 @@ impl DepthCloudDrawData {
 
         if depth_clouds.is_empty() {
             return Ok(DepthCloudDrawData {
-                bind_groups: Vec::new(),
+                instances: Vec::new(),
             });
         }
 
@@ -149,13 +162,14 @@ impl DepthCloudDrawData {
             depth_clouds.iter().map(|info| gpu_data::DepthCloudInfoUBO {
                 depth_camera_extrinsics: info.depth_camera_extrinsics.into(),
                 depth_camera_intrinsics: info.depth_camera_intrinsics.into(),
-                radius_scale: info.radius_scale.into(),
-                colormap: (info.colormap as u32).into(),
+                radius_scale: info.radius_scale,
+                colormap: info.colormap as u32,
+                outline_mask_id: info.outline_mask_id.0.unwrap_or_default().into(),
                 end_padding: Default::default(),
             }),
         );
 
-        let mut bind_groups = Vec::with_capacity(depth_clouds.len());
+        let mut instances = Vec::with_capacity(depth_clouds.len());
         for (depth_cloud, ubo) in depth_clouds.iter().zip(depth_cloud_ubos.into_iter()) {
             let depth_texture = match &depth_cloud.depth_data {
                 // On native, we can use D16 textures without issues, but they aren't supported on
@@ -182,9 +196,9 @@ impl DepthCloudDrawData {
                 }
             };
 
-            bind_groups.push((
-                depth_cloud.depth_dimensions.x * depth_cloud.depth_dimensions.y,
-                ctx.gpu_resources.bind_groups.alloc(
+            instances.push(DepthCloudDrawInstance {
+                num_points: depth_cloud.depth_dimensions.x * depth_cloud.depth_dimensions.y,
+                bind_group: ctx.gpu_resources.bind_groups.alloc(
                     &ctx.device,
                     &ctx.gpu_resources,
                     &BindGroupDesc {
@@ -196,10 +210,11 @@ impl DepthCloudDrawData {
                         layout: bg_layout,
                     },
                 ),
-            ));
+                render_outline_mask: depth_cloud.outline_mask_id.is_some(),
+            });
         }
 
-        Ok(DepthCloudDrawData { bind_groups })
+        Ok(DepthCloudDrawData { instances })
     }
 }
 
@@ -292,12 +307,17 @@ fn create_and_upload_texture<T: bytemuck::Pod>(
 }
 
 pub struct DepthCloudRenderer {
-    render_pipeline: GpuRenderPipelineHandle,
+    render_pipeline_color: GpuRenderPipelineHandle,
+    render_pipeline_outline_mask: GpuRenderPipelineHandle,
     bind_group_layout: GpuBindGroupLayoutHandle,
 }
 
 impl Renderer for DepthCloudRenderer {
     type RendererDrawData = DepthCloudDrawData;
+
+    fn participated_phases() -> &'static [DrawPhase] {
+        &[DrawPhase::OutlineMask, DrawPhase::Opaque]
+    }
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
@@ -357,35 +377,54 @@ impl Renderer for DepthCloudRenderer {
             },
         );
 
-        let render_pipeline = pools.render_pipelines.get_or_create(
+        let render_pipeline_desc_color = RenderPipelineDesc {
+            label: "DepthCloudRenderer::render_pipeline_desc_color".into(),
+            pipeline_layout,
+            vertex_entrypoint: "vs_main".into(),
+            vertex_handle: shader_module,
+            fragment_entrypoint: "fs_main".into(),
+            fragment_handle: shader_module,
+            vertex_buffers: smallvec![],
+            render_targets: smallvec![Some(ViewBuilder::MAIN_TARGET_COLOR_FORMAT.into())],
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: ViewBuilder::MAIN_TARGET_DEFAULT_DEPTH_STATE,
+            multisample: wgpu::MultisampleState {
+                // We discard pixels to do the round cutout, therefore we need to
+                // calculate our own sampling mask.
+                alpha_to_coverage_enabled: true,
+                ..ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE
+            },
+        };
+        let render_pipeline_color = pools.render_pipelines.get_or_create(
+            device,
+            &render_pipeline_desc_color,
+            &pools.pipeline_layouts,
+            &pools.shader_modules,
+        );
+
+        let render_pipeline_outline_mask = pools.render_pipelines.get_or_create(
             device,
             &RenderPipelineDesc {
-                label: "depth_cloud_rp".into(),
-                pipeline_layout,
-                vertex_entrypoint: "vs_main".into(),
-                vertex_handle: shader_module,
-                fragment_entrypoint: "fs_main".into(),
-                fragment_handle: shader_module,
-                vertex_buffers: smallvec![],
-                render_targets: smallvec![Some(ViewBuilder::MAIN_TARGET_COLOR_FORMAT.into())],
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    ..Default::default()
-                },
-                depth_stencil: ViewBuilder::MAIN_TARGET_DEFAULT_DEPTH_STATE,
-                multisample: wgpu::MultisampleState {
-                    // We discard pixels to do the round cutout, therefore we need to
-                    // calculate our own sampling mask.
-                    alpha_to_coverage_enabled: true,
-                    ..ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE
-                },
+                label: "DepthCloudRenderer::render_pipeline_outline_mask".into(),
+                fragment_entrypoint: "fs_main_outline_mask".into(),
+                render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
+                depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
+                // Alpha to coverage doesn't work with the mask integer target.
+                multisample: OutlineMaskProcessor::mask_default_msaa_state(
+                    shared_data.config.hardware_tier,
+                ),
+                ..render_pipeline_desc_color
             },
             &pools.pipeline_layouts,
             &pools.shader_modules,
         );
 
         DepthCloudRenderer {
-            render_pipeline,
+            render_pipeline_color,
+            render_pipeline_outline_mask,
             bind_group_layout,
         }
     }
@@ -393,21 +432,31 @@ impl Renderer for DepthCloudRenderer {
     fn draw<'a>(
         &self,
         pools: &'a WgpuResourcePools,
-        _phase: DrawPhase,
+        phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'a>,
         draw_data: &'a Self::RendererDrawData,
     ) -> anyhow::Result<()> {
         crate::profile_function!();
-        if draw_data.bind_groups.is_empty() {
+        if draw_data.instances.is_empty() {
             return Ok(());
         }
 
-        let pipeline = pools.render_pipelines.get_resource(self.render_pipeline)?;
+        let pipeline_handle = if phase == DrawPhase::OutlineMask {
+            self.render_pipeline_outline_mask
+        } else {
+            self.render_pipeline_color
+        };
+        let pipeline = pools.render_pipelines.get_resource(pipeline_handle)?;
+
         pass.set_pipeline(pipeline);
 
-        for (num_points, bind_group) in &draw_data.bind_groups {
-            pass.set_bind_group(1, bind_group, &[]);
-            pass.draw(0..*num_points * 6, 0..1);
+        for instance in &draw_data.instances {
+            if phase == DrawPhase::OutlineMask && !instance.render_outline_mask {
+                continue;
+            }
+
+            pass.set_bind_group(1, &instance.bind_group, &[]);
+            pass.draw(0..instance.num_points * 6, 0..1);
         }
 
         Ok(())

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -441,10 +441,10 @@ impl Renderer for DepthCloudRenderer {
             return Ok(());
         }
 
-        let pipeline_handle = if phase == DrawPhase::OutlineMask {
-            self.render_pipeline_outline_mask
-        } else {
-            self.render_pipeline_color
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_color,
+            _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
         };
         let pipeline = pools.render_pipelines.get_resource(pipeline_handle)?;
 

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -618,7 +618,8 @@ impl LineRenderer {
         line_vertex_range: Range<u32>,
         active_phases: EnumSet<DrawPhase>,
     ) -> LineStripBatch {
-        // TODO(andreas): There should be only a single bindgroup with dynamic indices here.
+        // TODO(andreas): There should be only a single bindgroup with dynamic indices for all batches.
+        //                  (each batch would then know which dynamic indices to use in the bindgroup)
         let bind_group = ctx.gpu_resources.bind_groups.alloc(
             &ctx.device,
             &ctx.gpu_resources,

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -792,10 +792,10 @@ impl Renderer for LineRenderer {
             return Ok(()); // No lines submitted.
         };
 
-        let pipeline_handle = if phase == DrawPhase::OutlineMask {
-            self.render_pipeline_outline_mask
-        } else {
-            self.render_pipeline_color
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_color,
+            _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
         };
         let pipeline = pools.render_pipelines.get_resource(pipeline_handle)?;
 

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -248,7 +248,7 @@ pub struct LineBatchInfo {
     ///
     /// Having many of these individual outline masks can be slow as they require each their own uniform buffer & draw call.
     /// This feature is meant for a limited number of "extra selections"
-    /// If an overall mask is defined as well, the per-strip masks is overwriting the overall mask.
+    /// If an overall mask is defined as well, the per-vertex-range masks is overwriting the overall mask.
     pub additional_outline_mask_ids_vertex_ranges: Vec<(Range<u32>, OutlineMaskPreference)>,
 }
 
@@ -527,7 +527,7 @@ impl LineDrawData {
                     }),
             );
 
-            // Generate additional "micro batches" for each line strip that has a unique outline setting.
+            // Generate additional "micro batches" for each line vertex range that has a unique outline setting.
             // This is fairly costly if there's many, but easy and low-overhead if there's only few, which is usually what we expect!
             let mut uniform_buffer_bindings_mask_only_batches =
                 create_and_fill_uniform_buffer_batch(

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -393,10 +393,10 @@ impl Renderer for MeshRenderer {
             return Ok(()); // Instance buffer was empty.
         };
 
-        let pipeline_handle = if phase == DrawPhase::OutlineMask {
-            self.render_pipeline_outline_mask
-        } else {
-            self.render_pipeline_shaded
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_shaded,
+            _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
         };
         let pipeline = pools.render_pipelines.get_resource(pipeline_handle)?;
 

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -393,18 +393,13 @@ impl PointCloudDrawData {
                 ));
 
                 for (range, _) in &batch_info.additional_outline_mask_ids_vertex_ranges {
-                    batches_internal.push(
-                        point_renderer.create_point_cloud_batch(
-                            ctx,
-                            batch_info
-                                .label
-                                .clone()
-                                .push_str(&format!("strip-only {range:?}")),
-                            uniform_buffer_bindings_mask_only_batches.next().unwrap(),
-                            range.clone(),
-                            enum_set![DrawPhase::OutlineMask],
-                        ),
-                    );
+                    batches_internal.push(point_renderer.create_point_cloud_batch(
+                        ctx,
+                        format!("{:?} strip-only {:?}", batch_info.label, range).into(),
+                        uniform_buffer_bindings_mask_only_batches.next().unwrap(),
+                        range.clone(),
+                        enum_set![DrawPhase::OutlineMask],
+                    ));
                 }
 
                 start_point_for_next_batch = point_vertex_range_end;
@@ -439,7 +434,8 @@ impl PointCloudRenderer {
         vertex_range: Range<u32>,
         active_phases: EnumSet<DrawPhase>,
     ) -> PointCloudBatch {
-        // TODO(andreas): There should be only a single bindgroup with dynamic indices here.
+        // TODO(andreas): There should be only a single bindgroup with dynamic indices for all batches.
+        //                  (each batch would then know which dynamic indices to use in the bindgroup)
         let bind_group = ctx.gpu_resources.bind_groups.alloc(
             &ctx.device,
             &ctx.gpu_resources,

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -73,7 +73,7 @@ mod gpu_data {
     pub struct BatchUniformBuffer {
         pub world_from_obj: wgpu_buffer_types::Mat4,
         pub flags: wgpu_buffer_types::U32RowPadded, // PointCloudBatchFlags
-        pub outline_mask_ids: wgpu_buffer_types::UVec2RowPadded, // Could pack into above, but this is easier to deal with.
+        pub outline_mask: wgpu_buffer_types::UVec2RowPadded, // Could pack into above, but this is easier to deal with.
 
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 6],
     }
@@ -328,7 +328,7 @@ impl PointCloudDrawData {
                     .map(|batch_info| gpu_data::BatchUniformBuffer {
                         world_from_obj: batch_info.world_from_obj.into(),
                         flags: batch_info.flags.bits.into(),
-                        outline_mask_ids: batch_info
+                        outline_mask: batch_info
                             .overall_outline_mask_ids
                             .0
                             .unwrap_or_default()

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -607,10 +607,10 @@ impl Renderer for PointCloudRenderer {
             return Ok(()); // No points submitted.
         };
 
-        let pipeline_handle = if phase == DrawPhase::OutlineMask {
-            self.render_pipeline_outline_mask
-        } else {
-            self.render_pipeline_color
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_color,
+            _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
         };
         let pipeline = pools.render_pipelines.get_resource(pipeline_handle)?;
 

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -346,10 +346,10 @@ impl Renderer for RectangleRenderer {
             return Ok(());
         }
 
-        let pipeline_handle = if phase == DrawPhase::OutlineMask {
-            self.render_pipeline_outline_mask
-        } else {
-            self.render_pipeline_color
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_color,
+            _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
         };
         let pipeline = pools.render_pipelines.get_resource(pipeline_handle)?;
 

--- a/crates/re_renderer/src/wgpu_buffer_types.rs
+++ b/crates/re_renderer/src/wgpu_buffer_types.rs
@@ -82,6 +82,30 @@ impl From<glam::Vec2> for Vec2RowPadded {
     }
 }
 
+#[repr(C, align(8))]
+#[derive(Clone, Copy, Zeroable, Pod)]
+pub struct UVec2 {
+    pub x: u32,
+    pub y: u32,
+}
+
+impl From<glam::UVec2> for UVec2 {
+    #[inline]
+    fn from(v: glam::UVec2) -> Self {
+        UVec2 { x: v.x, y: v.y }
+    }
+}
+
+impl From<[u8; 2]> for UVec2 {
+    #[inline]
+    fn from(v: [u8; 2]) -> Self {
+        UVec2 {
+            x: v[0] as u32,
+            y: v[1] as u32,
+        }
+    }
+}
+
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Zeroable, Pod)]
 pub struct UVec2RowPadded {

--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -49,13 +49,6 @@ pub enum SelectionHighlight {
     Selection,
 }
 
-impl SelectionHighlight {
-    #[inline]
-    pub fn is_some(self) -> bool {
-        self != SelectionHighlight::None
-    }
-}
-
 /// Hover highlight, sorted from weakest to strongest.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum HoverHighlight {
@@ -67,13 +60,6 @@ pub enum HoverHighlight {
     Hovered,
 }
 
-impl HoverHighlight {
-    #[inline]
-    pub fn is_some(self) -> bool {
-        self != HoverHighlight::None
-    }
-}
-
 /// Combination of selection & hover highlight which can occur independently.
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct InteractionHighlight {
@@ -82,12 +68,6 @@ pub struct InteractionHighlight {
 }
 
 impl InteractionHighlight {
-    /// Any active highlight at all.
-    #[inline]
-    pub fn is_some(self) -> bool {
-        self.selection.is_some() || self.hover.is_some()
-    }
-
     /// Picks the stronger selection & hover highlight from two highlight descriptions.
     #[inline]
     pub fn max(&self, other: InteractionHighlight) -> Self {
@@ -120,20 +100,6 @@ impl<'a> OptionalSpaceViewEntityHighlight<'a> {
                 .unwrap_or_default()
                 .max(entity_highlight.overall),
             None => InteractionHighlight::default(),
-        }
-    }
-
-    pub fn any_selection_highlight(&self) -> bool {
-        match self.0 {
-            Some(entity_highlight) => {
-                // TODO(andreas): Could easily pre-compute this!
-                entity_highlight.overall.selection.is_some()
-                    || entity_highlight
-                        .instances
-                        .values()
-                        .any(|instance_highlight| instance_highlight.selection.is_some())
-            }
-            None => false,
         }
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -237,16 +237,6 @@ impl SceneSpatial {
         }
     }
 
-    fn apply_hover_and_selection_effect_color(
-        color: Color32,
-        highlight: InteractionHighlight,
-    ) -> Color32 {
-        let mut color = color;
-        // (counting on inlining to remove unused fields!)
-        Self::apply_hover_and_selection_effect(&mut Size::AUTO.clone(), &mut color, highlight);
-        color
-    }
-
     fn load_keypoint_connections(
         &mut self,
         entity_path: &re_data_store::EntityPath,

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -247,13 +247,6 @@ impl SceneSpatial {
         color
     }
 
-    fn apply_hover_and_selection_effect_size(size: Size, highlight: InteractionHighlight) -> Size {
-        let mut size = size;
-        // (counting on inlining to remove unused fields!)
-        Self::apply_hover_and_selection_effect(&mut size, &mut Color32::WHITE.clone(), highlight);
-        size
-    }
-
     fn load_keypoint_connections(
         &mut self,
         entity_path: &re_data_store::EntityPath,

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -10,10 +10,7 @@ use re_renderer::{renderer::OutlineMaskPreference, Color32, Size};
 
 use super::{eye::Eye, SpaceCamera3D, SpatialNavigationMode};
 use crate::{
-    misc::{
-        mesh_loader::LoadedMesh, HoverHighlight, InteractionHighlight, SelectionHighlight,
-        SpaceViewHighlights, TransformCache, ViewerContext,
-    },
+    misc::{mesh_loader::LoadedMesh, SpaceViewHighlights, TransformCache, ViewerContext},
     ui::{
         annotations::{auto_color, AnnotationMap},
         Annotations, SceneQuery,
@@ -188,54 +185,7 @@ impl SceneSpatial {
         self.primitives.recalculate_bounding_box();
     }
 
-    // TODO(andreas): Better ways to determine these?
-    const HOVER_COLOR: Color32 = Color32::from_rgb(255, 200, 200);
-    const SELECTION_COLOR: Color32 = Color32::from_rgb(255, 170, 170);
-    const SIBLING_SELECTION_COLOR: Color32 = Color32::from_rgb(255, 140, 140);
     const CAMERA_COLOR: Color32 = Color32::from_rgb(150, 150, 150);
-
-    fn size_boost(size: Size) -> Size {
-        if size.is_auto() {
-            Size::AUTO_LARGE
-        } else {
-            size * 1.33
-        }
-    }
-
-    fn apply_hover_and_selection_effect(
-        size: &mut Size,
-        color: &mut Color32,
-        highlight: InteractionHighlight,
-    ) {
-        // TODO(#889):
-        // We want to use outlines instead of color highlighting, but this is a bigger endeavour, so for now:
-
-        let mut highlight_color = *color;
-        if highlight.selection.is_some() {
-            *size = Self::size_boost(*size);
-            highlight_color = match highlight.selection {
-                SelectionHighlight::None => unreachable!(),
-                SelectionHighlight::SiblingSelection => Self::SIBLING_SELECTION_COLOR,
-                SelectionHighlight::Selection => Self::SELECTION_COLOR,
-            };
-        }
-        match highlight.hover {
-            HoverHighlight::None => {}
-            HoverHighlight::Hovered => {
-                highlight_color = Self::HOVER_COLOR;
-            }
-        }
-
-        if highlight.is_some() {
-            // Interpolate with factor 2/3 towards the highlight color (in gamma space for speed)
-            *color = Color32::from_rgba_premultiplied(
-                ((color.r() as u32 + highlight_color.r() as u32 * 2) / 3) as u8,
-                ((color.g() as u32 + highlight_color.g() as u32 * 2) / 3) as u8,
-                ((color.b() as u32 + highlight_color.b() as u32 * 2) / 3) as u8,
-                color.a(),
-            );
-        }
-    }
 
     fn load_keypoint_connections(
         &mut self,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -17,7 +17,10 @@ use re_renderer::{
 };
 
 use crate::{
-    misc::{caches::AsDynamicImage, SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{
+        caches::AsDynamicImage, SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache,
+        ViewerContext,
+    },
     ui::{
         scene::SceneQuery,
         view_spatial::{scene::scene_part::instance_path_hash_for_picking, Image, SceneSpatial},
@@ -154,6 +157,8 @@ impl ImagesPart {
                     return Ok(());
                 }
 
+                let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
+
                 if tensor.meaning == TensorDataMeaning::Depth {
                     if let Some(pinhole_ent_path) = properties.backproject_pinhole_ent_path.as_ref()
                     {
@@ -167,6 +172,7 @@ impl ImagesPart {
                             properties,
                             &tensor,
                             pinhole_ent_path,
+                            entity_highlight,
                         );
                         return Ok(());
                     };
@@ -179,7 +185,7 @@ impl ImagesPart {
                     properties,
                     ent_path,
                     world_from_obj,
-                    highlights,
+                    entity_highlight,
                     instance_key,
                     tensor,
                     color,
@@ -198,14 +204,12 @@ impl ImagesPart {
         properties: &EntityProperties,
         ent_path: &EntityPath,
         world_from_obj: glam::Mat4,
-        highlights: &SpaceViewHighlights,
+        entity_highlight: &SpaceViewOutlineMasks,
         instance_key: InstanceKey,
         tensor: Tensor,
         color: Option<ColorRGBA>,
     ) {
         crate::profile_function!();
-
-        let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
         let instance_path_hash = instance_path_hash_for_picking(
             ent_path,
@@ -253,6 +257,7 @@ impl ImagesPart {
         properties: &EntityProperties,
         tensor: &Tensor,
         pinhole_ent_path: &EntityPath,
+        entity_highlight: &SpaceViewOutlineMasks,
     ) {
         crate::profile_function!();
 
@@ -267,8 +272,8 @@ impl ImagesPart {
 
         // TODO(cmc): getting to those extrinsics is no easy task :|
         let Some(extrinsics) = pinhole_ent_path
-            .parent()
-            .and_then(|ent_path| transforms.reference_from_entity(&ent_path)) else {
+        .parent()
+        .and_then(|ent_path| transforms.reference_from_entity(&ent_path)) else {
             re_log::warn_once!("Couldn't fetch pinhole extrinsics at {pinhole_ent_path:?}");
             return;
         };
@@ -316,6 +321,7 @@ impl ImagesPart {
             depth_dimensions: dimensions,
             depth_data: data,
             colormap,
+            outline_mask_id: entity_highlight.overall,
         });
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
@@ -88,7 +88,7 @@ impl Points2DPart {
             let radius = radius.map_or(Size::AUTO, |r| Size::new_scene(r.0));
             let label = annotation_info.label(label.map(|l| l.0).as_ref());
 
-            let mut point_range_builder = point_batch
+            let point_range_builder = point_batch
                 .add_point_2d(pos)
                 .color(color)
                 .radius(radius)
@@ -96,7 +96,7 @@ impl Points2DPart {
 
             // Check if this point is individually highlighted.
             if let Some(instance_mask_ids) = entity_highlight.instances.get(&instance_key) {
-                point_range_builder = point_range_builder.outline_mask_id(*instance_mask_ids);
+                point_range_builder.outline_mask_id(*instance_mask_ids);
             }
 
             if let Some(label) = label {

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
@@ -50,7 +50,7 @@ impl Points2DPart {
             .world_from_obj(world_from_obj)
             .outline_mask_ids(entity_highlight.overall);
 
-        // TODO(andreas): This should follow the sample batch processing ans points3d.
+        // TODO(andreas): This should follow the same batch processing as points3d.
         let visitor = |instance_key: InstanceKey,
                        pos: Point2D,
                        color: Option<ColorRGBA>,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
@@ -12,10 +12,7 @@ use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::Size;
 
 use crate::{
-    misc::{
-        InteractionHighlight, OptionalSpaceViewEntityHighlight, SpaceViewHighlights,
-        TransformCache, ViewerContext,
-    },
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
     ui::{
         annotations::ResolvedAnnotationInfo,
         scene::SceneQuery,
@@ -81,38 +78,27 @@ impl Points3DPart {
     fn process_colors<'a>(
         entity_view: &'a EntityView<Point3D>,
         ent_path: &'a EntityPath,
-        highlights: &'a [InteractionHighlight],
         annotation_infos: &'a [ResolvedAnnotationInfo],
     ) -> Result<impl Iterator<Item = egui::Color32> + 'a, QueryError> {
         crate::profile_function!();
         let default_color = DefaultColor::EntityPath(ent_path);
 
         let colors = itertools::izip!(
-            highlights.iter(),
             annotation_infos.iter(),
             entity_view.iter_component::<ColorRGBA>()?,
         )
-        .map(move |(highlight, annotation_info, color)| {
-            SceneSpatial::apply_hover_and_selection_effect_color(
-                annotation_info.color(color.map(move |c| c.to_array()).as_ref(), default_color),
-                *highlight,
-            )
+        .map(move |(annotation_info, color)| {
+            annotation_info.color(color.map(move |c| c.to_array()).as_ref(), default_color)
         });
         Ok(colors)
     }
 
-    fn process_radii<'a>(
-        entity_view: &'a EntityView<Point3D>,
-        highlights: &'a [InteractionHighlight],
-    ) -> Result<impl Iterator<Item = Size> + 'a, QueryError> {
-        let radii = itertools::izip!(highlights.iter(), entity_view.iter_component::<Radius>()?,)
-            .map(move |(highlight, radius)| {
-                SceneSpatial::apply_hover_and_selection_effect_size(
-                    radius.map_or(Size::AUTO, |radius| Size::new_scene(radius.0)),
-                    *highlight,
-                )
-            });
-        Ok(radii)
+    fn process_radii(
+        entity_view: &EntityView<Point3D>,
+    ) -> Result<impl Iterator<Item = Size> + '_, QueryError> {
+        Ok(entity_view
+            .iter_component::<Radius>()?
+            .map(|radius| radius.map_or(Size::AUTO, |r| Size::new_scene(r.0))))
     }
 
     fn process_labels<'a>(
@@ -157,7 +143,7 @@ impl Points3DPart {
         entity_view: &EntityView<Point3D>,
         ent_path: &EntityPath,
         world_from_obj: Mat4,
-        entity_highlight: OptionalSpaceViewEntityHighlight<'_>,
+        entity_highlight: &SpaceViewOutlineMasks,
     ) -> Result<(), QueryError> {
         crate::profile_function!();
 
@@ -175,7 +161,6 @@ impl Points3DPart {
 
         let (annotation_infos, keypoints) =
             Self::process_annotations(query, entity_view, &annotations)?;
-        let any_part_selected = entity_highlight.any_selection_highlight();
         let instance_path_hashes = {
             crate::profile_scope!("instance_hashes");
             entity_view
@@ -186,29 +171,28 @@ impl Points3DPart {
                         instance_key,
                         entity_view,
                         properties,
-                        any_part_selected,
+                        entity_highlight.any_selection_highlight,
                     )
                 })
                 .collect::<Vec<_>>()
         };
 
-        let highlights = {
-            crate::profile_scope!("highlights");
-            instance_path_hashes
-                .iter()
-                .map(|hash| entity_highlight.index_highlight(hash.instance_key))
-                .collect::<Vec<_>>()
-        };
+        // TODO:
+        // let highlights = {
+        //     crate::profile_scope!("highlights");
+        //     instance_path_hashes
+        //         .iter()
+        //         .map(|hash| entity_highlight.index_highlight(hash.instance_key))
+        //         .collect::<Vec<_>>()
+        // };
 
-        let colors = Self::process_colors(entity_view, ent_path, &highlights, &annotation_infos)?;
-
-        let radii = Self::process_radii(entity_view, &highlights)?;
+        let colors = Self::process_colors(entity_view, ent_path, &annotation_infos)?;
+        let radii = Self::process_radii(entity_view)?;
 
         if show_labels && instance_path_hashes.len() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.
             let colors =
-                Self::process_colors(entity_view, ent_path, &highlights, &annotation_infos)?
-                    .collect::<Vec<_>>();
+                Self::process_colors(entity_view, ent_path, &annotation_infos)?.collect::<Vec<_>>();
 
             scene.ui.labels.extend(Self::process_labels(
                 entity_view,
@@ -224,6 +208,7 @@ impl Points3DPart {
             .points
             .batch("3d points")
             .world_from_obj(world_from_obj)
+            .outline_mask_ids(entity_highlight.overall)
             .add_points(entity_view.num_instances(), point_positions)
             .colors(colors)
             .radii(radii)
@@ -250,7 +235,7 @@ impl ScenePart for Points3DPart {
             let Some(world_from_obj) = transforms.reference_from_entity(ent_path) else {
                 continue;
             };
-            let entity_highlight = highlights.entity_highlight(ent_path.hash());
+            let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
             match query_primary_with_history::<Point3D, 7>(
                 &ctx.log_db.entity_db.data_store,


### PR DESCRIPTION
Migrates the last primitives, points 2d/3d & depth cloud, over to outline based selection. Closes #889, from here on out there is still cleanup and more improvements to make, but we got where we wanted to be in rough strokes!
Some of the cleanup already happens here because of unused-warnings, but there's a bit more to do.

Clip demonstrating what it looks like as well as what it looks like for small & large points. Unsurprisingly it works out best for connected points.
https://user-images.githubusercontent.com/1220815/224499438-abf2bba4-7262-414e-88c7-65d25f0014ea.mov
(yes it also works for 2D, not dmonstrated here because as time of recording that wasn't done yet)

Approach on single points is identical to #1553 

Note that depth cloud didn't have any selection highlight before (this pr naturally doesn't fix picking for it and doesn't allow selecting single points for it either)

Unsurprisingly this also speeds up point processing! Nowhere near the depth cloud feature and not nearly enough to close issue #850, but a fair bit!
For the the usual unscientific nyud demo testscenario (very long point history, loop a bunch of frames at end) I'm getting 2.5ms for free in release mode, mostly in color processing.

Before:
![Screenshot 2023-03-11 at 17 54 52](https://user-images.githubusercontent.com/1220815/224498419-52b68da4-108f-4dae-8c1a-67522b13799e.png)

After:
![Screenshot 2023-03-11 at 17 52 30](https://user-images.githubusercontent.com/1220815/224498446-2977562d-70d0-4b5d-9c17-1182c3d207bd.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
