### PR TITLE
Adapt UI for smaller screens

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -683,3 +683,8 @@ pub fn native_window_buttons_ui(frame: &mut eframe::Frame, ui: &mut egui::Ui) {
         frame.set_minimized(true);
     }
 }
+
+/// Is this a small-screen device?
+pub fn is_mobile(ctx: &egui::Context) -> bool {
+    ctx.screen_rect().width() < 500.0
+}

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1039,7 +1039,7 @@ fn top_panel(
         });
 }
 
-fn rerun_menu_button_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame, app: &mut App) {
+fn rerun_menu_button_ui(ui: &mut egui::Ui, frame: &mut eframe::Frame, app: &mut App) {
     // let desired_icon_height = ui.max_rect().height() - 2.0 * ui.spacing_mut().button_padding.y;
     let desired_icon_height = ui.max_rect().height() - 4.0; // TODO(emilk): figure out this fudge
     let desired_icon_height = desired_icon_height.at_most(28.0); // figma size 2023-02-03
@@ -1101,7 +1101,7 @@ fn rerun_menu_button_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame, app: &mut
         });
 
         ui.menu_button("Options", |ui| {
-            options_menu_ui(ui, &mut app.state.app_options);
+            options_menu_ui(ui, frame, &mut app.state.app_options);
         });
 
         ui.add_space(spacing);
@@ -1515,7 +1515,7 @@ fn recordings_menu(ui: &mut egui::Ui, app: &mut App) {
     }
 }
 
