### PR TITLE
Don't call wgpu::Device::poll on the web.

### DIFF
--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -202,7 +202,7 @@ impl RenderContext {
 
         // Browsers don't let us wait for GPU work via `poll`.
         // * WebGPU: `poll` is a no-op as the spec doesn't specify it at all.
-        // * WebGL: Internal timeout on can't go above a browser specific value.
+        // * WebGL: Internal timeout can't go above a browser specific value.
         //          Since wgpu ran into issues in the past with some browsers returning errors,
         //          it uses a timeout of zero and ignores errors there.
         //          TODO(andreas): That's not the only thing that's weird with `maintain` in general.

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -97,11 +97,7 @@ impl RenderContext {
     ///
     /// Should be somewhere between 1-4, too high and we use up more memory and introduce latency,
     /// too low and we may starve the GPU.
-    /// On the web we want to go lower because a lot more memory constraint.
-    #[cfg(not(target_arch = "wasm32"))]
     const MAX_NUM_INFLIGHT_QUEUE_SUBMISSIONS: usize = 4;
-    #[cfg(target_arch = "wasm32")]
-    const MAX_NUM_INFLIGHT_QUEUE_SUBMISSIONS: usize = 2;
 
     pub fn new(
         device: Arc<wgpu::Device>,
@@ -203,6 +199,17 @@ impl RenderContext {
 
     fn poll_device(&mut self) {
         crate::profile_function!();
+
+        // Browsers don't let us wait for GPU work via `poll`.
+        // * WebGPU: `poll` is a no-op as the spec doesn't specify it at all.
+        // * WebGL: Internal timeout on can't go above a browser specific value.
+        //          Since wgpu ran into issues in the past with some browsers returning errors,
+        //          it uses a timeout of zero and ignores errors there.
+        //          TODO(andreas): That's not the only thing that's weird with `maintain` in general.
+        //                          See https://github.com/gfx-rs/wgpu/issues/3601
+        if cfg!(target_arch = "wasm32") {
+            return;
+        }
 
         // Ensure not too many queue submissions are in flight.
         let num_submissions_to_wait_for = self


### PR DESCRIPTION
Reasons detailed in the comment. Polling is broken on timeout (see  https://github.com/gfx-rs/wgpu/issues/3601) and timeout on WebGL is hardcoded to zero because of other issues.
Since dropping (cpu user code discarded) in-gpu-use frames doesn't have any repercussions for GL resources, this doesn't change much, but makes overall behavior more consistent and less confusing & error prone.

Discovered while working on https://github.com/rerun-io/rerun/issues/909

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
