### PR TITLE
Fix crash on serve exit, second attempt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4087,7 +4087,6 @@ dependencies = [
  "bytemuck",
  "cocoa",
  "console_error_panic_hook",
- "ctrlc",
  "eframe",
  "egui",
  "egui-wgpu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,6 +4012,7 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_smart_channel",
+ "tokio",
 ]
 
 [[package]]
@@ -4148,6 +4149,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "ctrlc",
  "document-features",
  "futures-util",
  "glob",
@@ -4237,6 +4239,7 @@ dependencies = [
  "backtrace",
  "clap 4.1.4",
  "crossbeam",
+ "ctrlc",
  "document-features",
  "egui",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ arrow2 = "0.16"
 arrow2_convert = "0.4.2"
 clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }
+ctrlc = { version = "3.0", features = ["termination"] }
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = "0.21.0"

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -35,3 +35,4 @@ bincode = "1.3"
 crossbeam = "0.8"
 document-features = "0.2"
 rand = { version = "0.8.5", features = ["small_rng"] }
+tokio.workspace = true

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -7,6 +7,7 @@ use rand::{Rng as _, SeedableRng};
 
 use re_log_types::{LogMsg, TimePoint, TimeType, TimelineName};
 use re_smart_channel::{Receiver, Sender};
+use tokio::net::{TcpListener, TcpStream};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ServerOptions {
@@ -27,37 +28,18 @@ impl Default for ServerOptions {
     }
 }
 
-/// Listen to multiple SDK:s connecting to us over TCP.
-///
-/// ``` no_run
-/// # use re_sdk_comms::{serve, ServerOptions};
-/// let log_msg_rx = serve(80, ServerOptions::default())?;
-/// # Ok::<(), anyhow::Error>(())
-/// ```
-pub fn serve(port: u16, options: ServerOptions) -> anyhow::Result<Receiver<LogMsg>> {
+async fn listen_for_new_clients(
+    port: u16,
+    options: ServerOptions,
+    tx: Sender<LogMsg>,
+    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) {
     let bind_addr = format!("0.0.0.0:{port}");
 
-    let listener = std::net::TcpListener::bind(&bind_addr)
-        .with_context(|| format!("Failed to bind TCP address {bind_addr:?} for our WS server."))?;
-
-    let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::TcpServer { port });
-
-    std::thread::Builder::new()
-        .name("sdk-server".into())
-        .spawn(move || {
-            for stream in listener.incoming() {
-                match stream {
-                    Ok(stream) => {
-                        let tx = tx.clone();
-                        spawn_client(stream, tx, options);
-                    }
-                    Err(err) => {
-                        re_log::warn!("Failed to accept incoming SDK client: {err}");
-                    }
-                }
-            }
-        })
-        .expect("Failed to spawn thread");
+    let listener = TcpListener::bind(&bind_addr)
+        .await
+        .with_context(|| format!("Failed to bind TCP address {bind_addr:?}"))
+        .unwrap();
 
     if options.quiet {
         re_log::debug!(
@@ -69,43 +51,72 @@ pub fn serve(port: u16, options: ServerOptions) -> anyhow::Result<Receiver<LogMs
         );
     }
 
+    loop {
+        let incoming = tokio::select! {
+            res = listener.accept() => res,
+            _ = shutdown_rx.recv() => {
+                return;
+            }
+        };
+        match incoming {
+            Ok((stream, _)) => {
+                let tx = tx.clone();
+                spawn_client(stream, tx, options);
+            }
+            Err(err) => {
+                re_log::warn!("Failed to accept incoming SDK client: {err}");
+            }
+        }
+    }
+}
+
+/// Listen to multiple SDK:s connecting to us over TCP.
+///
+/// ``` no_run
+/// # use re_sdk_comms::{serve, ServerOptions};
+/// let (sender, receiver) = tokio::sync::broadcast::channel(1);
+/// let log_msg_rx = serve(80, ServerOptions::default(), receiver)?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn serve(
+    port: u16,
+    options: ServerOptions,
+    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) -> anyhow::Result<Receiver<LogMsg>> {
+    let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::TcpServer { port });
+
+    tokio::spawn(listen_for_new_clients(port, options, tx, shutdown_rx));
+
     Ok(rx)
 }
 
