### PR TITLE
Use `log` as our log backend instead of `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "epaint"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,15 +2599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,16 +2868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,12 +3128,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -3724,7 +3718,6 @@ dependencies = [
  "sha2",
  "thiserror",
  "time 0.3.20",
- "tracing-subscriber",
  "ureq",
  "uuid",
  "web-sys",
@@ -3829,10 +3822,12 @@ dependencies = [
 name = "re_log"
 version = "0.3.1"
 dependencies = [
+ "env_logger",
+ "js-sys",
+ "log",
  "log-once",
  "tracing",
- "tracing-subscriber",
- "tracing-wasm",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3959,7 +3954,6 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "tobj",
- "tracing",
  "type-map",
  "unindent",
  "walkdir",
@@ -4130,7 +4124,6 @@ dependencies = [
  "smallvec",
  "thiserror",
  "time 0.3.20",
- "tracing",
  "uuid",
  "vec1",
  "wasm-bindgen-futures",
@@ -4210,15 +4203,6 @@ checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
  "regex-syntax",
 ]
 
@@ -4590,15 +4574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "signal-hook"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,15 +4907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "tiff"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5150,6 +5116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5173,47 +5140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
-name = "tracing-wasm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
-dependencies = [
- "tracing",
- "tracing-subscriber",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5377,12 +5303,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,6 @@ puffin = "0.14"
 thiserror = "1.0"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tokio = "1.24"
-tracing = "0.1"
-tracing-subscriber = "0.3"
 wgpu = { version = "0.15", default-features = false }
 wgpu-core = { version = "0.15", default-features = false }
 

--- a/crates/re_analytics/Cargo.toml
+++ b/crates/re_analytics/Cargo.toml
@@ -42,9 +42,5 @@ ureq = { version = "2.6", features = [
 web-sys = { version = "0.3.58", features = ["Storage"] }
 
 
-[dev-dependencies]
-tracing-subscriber.workspace = true
-
-
 [build-dependencies]
 re_build_build_info.workspace = true

--- a/crates/re_analytics/examples/end_to_end.rs
+++ b/crates/re_analytics/examples/end_to_end.rs
@@ -7,7 +7,7 @@ fn input_filled_event(body: String) -> Event {
 }
 
 fn main() {
-    tracing_subscriber::fmt::init(); // log to stdout
+    re_log::setup_native_logging();
 
     let mut analytics = Analytics::new(Duration::from_secs(3)).unwrap();
     analytics.register_append_property("application_id", "end_to_end_example");

--- a/crates/re_log/Cargo.toml
+++ b/crates/re_log/Cargo.toml
@@ -17,10 +17,17 @@ all-features = true
 
 
 [dependencies]
+log = { version = "0.4", features = ["std"] }
 log-once = "0.4"
-tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+# make sure dependencies that user tracing gets forwarded to `log`:
+tracing = { version = "0.1", features = ["log"] }
+
+# Native dependencies:
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+env_logger = "0.10"
 
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tracing-wasm = "0.2"
+js-sys = "0.3"
+wasm-bindgen = "=0.2.84"

--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -9,13 +9,54 @@
 //! The `warn_once` etc macros are for when you want to suppress repeated
 //! logging of the exact same message.
 
+// The tracing macros support more syntax features than the log, that's why we use them:
 pub use tracing::{debug, error, info, trace, warn};
 
 // The `re_log::info_once!(…)` etc are nice helpers, but the `log-once` crate is a bit lacking.
-// In the future we should implement our own `tracing` layer and de-duplicate based on the callsite,
+// In the future we should implement our own macros to de-duplicate based on the callsite,
 // similar to how the log console in a browser will automatically suppress duplicates.
 pub use log_once::{debug_once, error_once, info_once, trace_once, warn_once};
 
 mod setup;
 
 pub use setup::*;
+
+#[cfg(target_arch = "wasm32")]
+mod log_web;
+
+/// Shorten a path to a Rust source file.
+///
+/// Example input:
+/// * `/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs`
+/// * `crates/rerun/src/main.rs`
+/// * `/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs`
+///
+/// Example output:
+/// * `tokio-1.24.1/src/runtime/runtime.rs`
+/// * `rerun/src/main.rs`
+/// * `core/src/ops/function.rs`
+#[allow(dead_code)] // only used on web and in tests
+fn shorten_file_path(file_path: &str) -> &str {
+    if let Some(i) = file_path.rfind("/src/") {
+        if let Some(prev_slash) = file_path[..i].rfind('/') {
+            &file_path[prev_slash + 1..]
+        } else {
+            file_path
+        }
+    } else {
+        file_path
+    }
+}
+
+#[test]
+fn test_shorten_file_path() {
+    for (before, after) in [
+        ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/src/runtime/runtime.rs"),
+        ("crates/rerun/src/main.rs", "rerun/src/main.rs"),
+        ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/src/ops/function.rs"),
+        ("/weird/path/file.rs", "/weird/path/file.rs"),
+        ]
+    {
+        assert_eq!(shorten_file_path(before), after);
+    }
+}

--- a/crates/re_log/src/log_web.rs
+++ b/crates/re_log/src/log_web.rs
@@ -21,10 +21,6 @@ impl log::Log for WebLogger {
             // TODO(emilk): remove once https://github.com/gfx-rs/wgpu/issues/3206 is fixed
             return metadata.level() <= log::LevelFilter::Warn;
         }
-        if metadata.target().starts_with("re_renderer") {
-            // re_renderer is also a bit too loud imho
-            return metadata.level() <= log::LevelFilter::Info;
-        }
 
         metadata.level() <= self.filter
     }

--- a/crates/re_log/src/log_web.rs
+++ b/crates/re_log/src/log_web.rs
@@ -1,0 +1,82 @@
+/// Implements [`log::Log`] to log messages to `console.log`, `console.warn`, etc.
+pub struct WebLogger {
+    filter: log::LevelFilter,
+}
+
+impl WebLogger {
+    pub fn new(filter: log::LevelFilter) -> Self {
+        Self { filter }
+    }
+
+    /// Install this logger as the global logger.
+    pub fn init(filter: log::LevelFilter) -> Result<(), log::SetLoggerError> {
+        log::set_max_level(filter);
+        log::set_boxed_logger(Box::new(Self::new(filter)))
+    }
+}
+
+impl log::Log for WebLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        if metadata.target().starts_with("wgpu") || metadata.target().starts_with("naga") {
+            // TODO(emilk): remove once https://github.com/gfx-rs/wgpu/issues/3206 is fixed
+            return metadata.level() <= log::LevelFilter::Warn;
+        }
+        if metadata.target().starts_with("re_renderer") {
+            // re_renderer is also a bit too loud imho
+            return metadata.level() <= log::LevelFilter::Info;
+        }
+
+        metadata.level() <= self.filter
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let msg = if let (Some(file), Some(line)) = (record.file(), record.line()) {
+            let file = crate::shorten_file_path(file);
+            format!("[{}] {file}:{line}: {}", record.target(), record.args())
+        } else {
+            format!("[{}] {}", record.target(), record.args())
+        };
+
+        match record.level() {
+            log::Level::Trace => console::trace(&msg),
+            log::Level::Debug => console::debug(&msg),
+            log::Level::Info => console::info(&msg),
+            log::Level::Warn => console::warn(&msg),
+            log::Level::Error => console::error(&msg),
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// js-bindings for console.log, console.warn, etc
+mod console {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        /// `console.trace`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn trace(s: &str);
+
+        /// `console.debug`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn debug(s: &str);
+
+        /// `console.info`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn info(s: &str);
+
+        /// `console.warn`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn warn(s: &str);
+
+        /// `console.error`
+        #[wasm_bindgen(js_namespace = console)]
+        pub fn error(s: &str);
+    }
+}

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -35,24 +35,11 @@ fn set_default_rust_log_env() {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn setup_native_logging() {
     set_default_rust_log_env();
-    tracing_subscriber::fmt::init(); // log to stdout
-}
-
-#[cfg(target_arch = "wasm32")]
-fn default_web_log_filter() -> String {
-    // TODO(#1513): Logging a lot of things (every frame?) causes the web viewer to crash after a while in some scenes.
-    "warn".to_owned()
+    env_logger::init();
 }
 
 #[cfg(target_arch = "wasm32")]
 pub fn setup_web_logging() {
-    use tracing_subscriber::layer::SubscriberExt as _;
-    tracing::subscriber::set_global_default(
-        tracing_subscriber::Registry::default()
-            .with(tracing_subscriber::EnvFilter::new(default_web_log_filter()))
-            .with(tracing_wasm::WASMLayer::new(
-                tracing_wasm::WASMLayerConfig::default(),
-            )),
-    )
-    .expect("Failed to set tracing subscriber.");
+    crate::log_web::WebLogger::init(log::LevelFilter::Debug)
+        .expect("Failed to set log subscriber.");
 }

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -93,7 +93,6 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"
 pollster = "0.3"
 rand = "0.8"
-tracing.workspace = true
 winit = "0.28.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 

--- a/crates/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
@@ -107,7 +107,7 @@ where
         }
 
         // Otherwise create a new resource
-        re_log::debug!(?desc, "Allocated new resource");
+        re_log::trace!(?desc, "Allocated new resource");
         let inner_resource = creation_func(desc);
         self.total_resource_size_in_bytes.fetch_add(
             desc.resource_size_in_bytes(),

--- a/crates/re_renderer/src/wgpu_resources/static_resource_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/static_resource_pool.rs
@@ -52,7 +52,7 @@ where
     ) -> Handle {
         *self.lookup.entry(desc.clone()).or_insert_with(|| {
             crate::profile_scope!("Creating new static resource", std::any::type_name::<Res>());
-            re_log::debug!(?desc, "Created new resource");
+            re_log::trace!(?desc, "Created new resource");
             let resource = creation_func(desc);
             self.resources.insert(StoredResource {
                 resource,

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -124,7 +124,6 @@ winapi = "0.3.9"
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
-tracing.workspace = true
 wasm-bindgen-futures = "0.4"
 
 


### PR DESCRIPTION
It is _so_ much simpler to write a backend for the `log` crate compared to `tracing`.

So this PR also adds a new log backend for the web which uses `console.debug` for debug-level logs, `console.warn` for warn level, etc etc. This means we can filter the logs in the browser.

Closes https://github.com/rerun-io/rerun/issues/1513

I tried this with all `debug/info` spam from wgpu, and there were no web crashes.

In the end, I still decided to put the `wgpu` log level at `warn` because of https://github.com/gfx-rs/wgpu/issues/3206

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
