### PR TITLE
Print our own callstack on panics

### DIFF
--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -23,8 +23,41 @@ fn install_panic_hook(_build_info: BuildInfo) {
     let previous_panic_hook = std::panic::take_hook();
 
     std::panic::set_hook(Box::new(move |panic_info: &std::panic::PanicInfo<'_>| {
-        // This prints the callstack etc
-        (*previous_panic_hook)(panic_info);
+        let callstack = callstack_from("panicking::panic_fmt\n");
+
+        let file_line = panic_info.location().map(|location| {
+            let file = anonymize_source_file_path(&std::path::PathBuf::from(location.file()));
+            format!("{file}:{}", location.line())
+        });
+
+        // `panic_info.message` is unstable, so this is the recommended way of getting
+        // the panic message out. We need both the `&str` and `String` variants.
+        let msg = panic_info_message(panic_info);
+
+        if let Some(msg) = &msg {
+            // Print our own panic message.
+            // Our formatting is nicer than `std` since we shorten the file paths (for privacy reasons).
+            // This also makes it easier for users to copy-paste the callstack into an issue
+            // without having any sensitive data in it.
+
+            let thread = std::thread::current();
+            let thread_name = thread
+                .name()
+                .map_or_else(|| format!("{:?}", thread.id()), |name| name.to_owned());
+
+            let file_line_suffix = if let Some(file_line) = &file_line {
+                format!(", {file_line}")
+            } else {
+                String::new()
+            };
+
+            eprintln!(
+                "\nthread '{thread_name}' panicked at '{msg}'{file_line_suffix}\n\n{callstack}"
+            );
+        } else {
+            // This prints the panic message and callstack:
+            (*previous_panic_hook)(panic_info);
+        }
 
         eprintln!(
             "\n\
@@ -35,26 +68,21 @@ fn install_panic_hook(_build_info: BuildInfo) {
         {
             if let Ok(analytics) = re_analytics::Analytics::new(std::time::Duration::from_millis(1))
             {
-                let callstack = callstack_from("panicking::panic_fmt\n");
                 let mut event = re_analytics::Event::append("crash-panic")
                     .with_build_info(&_build_info)
                     .with_prop("callstack", callstack);
 
-                let include_panic_message = false; // Don't include it, because it can contain sensitive information (`panic!("Couldn't read {file_path}")`)
+                let include_panic_message = false; // Don't include it, because it can contain sensitive information (`panic!("Couldn't read {sensitive_file_path}")`)
                 if include_panic_message {
                     // `panic_info.message` is unstable, so this is the recommended way of getting
                     // the panic message out. We need both the `&str` and `String` variants.
-                    if let Some(msg) = panic_info.payload().downcast_ref::<&str>() {
-                        event = event.with_prop("message", *msg);
-                    } else if let Some(msg) = panic_info.payload().downcast_ref::<String>() {
-                        event = event.with_prop("message", msg.clone());
+                    if let Some(msg) = msg {
+                        event = event.with_prop("message", msg);
                     }
                 }
 
-                if let Some(location) = panic_info.location() {
-                    let file =
-                        anonymize_source_file_path(&std::path::PathBuf::from(location.file()));
-                    event = event.with_prop("file_line", format!("{file}:{}", location.line()));
+                if let Some(file_line) = file_line {
+                    event = event.with_prop("file_line", file_line);
                 }
 
                 analytics.record(event);
@@ -63,6 +91,17 @@ fn install_panic_hook(_build_info: BuildInfo) {
             }
         }
     }));
+}
+
+fn panic_info_message(panic_info: &std::panic::PanicInfo<'_>) -> Option<String> {
+    #[allow(clippy::manual_map)]
+    if let Some(msg) = panic_info.payload().downcast_ref::<&str>() {
+        Some((*msg).to_owned())
+    } else if let Some(msg) = panic_info.payload().downcast_ref::<String>() {
+        Some(msg.clone())
+    } else {
+        None
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -183,21 +222,28 @@ fn callstack_from(start_pattern: &str) -> String {
     let mut stack = stack.as_str();
 
     // Trim the top (closest to the panic handler) to cut out some noise:
-    if let Some(start_offset) = stack.find(start_pattern) {
-        stack = &stack[start_offset + start_pattern.len()..];
+    if let Some(offset) = stack.find(start_pattern) {
+        let prev_newline = stack[..offset].rfind('\n').map_or(0, |newline| newline + 1);
+        stack = &stack[prev_newline..];
     }
 
     // Trim the bottom to cut out code that sets up the callstack:
-    if let Some(end_offset) = stack.find("std::sys_common::backtrace::__rust_begin_short_backtrace")
-    {
-        stack = &stack[..end_offset];
-    }
+    let end_patterns = [
+        "std::sys_common::backtrace::__rust_begin_short_backtrace",
+        // Trim the bottom even more to exclude any user code that potentially used `rerun`
+        // as a library to show a viewer. In these cases there may be sensitive user code
+        // that called `rerun::run`, and we do not want to include it:
+        "run_native_app",
+    ];
 
-    // Trim the bottom even more to exclude any user code that potentially used `rerun`
-    // as a library to show a viewer. In these cases there may be sensitive user code
-    // that called `rerun::run`, and we do not want to include it:
-    if let Some(end_offset) = stack.find("run_native_app") {
-        stack = &stack[..end_offset];
+    for end_pattern in end_patterns {
+        if let Some(offset) = stack.find(end_pattern) {
+            if let Some(start_of_line) = stack[..offset].rfind('\n') {
+                stack = &stack[..start_of_line];
+            } else {
+                stack = &stack[..offset];
+            }
+        }
     }
 
     stack.into()


### PR DESCRIPTION
The panic handler prints very long filenames, which can include sensitive paths. By cutting out the sensitive parts we get two benefits:

* Users can copy-paste the callstack from the terminal into a rerun issue without any sensitive paths leaking
* The callstack is much more readable.


### Before:
```
[2023-03-20T14:51:43Z INFO  rerun::run] Loading "../api_demo.rrd"…
thread 'main' panicked at 'assertion failed: from.start() != from.end()', /Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/emath-0.21.0/src/lib.rs:142:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:64:14
   2: core::panicking::panic
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:111:5
   3: emath::rect_transform::RectTransform::transform_pos
   4: emath::rect_transform::RectTransform::transform_rect
             at /Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/emath-0.21.0/src/rect_transform.rs:52:18
   5: re_viewer::ui::view_spatial::ui::create_labels
             at ./crates/re_viewer/src/ui/view_spatial/ui.rs:616:13
```

### After:
```
[2023-03-20T14:49:46Z INFO  rerun::run] Loading "../api_demo.rrd"…

thread 'main' panicked at 'assertion failed: from.start() != from.end()', emath-0.21.0/src/lib.rs:142

   7: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   8: core::panicking::panic
             at core/src/panicking.rs:111:5
   9: emath::rect_transform::RectTransform::transform_pos
      emath::rect_transform::RectTransform::transform_rect
             at emath-0.21.0/src/rect_transform.rs:52:18
  10: re_viewer::ui::view_spatial::ui::create_labels
             at re_viewer/src/ui/view_spatial/ui.rs:616:13
…
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