-fn spawn_client(stream: std::net::TcpStream, tx: Sender<LogMsg>, options: ServerOptions) {
-    std::thread::Builder::new()
-        .name(format!(
-            "sdk-server-client-handler-{:?}",
-            stream.peer_addr()
-        ))
-        .spawn(move || {
-            let addr_string = stream
-                .peer_addr()
-                .map_or_else(|_| "(unknown ip)".to_owned(), |addr| addr.to_string());
-            if options.quiet {
-                re_log::debug!("New SDK client connected: {addr_string}");
-            } else {
-                re_log::info!("New SDK client connected: {addr_string}");
-            }
-
-            if let Err(err) = run_client(stream, &tx, options) {
-                re_log::warn!("Closing connection to client: {err}");
-            }
-        })
-        .expect("Failed to spawn thread");
+fn spawn_client(stream: TcpStream, tx: Sender<LogMsg>, options: ServerOptions) {
+    tokio::spawn(async move {
+        let addr_string = stream
+            .peer_addr()
+            .map_or_else(|_| "(unknown ip)".to_owned(), |addr| addr.to_string());
+        if options.quiet {
+            re_log::debug!("New SDK client connected: {addr_string}");
+        } else {
+            re_log::info!("New SDK client connected: {addr_string}");
+        }
+        if let Err(err) = run_client(stream, &tx, options).await {
+            re_log::warn!("Closing connection to client: {err}");
+        }
+    });
 }
 
-fn run_client(
-    mut stream: std::net::TcpStream,
+async fn run_client(
+    mut stream: TcpStream,
     tx: &Sender<LogMsg>,
     options: ServerOptions,
 ) -> anyhow::Result<()> {
     #![allow(clippy::read_zero_byte_vec)] // false positive: https://github.com/rust-lang/rust-clippy/issues/9274
 
-    use std::io::Read as _;
+    use tokio::io::AsyncReadExt as _;
 
     let mut client_version = [0_u8; 2];
-    stream.read_exact(&mut client_version)?;
+    stream.read_exact(&mut client_version).await?;
     let client_version = u16::from_le_bytes(client_version);
 
     match client_version.cmp(&crate::PROTOCOL_VERSION) {
@@ -132,11 +143,11 @@ fn run_client(
 
     loop {
         let mut packet_size = [0_u8; 4];
-        stream.read_exact(&mut packet_size)?;
+        stream.read_exact(&mut packet_size).await?;
         let packet_size = u32::from_le_bytes(packet_size);
 
         packet.resize(packet_size as usize, 0_u8);
-        stream.read_exact(&mut packet)?;
+        stream.read_exact(&mut packet).await?;
 
         re_log::trace!("Received log message of size {packet_size}.");
 

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -110,7 +110,7 @@ wgpu.workspace = true
 arboard = { version = "3.2", default-features = false, features = [
   "image-data",
 ] }
-ctrlc = { version = "3.0", features = ["termination"] }
+ctrlc.workspace = true
 puffin_http = "0.11"
 puffin.workspace = true
 

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -110,7 +110,6 @@ wgpu.workspace = true
 arboard = { version = "3.2", default-features = false, features = [
   "image-data",
 ] }
-ctrlc.workspace = true
 puffin_http = "0.11"
 puffin.workspace = true
 

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -58,6 +58,7 @@ pub fn run_native_viewer_with_messages(
             re_ui,
             cc.storage,
             rx,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         ))
     }))
 }

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -71,6 +71,7 @@ impl RemoteViewerApp {
                     self.re_ui.clone(),
                     storage,
                     rx,
+                    std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 );
 
                 self.app = Some((connection, app));

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -60,6 +60,7 @@ pub async fn start(
                         re_ui,
                         cc.storage,
                         rx,
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     ))
                 }
                 EndpointCategory::WebSocket(url) => {

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -39,6 +39,7 @@ analytics = ["dep:re_analytics"]
 re_log.workspace = true
 
 anyhow.workspace = true
+ctrlc.workspace = true
 document-features = "0.2"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -159,8 +159,15 @@ impl WebViewerServer {
         Self { server }
     }
 
-    pub async fn serve(self) -> anyhow::Result<()> {
-        self.server.await?;
+    pub async fn serve(
+        self,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    ) -> anyhow::Result<()> {
+        self.server
+            .with_graceful_shutdown(async {
+                shutdown_rx.recv().await.ok();
+            })
+            .await?;
         Ok(())
     }
 }

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -6,8 +6,17 @@ async fn main() {
     re_log::setup_native_logging();
     let port = 9090;
     eprintln!("Hosting web-viewer on http://127.0.0.1:{port}");
+
+    // Shutdown server via Ctrl+C
+    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+    ctrlc::set_handler(move || {
+        re_log::debug!("Ctrl-C detected - Closing web server.");
+        shutdown_tx.send(()).unwrap();
+    })
+    .expect("Error setting Ctrl-C handler");
+
     re_web_viewer_server::WebViewerServer::new(port)
-        .serve()
+        .serve(shutdown_rx)
         .await
         .unwrap();
 }

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -97,6 +97,7 @@ backtrace = "0.3"
 clap = { workspace = true, features = ["derive"] }
 mimalloc.workspace = true
 puffin_http = "0.11"
+ctrlc.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # Native unix dependencies:

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -74,6 +74,18 @@ impl RerunArgs {
         default_enabled: bool,
         run: impl FnOnce(Session) + Send + 'static,
     ) -> anyhow::Result<()> {
+        // Ensure we have a running tokio runtime.
+        #[allow(unused_assignments)]
+        let mut tokio_runtime = None;
+        let tokio_runtime_handle = if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle
+        } else {
+            tokio_runtime =
+                Some(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));
+            tokio_runtime.as_ref().unwrap().handle().clone()
+        };
+        let _tokio_runtime_guard = tokio_runtime_handle.enter();
+
         let (rerun_enabled, recording_info) = crate::SessionBuilder::new(application_id)
             .default_enabled(default_enabled)
             .finalize();
