### PR TITLE
Revert "Handle ctrl+c to gracefully shutdown the server(s)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,6 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_smart_channel",
- "tokio",
 ]
 
 [[package]]
@@ -4149,7 +4148,6 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "ctrlc",
  "document-features",
  "futures-util",
  "glob",
@@ -4239,7 +4237,6 @@ dependencies = [
  "backtrace",
  "clap 4.1.4",
  "crossbeam",
- "ctrlc",
  "document-features",
  "egui",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ arrow2 = "0.16"
 arrow2_convert = "0.4.2"
 clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }
-ctrlc = { version = "3.0", features = ["termination"] }
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = "0.21.0"

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -35,4 +35,3 @@ bincode = "1.3"
 crossbeam = "0.8"
 document-features = "0.2"
 rand = { version = "0.8.5", features = ["small_rng"] }
-tokio.workspace = true

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -110,7 +110,7 @@ wgpu.workspace = true
 arboard = { version = "3.2", default-features = false, features = [
   "image-data",
 ] }
-ctrlc.workspace = true
+ctrlc = { version = "3.0", features = ["termination"] }
 puffin_http = "0.11"
 puffin.workspace = true
 

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -39,7 +39,6 @@ analytics = ["dep:re_analytics"]
 re_log.workspace = true
 
 anyhow.workspace = true
-ctrlc.workspace = true
 document-features = "0.2"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -159,15 +159,8 @@ impl WebViewerServer {
         Self { server }
     }
 
-    pub async fn serve(
-        self,
-        mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
-    ) -> anyhow::Result<()> {
-        self.server
-            .with_graceful_shutdown(async {
-                shutdown_rx.recv().await.ok();
-            })
-            .await?;
+    pub async fn serve(self) -> anyhow::Result<()> {
+        self.server.await?;
         Ok(())
     }
 }

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -6,17 +6,8 @@ async fn main() {
     re_log::setup_native_logging();
     let port = 9090;
     eprintln!("Hosting web-viewer on http://127.0.0.1:{port}");
-
-    // Shutdown server via Ctrl+C
-    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
-    ctrlc::set_handler(move || {
-        re_log::debug!("Ctrl-C detected - Closing web server.");
-        shutdown_tx.send(()).unwrap();
-    })
-    .expect("Error setting Ctrl-C handler");
-
     re_web_viewer_server::WebViewerServer::new(port)
-        .serve(shutdown_rx)
+        .serve()
         .await
         .unwrap();
 }

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -97,7 +97,6 @@ backtrace = "0.3"
 clap = { workspace = true, features = ["derive"] }
 mimalloc.workspace = true
 puffin_http = "0.11"
-ctrlc.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # Native unix dependencies:

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -4,74 +4,52 @@ use re_log_types::LogMsg;
 /// * A web-server, serving the web-viewer
 /// * A `WebSocket` server, server [`LogMsg`]es to remote viewer(s).
 struct RemoteViewerServer {
+    web_server_join_handle: tokio::task::JoinHandle<()>,
     sender: re_smart_channel::Sender<LogMsg>,
-    shutdown_tx: tokio::sync::broadcast::Sender<()>,
 }
 
 impl Drop for RemoteViewerServer {
     fn drop(&mut self) {
         re_log::info!("Shutting down web server.");
-        self.shutdown_tx.send(()).ok();
+        self.web_server_join_handle.abort();
     }
 }
 
 impl RemoteViewerServer {
-    pub fn new(open_browser: bool) -> Self {
+    pub fn new(tokio_rt: &tokio::runtime::Runtime, open_browser: bool) -> Self {
         let (rerun_tx, rerun_rx) = re_smart_channel::smart_channel(re_smart_channel::Source::Sdk);
-        let (shutdown_tx, shutdown_rx_ws_server) = tokio::sync::broadcast::channel(1);
-        let shutdown_rx_web_server = shutdown_tx.subscribe();
 
-        tokio::spawn(async move {
+        let web_server_join_handle = tokio_rt.spawn(async move {
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::Server::new(re_ws_comms::DEFAULT_WS_SERVER_PORT)
                 .await
                 .unwrap();
-            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx, shutdown_rx_ws_server));
+            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx)); // TODO(emilk): use tokio_rt ?
 
             // This is the server that serves the Wasm+HTML:
+            let web_port = 9090;
+            let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
+            let web_server_handle = tokio::spawn(async move {
+                web_server.serve().await.unwrap();
+            });
+
             let ws_server_url = re_ws_comms::default_server_url();
-            let web_server_handle = tokio::spawn(host_web_viewer(
-                open_browser,
-                ws_server_url,
-                shutdown_rx_web_server,
-            ));
+            let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
+            if open_browser {
+                webbrowser::open(&viewer_url).ok();
+            } else {
+                re_log::info!("Web server is running - view it at {viewer_url}");
+            }
 
             ws_server_handle.await.unwrap().unwrap();
-            web_server_handle.await.unwrap().unwrap();
+            web_server_handle.await.unwrap();
         });
 
         Self {
+            web_server_join_handle,
             sender: rerun_tx,
-            shutdown_tx,
         }
     }
