### PR TITLE
Run clippy for wasm, with own clippy.toml config file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,10 +215,7 @@ jobs:
           save-if: ${{ github.event_name == 'push'}}
 
       - name: Check re_viewer wasm32
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --all-features --lib --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer
+        run: ./scripts/clippy_wasm.sh
 
       - name: Check re_renderer examples wasm32
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -202,7 +202,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
+          profile: default
           toolchain: 1.67.0
           target: wasm32-unknown-unknown
           override: true
@@ -215,7 +215,7 @@ jobs:
           save-if: ${{ github.event_name == 'push'}}
 
       - name: Check re_viewer wasm32
-        run: rustup component add clippy && ./scripts/clippy_wasm.sh
+        run: ./scripts/clippy_wasm.sh
 
       - name: Check re_renderer examples wasm32
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -214,7 +214,7 @@ jobs:
           # See: https://github.com/rerun-io/rerun/pull/497
           save-if: ${{ github.event_name == 'push'}}
 
-      - name: Check re_viewer wasm32
+      - name: clippy check re_viewer wasm32
         run: ./scripts/clippy_wasm.sh
 
       - name: Check re_renderer examples wasm32

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -203,7 +203,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.67.0
+          toolchain: 1.67.1
           target: wasm32-unknown-unknown
           override: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,7 +215,7 @@ jobs:
           save-if: ${{ github.event_name == 'push'}}
 
       - name: Check re_viewer wasm32
-        run: ./scripts/clippy_wasm.sh
+        run: rustup component add clippy && ./scripts/clippy_wasm.sh
 
       - name: Check re_renderer examples wasm32
         uses: actions-rs/cargo@v1

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.67.0
+          toolchain: 1.67.1
           override: true
 
       - name: Set up cargo cache

--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ This is a guide to how to build Rerun.
 If you are using an Apple-silicon Mac (M1, M2), make sure `rustc -vV` outputs `host: aarch64-apple-darwin`. If not, this should fix it:
 
 ```sh
-rustup set default-host aarch64-apple-darwin && rustup install 1.67
+rustup set default-host aarch64-apple-darwin && rustup install 1.67.1
 ```
 
 ## Building the docs

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,7 +15,7 @@ This is a guide to how to build Rerun.
 * Install the Rust toolchain: <https://rustup.rs/>
 * `git clone git@github.com:rerun-io/rerun.git && cd rerun`
 * Run `./scripts/setup_dev.sh`.
-* Make sure `cargo --version` prints `1.67.0` once you are done
+* Make sure `cargo --version` prints `1.67.1` once you are done
 
 
 ### Apple-silicon Macs

