### PR TITLE
Fix outlines being offset diagonally by about half a pixel

### DIFF
--- a/crates/re_renderer/shader/composite.wgsl
+++ b/crates/re_renderer/shader/composite.wgsl
@@ -20,7 +20,7 @@ var outline_voronoi_texture: texture_2d<f32>;
 @fragment
 fn main(in: FragmentInput) -> @location(0) Vec4 {
     let resolution = Vec2(textureDimensions(color_texture).xy);
-    let pixel_coordinates = resolution * in.texcoord;
+    let pixel_coordinates = floor(resolution * in.texcoord);
 
     // Note that we can't use a simple textureLoad using @builtin(position) here despite the lack of filtering.
     // The issue is that positions provided by @builtin(position) are not dependent on the set viewport,

--- a/crates/re_renderer/shader/outlines/jumpflooding_step.wgsl
+++ b/crates/re_renderer/shader/outlines/jumpflooding_step.wgsl
@@ -20,7 +20,7 @@ var<uniform> uniforms: FrameUniformBuffer;
 fn main(in: FragmentInput) -> @location(0) Vec4 {
     let resolution = Vec2(textureDimensions(voronoi_texture).xy);
     let pixel_step = Vec2(f32(uniforms.step_width), f32(uniforms.step_width)) / resolution;
-    let pixel_coordinates = resolution * in.texcoord;
+    let pixel_coordinates = floor(resolution * in.texcoord);
 
     var closest_positions_a = Vec2(f32min);
     var closest_distance_sq_a = f32max;


### PR DESCRIPTION
Fixes very subtle bug that caused outlines to be offset. With the gaps introduced in #1667 this became more quite apparent in some situations (at least if you're glued with your nose to the screen like myself ;))

Before:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/1220815/226886621-8930c5f0-9b26-4e45-ae57-35a1d48b0ac8.png">

After:
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/1220815/226886586-0b1b7f29-99fd-43f3-90df-3ab06c9bb5d5.png">

Note how the gap of the blue outline to the bright point in the middle is shifted in the before image - the distance is more equal in the after picture


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
