### PR TITLE
Upload web viewer to a bucket

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -236,6 +236,10 @@ jobs:
 
   rs-build-web-viewer:
     name: Check Rust web build (wasm32 + wasm-bindgen)
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     # if: github.ref == 'refs/heads/main' # TODO: before we merge this
     runs-on: ubuntu-latest-16-cores
     container:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -235,7 +235,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   rs-build-web-viewer:
-    name: Check Rust web build (wasm32 + wasm-bindgen)
+    name: Upload web build to google cloud (wasm32 + wasm-bindgen)
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -237,10 +237,10 @@ jobs:
   rs-build-web-viewer:
     name: Upload web build to google cloud (wasm32 + wasm-bindgen)
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
 
-    # if: github.ref == 'refs/heads/main' # TODO: before we merge this
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.6

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -234,6 +234,53 @@ jobs:
 
   # ---------------------------------------------------------------------------
 
+  rs-build-web-viewer:
+    name: Check Rust web build (wasm32 + wasm-bindgen)
+    # if: github.ref == 'refs/heads/main' # TODO: before we merge this
+    runs-on: ubuntu-latest-16-cores
+    container:
+      image: rerunio/ci_docker:0.5
+      env:
+        RUSTFLAGS: ${{env.RUSTFLAGS}}
+        RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS}}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.67.0
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST CACHE_KEY
+          # See: https://github.com/rerun-io/rerun/pull/497
+          save-if: ${{ github.event_name == 'push'}}
+
+      - name: Build web-viewer (release)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --locked -p re_build_web_viewer -- --release
+
+      # Upload the wasm, html etc to a Google cloud bucket:
+      - id: "auth"
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: "projects/11779445316/locations/global/workloadIdentityPools/rerun-github-actions-ci/providers/github"
+          service_account: "github-actions-ci@rerun-open.iam.gserviceaccount.com"
+
+      - id: "upload-folder"
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "web_viewer"
+          destination: "rerun-web-viewer"
+
+  # ---------------------------------------------------------------------------
+
   rs-cargo-deny:
     name: Check Rust dependencies (cargo-deny)
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,7 +247,7 @@ jobs:
       contents: "read"
       id-token: "write"
 
-    if: github.ref == 'refs/heads/main' || github.event.inputs.force_update_web_build
+    #if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event.inputs.force_update_web_build
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.6
@@ -281,14 +281,26 @@ jobs:
       - id: "auth"
         uses: google-github-actions/auth@v1
         with:
-          workload_identity_provider: "projects/11779445316/locations/global/workloadIdentityPools/rerun-github-actions-ci/providers/github"
-          service_account: "github-actions-ci@rerun-open.iam.gserviceaccount.com"
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
-      - id: "upload-folder"
+      - name: Add SHORT_SHA env property with commit short sha
+        run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-8`" >> $GITHUB_ENV
+
+      - name: "Upload web-viewer"
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "web_viewer"
-          destination: "rerun-web-viewer"
+          destination: "rerun-web-viewer/commit/${{env.SHORT_SHA}}"
+          parent: false
+
+      - name: "Upload web-viewer (tagged)"
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "web_viewer"
+          destination: "rerun-web-viewer/version/${{github.ref_name}}"
+          parent: false
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - "main"
   pull_request:
+  workflow_dispatch:
+    inputs:
+      force_update_web_build:
+        description: "Upload web build to google cloud"
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }} # Cancel previous CI jobs on the same branch
@@ -240,7 +247,7 @@ jobs:
       contents: "read"
       id-token: "write"
 
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event.inputs.force_update_web_build
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.6

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,7 +243,7 @@ jobs:
     # if: github.ref == 'refs/heads/main' # TODO: before we merge this
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.5
+      image: rerunio/ci_docker:0.6
       env:
         RUSTFLAGS: ${{env.RUSTFLAGS}}
         RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS}}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,7 +247,7 @@ jobs:
       contents: "read"
       id-token: "write"
 
-    #if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event.inputs.force_update_web_build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event.inputs.force_update_web_build
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.6


### PR DESCRIPTION
Each merge to `main` will produce a web-viewer which is pushed to a google cloud bucket, which can be tested with:

<https://storage.googleapis.com/rerun-web-viewer/web_viewer/index.html?url=https://storage.googleapis.com/rerun-example-rrd/test-rrd/fiat.rrd>

Part of https://github.com/rerun-io/rerun/issues/1494

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
