### PR TITLE
Use a patched wasm-bindgen-cli with fix for 2GiB bug

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -89,7 +89,7 @@ jobs:
           matrix+=('{"platform": "macos", "target": "x86_64-apple-darwin", "runs_on": "macos-latest"},')
           matrix+=('{"platform": "macos", "target": "aarch64-apple-darwin", "runs_on": "macos-latest"},')
           matrix+=('{"platform": "windows", "target": "x86_64-pc-windows-msvc", "runs_on": "windows-latest-8-cores"},')
-          matrix+=('{"platform": "linux", "target": "x86_64-unknown-linux-gnu", "runs_on": "ubuntu-latest-16-cores", container: {"image": "rerunio/ci_docker:0.5"}}')
+          matrix+=('{"platform": "linux", "target": "x86_64-unknown-linux-gnu", "runs_on": "ubuntu-latest-16-cores", container: {"image": "rerunio/ci_docker:0.6"}}')
 
           echo "Matrix values: ${matrix[@]}"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
 
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.5
+      image: rerunio/ci_docker:0.6
       env:
         RUSTFLAGS: ${{env.RUSTFLAGS}}
         RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS}}
@@ -89,7 +89,7 @@ jobs:
     name: Rust lints (fmt, check, cranky, tests, doc)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.5
+      image: rerunio/ci_docker:0.6
       env:
         RUSTFLAGS: ${{env.RUSTFLAGS}}
         RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS}}
@@ -193,7 +193,7 @@ jobs:
     name: Check Rust web build (wasm32 + wasm-bindgen)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.5
+      image: rerunio/ci_docker:0.6
       env:
         RUSTFLAGS: ${{env.RUSTFLAGS}}
         RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS}}
@@ -238,7 +238,7 @@ jobs:
     name: Check Rust dependencies (cargo-deny)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.5
+      image: rerunio/ci_docker:0.6
       env:
         RUSTFLAGS: ${{env.RUSTFLAGS}}
         RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS}}

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 LABEL maintainer="opensource@rerun.io"
 # Remember to update the version in publish.sh
 # TODO(jleibs) use this version in the publish.sh script and below in the CACHE_KEY
-LABEL version="0.5"
+LABEL version="0.6"
 LABEL description="Docker image used for the CI of https://github.com/rerun-io/rerun"
 
 # Install the ubuntu package dependencies
@@ -65,12 +65,12 @@ ADD rerun_py/requirements-build.txt requirements-build.txt
 RUN pip install -r requirements-build.txt
 
 # Install tools from setup_web.sh
-RUN cargo install wasm-bindgen-cli@0.2.84
+RUN cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.git --rev 13283975ddf48c2d90758095e235b28d381c5762
 # Note: We need a more modern binaryen than ships on ubuntu-20.4, so we pull it from github
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz | tar xzk --strip-components 1
 
 # Increment this to invalidate cache
-ENV CACHE_KEY=rerun_docker_v0.5
+ENV CACHE_KEY=rerun_docker_v0.6
 
 # See: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
 RUN git config --system --add safe.directory '*'

--- a/ci_docker/publish.sh
+++ b/ci_docker/publish.sh
@@ -1,4 +1,4 @@
-VERSION=0.5 # Bump on each new version. Remember to update the version in the Dockerfile too.
+VERSION=0.6 # Bump on each new version. Remember to update the version in the Dockerfile too.
 
 # The build needs to run from top of repo to access the requirements.txt
 cd `git rev-parse --show-toplevel`

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -12,7 +12,9 @@ set -x
 rustup target add wasm32-unknown-unknown
 
 # For generating JS bindings:
-cargo install wasm-bindgen-cli --version 0.2.84
+# cargo install wasm-bindgen-cli --version 0.2.84
+# We use our own patched version containing this critical fix: https://github.com/rustwasm/wasm-bindgen/pull/3310
+cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.git --rev 13283975ddf48c2d90758095e235b28d381c5762
 
 # For local tests with `start_server.sh`:
 # cargo install basic-http-server

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -14,6 +14,7 @@ rustup target add wasm32-unknown-unknown
 # For generating JS bindings:
 # cargo install wasm-bindgen-cli --version 0.2.84
 # We use our own patched version containing this critical fix: https://github.com/rustwasm/wasm-bindgen/pull/3310
+# See https://github.com/rerun-io/wasm-bindgen/commits/0.2.84-patch
 cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.git --rev 13283975ddf48c2d90758095e235b28d381c5762
 
 # For local tests with `start_server.sh`:


### PR DESCRIPTION
Uses a version of `wasm-bindgen-cli` which is `0.2.84` plus https://github.com/rustwasm/wasm-bindgen/pull/3310

See https://github.com/rerun-io/wasm-bindgen/commits/0.2.84-patch

Closes https://github.com/rerun-io/rerun/issues/1513

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