-fn options_menu_ui(ui: &mut egui::Ui, options: &mut AppOptions) {
+fn options_menu_ui(ui: &mut egui::Ui, frame: &mut eframe::Frame, options: &mut AppOptions) {
     ui.style_mut().wrap = Some(false);
 
     if ui
@@ -1530,45 +1530,58 @@ fn options_menu_ui(ui: &mut egui::Ui, options: &mut AppOptions) {
     {
         ui.separator();
         ui.label("Debug:");
-        debug_menu_options_ui(ui);
+        debug_menu_options_ui(ui, frame);
     }
 }
 
 #[cfg(debug_assertions)]
-fn debug_menu_options_ui(ui: &mut egui::Ui) {
-    let mut debug = ui.style().debug;
-    let mut any_clicked = false;
+fn debug_menu_options_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    {
+        let mut debug = ui.style().debug;
+        let mut any_clicked = false;
 
-    any_clicked |= ui
-        .checkbox(&mut debug.debug_on_hover, "Ui debug on hover")
-        .on_hover_text("However over widgets to see their rectangles")
-        .changed();
-    any_clicked |= ui
-        .checkbox(&mut debug.show_expand_width, "Show expand width")
-        .on_hover_text("Show which widgets make their parent wider")
-        .changed();
-    any_clicked |= ui
-        .checkbox(&mut debug.show_expand_height, "Show expand height")
-        .on_hover_text("Show which widgets make their parent higher")
-        .changed();
-    any_clicked |= ui.checkbox(&mut debug.show_resize, "Show resize").changed();
-    any_clicked |= ui
-        .checkbox(
-            &mut debug.show_interactive_widgets,
-            "Show interactive widgets",
-        )
-        .on_hover_text("Show an overlay on all interactive widgets.")
-        .changed();
-    // This option currently causes the viewer to hang.
-    // any_clicked |= ui
-    //     .checkbox(&mut debug.show_blocking_widget, "Show blocking widgets")
-    //     .on_hover_text("Show what widget blocks the interaction of another widget.")
-    //     .changed();
+        any_clicked |= ui
+            .checkbox(&mut debug.debug_on_hover, "Ui debug on hover")
+            .on_hover_text("However over widgets to see their rectangles")
+            .changed();
+        any_clicked |= ui
+            .checkbox(&mut debug.show_expand_width, "Show expand width")
+            .on_hover_text("Show which widgets make their parent wider")
+            .changed();
+        any_clicked |= ui
+            .checkbox(&mut debug.show_expand_height, "Show expand height")
+            .on_hover_text("Show which widgets make their parent higher")
+            .changed();
+        any_clicked |= ui.checkbox(&mut debug.show_resize, "Show resize").changed();
+        any_clicked |= ui
+            .checkbox(
+                &mut debug.show_interactive_widgets,
+                "Show interactive widgets",
+            )
+            .on_hover_text("Show an overlay on all interactive widgets.")
+            .changed();
+        // This option currently causes the viewer to hang.
+        // any_clicked |= ui
+        //     .checkbox(&mut debug.show_blocking_widget, "Show blocking widgets")
+        //     .on_hover_text("Show what widget blocks the interaction of another widget.")
+        //     .changed();
 
-    if any_clicked {
-        let mut style = (*ui.ctx().style()).clone();
-        style.debug = debug;
-        ui.ctx().set_style(style);
+        if any_clicked {
+            let mut style = (*ui.ctx().style()).clone();
+            style.debug = debug;
+            ui.ctx().set_style(style);
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        ui.separator();
+        if ui.button("Mobile size").clicked() {
+            // frame.set_window_size(egui::vec2(375.0, 812.0)); // iPhone 12 mini
+            _frame.set_window_size(egui::vec2(375.0, 667.0)); //  iPhone SE 2nd gen
+            _frame.set_fullscreen(false);
+            ui.close_menu();
+        }
     }
 
     ui.separator();

--- a/crates/re_viewer/src/misc/time_control_ui.rs
+++ b/crates/re_viewer/src/misc/time_control_ui.rs
@@ -6,19 +6,11 @@ use re_log_types::TimeType;
 use super::time_control::{Looping, PlayState, TimeControl};
 
 impl TimeControl {
-    pub fn time_control_ui(
+    pub fn timeline_selector_ui(
         &mut self,
-        re_ui: &re_ui::ReUi,
         times_per_timeline: &TimesPerTimeline,
         ui: &mut egui::Ui,
     ) {
-        self.play_pause_ui(re_ui, times_per_timeline, ui);
-        self.timeline_selector_ui(times_per_timeline, ui);
-        self.playback_speed_ui(ui);
-        self.fps_ui(ui);
-    }
-
-    fn timeline_selector_ui(&mut self, times_per_timeline: &TimesPerTimeline, ui: &mut egui::Ui) {
         self.select_a_valid_timeline(times_per_timeline);
 
         egui::ComboBox::from_id_source("timeline")
@@ -38,7 +30,7 @@ impl TimeControl {
             });
     }
 
-    fn fps_ui(&mut self, ui: &mut egui::Ui) {
+    pub fn fps_ui(&mut self, ui: &mut egui::Ui) {
         if self.time_type() == TimeType::Sequence {
             if let Some(mut fps) = self.fps() {
                 ui.add(
@@ -53,7 +45,7 @@ impl TimeControl {
         }
     }
 
-    fn play_pause_ui(
+    pub fn play_pause_ui(
         &mut self,
         re_ui: &re_ui::ReUi,
         times_per_timeline: &TimesPerTimeline,
@@ -178,7 +170,7 @@ impl TimeControl {
         });
     }
 
-    fn playback_speed_ui(&mut self, ui: &mut egui::Ui) {
+    pub fn playback_speed_ui(&mut self, ui: &mut egui::Ui) {
         let mut speed = self.speed();
         let drag_speed = (speed * 0.02).at_least(0.01);
         ui.add(

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -9,7 +9,7 @@ type AppCreator =
 pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
     let native_options = eframe::NativeOptions {
         initial_window_size: Some([1600.0, 1200.0].into()),
-        min_window_size: Some([600.0, 450.0].into()), // Should be high enough to fit the rerun menu
+        min_window_size: Some([300.0, 450.0].into()), // Should be high enough to fit the rerun menu
 
         #[cfg(target_os = "macos")]
         fullsize_content: re_ui::FULLSIZE_CONTENT,

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -9,7 +9,7 @@ type AppCreator =
 pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
     let native_options = eframe::NativeOptions {
         initial_window_size: Some([1600.0, 1200.0].into()),
-        min_window_size: Some([300.0, 450.0].into()), // Should be high enough to fit the rerun menu
+        min_window_size: Some([320.0, 450.0].into()), // Should be high enough to fit the rerun menu
 
         #[cfg(target_os = "macos")]
         fullsize_content: re_ui::FULLSIZE_CONTENT,

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -16,11 +16,11 @@ pub struct Blueprint {
 impl Blueprint {
     /// Prefer this to [`Blueprint::default`] to get better defaults based on screen size.
     pub fn new(egui_ctx: &egui::Context) -> Self {
-        let is_mobile = re_ui::is_mobile(egui_ctx);
+        let screen_size = egui_ctx.screen_rect().size();
         Self {
-            blueprint_panel_expanded: !is_mobile,
-            selection_panel_expanded: !is_mobile,
-            time_panel_expanded: !is_mobile,
+            blueprint_panel_expanded: screen_size.x > 750.0,
+            selection_panel_expanded: screen_size.x > 1000.0,
+            time_panel_expanded: screen_size.y > 550.0,
             viewport: Default::default(),
         }
     }

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -52,6 +52,8 @@ impl Blueprint {
         ui: &mut egui::Ui,
         spaces_info: &SpaceInfoCollection,
     ) {
+        let screen_width = ui.ctx().screen_rect().width();
+
         let panel = egui::SidePanel::left("blueprint_panel")
             .resizable(true)
             .frame(egui::Frame {
@@ -59,7 +61,7 @@ impl Blueprint {
                 ..Default::default()
             })
             .min_width(120.0)
-            .default_width(200.0);
+            .default_width((0.35 * screen_width).min(200.0).round());
 
         panel.show_animated_inside(ui, self.blueprint_panel_expanded, |ui: &mut egui::Ui| {
             self.title_bar_ui(ctx, ui, spaces_info);

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -3,7 +3,7 @@ use crate::misc::{space_info::SpaceInfoCollection, ViewerContext};
 use super::viewport::Viewport;
 
 /// Defines the layout of the whole Viewer (or will, eventually).
-#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(Default, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct Blueprint {
     pub blueprint_panel_expanded: bool,
@@ -13,18 +13,18 @@ pub struct Blueprint {
     pub viewport: Viewport,
 }
 
-impl Default for Blueprint {
-    fn default() -> Self {
+impl Blueprint {
+    /// Prefer this to [`Blueprint::default`] to get better defaults based on screen size.
+    pub fn new(egui_ctx: &egui::Context) -> Self {
+        let is_mobile = re_ui::is_mobile(egui_ctx);
         Self {
-            blueprint_panel_expanded: true,
-            selection_panel_expanded: true,
-            time_panel_expanded: true,
+            blueprint_panel_expanded: !is_mobile,
+            selection_panel_expanded: !is_mobile,
+            time_panel_expanded: !is_mobile,
             viewport: Default::default(),
         }
     }
-}
 
-impl Blueprint {
     pub fn blueprint_panel_and_viewport(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         crate::profile_function!();
 

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -20,7 +20,7 @@ impl Blueprint {
         Self {
             blueprint_panel_expanded: screen_size.x > 750.0,
             selection_panel_expanded: screen_size.x > 1000.0,
-            time_panel_expanded: screen_size.y > 550.0,
+            time_panel_expanded: screen_size.y > 600.0,
             viewport: Default::default(),
         }
     }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -29,9 +29,12 @@ impl SelectionPanel {
         ui: &mut egui::Ui,
         blueprint: &mut Blueprint,
     ) {
+        let screen_width = ui.ctx().screen_rect().width();
+
         let panel = egui::SidePanel::right("selection_view")
             .min_width(120.0)
-            .default_width(250.0)
+            .default_width((0.45 * screen_width).min(250.0).round())
+            .max_width((0.65 * screen_width).round())
             .resizable(true)
             .frame(egui::Frame {
                 fill: ui.style().visuals.panel_fill,

--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -188,13 +188,16 @@ impl TimePanel {
 
         self.next_col_right = ui.min_rect().left(); // next_col_right will expand during the call
 
-        let time_x_left = ui.min_rect().left() + self.prev_col_width + ui.spacing().item_spacing.x;
+        let time_x_left =
+            (ui.min_rect().left() + self.prev_col_width + ui.spacing().item_spacing.x)
+                .at_most(ui.max_rect().right() - 100.0);
 
         // Where the time will be shown.
         let time_bg_x_range = time_x_left..=ui.max_rect().right();
         let time_fg_x_range = {
             // Painting to the right of the scroll bar (if any) looks bad:
             let right = ui.max_rect().right() - ui.spacing_mut().scroll_bar_outer_margin;
+            debug_assert!(time_x_left < right);
             time_x_left..=right
         };
 

--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -144,18 +144,17 @@ impl TimePanel {
             // Narrow screen, e.g. mobile. Split the controls into two rows.
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
-                    let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
-                    let times_per_timeline = ctx.log_db.times_per_timeline();
-                    time_ctrl.timeline_selector_ui(times_per_timeline, ui);
-                    collapsed_time_marker_and_time(ui, ctx);
-                });
-                ui.horizontal(|ui| {
                     let re_ui = &ctx.re_ui;
                     let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
                     let times_per_timeline = ctx.log_db.times_per_timeline();
                     time_ctrl.play_pause_ui(re_ui, times_per_timeline, ui);
                     time_ctrl.playback_speed_ui(ui);
                     time_ctrl.fps_ui(ui);
+                });
+                ui.horizontal(|ui| {
+                    let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
+                    time_ctrl.timeline_selector_ui(ctx.log_db.times_per_timeline(), ui);
+                    collapsed_time_marker_and_time(ui, ctx);
                 });
             });
         } else {
@@ -629,7 +628,30 @@ fn paint_streams_guide_line(
 fn top_row_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
     ui.spacing_mut().item_spacing.x = 18.0; // from figma
 
-    {
+    if ui.max_rect().width() < 600.0 {
+        // Narrow screen, e.g. mobile. Split the controls into two rows.
+        ui.vertical(|ui| {
+            ui.horizontal(|ui| {
+                let re_ui = &ctx.re_ui;
+                let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
+                let times_per_timeline = ctx.log_db.times_per_timeline();
+                time_ctrl.play_pause_ui(re_ui, times_per_timeline, ui);
+                time_ctrl.playback_speed_ui(ui);
+                time_ctrl.fps_ui(ui);
+            });
+            ui.horizontal(|ui| {
+                let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
+                time_ctrl.timeline_selector_ui(ctx.log_db.times_per_timeline(), ui);
+
+                current_time_ui(ctx, ui);
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    help_button(ui);
+                });
+            });
+        });
+    } else {
+        // One row:
         let re_ui = &ctx.re_ui;
         let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
         let times_per_timeline = ctx.log_db.times_per_timeline();
@@ -638,13 +660,12 @@ fn top_row_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         time_ctrl.timeline_selector_ui(times_per_timeline, ui);
         time_ctrl.playback_speed_ui(ui);
         time_ctrl.fps_ui(ui);
+        current_time_ui(ctx, ui);
+
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            help_button(ui);
+        });
     }
-
-    current_time_ui(ctx, ui);
-
-    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-        help_button(ui);
-    });
 }
 
 fn help_button(ui: &mut egui::Ui) {

--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -68,17 +68,21 @@ impl TimePanel {
             panel_frame.inner_margin.right = 0.0;
         }
 
+        let screen_height = ui.ctx().screen_rect().width();
+
         let collapsed = egui::TopBottomPanel::bottom("time_panel_collapsed")
             .resizable(false)
             .show_separator_line(false)
             .frame(panel_frame)
-            .default_height(16.0);
+            .default_height(44.0);
+
+        let min_height = 150.0;
         let expanded = egui::TopBottomPanel::bottom("time_panel_expanded")
             .resizable(true)
             .show_separator_line(false)
             .frame(panel_frame)
-            .min_height(150.0)
-            .default_height(250.0);
+            .min_height(min_height)
+            .default_height((0.25 * screen_height).clamp(min_height, 250.0).round());
 
         egui::TopBottomPanel::show_animated_between_inside(
             ui,

--- a/crates/re_viewer/src/ui/time_panel/time_ranges_ui.rs
+++ b/crates/re_viewer/src/ui/time_panel/time_ranges_ui.rs
@@ -101,6 +101,8 @@ impl TimeRangesUi {
     ) -> Self {
         crate::profile_function!();
 
+        debug_assert!(x_range.start() < x_range.end());
+
         //        <------- time_view ------>
         //        <-------- x_range ------->
         //        |                        |


### PR DESCRIPTION
Some low-hanging fruit to make the UI more usable on small screens (e.g. mobile web).

![image](https://user-images.githubusercontent.com/1148717/226100406-2dbe7ca1-18fc-4330-afe3-cea5163f9c95.png)

Future work:
* Fix the Rerun menu
* Fix hover tooltips
* Always show the blueprint buttons on touch screens (instead of "hover to reveal them")

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
