### PR TITLE
Handle ctrl+c to gracefully shutdown the server(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4156,6 +4156,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "ctrlc",
  "document-features",
  "futures-util",
  "glob",
@@ -4245,6 +4246,7 @@ dependencies = [
  "backtrace",
  "clap 4.1.4",
  "crossbeam",
+ "ctrlc",
  "document-features",
  "egui",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ arrow2 = "0.16"
 arrow2_convert = "0.4.2"
 clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }
+ctrlc = { version = "3.0", features = ["termination"] }
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = "0.21.0"

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -111,7 +111,7 @@ wgpu.workspace = true
 arboard = { version = "3.2", default-features = false, features = [
   "image-data",
 ] }
-ctrlc = { version = "3.0", features = ["termination"] }
+ctrlc.workspace = true
 puffin_http = "0.11"
 puffin.workspace = true
 

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -39,6 +39,7 @@ analytics = ["dep:re_analytics"]
 re_log.workspace = true
 
 anyhow.workspace = true
+ctrlc.workspace = true
 document-features = "0.2"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -157,8 +157,15 @@ impl WebViewerServer {
         Self { server }
     }
 
-    pub async fn serve(self) -> anyhow::Result<()> {
-        self.server.await?;
+    pub async fn serve(
+        self,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    ) -> anyhow::Result<()> {
+        self.server
+            .with_graceful_shutdown(async {
+                shutdown_rx.recv().await.ok();
+            })
+            .await?;
         Ok(())
     }
 }

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -6,8 +6,17 @@ async fn main() {
     re_log::setup_native_logging();
     let port = 9090;
     eprintln!("Hosting web-viewer on http://127.0.0.1:{port}");
+
+    // Shutdown server via Ctrl+C
+    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+    ctrlc::set_handler(move || {
+        re_log::debug!("Ctrl-C detected - Closing server.");
+        shutdown_tx.send(()).unwrap();
+    })
+    .expect("Error setting Ctrl-C handler");
+
     re_web_viewer_server::WebViewerServer::new(port)
-        .serve()
+        .serve(shutdown_rx)
         .await
         .unwrap();
 }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -41,14 +41,25 @@ impl Server {
     }
 
     /// Accept new connections forever
-    pub async fn listen(self, rx: Receiver<LogMsg>) -> anyhow::Result<()> {
+    pub async fn listen(
+        self,
+        rx: Receiver<LogMsg>,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    ) -> anyhow::Result<()> {
         use anyhow::Context as _;
 
         let history = Arc::new(Mutex::new(Vec::new()));
 
         let log_stream = to_broadcast_stream(rx, history.clone());
 
-        while let Ok((tcp_stream, _)) = self.listener.accept().await {
+        loop {
+            let (tcp_stream, _) = tokio::select! {
+                res = self.listener.accept() => res?,
+                _ = shutdown_rx.recv() => {
+                    return Ok(());
+                }
+            };
+
             let peer = tcp_stream
                 .peer_addr()
                 .context("connected streams should have a peer address")?;
@@ -59,8 +70,6 @@ impl Server {
                 history.clone(),
             ));
         }
-
-        Ok(())
     }
 }
 

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -97,6 +97,7 @@ backtrace = "0.3"
 clap = { workspace = true, features = ["derive"] }
 mimalloc.workspace = true
 puffin_http = "0.11"
+ctrlc.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # Native unix dependencies:

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -6,6 +6,8 @@ use re_log_types::LogMsg;
 struct RemoteViewerServer {
     web_server_join_handle: tokio::task::JoinHandle<()>,
     sender: re_smart_channel::Sender<LogMsg>,
+    #[allow(dead_code)] // Unused currently, but can be used later to cancel a serve.
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
 }
 
 impl Drop for RemoteViewerServer {
@@ -18,38 +20,56 @@ impl Drop for RemoteViewerServer {
 impl RemoteViewerServer {
     pub fn new(tokio_rt: &tokio::runtime::Runtime, open_browser: bool) -> Self {
         let (rerun_tx, rerun_rx) = re_smart_channel::smart_channel(re_smart_channel::Source::Sdk);
+        let (shutdown_tx, shutdown_rx_ws_server) = tokio::sync::broadcast::channel(1);
+        let shutdown_rx_web_server = shutdown_tx.subscribe();
 
         let web_server_join_handle = tokio_rt.spawn(async move {
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::Server::new(re_ws_comms::DEFAULT_WS_SERVER_PORT)
                 .await
                 .unwrap();
-            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx)); // TODO(emilk): use tokio_rt ?
+            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx, shutdown_rx_ws_server)); // TODO(emilk): use tokio_rt ?
 
             // This is the server that serves the Wasm+HTML:
-            let web_port = 9090;
-            let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
-            let web_server_handle = tokio::spawn(async move {
-                web_server.serve().await.unwrap();
-            });
-
             let ws_server_url = re_ws_comms::default_server_url();
-            let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
-            if open_browser {
-                webbrowser::open(&viewer_url).ok();
-            } else {
-                re_log::info!("Web server is running - view it at {viewer_url}");
-            }
+            let web_server_handle = tokio::spawn(host_web_viewer(
+                open_browser,
+                ws_server_url,
+                shutdown_rx_web_server,
+            ));
 
             ws_server_handle.await.unwrap().unwrap();
-            web_server_handle.await.unwrap();
+            web_server_handle.await.unwrap().unwrap();
         });
 
         Self {
             web_server_join_handle,
             sender: rerun_tx,
+            shutdown_tx,
         }
     }
+}
+
+/// Start a web server for localhost and optionally spawns a browser to view it.
+#[cfg(feature = "web_viewer")]
+pub async fn host_web_viewer(
+    open_browser: bool,
+    ws_server_url: String,
+    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) -> anyhow::Result<()> {
+    let web_port = 9090;
+    let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
+
+    let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
+    let web_server_handle = tokio::spawn(web_server.serve(shutdown_rx));
+
+    if open_browser {
+        webbrowser::open(&viewer_url).ok();
+    } else {
+        re_log::info!("Web server is running - view it at {viewer_url}");
+    }
+
+    web_server_handle.await?
 }
 
 impl crate::sink::LogSink for RemoteViewerServer {

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -18,9 +18,7 @@ rr.script_teardown(args)
 ```
 
 """
-import contextlib
 from argparse import ArgumentParser, Namespace
-from time import sleep
 
 import rerun as rr
 
@@ -93,6 +91,10 @@ def script_teardown(args: Namespace) -> None:
 
     """
     if args.serve:
+        from threading import Event
+        import signal
+
+        exit = Event()
+        signal.signal(signal.SIGINT, lambda sig, frame: exit.set())
         print("Sleeping while serving the web viewer. Abort with Ctrl-C")
-        with contextlib.suppress(Exception):
-            sleep(1_000_000_000)
+        exit.wait()


### PR DESCRIPTION
Fixes 
* #1520
* #1367

Tried to use tokio's ctrl-c detection but ran into issues with it, so used the ctrlc crate we already depend on and got it working nicely with that.

Tested ctrl'c'ing with:

Serving
* `cargo run -p rerun --features web_viewer -- ../api_demo.rrd --web-viewer`
* `python ./examples/python/api_demo/main.py --serve`
* `cargo run -p re_web_viewer_server`

Not serving, just to see if something else broke
* `python ./examples/python/tracking_hf_opencv/main.py`
* `cargo run -p api_demo`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)