### PR TITLE
Update tokio v1.24.1 -> v1.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5052,7 +5052,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,7 @@ vulnerability = "deny"
 unmaintained = "warn"
 yanked = "deny"
 ignore = [
-  "RUSTSEC-2020-0071", # https://rustsec.org/advisories/RUSTSEC-2020-0071 - Potential segfault in the time crate. TODO(emilk): fix in arrow2
+  "RUSTSEC-2020-0071", # https://rustsec.org/advisories/RUSTSEC-2020-0071 - Potential segfault in the time crate. Remove once a new polars is released with https://github.com/pola-rs/polars/pull/6979
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,7 @@ vulnerability = "deny"
 unmaintained = "warn"
 yanked = "deny"
 ignore = [
-  "RUSTSEC-2020-0071", # https://rustsec.org/advisories/RUSTSEC-2020-0071 - Potential segfault in the time crate.
+  "RUSTSEC-2020-0071", # https://rustsec.org/advisories/RUSTSEC-2020-0071 - Potential segfault in the time crate. TODO(emilk): fix in arrow2
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -22,7 +22,6 @@ unmaintained = "warn"
 yanked = "deny"
 ignore = [
   "RUSTSEC-2020-0071", # https://rustsec.org/advisories/RUSTSEC-2020-0071 - Potential segfault in the time crate.
-  "RUSTSEC-2020-0159", # https://rustsec.org/advisories/RUSTSEC-2020-0159 - Potential segfault in `localtime_r` invocations.
 ]
 
 [bans]


### PR DESCRIPTION
Silencing one of our security warning in https://github.com/rerun-io/rerun/security/dependabot

The other will be fixed when a new polars is released with https://github.com/pola-rs/polars/pull/6979

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
