### PR TITLE
Show log messages in egui toast notifications

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -58,7 +58,7 @@ The log is for several distinct users:
 
 We are all sharing the same log stream, so we must cooperate carefully.
 
-The Rerun viewer wll show log messages at `INFO`, `WARNING` and `ERROR` to the user as a toast notifications.
+The Rerun viewer will show log messages at `INFO`, `WARNING` and `ERROR` to the user as a toast notifications.
 
 #### `ERROR`
 This is for _unrecoverable_ problems. The application or library couldn't complete an operation.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -58,6 +58,8 @@ The log is for several distinct users:
 
 We are all sharing the same log stream, so we must cooperate carefully.
 
+The Rerun viewer wll show log messages at `INFO`, `WARNING` and `ERROR` to the user as a toast notifications.
+
 #### `ERROR`
 This is for _unrecoverable_ problems. The application or library couldn't complete an operation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,6 +3826,7 @@ dependencies = [
  "js-sys",
  "log",
  "log-once",
+ "parking_lot 0.12.1",
  "tracing",
  "wasm-bindgen",
 ]

--- a/crates/re_analytics/src/pipeline_native.rs
+++ b/crates/re_analytics/src/pipeline_native.rs
@@ -318,7 +318,19 @@ fn flush_events(
     }
 
     if let Err(err) = sink.send(analytics_id, session_id, &events) {
-        warn!(%err, "failed to send analytics down the sink, will try again later");
+        if matches!(err, SinkError::HttpTransport(_)) {
+            // No internet connection. No biggie, we'll try again later.
+            re_log::debug_once!(
+                "Failed to send analytics down the sink, will try again later.\n{err}
+            "
+            );
+        } else {
+            // A more unusual error. Show it to the user.
+            re_log::warn_once!(
+                "Failed to send analytics down the sink, will try again later.\n{err}
+            "
+            );
+        }
         return Err(err);
     }
 