@@ -102,12 +114,17 @@ impl RerunArgs {
         };
 
         let session = Session::new(recording_info, sink);
+        let _sink = session.sink().clone(); // Keep sink (and potential associated servers) alive until the end of this function scope.
         run(session);
 
         #[cfg(feature = "web_viewer")]
         if matches!(self.to_behavior(), Ok(RerunBehavior::Serve)) {
-            eprintln!("Sleeping while serving the web viewer. Abort with Ctrl-C");
-            std::thread::sleep(std::time::Duration::from_secs(1_000_000_000));
+            use anyhow::Context as _;
+
+            let mut shutdown_rx = crate::run::setup_ctrl_c_handler();
+            return tokio_runtime_handle
+                .block_on(async { shutdown_rx.recv().await })
+                .context("Failed to wait for shutdown signal.");
         }
 
         Ok(())

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -121,7 +121,7 @@ impl RerunArgs {
         if matches!(self.to_behavior(), Ok(RerunBehavior::Serve)) {
             use anyhow::Context as _;
 
-            let mut shutdown_rx = crate::run::setup_ctrl_c_handler();
+            let (mut shutdown_rx, _) = crate::run::setup_ctrl_c_handler();
             return tokio_runtime_handle
                 .block_on(async { shutdown_rx.recv().await })
                 .context("Failed to wait for shutdown signal.");

--- a/crates/rerun/src/native_viewer.rs
+++ b/crates/rerun/src/native_viewer.rs
@@ -44,6 +44,7 @@ where
             re_ui,
             cc.storage,
             rx,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         ))
     }))
 }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -4,6 +4,9 @@ use re_smart_channel::Receiver;
 use anyhow::Context as _;
 use clap::Subcommand;
 
+#[cfg(feature = "web_viewer")]
+use crate::web_viewer::host_web_viewer;
+
 // Note the extra blank lines between the point-lists below: it is required by `clap`.
 
 /// The Rerun Viewer and Server
@@ -248,6 +251,8 @@ async fn run_impl(
         }),
     };
 
