### PR TITLE
Avoid using undefined extern "C" on windows

### DIFF
--- a/crates/re_log_types/src/component_types/arrow_convert_shims.rs
+++ b/crates/re_log_types/src/component_types/arrow_convert_shims.rs
@@ -91,9 +91,7 @@ impl<'a> IntoIterator for &'a BufferBinaryArray {
     // We'll still catch the issue on build in Linux, but on windows just fall back to panic.
     #[cfg(target_os = "windows")]
     fn into_iter(self) -> Self::IntoIter {
-        panic!(
-        "Use iter_from_array_ref. This is a quirk of the way the traits work in arrow2_convert."
-    );
+        panic!("Use iter_from_array_ref. This is a quirk of the way the traits work in arrow2_convert.");
     }
 }
 

--- a/crates/re_log_types/src/component_types/arrow_convert_shims.rs
+++ b/crates/re_log_types/src/component_types/arrow_convert_shims.rs
@@ -74,6 +74,7 @@ impl<'a> IntoIterator for &'a BufferBinaryArray {
 
     type IntoIter = BufferBinaryArrayIter<'a>;
 
+    #[cfg(not(target_os = "windows"))]
     fn into_iter(self) -> Self::IntoIter {
         #[allow(unsafe_code)]
         // SAFETY:
@@ -84,6 +85,15 @@ impl<'a> IntoIterator for &'a BufferBinaryArray {
             do_not_call_into_iter();
         }
         unreachable!()
+    }
+
+    // On windows the above linker trick doesn't work.
+    // We'll still catch the issue on build in Linux, but on windows just fall back to panic.
+    #[cfg(target_os = "windows")]
+    fn into_iter(self) -> Self::IntoIter {
+        panic!(
+        "Use iter_from_array_ref. This is a quirk of the way the traits work in arrow2_convert."
+    );
     }
 }
 

--- a/crates/re_log_types/src/component_types/mod.rs
+++ b/crates/re_log_types/src/component_types/mod.rs
@@ -241,9 +241,7 @@ where
     // We'll still catch the issue on build in Linux, but on windows just fall back to panic.
     #[cfg(target_os = "windows")]
     fn into_iter(self) -> Self::IntoIter {
-        panic!(
-        "Use iter_from_array_ref. This is a quirk of the way the traits work in arrow2_convert."
-    );
+        panic!("Use iter_from_array_ref. This is a quirk of the way the traits work in arrow2_convert.");
     }
 }
 

--- a/crates/re_log_types/src/component_types/mod.rs
+++ b/crates/re_log_types/src/component_types/mod.rs
@@ -224,6 +224,7 @@ where
 
     type IntoIter = FastFixedSizeArrayIter<'a, T, SIZE>;
 
+    #[cfg(not(target_os = "windows"))]
     fn into_iter(self) -> Self::IntoIter {
         #[allow(unsafe_code)]
         // SAFETY:
@@ -234,6 +235,15 @@ where
             do_not_call_into_iter();
         }
         unreachable!();
+    }
+
+    // On windows the above linker trick doesn't work.
+    // We'll still catch the issue on build in Linux, but on windows just fall back to panic.
+    #[cfg(target_os = "windows")]
+    fn into_iter(self) -> Self::IntoIter {
+        panic!(
+        "Use iter_from_array_ref. This is a quirk of the way the traits work in arrow2_convert."
+    );
     }
 }
 


### PR DESCRIPTION
This trick appears not to have worked on windows.

See: https://github.com/rerun-io/rerun/actions/runs/4406095342/jobs/7717895318
```
msvc\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:C:\\Users\\runneradmin\\.rustup\\toolchains\\1.67-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libstd.natvis"
  = note:    Creating library C:\a\rerun\rerun\target\x86_64-pc-windows-msvc\release\deps\re_viewer.dll.lib and object C:\a\rerun\rerun\target\x86_64-pc-windows-msvc\release\deps\re_viewer.dll.exp
          libre_log_types-c3e4ebfd91fc6bfd.rlib(re_log_types-c3e4ebfd91fc6bfd.re_log_types.67a257e1-cgu.6.rcgu.o) : error LNK2019: unresolved external symbol do_not_call_into_iter referenced in function _ZN135_$LT$$RF$re_log_types..component_types..arrow_convert_shims..BufferBinaryArray$u20$as$u20$core..iter..traits..collect..IntoIterator$GT$9into_iter17h35db1eaabf37072bE
          C:\a\rerun\rerun\target\x86_64-pc-windows-msvc\release\deps\re_viewer.dll : fatal error LNK1120: 1 unresolved externals
```

Instead use panic! as we have elsewhere.

Wheel-building results: https://github.com/rerun-io/rerun/actions/runs/4410197859

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