--- a/crates/re_analytics/src/sink_native.rs
+++ b/crates/re_analytics/src/sink_native.rs
@@ -22,6 +22,7 @@ pub enum SinkError {
     #[error("JSON: {0}")]
     Serde(#[from] serde_json::Error),
 
+    /// Usually because there is no internet.
     #[error("HTTP transport: {0}")]
     HttpTransport(Box<ureq::Transport>),
 

--- a/crates/re_log/Cargo.toml
+++ b/crates/re_log/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 log-once = "0.4"
+parking_lot.workspace = true
 
 # make sure dependencies that user tracing gets forwarded to `log`:
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/re_log/src/channel_logger.rs
+++ b/crates/re_log/src/channel_logger.rs
@@ -26,12 +26,7 @@ impl ChannelLogger {
 
 impl log::Log for ChannelLogger {
     fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        if metadata.target().starts_with("wgpu") || metadata.target().starts_with("naga") {
-            // TODO(emilk): remove once https://github.com/gfx-rs/wgpu/issues/3206 is fixed
-            return metadata.level() <= log::LevelFilter::Warn;
-        }
-
-        metadata.level() <= self.filter
+        crate::is_log_enabled(self.filter, metadata)
     }
 
     fn log(&self, record: &log::Record<'_>) {

--- a/crates/re_log/src/channel_logger.rs
+++ b/crates/re_log/src/channel_logger.rs
@@ -1,0 +1,52 @@
+//! Capture log messages and send them to some receiver over a channel.
+
+pub struct LogMsg {
+    pub level: log::Level,
+    pub msg: String,
+}
+
+/// Pipe log messages to a channel.
+pub struct ChannelLogger {
+    filter: log::LevelFilter,
+    tx: parking_lot::Mutex<std::sync::mpsc::Sender<LogMsg>>,
+}
+
+impl ChannelLogger {
+    pub fn new(filter: log::LevelFilter) -> (Self, std::sync::mpsc::Receiver<LogMsg>) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        (
+            Self {
+                filter,
+                tx: tx.into(),
+            },
+            rx,
+        )
+    }
+}
+
+impl log::Log for ChannelLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        if metadata.target().starts_with("wgpu") || metadata.target().starts_with("naga") {
+            // TODO(emilk): remove once https://github.com/gfx-rs/wgpu/issues/3206 is fixed
+            return metadata.level() <= log::LevelFilter::Warn;
+        }
+
+        metadata.level() <= self.filter
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        self.tx
+            .lock()
+            .send(LogMsg {
+                level: record.level(),
+                msg: record.args().to_string(),
+            })
+            .ok();
+    }
+
+    fn flush(&self) {}
+}

--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -23,6 +23,10 @@ pub use setup::*;
 
 pub use log::{Level, LevelFilter};
 
+mod multi_logger;
+
+pub use multi_logger::{add_boxed_logger, add_logger};
+
 #[cfg(target_arch = "wasm32")]
 mod log_web;
 
@@ -65,58 +69,10 @@ fn test_shorten_file_path() {
 
 // ----------------------------------------------------------------------------
 
-static MULTI_LOGGER: MultiLogger = MultiLogger::new();
-
-/// Install an additional global logger.
-pub fn add_boxed_logger(logger: Box<dyn log::Log>) {
-    add_logger(Box::leak(logger));
-}
-
-/// Install an additional global logger.
-pub fn add_logger(logger: &'static dyn log::Log) {
-    MULTI_LOGGER.loggers.write().push(logger);
-}
-
-/// Forward log messages to multiple [`log::log`] receivers.
-struct MultiLogger {
-    loggers: parking_lot::RwLock<Vec<&'static dyn log::Log>>,
-}
-
-impl MultiLogger {
-    pub const fn new() -> Self {
-        Self {
-            loggers: parking_lot::RwLock::new(vec![]),
-        }
-    }
-}
-
-impl log::Log for MultiLogger {
-    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        self.loggers
-            .read()
-            .iter()
-            .any(|logger| logger.enabled(metadata))
-    }
-
-    fn log(&self, record: &log::Record<'_>) {
-        for logger in self.loggers.read().iter() {
-            logger.log(record);
-        }
-    }
-
-    fn flush(&self) {
-        for logger in self.loggers.read().iter() {
-            logger.flush();
-        }
-    }
-}
-
 pub struct LogMsg {
     pub level: Level,
     pub msg: String,
 }
-
-// ----------------------------------------------------------------------------
 
 /// Pipe log messages to a channel.
 pub struct ChannelLogger {

--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -17,7 +17,7 @@ mod multi_logger;
 mod setup;
 
 #[cfg(target_arch = "wasm32")]
-mod log_web;
+mod web_logger;
 
 pub use log::{Level, LevelFilter};
 

--- a/crates/re_log/src/multi_logger.rs
+++ b/crates/re_log/src/multi_logger.rs
@@ -1,0 +1,52 @@
+//! Have multiple loggers implementing [`log::Log`] at once.
+
+static MULTI_LOGGER: MultiLogger = MultiLogger::new();
+
+/// Install the multi-logger as the default logger.
+pub fn init() -> Result<(), log::SetLoggerError> {
+    log::set_logger(&MULTI_LOGGER)
+}
+
+/// Install an additional global logger.
+pub fn add_boxed_logger(logger: Box<dyn log::Log>) {
+    add_logger(Box::leak(logger));
+}
+
+/// Install an additional global logger.
+pub fn add_logger(logger: &'static dyn log::Log) {
+    MULTI_LOGGER.loggers.write().push(logger);
+}
+
+/// Forward log messages to multiple [`log::log`] receivers.
+struct MultiLogger {
+    loggers: parking_lot::RwLock<Vec<&'static dyn log::Log>>,
+}
+
+impl MultiLogger {
+    pub const fn new() -> Self {
+        Self {
+            loggers: parking_lot::RwLock::new(vec![]),
+        }
+    }
+}
+
+impl log::Log for MultiLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        self.loggers
+            .read()
+            .iter()
+            .any(|logger| logger.enabled(metadata))
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        for logger in self.loggers.read().iter() {
+            logger.log(record);
+        }
+    }
+
+    fn flush(&self) {
+        for logger in self.loggers.read().iter() {
+            logger.flush();
+        }
+    }
+}

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -35,11 +35,14 @@ fn set_default_rust_log_env() {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn setup_native_logging() {
     set_default_rust_log_env();
-    env_logger::init();
+    log::set_max_level(log::LevelFilter::Debug);
+    log::set_logger(&crate::MULTI_LOGGER).expect("Failed to set logger");
+    crate::add_boxed_logger(Box::new(env_logger::Builder::from_env("MY_LOG").build()));
 }
 
 #[cfg(target_arch = "wasm32")]
 pub fn setup_web_logging() {
-    crate::log_web::WebLogger::init(log::LevelFilter::Debug)
-        .expect("Failed to set log subscriber.");
+    log::set_max_level(log::LevelFilter::Debug);
+    log::set_logger(&crate::MULTI_LOGGER).expect("Failed to set logger");
+    log::set_boxed_logger(Box::new(Self::new(log::LevelFilter::Debug)))
 }

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -36,13 +36,13 @@ fn set_default_rust_log_env() {
 pub fn setup_native_logging() {
     set_default_rust_log_env();
     log::set_max_level(log::LevelFilter::Debug);
-    log::set_logger(&crate::MULTI_LOGGER).expect("Failed to set logger");
-    crate::add_boxed_logger(Box::new(env_logger::Builder::from_env("MY_LOG").build()));
+    crate::multi_logger::init().expect("Failed to set logger");
+    crate::add_boxed_logger(Box::new(env_logger::Builder::from_env("RUST_LOG").build()));
 }
 
 #[cfg(target_arch = "wasm32")]
 pub fn setup_web_logging() {
     log::set_max_level(log::LevelFilter::Debug);
-    log::set_logger(&crate::MULTI_LOGGER).expect("Failed to set logger");
+    crate::multi_logger::init().expect("Failed to set logger");
     log::set_boxed_logger(Box::new(Self::new(log::LevelFilter::Debug)))
 }

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -7,21 +7,14 @@
 fn log_filter() -> String {
     let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
 
-    const LOUD_CRATES: [&str; 7] = [
-        // wgpu crates spam a lot on info level, which is really annoying
-        // TODO(emilk): remove once https://github.com/gfx-rs/wgpu/issues/3206 is fixed
-        "naga",
-        "wgpu_core",
-        "wgpu_hal",
-        // These are quite spammy on debug, drowning out what we care about:
-        "h2",
-        "hyper",
-        "rustls",
-        "ureq",
-    ];
-    for loud_crate in LOUD_CRATES {
-        if !rust_log.contains(&format!("{loud_crate}=")) {
-            rust_log += &format!(",{loud_crate}=warn");
+    for crate_name in crate::CRATES_AT_WARN_LEVEL {
+        if !rust_log.contains(&format!("{crate_name}=")) {
+            rust_log += &format!(",{crate_name}=warn");
+        }
+    }
+    for crate_name in crate::CRATES_FORCED_TO_INFO {
+        if !rust_log.contains(&format!("{crate_name}=")) {
+            rust_log += &format!(",{crate_name}=info");
         }
     }
 

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -44,5 +44,7 @@ pub fn setup_native_logging() {
 pub fn setup_web_logging() {
     log::set_max_level(log::LevelFilter::Debug);
     crate::multi_logger::init().expect("Failed to set logger");
-    log::set_boxed_logger(Box::new(Self::new(log::LevelFilter::Debug)))
+    crate::add_boxed_logger(Box::new(crate::web_logger::WebLogger::new(
+        log::LevelFilter::Debug,
+    )))
 }

--- a/crates/re_log/src/web_logger.rs
+++ b/crates/re_log/src/web_logger.rs
@@ -11,12 +11,7 @@ impl WebLogger {
 
 impl log::Log for WebLogger {
     fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        if metadata.target().starts_with("wgpu") || metadata.target().starts_with("naga") {
-            // TODO(emilk): remove once https://github.com/gfx-rs/wgpu/issues/3206 is fixed
-            return metadata.level() <= log::LevelFilter::Warn;
-        }
-
-        metadata.level() <= self.filter
+        crate::is_log_enabled(self.filter, metadata)
     }
 
     fn log(&self, record: &log::Record<'_>) {

--- a/crates/re_log/src/web_logger.rs
+++ b/crates/re_log/src/web_logger.rs
@@ -7,12 +7,6 @@ impl WebLogger {
     pub fn new(filter: log::LevelFilter) -> Self {
         Self { filter }
     }
-
-    /// Install this logger as the global logger.
-    pub fn init(filter: log::LevelFilter) -> Result<(), log::SetLoggerError> {
-        log::set_max_level(filter);
-        log::set_boxed_logger(Box::new(Self::new(filter)))
-    }
 }
 
 impl log::Log for WebLogger {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -60,7 +60,7 @@ pub struct App {
     startup_options: StartupOptions,
     re_ui: re_ui::ReUi,
 
-    /// Listenes to the local log stream
+    /// Listens to the local log stream
     text_log_rx: std::sync::mpsc::Receiver<re_log::LogMsg>,
 
     component_ui_registry: ComponentUiRegistry,


### PR DESCRIPTION
Show INFO, WARN, and ERROR in GUI as toast notifications. Otherwise users can easily miss important messages.

I've wanted to do this for a loooong time.

TODO: check if we both log and show notifications in some cases

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