+    let shutdown_rx = setup_ctrl_c_handler();
+
     // Where do we get the data from?
     let rx = if let Some(url_or_path) = args.url_or_path.clone() {
         match categorize_argument(url_or_path) {
@@ -262,7 +267,16 @@ async fn run_impl(
                 // We are connecting to a server at a websocket address:
 
                 if args.web_viewer {
-                    return host_web_viewer(rerun_server_ws_url).await;
+                    #[cfg(feature = "web_viewer")]
+                    {
+                        let web_viewer =
+                            host_web_viewer(true, rerun_server_ws_url, shutdown_rx.resubscribe());
+                        return web_viewer.await;
+                    }
+                    #[cfg(not(feature = "web_viewer"))]
+                    {
+                        panic!("Can't host web-viewer - rerun was not compiled with the 'web_viewer' feature");
+                    }
                 } else {
                     #[cfg(feature = "native_viewer")]
                     return native_viewer_connect_to_ws_url(
@@ -290,7 +304,7 @@ async fn run_impl(
                 // `rerun.spawn()` doesn't need to log that a connection has been made
                 quiet: call_source.is_python(),
             };
-            re_sdk_comms::serve(args.port, server_options)?
+            re_sdk_comms::serve(args.port, server_options, shutdown_rx.resubscribe())?
         }
 
         #[cfg(not(feature = "server"))]
@@ -311,13 +325,21 @@ async fn run_impl(
                 );
             }
 
+            // Make it possible to gracefully shutdown the servers on ctrl-c.
+            let shutdown_ws_server = shutdown_rx.resubscribe();
+            let shutdown_web_viewer = shutdown_rx.resubscribe();
+
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::Server::new(re_ws_comms::DEFAULT_WS_SERVER_PORT).await?;
-            let server_handle = tokio::spawn(ws_server.listen(rx));
+            let server_handle = tokio::spawn(ws_server.listen(rx, shutdown_ws_server));
 
-            let rerun_ws_server_url = re_ws_comms::default_server_url();
-            host_web_viewer(rerun_ws_server_url).await?;
+            // This is the server that serves the Wasm+HTML:
+            let ws_server_url = re_ws_comms::default_server_url();
+            let ws_server_handle =
+                tokio::spawn(host_web_viewer(true, ws_server_url, shutdown_web_viewer));
 
+            // Wait for both servers to shutdown.
+            ws_server_handle.await?.ok();
             return server_handle.await?;
         }
 
@@ -439,33 +461,20 @@ fn load_file_to_channel(path: &std::path::Path) -> anyhow::Result<Receiver<LogMs
     Ok(rx)
 }
 
-#[cfg(feature = "web_viewer")]
-async fn host_web_viewer(rerun_ws_server_url: String) -> anyhow::Result<()> {
-    let web_port = 9090;
-    let viewer_url = format!("http://127.0.0.1:{web_port}?url={rerun_ws_server_url}");
-
-    let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
-    let web_server_handle = tokio::spawn(web_server.serve());
-
-    let open = true;
-    if open {
-        webbrowser::open(&viewer_url).ok();
-    } else {
-        println!("Hosting Rerun Web Viewer at {viewer_url}.");
-    }
-
-    web_server_handle.await?
-}
-
-#[cfg(not(feature = "web_viewer"))]
-async fn host_web_viewer(_rerun_ws_server_url: String) -> anyhow::Result<()> {
-    panic!("Can't host web-viewer - rerun was not compiled with the 'web_viewer' feature");
-}
-
 #[cfg(feature = "server")]
 fn parse_max_latency(max_latency: Option<&String>) -> f32 {
     max_latency.as_ref().map_or(f32::INFINITY, |time| {
         re_format::parse_duration(time)
             .unwrap_or_else(|err| panic!("Failed to parse max_latency ({max_latency:?}): {err}"))
     })
+}
+
+pub fn setup_ctrl_c_handler() -> tokio::sync::broadcast::Receiver<()> {
+    let (sender, receiver) = tokio::sync::broadcast::channel(1);
+    ctrlc::set_handler(move || {
+        re_log::debug!("Ctrl-C detected, shutting down.");
+        sender.send(()).unwrap();
+    })
+    .expect("Error setting Ctrl-C handler");
+    receiver
 }

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -4,52 +4,74 @@ use re_log_types::LogMsg;
 /// * A web-server, serving the web-viewer
 /// * A `WebSocket` server, server [`LogMsg`]es to remote viewer(s).
 struct RemoteViewerServer {
-    web_server_join_handle: tokio::task::JoinHandle<()>,
     sender: re_smart_channel::Sender<LogMsg>,
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
 }
 
 impl Drop for RemoteViewerServer {
     fn drop(&mut self) {
         re_log::info!("Shutting down web server.");
-        self.web_server_join_handle.abort();
+        self.shutdown_tx.send(()).ok();
     }
 }
 
 impl RemoteViewerServer {
-    pub fn new(tokio_rt: &tokio::runtime::Runtime, open_browser: bool) -> Self {
+    pub fn new(open_browser: bool) -> Self {
         let (rerun_tx, rerun_rx) = re_smart_channel::smart_channel(re_smart_channel::Source::Sdk);
+        let (shutdown_tx, shutdown_rx_ws_server) = tokio::sync::broadcast::channel(1);
+        let shutdown_rx_web_server = shutdown_tx.subscribe();
 
-        let web_server_join_handle = tokio_rt.spawn(async move {
+        tokio::spawn(async move {
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::Server::new(re_ws_comms::DEFAULT_WS_SERVER_PORT)
                 .await
                 .unwrap();
-            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx)); // TODO(emilk): use tokio_rt ?
+            let ws_server_handle = tokio::spawn(ws_server.listen(rerun_rx, shutdown_rx_ws_server));
 
             // This is the server that serves the Wasm+HTML:
-            let web_port = 9090;
-            let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
-            let web_server_handle = tokio::spawn(async move {
-                web_server.serve().await.unwrap();
-            });
-
             let ws_server_url = re_ws_comms::default_server_url();
-            let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
-            if open_browser {
-                webbrowser::open(&viewer_url).ok();
-            } else {
-                re_log::info!("Web server is running - view it at {viewer_url}");
-            }
+            let web_server_handle = tokio::spawn(host_web_viewer(
+                open_browser,
+                ws_server_url,
+                shutdown_rx_web_server,
+            ));
 
             ws_server_handle.await.unwrap().unwrap();
-            web_server_handle.await.unwrap();
+            web_server_handle.await.unwrap().unwrap();
         });
 
         Self {
-            web_server_join_handle,
             sender: rerun_tx,
+            shutdown_tx,
         }
     }
+}
+
+/// Hosts two servers:
+/// * A web-server, serving the web-viewer
+/// * A `WebSocket` server, server [`LogMsg`]es to remote viewer(s).
+///
+/// Optionally opens a browser with the web-viewer.
+#[cfg(feature = "web_viewer")]
+pub async fn host_web_viewer(
+    open_browser: bool,
+    ws_server_url: String,
+    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) -> anyhow::Result<()> {
+    let web_port = 9090;
+    let viewer_url = format!("http://127.0.0.1:{web_port}?url={ws_server_url}");
+
+    let web_server = re_web_viewer_server::WebViewerServer::new(web_port);
+    let web_server_handle = tokio::spawn(web_server.serve(shutdown_rx));
+
+    re_log::info!("Web server is running - view it at {viewer_url}");
+    if open_browser {
+        webbrowser::open(&viewer_url).ok();
+    } else {
+        re_log::info!("Web server is running - view it at {viewer_url}");
+    }
+
+    web_server_handle.await?
 }
 
 impl crate::sink::LogSink for RemoteViewerServer {
@@ -72,14 +94,9 @@ impl crate::sink::LogSink for RemoteViewerServer {
 /// NOTE: you can not connect one `Session` to another.
 ///
 /// This function returns immediately.
+///
+/// The caller needs to ensure that there is a `tokio` runtime running.
 #[must_use]
 pub fn new_sink(open_browser: bool) -> Box<dyn crate::sink::LogSink> {
-    // TODO(emilk): creating a tokio runtime on-demand like this is not great. Not sure how this interacts with `#[tokio::main]`, for instance.
-    use once_cell::sync::Lazy;
-    use parking_lot::Mutex;
-    static TOKIO_RUNTIME: Lazy<Mutex<tokio::runtime::Runtime>> = Lazy::new(|| {
-        Mutex::new(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"))
-    });
-
-    Box::new(RemoteViewerServer::new(&TOKIO_RUNTIME.lock(), open_browser))
+    Box::new(RemoteViewerServer::new(open_browser))
 }

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -18,9 +18,7 @@ rr.script_teardown(args)
 ```
 
 """
-import contextlib
 from argparse import ArgumentParser, Namespace
-from time import sleep
 
 import rerun as rr
 
@@ -93,6 +91,10 @@ def script_teardown(args: Namespace) -> None:
 
     """
     if args.serve:
+        import signal
+        from threading import Event
+
+        exit = Event()
+        signal.signal(signal.SIGINT, lambda sig, frame: exit.set())
         print("Sleeping while serving the web viewer. Abort with Ctrl-C")
-        with contextlib.suppress(Exception):
-            sleep(1_000_000_000)
+        exit.wait()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -295,7 +295,12 @@ fn serve(open_browser: bool) -> PyResult<()> {
             return Ok(());
         }
 
+        use once_cell::sync::Lazy;
+        static TOKIO_RUNTIME: Lazy<tokio::runtime::Runtime> =
+            Lazy::new(|| tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));
+        let _guard = TOKIO_RUNTIME.enter();
         session.set_sink(rerun::web_viewer::new_sink(open_browser));
+
         Ok(())
     }
 


### PR DESCRIPTION
Second attempt to #1613.

New commit is separate - passing shutdown bool around in order to not infect everything with tokio.
It **seems** we almost never need to hook it up, somewhat suspicious but I couldn't find any missing case.

Testing list. All of these were tested on 13aad6879a66aa223a05ea2b56c491899e4b059c
* `cargo r -p rerun -- ../nyud.rrd`
* `cargo run -p rerun --features web_viewer -- ../api_demo.rrd --web-viewer`
* `cargo run -p re_web_viewer_server`
*  `cargo run -p api_demo -- --serve`
* `python ./examples/python/api_demo/main.py --serve`
* `python -m rerun --web-viewer ../objectron.rrd`
* `python ./examples/python/tracking_hf_opencv/main.py
* `cargo run -p api_demo`


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
