### PR TITLE
Name space views after the space and indicate duplicate names

### DIFF
--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -62,6 +62,10 @@ impl SpaceView {
         space_path: &EntityPath,
         queries_entities: &[EntityPath],
     ) -> Self {
+        // We previously named the [`SpaceView`] after the [`EntityPath`] if there was only a single entity. However,
+        // this led to somewhat confusing and inconsistent behavior. See https://github.com/rerun-io/rerun/issues/1220
+        // Spaces are now always named after the final element of the space-path (or the root), independent of the
+        // query entities.
         let display_name = if let Some(name) = space_path.iter().last() {
             name.to_string()
         } else {

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -62,12 +62,7 @@ impl SpaceView {
         space_path: &EntityPath,
         queries_entities: &[EntityPath],
     ) -> Self {
-        let display_name = if queries_entities.len() == 1 {
-            // A single entity in this space-view - name the space after it.
-            queries_entities[0]
-                .last()
-                .map_or_else(|| "/".to_owned(), |part| part.to_string())
-        } else if let Some(name) = space_path.iter().last() {
+        let display_name = if let Some(name) = space_path.iter().last() {
             name.to_string()
         } else {
             // Include category name in the display for root paths because they look a tad bit too short otherwise.

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -323,8 +323,26 @@ impl Viewport {
         self.has_been_user_edited = true;
     }
 
-    pub(crate) fn add_space_view(&mut self, space_view: SpaceView) -> SpaceViewId {
+    pub(crate) fn add_space_view(&mut self, mut space_view: SpaceView) -> SpaceViewId {
         let id = space_view.id;
+
+        // Find a unique name for the space view
+        let mut candidate_name = space_view.display_name.clone();
+        let mut append_count = 1;
+        let unique_name = 'outer: loop {
+            for view in &self.space_views {
+                if candidate_name == view.1.display_name {
+                    append_count += 1;
+                    candidate_name = format!("{} ({})", space_view.display_name, append_count);
+
+                    continue 'outer;
+                }
+            }
+            break candidate_name;
+        };
+
+        space_view.display_name = unique_name;
+
         self.space_views.insert(id, space_view);
         self.visible.insert(id);
         self.trees.clear(); // Reset them


### PR DESCRIPTION
Resolves: https://github.com/rerun-io/rerun/issues/1220

Consider this (admittedly silly) code:
```
import rerun as rr
import numpy as np

rr.init("space_test", spawn=True)
rr.log_points("space_a/points", positions=np.random.rand(10, 3))
rr.log_points("space_b/space_a/points", positions=np.random.rand(10, 3))
rr.log_points("space_c/points", positions=np.random.rand(10, 3))
rr.log_unknown_transform("space_b/space_a")
```

Before:
![image](https://user-images.githubusercontent.com/3312232/226642504-c1d0d39f-0f7a-4d45-837f-200e08334b29.png)


After:
![image](https://user-images.githubusercontent.com/3312232/226642883-9407534e-6ff4-4bb7-85ca-d6560813e3c6.png)

Additionally hitting "clone view" now generally does the right thing.
![image](https://user-images.githubusercontent.com/3312232/226643992-4a085695-a8cd-4f6a-9449-46b6aa0ba349.png)



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
