### PR TITLE
Fix some `1.68` clippy lints

### DIFF
--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -148,7 +148,6 @@ criterion_main!(benches);
 
 fn build_messages(n: usize) -> Vec<MsgBundle> {
     (0..NUM_FRAMES)
-        .into_iter()
         .map(move |frame_idx| {
             try_build_msg_bundle2(
                 MsgId::ZERO,

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -116,9 +116,7 @@ impl DataStore {
         let components = match (timeless, temporal) {
             (None, Some(temporal)) => temporal.iter().cloned().collect_vec(),
             (Some(timeless), None) => timeless.iter().cloned().collect_vec(),
-            (Some(timeless), Some(temporal)) => {
-                timeless.union(temporal).cloned().into_iter().collect_vec()
-            }
+            (Some(timeless), Some(temporal)) => timeless.union(temporal).cloned().collect_vec(),
             (None, None) => return None,
         };
 

--- a/crates/re_log_types/src/datagen.rs
+++ b/crates/re_log_types/src/datagen.rs
@@ -8,7 +8,6 @@ use crate::{
 /// Create `len` dummy rectangles
 pub fn build_some_rects(len: usize) -> Vec<component_types::Rect2D> {
     (0..len)
-        .into_iter()
         .map(|i| {
             component_types::Rect2D::from_xywh(i as f32, i as f32, (i / 2) as f32, (i / 2) as f32)
         })
@@ -18,14 +17,13 @@ pub fn build_some_rects(len: usize) -> Vec<component_types::Rect2D> {
 /// Create `len` dummy colors
 pub fn build_some_colors(len: usize) -> Vec<component_types::ColorRGBA> {
     (0..len)
-        .into_iter()
         .map(|i| component_types::ColorRGBA(i as u32))
         .collect()
 }
 
 /// Create `len` dummy labels
 pub fn build_some_labels(len: usize) -> Vec<String> {
-    (0..len).into_iter().map(|i| format!("label{i}")).collect()
+    (0..len).map(|i| format!("label{i}")).collect()
 }
 
 /// Create `len` dummy `Point2D`
@@ -34,7 +32,6 @@ pub fn build_some_point2d(len: usize) -> Vec<component_types::Point2D> {
     let mut rng = rand::thread_rng();
 
     (0..len)
-        .into_iter()
         .map(|_| component_types::Point2D {
             x: rng.gen_range(0.0..10.0),
             y: rng.gen_range(0.0..10.0),
@@ -48,7 +45,6 @@ pub fn build_some_vec3d(len: usize) -> Vec<component_types::Vec3D> {
     let mut rng = rand::thread_rng();
 
     (0..len)
-        .into_iter()
         .map(|_| {
             component_types::Vec3D::new(
                 rng.gen_range(0.0..10.0),

--- a/crates/re_query/benches/query_benchmark.rs
+++ b/crates/re_query/benches/query_benchmark.rs
@@ -43,7 +43,6 @@ criterion_main!(benches);
 fn mono_points(c: &mut Criterion) {
     // Each mono point gets logged at a different path
     let paths = (0..NUM_POINTS)
-        .into_iter()
         .map(move |point_idx| entity_path!("points", Index::Sequence(point_idx as _)))
         .collect_vec();
     let msgs = build_points_messages(&paths, 1);
@@ -124,7 +123,6 @@ fn batch_vecs(c: &mut Criterion) {
 
 fn build_points_messages(paths: &[EntityPath], pts: usize) -> Vec<MsgBundle> {
     (0..NUM_FRAMES_POINTS)
-        .into_iter()
         .flat_map(move |frame_idx| {
             paths.iter().map(move |path| {
                 try_build_msg_bundle2(
@@ -141,7 +139,6 @@ fn build_points_messages(paths: &[EntityPath], pts: usize) -> Vec<MsgBundle> {
 
 fn build_vecs_messages(paths: &[EntityPath], pts: usize) -> Vec<MsgBundle> {
     (0..NUM_FRAMES_VECS)
-        .into_iter()
         .flat_map(move |frame_idx| {
             paths.iter().map(move |path| {
                 try_build_msg_bundle1(

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -77,7 +77,6 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod>(
     staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(), &buffer, 0);
 
     (0..num_buffers)
-        .into_iter()
         .map(|i| BindGroupEntry::Buffer {
             handle: buffer.handle,
             offset: i * element_size,

--- a/crates/re_renderer/src/renderer/outlines.rs
+++ b/crates/re_renderer/src/renderer/outlines.rs
@@ -547,12 +547,10 @@ impl OutlineMaskProcessor {
         let uniform_buffer_jumpflooding_steps_bindings = create_and_fill_uniform_buffer_batch(
             ctx,
             "jumpflooding uniformbuffer".into(),
-            (0..num_steps)
-                .into_iter()
-                .map(|step| gpu_data::JumpfloodingStepUniformBuffer {
-                    step_width: (max_step_width >> step).into(),
-                    end_padding: Default::default(),
-                }),
+            (0..num_steps).map(|step| gpu_data::JumpfloodingStepUniformBuffer {
+                step_width: (max_step_width >> step).into(),
+                end_padding: Default::default(),
+            }),
         );
         let sampler = ctx.gpu_resources.samplers.get_or_create(
             &ctx.device,

--- a/crates/re_string_interner/src/lib.rs
+++ b/crates/re_string_interner/src/lib.rs
@@ -166,8 +166,8 @@ impl StringInterner {
 
     pub fn bytes_used(&self) -> usize {
         self.map
-            .iter()
-            .map(|(k, v)| std::mem::size_of_val(k) + std::mem::size_of_val(v) + v.len())
+            .values()
+            .map(|string| std::mem::size_of::<u64>() + std::mem::size_of::<&str>() + string.len())
             .sum()
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -32,10 +32,12 @@ pub struct View2DState {
     zoom: ZoomState2D,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 /// Sub-state specific to the Zoom/Scale/Pan engine
 pub enum ZoomState2D {
+    #[default]
     Auto,
+
     Scaled {
         /// Number of ui points per scene unit
         scale: f32,
@@ -46,12 +48,6 @@ pub enum ZoomState2D {
         /// Whether to allow the state to be updated by the current `ScrollArea` offsets
         accepting_scroll: bool,
     },
-}
-
-impl Default for ZoomState2D {
-    fn default() -> Self {
-        ZoomState2D::Auto
-    }
 }
 
 impl View2DState {


### PR DESCRIPTION
Found with `cargo +1.68.0 cranky --all-targets --all-features -- --deny warnings`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