--- a/Cranky.toml
+++ b/Cranky.toml
@@ -104,6 +104,7 @@ warn = [
   "clippy::unchecked_duration_subtraction",
   "clippy::undocumented_unsafe_blocks",
   "clippy::unimplemented",
+  "clippy::uninlined_format_args",
   "clippy::unnecessary_safety_doc",
   "clippy::unnecessary_wraps",
   "clippy::unnested_or_patterns",

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -L https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.67 \
+    RUST_VERSION=1.67.1 \
     RUSTUP_VERSION=1.25.2
 
 # Install Rust

--- a/ci_docker/publish.sh
+++ b/ci_docker/publish.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+
 VERSION=0.6 # Bump on each new version. Remember to update the version in the Dockerfile too.
 
 # The build needs to run from top of repo to access the requirements.txt

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-# There is also a clippy_wasm.toml which forbids some mthods that are not available in wasm.
+# There is also a clippy_wasm/clippy.toml which forbids some mthods that are not available in wasm.
 
 msrv = "1.67"
 
@@ -45,7 +45,7 @@ disallowed-types = [
 
 # Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
 doc-valid-idents = [
-  # You must also update the same list in `clippy_wasm.toml`!
+  # You must also update the same list in `clippy_wasm/clippy.toml`!
   "GitHub",
   "GLB",
   "GLTF",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,5 @@
+# There is also a clippy_wasm.toml which forbids some mthods that are not available in wasm.
+
 msrv = "1.67"
 
 
@@ -18,10 +20,9 @@ disallowed-macros = [
 disallowed-methods = [
   "std::env::temp_dir", # Use the tempdir crate instead
 
-  # Disabled because of https://github.com/rust-lang/rust-clippy/issues/10406
-  #   "std::time::Instant::now",      # use `instant` crate instead for wasm/web compatibility
-  "std::time::Duration::elapsed", # use `instant` crate instead for wasm/web compatibility
-  "std::time::SystemTime::now",   # use `instant` or `time` crates instead for wasm/web compatibility
+  # There are many things that aren't allowed on wasm,
+  # but we cannot disable them all here (because of e.g. https://github.com/rust-lang/rust-clippy/issues/10406)
+  # so we do that in `clipppy_wasm.toml` instead.
 
   "std::thread::spawn", # Use `std::thread::Builder` and name the thread
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -45,6 +45,7 @@ disallowed-types = [
 
 # Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
 doc-valid-idents = [
+  # You must also update the same list in `clippy_wasm.toml`!
   "GitHub",
   "GLB",
   "GLTF",

--- a/clippy_wasm.toml
+++ b/clippy_wasm.toml
@@ -1,0 +1,30 @@
+# This is used by `scripts/clippy_wasm.sh` so we can forbid some methods that are not available in wasm.
+#
+# We cannot forbid all these methods in the main `clippy.toml` because of
+# https://github.com/rust-lang/rust-clippy/issues/10406
+
+msrv = "1.67"
+
+# https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
+disallowed-methods = [
+  "std::time::Instant::now",      # use `instant` crate instead for wasm/web compatibility
+  "std::time::Duration::elapsed", # use `instant` crate instead for wasm/web compatibility
+  "std::time::SystemTime::now",   # use `instant` or `time` crates instead for wasm/web compatibility
+]
+
+# Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+doc-valid-idents = [
+  "GitHub",
+  "GLB",
+  "GLTF",
+  "iOS",
+  "macOS",
+  "NaN",
+  "OBJ",
+  "PyPI",
+  "sRGB",
+  "sRGBA",
+  "WebGL",
+  "WebSockets",
+  "..",
+]

--- a/clippy_wasm.toml
+++ b/clippy_wasm.toml
@@ -10,6 +10,15 @@ disallowed-methods = [
   "std::time::Instant::now",      # use `instant` crate instead for wasm/web compatibility
   "std::time::Duration::elapsed", # use `instant` crate instead for wasm/web compatibility
   "std::time::SystemTime::now",   # use `instant` or `time` crates instead for wasm/web compatibility
+
+  # Cannot spawn threads on wasm:
+  "std::thread::spawn",
+]
+
+# https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_types
+disallowed-types = [
+  # Cannot spawn threads on wasm:
+  "std::thread::Builder",
 ]
 
 # Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown

--- a/clippy_wasm.toml
+++ b/clippy_wasm.toml
@@ -23,6 +23,7 @@ disallowed-types = [
 
 # Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
 doc-valid-idents = [
+  # You must also update the same list in `clippy.toml`!
   "GitHub",
   "GLB",
   "GLTF",

--- a/clippy_wasm/clippy.toml
+++ b/clippy_wasm/clippy.toml
@@ -23,7 +23,7 @@ disallowed-types = [
 
 # Allow-list of words for markdown in dosctrings https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
 doc-valid-idents = [
-  # You must also update the same list in `clippy.toml`!
+  # You must also update the same list in the root `clippy.toml`!
   "GitHub",
   "GLB",
   "GLTF",

--- a/crates/re_arrow_store/src/store_format.rs
+++ b/crates/re_arrow_store/src/store_format.rs
@@ -231,7 +231,7 @@ impl std::fmt::Display for IndexBucket {
                 "time range: N/A\n".to_owned()
             }
         };
-        f.write_fmt(format_args!("{}\n", time_range))?;
+        f.write_fmt(format_args!("{time_range}\n"))?;
 
         let (timeline_name, times) = self.times();
         let (col_names, cols): (Vec<_>, Vec<_>) = {

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -51,5 +51,5 @@ pub fn setup_web_logging() {
     log::set_max_level(log::LevelFilter::Debug);
     crate::add_boxed_logger(Box::new(crate::web_logger::WebLogger::new(
         log::LevelFilter::Debug,
-    )))
+    )));
 }

--- a/crates/re_viewer/src/stream_rrd_from_http.rs
+++ b/crates/re_viewer/src/stream_rrd_from_http.rs
@@ -61,7 +61,7 @@ fn decode_rrd(rrd_bytes: Vec<u8>, on_msg: Box<dyn Fn(re_log_types::LogMsg) + Sen
 #[cfg(target_arch = "wasm32")]
 mod web_decode {
     pub fn decode_rrd(rrd_bytes: Vec<u8>, on_msg: Box<dyn Fn(re_log_types::LogMsg) + Send>) {
-        wasm_bindgen_futures::spawn_local(decode_rrd_async(rrd_bytes, on_msg))
+        wasm_bindgen_futures::spawn_local(decode_rrd_async(rrd_bytes, on_msg));
     }
 
     /// Decodes the file in chunks, with an yield between each chunk.

--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -96,6 +96,7 @@ impl DataUi for Tensor {
                         }
                     }
 
+                    #[allow(clippy::collapsible_match)] // false positive on wasm32
                     if let Some(dynamic_img) = tensor_view.dynamic_img() {
                         // TODO(emilk): support copying and saving images on web
                         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -343,10 +343,10 @@ pub fn show_zoomed_image_region(
                 let tensor = tensor_view.tensor;
 
                 let text = match tensor.num_dim() {
-                    2 => tensor.get(&[x, y]).map(|v| format!("Val: {}", v)),
+                    2 => tensor.get(&[x, y]).map(|v| format!("Val: {v}")),
                     3 => match tensor.shape()[2].size {
                         0 => Some("Cannot preview 0-size channel".to_owned()),
-                        1 => tensor.get(&[x, y, 0]).map(|v| format!("Val: {}", v)),
+                        1 => tensor.get(&[x, y, 0]).map(|v| format!("Val: {v}")),
                         3 => {
                             // TODO(jleibs): Track RGB ordering somehow -- don't just assume it
                             if let (Some(r), Some(g), Some(b)) = (
@@ -396,11 +396,11 @@ pub fn show_zoomed_image_region(
                             }
                         },
                         channels => {
-                            Some(format!("Cannot preview {}-channel image", channels))
+                            Some(format!("Cannot preview {channels}-channel image"))
                         }
                     },
                     dims => {
-                        Some(format!("Cannot preview {}-dimensional image", dims))
+                        Some(format!("Cannot preview {dims}-dimensional image"))
                     }
                 };
 

--- a/rerun_py/README.md
+++ b/rerun_py/README.md
@@ -61,7 +61,7 @@ Setup:
 * Install the Rust toolchain: <https://rustup.rs/>
 * `git clone git@github.com:rerun-io/rerun.git && cd rerun`
 * Run `./scripts/setup_dev.sh`.
-* Make sure `cargo --version` prints `1.67.0` once you are done
+* Make sure `cargo --version` prints `1.67.1` once you are done
 
 ## Building
 To build from source and install Rerun into your *current* Python environment run:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.67"
+channel = "1.67.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/clippy_wasm.sh
+++ b/scripts/clippy_wasm.sh
@@ -17,6 +17,4 @@ function cleanup()
 
 trap cleanup EXIT
 
-cargo clippy --version
-
 cargo cranky --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings

--- a/scripts/clippy_wasm.sh
+++ b/scripts/clippy_wasm.sh
@@ -1,20 +1,13 @@
 #!/usr/bin/env bash
 # This scripts run clippy on the wasm32-unknown-unknown target,
-# using a special clippy_wasm.toml config file which forbids a few more things.
+# using a special clippy.toml config file which forbids a few more things.
 
 set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/.."
 set -x
 
-mv clippy.toml clippy.toml.bak
-cp clippy_wasm.toml clippy.toml
-
-function cleanup()
-{
-    mv clippy.toml.bak clippy.toml
-}
-
-trap cleanup EXIT
+# Use clippy_wasm/clippy.toml
+export CLIPPY_CONF_DIR="clippy_wasm"
 
 cargo cranky --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings

--- a/scripts/clippy_wasm.sh
+++ b/scripts/clippy_wasm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# This scripts run clippy on the wasm32-unknown-unknown target,
+# using a special clippy_wasm.toml config file which forbids a few more things.
+
+set -eu
+script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$script_path/.."
+set -x
+
+mv clippy.toml clippy.toml.bak
+cp clippy_wasm.toml clippy.toml
+
+function cleanup()
+{
+    mv clippy.toml.bak clippy.toml
+}
+
+trap cleanup EXIT
+
+cargo cranky --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings

--- a/scripts/clippy_wasm.sh
+++ b/scripts/clippy_wasm.sh
@@ -17,4 +17,6 @@ function cleanup()
 
 trap cleanup EXIT
 
+cargo clippy --version
+
 cargo cranky --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,7 +32,7 @@ elif [ -x "$(command -v dnf)" ];   then
 fi
 
 # Needed to compile and check the code:
-rustup install 1.67.0
+rustup install 1.67.1
 ./scripts/setup_web.sh
 
 echo "setup.sh completed!"


### PR DESCRIPTION
Closes:
* https://github.com/rerun-io/rerun/pull/317
* https://github.com/rerun-io/rerun/issues/1446
*  https://github.com/rerun-io/rerun/pull/1447

It is way to easy to accidentally use `std::time::Instant::now`, which will break the web-viewer at runtime. With this PR, we now check that we don't use it, or similarly banned method, when compiling for wasm32.

I ran into a subtle difference between how clippy acted on `1.67.0` and `1.67.1`. I've now made sure we always use `1.67.1` both locally and on CI.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
