### PR TITLE
Nicer toast notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,15 +1302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui-notify"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa87d2d91ebea916ae30837068f869f9b91242107f86f6abc3f085fbd160e195"
-dependencies = [
- "egui",
-]
-
-[[package]]
 name = "egui-wgpu"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,7 +4088,6 @@ dependencies = [
  "ctrlc",
  "eframe",
  "egui",
- "egui-notify",
  "egui-wgpu",
  "egui_dock",
  "egui_extras",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,6 +4068,7 @@ dependencies = [
  "egui_extras",
  "image",
  "parking_lot 0.12.1",
+ "re_log",
  "serde",
  "serde_json",
  "strum 0.24.1",

--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use arrow2::array::{Array, ListArray};
-use re_log::{info, trace};
+
+use re_log::trace;
 use re_log_types::{ComponentName, TimeRange, Timeline};
 
 use crate::{ComponentBucket, DataStore};
@@ -59,7 +60,7 @@ impl DataStore {
                 let drop_at_least_size_bytes = initial_size_bytes * p;
                 let target_size_bytes = initial_size_bytes - drop_at_least_size_bytes;
 
-                info!(
+                re_log::debug!(
                     kind = "gc",
                     id = self.gc_id,
                     %target,
@@ -86,7 +87,7 @@ impl DataStore {
         let new_nb_rows = self.total_temporal_component_rows();
         let new_size_bytes = self.total_temporal_component_size_bytes() as f64;
 
-        info!(
+        re_log::debug!(
             kind = "gc",
             id = self.gc_id,
             %target,

--- a/crates/re_log/src/channel_logger.rs
+++ b/crates/re_log/src/channel_logger.rs
@@ -1,7 +1,13 @@
 //! Capture log messages and send them to some receiver over a channel.
 
 pub struct LogMsg {
+    /// The verbosity level.
     pub level: log::Level,
+
+    /// The module, starting with the crate name.
+    pub target: String,
+
+    /// The contents of the log message.
     pub msg: String,
 }
 
@@ -38,6 +44,7 @@ impl log::Log for ChannelLogger {
             .lock()
             .send(LogMsg {
                 level: record.level(),
+                target: record.target().to_owned(),
                 msg: record.args().to_string(),
             })
             .ok();

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -38,7 +38,7 @@ pub fn serve(port: u16, options: ServerOptions) -> anyhow::Result<Receiver<LogMs
     let bind_addr = format!("0.0.0.0:{port}");
 
     let listener = std::net::TcpListener::bind(&bind_addr)
-        .with_context(|| format!("Failed to bind address {bind_addr:?}"))?;
+        .with_context(|| format!("Failed to bind TCP address {bind_addr:?} for our WS server."))?;
 
     let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::TcpServer { port });
 

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -46,3 +46,4 @@ egui_dock = { workspace = true, optional = true, features = ["serde"] }
 
 [dev-dependencies]
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }
+re_log.workspace = true

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -79,7 +79,12 @@ impl ExampleApp {
 
     /// Show recent text log messages to the user as toast notifications.
     fn show_text_logs_as_notifications(&mut self) {
-        while let Ok(re_log::LogMsg { level, msg }) = self.text_log_rx.try_recv() {
+        while let Ok(re_log::LogMsg {
+            level,
+            target: _,
+            msg,
+        }) = self.text_log_rx.try_recv()
+        {
             let kind = match level {
                 re_log::Level::Error => toasts::ToastKind::Error,
                 re_log::Level::Warn => toasts::ToastKind::Warning,

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -5,6 +5,7 @@ mod command_palette;
 mod design_tokens;
 pub mod icons;
 mod static_image_cache;
+pub mod toasts;
 mod toggle_switch;
 
 pub use command::Command;

--- a/crates/re_ui/src/toasts.rs
+++ b/crates/re_ui/src/toasts.rs
@@ -1,0 +1,152 @@
+///! A toast notification system for egui, roughly based on <https://github.com/urholaukkarinen/egui-toast>.
+use std::collections::HashMap;
+
+use egui::{Color32, NumExt as _};
+
+pub const INFO_COLOR: Color32 = Color32::from_rgb(0, 155, 255);
+pub const WARNING_COLOR: Color32 = Color32::from_rgb(255, 212, 0);
+pub const ERROR_COLOR: Color32 = Color32::from_rgb(255, 32, 0);
+pub const SUCCESS_COLOR: Color32 = Color32::from_rgb(0, 255, 32);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ToastKind {
+    Info,
+    Warning,
+    Error,
+    Success,
+    Custom(u32),
+}
+
+#[derive(Clone)]
+pub struct Toast {
+    pub kind: ToastKind,
+    pub text: String,
+    pub options: ToastOptions,
+}
+
+#[derive(Copy, Clone)]
+pub struct ToastOptions {
+    /// This can be used to show or hide the toast type icon.
+    pub show_icon: bool,
+
+    /// Time to live in seconds.
+    pub ttl_sec: f64,
+}
+
+impl ToastOptions {
+    pub fn with_ttl_in_seconds(ttl_sec: f64) -> Self {
+        Self {
+            show_icon: true,
+            ttl_sec,
+        }
+    }
+}
+
+impl Toast {
+    pub fn close(&mut self) {
+        self.options.ttl_sec = 0.0;
+    }
+}
+
+pub type ToastContents = dyn Fn(&mut egui::Ui, &mut Toast) -> egui::Response;
+
+pub struct Toasts {
+    id: egui::Id,
+    custom_toast_contents: HashMap<ToastKind, Box<ToastContents>>,
+    toasts: Vec<Toast>,
+}
+
+impl Default for Toasts {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Toasts {
+    pub fn new() -> Self {
+        Self {
+            id: egui::Id::new("__toasts"),
+            custom_toast_contents: Default::default(),
+            toasts: Vec::new(),
+        }
+    }
+
+    /// Adds a new toast
+    pub fn add(&mut self, toast: Toast) -> &mut Self {
+        self.toasts.push(toast);
+        self
+    }
+
+    /// Shows and updates all toasts
+    pub fn show(&mut self, ctx: &egui::Context) {
+        let Self {
+            id,
+            custom_toast_contents,
+            toasts,
+        } = self;
+
+        let dt = ctx.input(|i| i.stable_dt).at_most(0.1) as f64;
+
+        toasts.retain(|toast| 0.0 < toast.options.ttl_sec);
+
+        let mut offset = egui::vec2(-8.0, 8.0);
+
+        for (i, toast) in toasts.iter_mut().enumerate() {
+            let response = egui::Area::new(id.with(i))
+                .anchor(egui::Align2::RIGHT_TOP, offset)
+                .order(egui::Order::Foreground)
+                .interactable(true)
+                .movable(false)
+                .show(ctx, |ui| {
+                    if let Some(add_contents) = custom_toast_contents.get_mut(&toast.kind) {
+                        add_contents(ui, toast);
+                    } else {
+                        default_toast_contents(ui, toast);
+                    };
+                })
+                .response;
+
+            if !response.hovered() {
+                toast.options.ttl_sec -= dt;
+                if toast.options.ttl_sec.is_finite() {
+                    ctx.request_repaint();
+                }
+            }
+
+            offset.y += response.rect.height() + 8.0;
+        }
+    }
+}
+
+fn default_toast_contents(ui: &mut egui::Ui, toast: &mut Toast) -> egui::Response {
+    egui::Frame::window(ui.style())
+        .inner_margin(10.0)
+        .show(ui, |ui| {
+            let clicked = ui
+                .horizontal(|ui| {
+                    ui.style_mut().wrap = Some(true);
+                    ui.set_max_width(400.0);
+                    ui.spacing_mut().item_spacing = egui::Vec2::splat(5.0);
+
+                    if toast.options.show_icon {
+                        let (icon, icon_color) = match toast.kind {
+                            ToastKind::Warning => ("⚠", WARNING_COLOR),
+                            ToastKind::Error => ("❗", ERROR_COLOR),
+                            ToastKind::Success => ("✔", SUCCESS_COLOR),
+                            _ => ("ℹ", INFO_COLOR),
+                        };
+                        ui.label(egui::RichText::new(icon).color(icon_color));
+                    }
+                    ui.label(toast.text.clone());
+                })
+                .response
+                .interact(egui::Sense::click())
+                .clicked();
+
+            if clicked {
+                ui.output_mut(|o| o.copied_text = toast.text.clone());
+                toast.close();
+            }
+        })
+        .response
+}

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -75,7 +75,6 @@ eframe = { workspace = true, default-features = false, features = [
 egui = { workspace = true, features = ["extra_debug_asserts", "tracing"] }
 egui_dock = { workspace = true, features = ["serde"] }
 egui_extras = { workspace = true, features = ["tracing"] }
-egui-notify = "0.6"
 egui-wgpu.workspace = true
 ehttp = "0.2"
 enumset.workspace = true

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -2,7 +2,6 @@ use std::{any::Any, hash::Hash};
 
 use ahash::HashMap;
 use egui::NumExt as _;
-use egui_notify::Toasts;
 use instant::Instant;
 use itertools::Itertools as _;
 use nohash_hasher::IntMap;
@@ -14,7 +13,7 @@ use re_format::format_number;
 use re_log_types::{ApplicationId, LogMsg, RecordingId};
 use re_renderer::WgpuResourcePoolStatistics;
 use re_smart_channel::Receiver;
-use re_ui::Command;
+use re_ui::{toasts, Command};
 
 use crate::{
     app_icon::setup_app_icon,
@@ -80,8 +79,8 @@ pub struct App {
     /// Pending background tasks, using `poll_promise`.
     pending_promises: HashMap<String, Promise<Box<dyn Any + Send>>>,
 
-    /// Toast notifications, using `egui-notify`.
-    toasts: Toasts,
+    /// Toast notifications.
+    toasts: toasts::Toasts,
 
     latest_memory_purge: instant::Instant,
     memory_panel: crate::memory_panel::MemoryPanel,
@@ -151,7 +150,7 @@ impl App {
             #[cfg(not(target_arch = "wasm32"))]
             ctrl_c,
             pending_promises: Default::default(),
-            toasts: Toasts::new(),
+            toasts: toasts::Toasts::new(),
             latest_memory_purge: instant::Instant::now(), // TODO(emilk): `Instant::MIN` when we have our own `Instant` that supports it.
             memory_panel: Default::default(),
             memory_panel_open: false,
@@ -636,23 +635,21 @@ impl App {
     fn show_text_logs_as_notifications(&mut self) {
         crate::profile_function!();
 
-        let duration = Some(std::time::Duration::from_secs(4));
-
         while let Ok(re_log::LogMsg { level, msg }) = self.text_log_rx.try_recv() {
-            match level {
-                re_log::Level::Error => {
-                    self.toasts.error(msg).set_duration(duration);
-                }
-                re_log::Level::Warn => {
-                    self.toasts.warning(msg).set_duration(duration);
-                }
-                re_log::Level::Info => {
-                    self.toasts.info(msg).set_duration(duration);
-                }
+            let kind = match level {
+                re_log::Level::Error => toasts::ToastKind::Error,
+                re_log::Level::Warn => toasts::ToastKind::Warning,
+                re_log::Level::Info => toasts::ToastKind::Info,
                 re_log::Level::Debug | re_log::Level::Trace => {
-                    // too spammy
+                    continue; // too spammy
                 }
-            }
+            };
+
+            self.toasts.add(toasts::Toast {
+                kind,
+                text: msg,
+                options: toasts::ToastOptions::with_ttl_in_seconds(4.0),
+            });
         }
     }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -635,7 +635,12 @@ impl App {
     fn show_text_logs_as_notifications(&mut self) {
         crate::profile_function!();
 
-        while let Ok(re_log::LogMsg { level, msg }) = self.text_log_rx.try_recv() {
+        while let Ok(re_log::LogMsg { level, target, msg }) = self.text_log_rx.try_recv() {
+            let is_rerun_crate = target.starts_with("rerun") || target.starts_with("re_");
+            if !is_rerun_crate {
+                continue;
+            }
+
             let kind = match level {
                 re_log::Level::Error => toasts::ToastKind::Error,
                 re_log::Level::Warn => toasts::ToastKind::Warning,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -59,7 +59,7 @@ pub struct App {
     startup_options: StartupOptions,
     re_ui: re_ui::ReUi,
 
-    /// Listens to the local log stream
+    /// Listens to the local text log stream
     text_log_rx: std::sync::mpsc::Receiver<re_log::LogMsg>,
 
     component_ui_registry: ComponentUiRegistry,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -759,7 +759,7 @@ impl App {
             {
                 crate::profile_scope!("pruning");
                 if let Some(counted) = mem_use_before.counted {
-                    re_log::info!(
+                    re_log::debug!(
                         "Attempting to purge {:.1}% of used RAM ({})…",
                         100.0 * fraction_to_purge,
                         format_bytes(counted as f64 * fraction_to_purge as f64)
@@ -778,7 +778,7 @@ impl App {
             if let (Some(counted_before), Some(counted_diff)) =
                 (mem_use_before.counted, freed_memory.counted)
             {
-                re_log::info!(
+                re_log::debug!(
                     "Freed up {} ({:.1}%)",
                     format_bytes(counted_diff as _),
                     100.0 * counted_diff as f32 / counted_before as f32


### PR DESCRIPTION
The toast notifications have been improved in a few ways:

* Line wrapping
* Smaller text
* No countdown-slider
* Hover to keep it open
* Close to click and copy text

![Screen Shot 2023-03-20 at 14 57 10](https://user-images.githubusercontent.com/1148717/226362077-bef61e63-42fd-4df3-9786-5ed74e1ed6ca.png)

(The "click-to-close" tooltip is only there because I'm hovering the last notification)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
