### PR TITLE
Load .rrd file over HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ehttp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b69a6f9168b96c0ae04763bec27a8b06b34343c334dd2703a4ec21f0f5e110"
+dependencies = [
+ "js-sys",
+ "ureq",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4100,7 @@ dependencies = [
  "egui-wgpu",
  "egui_dock",
  "egui_extras",
+ "ehttp",
  "enumset",
  "glam",
  "half 2.2.1",

--- a/crates/re_smart_channel/src/lib.rs
+++ b/crates/re_smart_channel/src/lib.rs
@@ -14,6 +14,9 @@ pub enum Source {
     /// The source if a file on disk
     File { path: std::path::PathBuf },
 
+    /// Streaming an `.rrd` file over http.
+    RrdHttpStream { url: String },
+
     /// The source is the logging sdk directly, same process.
     Sdk,
 
@@ -33,7 +36,7 @@ impl Source {
     pub fn is_network(&self) -> bool {
         match self {
             Self::File { .. } | Self::Sdk => false,
-            Self::WsClient { .. } | Self::TcpServer { .. } => true,
+            Self::RrdHttpStream { .. } | Self::WsClient { .. } | Self::TcpServer { .. } => true,
         }
     }
 }

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -77,6 +77,7 @@ egui_dock = { workspace = true, features = ["serde"] }
 egui_extras = { workspace = true, features = ["tracing"] }
 egui-notify = "0.6"
 egui-wgpu.workspace = true
+ehttp = "0.2"
 enumset.workspace = true
 glam = { workspace = true, features = [
   "mint",

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -606,6 +606,9 @@ fn wait_screen_ui(ui: &mut egui::Ui, rx: &Receiver<LogMsg>) {
             re_smart_channel::Source::File { path } => {
                 ui.strong(format!("Loading {}…", path.display()));
             }
+            re_smart_channel::Source::RrdHttpStream { url } => {
+                ui.strong(format!("Loading {url}…"));
+            }
             re_smart_channel::Source::Sdk => {
                 ready_and_waiting(ui, "Waiting for logging data from SDK");
             }
@@ -1781,7 +1784,8 @@ fn new_recording_confg(
         re_smart_channel::Source::File { .. } => PlayState::Playing,
 
         // Live data - follow it!
-        re_smart_channel::Source::Sdk
+        re_smart_channel::Source::RrdHttpStream { .. }
+        | re_smart_channel::Source::Sdk
         | re_smart_channel::Source::WsClient { .. }
         | re_smart_channel::Source::TcpServer { .. } => PlayState::Following,
     };

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -200,6 +200,8 @@ pub fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
 }
 
 pub fn stream_rrd_from_http(url: String) -> re_smart_channel::Receiver<re_log_types::LogMsg> {
+    re_log::debug!("Downloading .rrd file from {url:?}…");
+
     let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::RrdHttpStream {
         url: url.clone(),
     });
@@ -208,6 +210,8 @@ pub fn stream_rrd_from_http(url: String) -> re_smart_channel::Receiver<re_log_ty
     ehttp::fetch(ehttp::Request::get(&url), move |result| match result {
         Ok(response) => {
             if response.ok {
+                re_log::debug!("Decoding .rrd file from {url:?}…");
+                // TODO(emilk): on web, decode in chunks an schedule a timeout to continue decoding.
                 let decoder =
                     re_log_types::encoding::Decoder::new(std::io::Cursor::new(&response.bytes));
                 match decoder {

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -183,7 +183,8 @@ impl ViewerAnalytics {
         if let Some(data_source) = &log_db.data_source {
             let data_source = match data_source {
                 re_smart_channel::Source::File { .. } => "file", // .rrd
-                re_smart_channel::Source::Sdk => "sdk",          // show()
+                re_smart_channel::Source::RrdHttpStream { .. } => "http",
+                re_smart_channel::Source::Sdk => "sdk", // show()
                 re_smart_channel::Source::WsClient { .. } => "ws_client", // spawn()
                 re_smart_channel::Source::TcpServer { .. } => "tcp_server", // connect()
             };

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -37,7 +37,7 @@ pub async fn start(
             let re_ui = crate::customize_eframe(cc);
             let url = url.unwrap_or_else(|| get_url(&cc.integration_info));
 
-            if url.starts_with("http") {
+            if url.starts_with("http") || url.ends_with(".rrd") {
                 // Download an .rrd file over http
                 let rx = crate::stream_rrd_from_http(url);
                 Box::new(crate::App::from_receiver(

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -7,10 +7,15 @@ static GLOBAL: AccountingAllocator<std::alloc::System> =
     AccountingAllocator::new(std::alloc::System);
 
 /// This is the entry-point for all the Wasm.
+///
 /// This is called once from the HTML.
 /// It loads the app, installs some callbacks, then returns.
+/// The `url` is an optional URL to either an .rrd file over http, or a Rerun WebSocket server.
 #[wasm_bindgen]
-pub async fn start(canvas_id: &str) -> std::result::Result<(), eframe::wasm_bindgen::JsValue> {
+pub async fn start(
+    canvas_id: &str,
+    url: Option<String>,
+) -> std::result::Result<(), eframe::wasm_bindgen::JsValue> {
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
 
@@ -30,7 +35,7 @@ pub async fn start(canvas_id: &str) -> std::result::Result<(), eframe::wasm_bind
             let app_env = crate::AppEnvironment::Web;
             let startup_options = crate::StartupOptions::default();
             let re_ui = crate::customize_eframe(cc);
-            let url = get_url(&cc.integration_info);
+            let url = url.unwrap_or_else(|| get_url(&cc.integration_info));
 
             if url.starts_with("http") {
                 // Download an .rrd file over http

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -134,7 +134,7 @@
             console.debug("wasm loaded. starting app…");
 
             // This call installs a bunch of callbacks and then returns:
-            let url = null; // you can use this to point to an .rrf file over http, or a WebSocket Rerun server.
+            let url = null; // you can use this to point to an .rrd file over http, or a WebSocket Rerun server.
             wasm_bindgen.start("the_canvas_id", url);
 
             console.debug("app started.");

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -134,7 +134,8 @@
             console.debug("wasm loaded. starting app…");
 
             // This call installs a bunch of callbacks and then returns:
-            wasm_bindgen.start("the_canvas_id");
+            let url = null; // you can use this to point to an .rrf file over http, or a WebSocket Rerun server.
+            wasm_bindgen.start("the_canvas_id", url);
 
             console.debug("app started.");
             document.getElementById("center_text").remove();


### PR DESCRIPTION
Minimal working version. It currently downloads the full .rrd file, then decodes the full thing. It is very basic and stupid, but works as a first prototype.

Tested on web and native.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
