### PR TITLE
Add `rerun --save`: stream incoming log stream to an rrd file

### DIFF
--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -23,12 +23,27 @@ mod encoder {
 
         #[error("MsgPack error: {0}")]
         MsgPack(#[from] rmp_serde::encode::Error),
+
+        #[error("Called append on already finished encoder")]
+        AlreadyFinshed,
     }
 
     /// Encode a stream of [`LogMsg`] into an `.rrd` file.
     pub struct Encoder<W: std::io::Write> {
-        zstd_encoder: zstd::stream::Encoder<'static, W>,
+        /// Set to None when finished.
+        zstd_encoder: Option<zstd::stream::Encoder<'static, W>>,
         buffer: Vec<u8>,
+    }
+
+    impl<W: std::io::Write> Drop for Encoder<W> {
+        fn drop(&mut self) {
+            if self.zstd_encoder.is_some() {
+                re_log::warn!("Encoder dropped without calling finish()!");
+                if let Err(err) = self.finish() {
+                    re_log::error!("Failed to finish encoding: {err}");
+                }
+            }
+        }
     }
 
     impl<W: std::io::Write> Encoder<W> {
@@ -45,7 +60,7 @@ mod encoder {
                 zstd::stream::Encoder::new(write, level).map_err(EncodeError::Zstd)?;
 
             Ok(Self {
-                zstd_encoder,
+                zstd_encoder: Some(zstd_encoder),
                 buffer: vec![],
             })
         }
@@ -56,20 +71,29 @@ mod encoder {
                 buffer,
             } = self;
 
-            buffer.clear();
-            rmp_serde::encode::write_named(buffer, message)?;
+            if let Some(zstd_encoder) = zstd_encoder {
+                buffer.clear();
+                rmp_serde::encode::write_named(buffer, message)?;
 
-            zstd_encoder
-                .write_all(&(buffer.len() as u64).to_le_bytes())
-                .map_err(EncodeError::Zstd)?;
-            zstd_encoder.write_all(buffer).map_err(EncodeError::Zstd)?;
+                zstd_encoder
+                    .write_all(&(buffer.len() as u64).to_le_bytes())
+                    .map_err(EncodeError::Zstd)?;
+                zstd_encoder.write_all(buffer).map_err(EncodeError::Zstd)?;
 
-            Ok(())
+                Ok(())
+            } else {
+                Err(EncodeError::AlreadyFinshed)
+            }
         }
 
-        pub fn finish(self) -> Result<(), EncodeError> {
-            self.zstd_encoder.finish().map_err(EncodeError::Zstd)?;
-            Ok(())
+        pub fn finish(&mut self) -> Result<(), EncodeError> {
+            if let Some(zstd_encoder) = self.zstd_encoder.take() {
+                zstd_encoder.finish().map_err(EncodeError::Zstd)?;
+                Ok(())
+            } else {
+                re_log::warn!("Encoder::finish called twice");
+                Ok(())
+            }
         }
     }
 

--- a/crates/re_log_types/src/encoding.rs
+++ b/crates/re_log_types/src/encoding.rs
@@ -25,7 +25,7 @@ mod encoder {
         MsgPack(#[from] rmp_serde::encode::Error),
 
         #[error("Called append on already finished encoder")]
-        AlreadyFinshed,
+        AlreadyFinished,
     }
 
     /// Encode a stream of [`LogMsg`] into an `.rrd` file.
@@ -82,7 +82,7 @@ mod encoder {
 
                 Ok(())
             } else {
-                Err(EncodeError::AlreadyFinshed)
+                Err(EncodeError::AlreadyFinished)
             }
         }
 


### PR DESCRIPTION
By popular request!

This allows you to save incoming log messages directly to disk with `rerun --save foo.rrd`.

This can be useful when you have multiple processes logging to the same `rerun` server, and you want to save it all to an `.rrd` file.

### Testing

In one terminal:
```
❯ RUST_LOG=debug cargo r -p rerun -- --save test.rrd
[2023-03-21T17:49:09Z INFO  re_sdk_comms::server] Hosting a SDK server over TCP at 0.0.0.0:9876. Connect with the Rerun logging SDK.
[2023-03-21T17:49:09Z WARN  rerun::run] Overwriting existing file at "test.rrd"
[2023-03-21T17:49:09Z INFO  rerun::run] Saving incoming log stream to "test.rrd". Abort with Ctrl-C.
[2023-03-21T17:49:16Z INFO  re_sdk_comms::server] New SDK client connected: 127.0.0.1:55903
[2023-03-21T17:49:17Z DEBUG re_sdk_comms::server] Client sent goodbye message.
^C[2023-03-21T17:49:23Z DEBUG rerun::run] Ctrl-C detected, shutting down.
[2023-03-21T17:49:23Z INFO  rerun::run] Log stream disconnected, stopping.
[2023-03-21T17:49:23Z INFO  rerun::run] File saved to "test.rrd"
```

In another terminal
```
cargo r -p objectron -- --connect
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