-}
-
-/// Hosts two servers:
-/// * A web-server, serving the web-viewer
-/// * A `WebSocket` server, server [`LogMsg`]es to remote viewer(s).
-///
-/// Optionally opens a browser with the web-viewer.
-#[cfg(feature = "web_viewer")]
-pub async fn host_web_viewer(
-    open_browser: bool,
-    ws_server_url: String,
-    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
-) -> anyhow::Result<()> {
-    let web_port = 9090;
-    let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
-
-    let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
-    let web_server_handle = tokio::spawn(web_server.serve(shutdown_rx));
-
-    re_log::info!("Web server is running - view it at {viewer_url}");
-    if open_browser {
-        webbrowser::open(&viewer_url).ok();
-    } else {
-        re_log::info!("Web server is running - view it at {viewer_url}");
-    }
-
-    web_server_handle.await?
 }
 
 impl crate::sink::LogSink for RemoteViewerServer {
@@ -94,9 +72,14 @@ impl crate::sink::LogSink for RemoteViewerServer {
 /// NOTE: you can not connect one `Session` to another.
 ///
 /// This function returns immediately.
-///
-/// The caller needs to ensure that there is a `tokio` runtime running.
 #[must_use]
 pub fn new_sink(open_browser: bool) -> Box<dyn crate::sink::LogSink> {
-    Box::new(RemoteViewerServer::new(open_browser))
+    // TODO(emilk): creating a tokio runtime on-demand like this is not great. Not sure how this interacts with `#[tokio::main]`, for instance.
+    use once_cell::sync::Lazy;
+    use parking_lot::Mutex;
+    static TOKIO_RUNTIME: Lazy<Mutex<tokio::runtime::Runtime>> = Lazy::new(|| {
+        Mutex::new(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"))
+    });
+
+    Box::new(RemoteViewerServer::new(&TOKIO_RUNTIME.lock(), open_browser))
 }

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -18,7 +18,9 @@ rr.script_teardown(args)
 ```
 
 """
+import contextlib
 from argparse import ArgumentParser, Namespace
+from time import sleep
 
 import rerun as rr
 
@@ -91,10 +93,6 @@ def script_teardown(args: Namespace) -> None:
 
     """
     if args.serve:
-        import signal
-        from threading import Event
-
-        exit = Event()
-        signal.signal(signal.SIGINT, lambda sig, frame: exit.set())
         print("Sleeping while serving the web viewer. Abort with Ctrl-C")
-        exit.wait()
+        with contextlib.suppress(Exception):
+            sleep(1_000_000_000)

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -295,12 +295,7 @@ fn serve(open_browser: bool) -> PyResult<()> {
             return Ok(());
         }
 
-        use once_cell::sync::Lazy;
-        static TOKIO_RUNTIME: Lazy<tokio::runtime::Runtime> =
-            Lazy::new(|| tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));
-        let _guard = TOKIO_RUNTIME.enter();
         session.set_sink(rerun::web_viewer::new_sink(open_browser));
-
         Ok(())
     }
 


### PR DESCRIPTION
Reverts rerun-io/rerun#1613

`cargo r -p rerun -- ../nyud.rrd` causes this:

```
[2023-03-21T08:15:56Z INFO  rerun::run] Loading "../nyud.rrd"…

thread 'main' panicked at 'Error setting Ctrl-C handler: MultipleHandlers', re_viewer/src/app.rs:131

   7: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   8: core::result::unwrap_failed
             at core/src/result.rs:1791:5
   9: core::result::Result<T,E>::expect
             at core/src/result.rs:1070:23
      re_viewer::app::App::from_receiver
             at re_viewer/src/app.rs:126:13
  10: rerun::run::run_impl::{{closure}}::{{closure}}
             at rerun/src/run.rs:357:27
      core::ops::function::FnOnce::call_once{{vtable.shim}}
             at core/src/ops/function.rs:507:5
  11: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at alloc/src/boxed.rs:2000:9

Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting
libc++abi: terminating with uncaught foreign exception


Rerun caught a signal: SIGABRT

Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting

      rerun::crash_handler::install_signal_handler::signal_handler
             at rerun/src/crash_handler.rs:163:25
   3: _OSAtomicTestAndClearBarrier
   4: __pthread_atfork_prepare_handlers
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>

Rerun caught a signal: SIGABRT
Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting

zsh: abort      cargo r -p rerun -- ../nyud.rrd
```