### PR TITLE
Misc: make example in `log_pinhole` runable

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log/camera.py
+++ b/rerun_py/rerun_sdk/rerun/log/camera.py
@@ -39,8 +39,8 @@ def log_pinhole(
     f_len = (height * width) ** 0.5
 
     rerun.log_pinhole("world/camera/image",
-                      child_from_parent = [[f_len, 0,     u_c],
-                                           [0,     f_len, v_c],
+                      child_from_parent = [[f_len, 0,     u_cen],
+                                           [0,     f_len, v_cen],
                                            [0,     0,     1  ]],
                       width = width,
                       height = height)


### PR DESCRIPTION
Small fix to make the example in `log_pinhole` runable.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~I've included a screenshot or gif (if applicable)~ not applicable

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
