### PR TITLE
Add support for mesh vertex colors

### DIFF
--- a/crates/re_log_types/src/component_types/color.rs
+++ b/crates/re_log_types/src/component_types/color.rs
@@ -2,7 +2,7 @@ use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
 
 use crate::msg_bundle::Component;
 
-/// An RGBA color tuple with unmultiplied/seprate alpha,
+/// An RGBA color tuple with unmultiplied/separate alpha,
 /// in sRGB gamma space with linear alpha.
 ///
 /// ```

--- a/crates/re_log_types/src/component_types/color.rs
+++ b/crates/re_log_types/src/component_types/color.rs
@@ -2,7 +2,8 @@ use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
 
 use crate::msg_bundle::Component;
 
-/// An RGBA color tuple.
+/// An RGBA color tuple with unmultiplied alpha,
+/// in sRGB color space and linear alpha.
 ///
 /// ```
 /// use re_log_types::component_types::ColorRGBA;
@@ -23,7 +24,7 @@ impl ColorRGBA {
     }
 
     #[inline]
-    pub fn from_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+    pub fn from_unmultiplied_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self::from([r, g, b, a])
     }
 

--- a/crates/re_log_types/src/component_types/color.rs
+++ b/crates/re_log_types/src/component_types/color.rs
@@ -2,8 +2,8 @@ use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
 
 use crate::msg_bundle::Component;
 
-/// An RGBA color tuple with unmultiplied alpha,
-/// in sRGB color space and linear alpha.
+/// An RGBA color tuple with unmultiplied/seprate alpha,
+/// in sRGB gamma space with linear alpha.
 ///
 /// ```
 /// use re_log_types::component_types::ColorRGBA;

--- a/crates/re_log_types/src/component_types/color.rs
+++ b/crates/re_log_types/src/component_types/color.rs
@@ -1,5 +1,3 @@
-use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
-
 use crate::msg_bundle::Component;
 
 /// An RGBA color tuple with unmultiplied/separate alpha,
@@ -12,9 +10,21 @@ use crate::msg_bundle::Component;
 ///
 /// assert_eq!(ColorRGBA::data_type(), DataType::UInt32);
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq, ArrowField, ArrowSerialize, ArrowDeserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+    arrow2_convert::ArrowField,
+    arrow2_convert::ArrowSerialize,
+    arrow2_convert::ArrowDeserialize,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[arrow_field(transparent)]
+#[repr(transparent)]
 pub struct ColorRGBA(pub u32);
 
 impl ColorRGBA {

--- a/crates/re_log_types/src/component_types/mesh3d.rs
+++ b/crates/re_log_types/src/component_types/mesh3d.rs
@@ -435,7 +435,7 @@ mod tests {
                 ColorRGBA(0x00ff00ff),
                 ColorRGBA(0x0000ffff),
             ]),
-            indices: vec![1, 2, 3].into(),
+            indices: vec![0, 1, 2].into(),
             vertex_normals: vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 80.0, 90.0, 100.0].into(),
             albedo_factor: Vec4D([0.5, 0.5, 0.5, 1.0]).into(),
         };

--- a/crates/re_log_types/src/component_types/mesh3d.rs
+++ b/crates/re_log_types/src/component_types/mesh3d.rs
@@ -146,7 +146,7 @@ pub struct RawMesh3D {
     /// and the length of this must be divisible by 9.
     pub positions: Vec<f32>,
 
-    /// Per-vertex colors.
+    /// Per-vertex albedo colors.
     pub vertex_colors: Option<Vec<ColorRGBA>>,
 
     /// Optionally, the flattened normals array for this mesh.
@@ -210,11 +210,17 @@ impl RawMesh3D {
     }
 
     #[inline]
-    pub fn num_triangles(&self) -> usize {
-        #[cfg(debug_assertions)]
-        self.sanity_check().unwrap();
-
+    pub fn num_vertices(&self) -> usize {
         self.positions.len() / 3
+    }
+
+    #[inline]
+    pub fn num_triangles(&self) -> usize {
+        if let Some(indices) = &self.indices {
+            indices.len() / 3
+        } else {
+            self.num_vertices() / 3
+        }
     }
 }
 

--- a/crates/re_log_types/src/component_types/mesh3d.rs
+++ b/crates/re_log_types/src/component_types/mesh3d.rs
@@ -117,14 +117,17 @@ pub enum RawMeshError {
 ///     RawMesh3D::data_type(),
 ///     DataType::Struct(vec![
 ///         Field::new("mesh_id", DataType::FixedSizeBinary(16), false),
-///         Field::new("positions", DataType::List(Box::new(
+///         Field::new("vertex_positions", DataType::List(Box::new(
 ///             Field::new("item", DataType::Float32, false)),
 ///         ), false),
-///         Field::new("indices", DataType::List(Box::new(
+///         Field::new("vertex_colors", DataType::List(Box::new(
 ///             Field::new("item", DataType::UInt32, false)),
 ///         ), true),
-///         Field::new("normals", DataType::List(Box::new(
+///         Field::new("vertex_normals", DataType::List(Box::new(
 ///             Field::new("item", DataType::Float32, false)),
+///         ), true),
+///         Field::new("indices", DataType::List(Box::new(
+///             Field::new("item", DataType::UInt32, false)),
 ///         ), true),
 ///         Field::new("albedo_factor", DataType::FixedSizeList(
 ///             Box::new(Field::new("item", DataType::Float32, false)),
@@ -144,7 +147,7 @@ pub struct RawMesh3D {
     ///
     /// If no indices are specified, then each triplet of vertex positions are intrpreted as a triangle
     /// and the length of this must be divisible by 9.
-    pub positions: Vec<f32>,
+    pub vertex_positions: Vec<f32>,
 
     /// Per-vertex albedo colors.
     pub vertex_colors: Option<Vec<ColorRGBA>>,
@@ -174,11 +177,13 @@ pub struct RawMesh3D {
 
 impl RawMesh3D {
     pub fn sanity_check(&self) -> Result<(), RawMeshError> {
-        if self.positions.len() % 3 != 0 {
-            return Err(RawMeshError::PositionsNotDivisibleBy3(self.positions.len()));
+        if self.vertex_positions.len() % 3 != 0 {
+            return Err(RawMeshError::PositionsNotDivisibleBy3(
+                self.vertex_positions.len(),
+            ));
         }
 
-        let num_vertices = self.positions.len() / 3;
+        let num_vertices = self.vertex_positions.len() / 3;
 
         if let Some(indices) = &self.indices {
             if indices.len() % 3 != 0 {
@@ -193,14 +198,16 @@ impl RawMesh3D {
                     });
                 }
             }
-        } else if self.positions.len() % 9 != 0 {
-            return Err(RawMeshError::PositionsAreNotTriangles(self.positions.len()));
+        } else if self.vertex_positions.len() % 9 != 0 {
+            return Err(RawMeshError::PositionsAreNotTriangles(
+                self.vertex_positions.len(),
+            ));
         }
 
         if let Some(normals) = &self.vertex_normals {
-            if normals.len() != self.positions.len() {
+            if normals.len() != self.vertex_positions.len() {
                 return Err(RawMeshError::MismatchedPositionsNormals(
-                    self.positions.len(),
+                    self.vertex_positions.len(),
                     normals.len(),
                 ));
             }
@@ -211,7 +218,7 @@ impl RawMesh3D {
 
     #[inline]
     pub fn num_vertices(&self) -> usize {
-        self.positions.len() / 3
+        self.vertex_positions.len() / 3
     }
 
     #[inline]
@@ -429,7 +436,7 @@ mod tests {
     fn example_raw_mesh() -> RawMesh3D {
         let mesh = RawMesh3D {
             mesh_id: MeshId::random(),
-            positions: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0],
+            vertex_positions: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0],
             vertex_colors: Some(vec![
                 ColorRGBA(0xff0000ff),
                 ColorRGBA(0x00ff00ff),

--- a/crates/re_log_types/src/component_types/mesh3d.rs
+++ b/crates/re_log_types/src/component_types/mesh3d.rs
@@ -9,7 +9,7 @@ use arrow2_convert::{serialize::ArrowSerialize, ArrowDeserialize, ArrowField, Ar
 
 use crate::msg_bundle::Component;
 
-use super::{FieldError, Vec4D};
+use super::{ColorRGBA, FieldError, Vec4D};
 
 // ----------------------------------------------------------------------------
 
@@ -145,6 +145,9 @@ pub struct RawMesh3D {
     /// If no indices are specified, then each triplet of vertex positions are intrpreted as a triangle
     /// and the length of this must be divisible by 9.
     pub positions: Vec<f32>,
+
+    /// Per-vertex colors.
+    pub vertex_colors: Option<Vec<ColorRGBA>>,
 
     /// Optionally, the flattened indices array for this mesh.
     ///
@@ -421,6 +424,11 @@ mod tests {
         let mesh = RawMesh3D {
             mesh_id: MeshId::random(),
             positions: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0],
+            vertex_colors: Some(vec![
+                ColorRGBA(0xff0000ff),
+                ColorRGBA(0x00ff00ff),
+                ColorRGBA(0x0000ffff),
+            ]),
             indices: vec![1, 2, 3].into(),
             normals: vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 80.0, 90.0, 100.0].into(),
             albedo_factor: Vec4D([0.5, 0.5, 0.5, 1.0]).into(),

--- a/crates/re_log_types/src/component_types/mesh3d.rs
+++ b/crates/re_log_types/src/component_types/mesh3d.rs
@@ -138,7 +138,7 @@ pub enum RawMeshError {
 pub struct RawMesh3D {
     pub mesh_id: MeshId,
 
-    /// The flattened positions array of this mesh.
+    /// The flattened vertex positions array of this mesh.
     ///
     /// The length of this vector should always be divisible by three (since this is a 3D mesh).
     ///
@@ -149,16 +149,16 @@ pub struct RawMesh3D {
     /// Per-vertex colors.
     pub vertex_colors: Option<Vec<ColorRGBA>>,
 
+    /// Optionally, the flattened normals array for this mesh.
+    ///
+    /// If specified, this must match the length of `Self::positions`.
+    pub vertex_normals: Option<Vec<f32>>,
+
     /// Optionally, the flattened indices array for this mesh.
     ///
     /// Meshes are always triangle lists, i.e. the length of this vector should always be
     /// divisible by three.
     pub indices: Option<Vec<u32>>,
-
-    /// Optionally, the flattened normals array for this mesh.
-    ///
-    /// If specified, this must match the length of `Self::positions`.
-    pub normals: Option<Vec<f32>>,
 
     /// Albedo factor applied to the final color of the mesh.
     ///
@@ -197,7 +197,7 @@ impl RawMesh3D {
             return Err(RawMeshError::PositionsAreNotTriangles(self.positions.len()));
         }
 
-        if let Some(normals) = &self.normals {
+        if let Some(normals) = &self.vertex_normals {
             if normals.len() != self.positions.len() {
                 return Err(RawMeshError::MismatchedPositionsNormals(
                     self.positions.len(),
@@ -430,7 +430,7 @@ mod tests {
                 ColorRGBA(0x0000ffff),
             ]),
             indices: vec![1, 2, 3].into(),
-            normals: vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 80.0, 90.0, 100.0].into(),
+            vertex_normals: vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 80.0, 90.0, 100.0].into(),
             albedo_factor: Vec4D([0.5, 0.5, 0.5, 1.0]).into(),
         };
         mesh.sanity_check().unwrap();

--- a/crates/re_renderer/shader/instanced_mesh.wgsl
+++ b/crates/re_renderer/shader/instanced_mesh.wgsl
@@ -19,7 +19,7 @@ struct VertexOut {
     @location(0) color: Vec4, // 0-1 linear space with unmultiplied/separate alpha
     @location(1) texcoord: Vec2,
     @location(2) normal_world_space: Vec3,
-    @location(3) additive_tint_rgb: Vec3,
+    @location(3) additive_tint_rgb: Vec3, // 0-1 linear space
     @location(4) @interpolate(flat)
     outline_mask_ids: UVec2,
 };

--- a/crates/re_renderer/shader/instanced_mesh.wgsl
+++ b/crates/re_renderer/shader/instanced_mesh.wgsl
@@ -10,6 +10,7 @@ var albedo_texture: texture_2d<f32>;
 struct MaterialUniformBuffer {
     albedo_factor: Vec4,
 };
+
 @group(1) @binding(1)
 var<uniform> material: MaterialUniformBuffer;
 

--- a/crates/re_renderer/shader/instanced_mesh.wgsl
+++ b/crates/re_renderer/shader/instanced_mesh.wgsl
@@ -16,11 +16,11 @@ var<uniform> material: MaterialUniformBuffer;
 
 struct VertexOut {
     @builtin(position) position: Vec4,
-    @location(0) texcoord: Vec2,
-    @location(1) normal_world_space: Vec3,
-    @location(2) additive_tint_rgb: Vec3,
-
-    @location(3) @interpolate(flat)
+    @location(0) color: Vec4, // 0-1 linear space with unmultiplied/separate alpha
+    @location(1) texcoord: Vec2,
+    @location(2) normal_world_space: Vec3,
+    @location(3) additive_tint_rgb: Vec3,
+    @location(4) @interpolate(flat)
     outline_mask_ids: UVec2,
 };
 
@@ -39,6 +39,7 @@ fn vs_main(in_vertex: VertexIn, in_instance: InstanceIn) -> VertexOut {
 
     var out: VertexOut;
     out.position = frame.projection_from_world * Vec4(world_position, 1.0);
+    out.color = linear_from_srgba(in_vertex.color);
     out.texcoord = in_vertex.texcoord;
     out.normal_world_space = world_normal;
     out.additive_tint_rgb = linear_from_srgb(in_instance.additive_tint_srgb.rgb);
@@ -50,16 +51,23 @@ fn vs_main(in_vertex: VertexIn, in_instance: InstanceIn) -> VertexOut {
 @fragment
 fn fs_main_shaded(in: VertexOut) -> @location(0) Vec4 {
     let albedo = textureSample(albedo_texture, trilinear_sampler, in.texcoord).rgb
-                 * material.albedo_factor.rgb + in.additive_tint_rgb;
+                 * in.color.rgb
+                 * material.albedo_factor.rgb
+                 + in.additive_tint_rgb;
 
-    // Hardcoded lambert lighting. TODO(andreas): Some microfacet model.
-    let light_dir = normalize(vec3(1.0, 2.0, 0.0)); // TODO(andreas): proper lighting
-    let normal = normalize(in.normal_world_space);
-    let shading = clamp(dot(normal, light_dir), 0.0, 1.0) + 0.2;
+    if (all(in.normal_world_space == Vec3(0.0, 0.0, 0.0))) {
+        // no normal, no shading
+        return Vec4(albedo, 1.0);
+    } else {
+        // Hardcoded lambert lighting. TODO(andreas): Some microfacet model.
+        let light_dir = normalize(vec3(1.0, 2.0, 0.0)); // TODO(andreas): proper lighting
+        let normal = normalize(in.normal_world_space);
+        let shading = clamp(dot(normal, light_dir), 0.0, 1.0) + 0.2;
 
-    let radiance = albedo * shading;
+        let radiance = albedo * shading;
 
-    return Vec4(radiance, 1.0);
+        return Vec4(radiance, 1.0);
+    }
 }
 
 @fragment

--- a/crates/re_renderer/shader/mesh_vertex.wgsl
+++ b/crates/re_renderer/shader/mesh_vertex.wgsl
@@ -1,7 +1,7 @@
 // See mesh.rs#MeshVertex
 struct VertexIn {
     @location(0) position: Vec3,
-    @location(1) color: Vec4,
+    @location(1) color: Vec4, // gamma-space 0-1, unmultiplied
     @location(2) normal: Vec3,
     @location(3) texcoord: Vec2,
 };

--- a/crates/re_renderer/shader/mesh_vertex.wgsl
+++ b/crates/re_renderer/shader/mesh_vertex.wgsl
@@ -1,20 +1,21 @@
 // See mesh.rs#MeshVertex
 struct VertexIn {
     @location(0) position: Vec3,
-    @location(1) normal: Vec3,
-    @location(2) texcoord: Vec2,
+    @location(1) color: Vec4,
+    @location(2) normal: Vec3,
+    @location(3) texcoord: Vec2,
 };
 
 // See mesh_renderer.rs
 struct InstanceIn {
     // We could alternatively store projection_from_mesh, but world position might be useful
     // in the future and this saves us a Vec4 and simplifies dataflow on the cpu side.
-    @location(3) world_from_mesh_row_0: Vec4,
-    @location(4) world_from_mesh_row_1: Vec4,
-    @location(5) world_from_mesh_row_2: Vec4,
-    @location(6) world_from_mesh_normal_row_0: Vec3,
-    @location(7) world_from_mesh_normal_row_1: Vec3,
-    @location(8) world_from_mesh_normal_row_2: Vec3,
-    @location(9) additive_tint_srgb: Vec4,
-    @location(10) outline_mask_ids: UVec2,
+    @location(4) world_from_mesh_row_0: Vec4,
+    @location(5) world_from_mesh_row_1: Vec4,
+    @location(6) world_from_mesh_row_2: Vec4,
+    @location(7) world_from_mesh_normal_row_0: Vec3,
+    @location(8) world_from_mesh_normal_row_1: Vec3,
+    @location(9) world_from_mesh_normal_row_2: Vec3,
+    @location(10) additive_tint_srgb: Vec4,
+    @location(11) outline_mask_ids: UVec2,
 };

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -29,7 +29,7 @@ var<private> TEXTURE_SIZE: i32 = 2048;
 
 struct VertexOut {
     @builtin(position) position: Vec4,
-    @location(0) color: Vec4,
+    @location(0) color: Vec4, // linear RGBA with unmulitplied/separate alpha
     @location(1) world_position: Vec3,
     @location(2) point_center: Vec3,
     @location(3) radius: f32,

--- a/crates/re_renderer/src/color.rs
+++ b/crates/re_renderer/src/color.rs
@@ -1,0 +1,22 @@
+/// RGBA color in sRGB gamma space, with separate/unmultiplied linear alpha.
+///
+/// This is the most common input color, e.g. speicied using CSS colors.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Rgba32Unmul(pub [u8; 4]);
+
+impl Rgba32Unmul {
+    pub const BLACK: Self = Self([0, 0, 0, 255]);
+    pub const WHITE: Self = Self([255, 255, 255, 255]);
+    pub const TRANSPARENT: Self = Self([0, 0, 0, 0]);
+
+    #[inline]
+    pub fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        Self([r, g, b, 255])
+    }
+
+    #[inline]
+    pub fn from_rgba_unmul_array(rgba_unmul: [u8; 4]) -> Self {
+        Self(rgba_unmul)
+    }
+}

--- a/crates/re_renderer/src/colormap.rs
+++ b/crates/re_renderer/src/colormap.rs
@@ -34,7 +34,7 @@ pub fn grayscale_srgb(t: f32) -> [u8; 4] {
     let t = t.powf(2.2);
     let t = ((t * u8::MAX as f32) + 0.5) as u8;
 
-    [t, t, t, t]
+    [t, t, t, 255]
 }
 
 // --- Turbo color map ---

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -173,17 +173,11 @@ fn import_mesh(
         } else {
             vertex_normals.resize(vertex_positions.len(), glam::Vec3::ZERO);
         }
-        if vertex_positions.len() != vertex_normals.len() {
-            anyhow::bail!("Number of positions was not equal number of normals.");
-        }
 
         if let Some(primitive_texcoords) = reader.read_tex_coords(set) {
             vertex_texcoords.extend(primitive_texcoords.into_f32().map(glam::Vec2::from));
         } else {
             vertex_texcoords.resize(vertex_positions.len(), glam::Vec2::ZERO);
-        }
-        if vertex_positions.len() != vertex_texcoords.len() {
-            anyhow::bail!("Number of positions was not equal number of texture coordiantes.");
         }
 
         let primitive_material = primitive.material();

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -12,7 +12,7 @@ use crate::{
         GpuMeshHandle, GpuTexture2DHandle, ResourceLifeTime, Texture2DCreationDesc,
         TextureManager2D,
     },
-    RenderContext,
+    RenderContext, Rgba32Unmul,
 };
 
 /// Loads both gltf and glb into the mesh & texture manager.
@@ -163,9 +163,13 @@ fn import_mesh(
         }
 
         if let Some(colors) = reader.read_colors(set) {
-            vertex_colors.extend(colors.into_rgba_u8());
+            vertex_colors.extend(
+                colors
+                    .into_rgba_u8()
+                    .map(Rgba32Unmul::from_rgba_unmul_array),
+            );
         } else {
-            vertex_colors.resize(vertex_positions.len(), [255; 4]);
+            vertex_colors.resize(vertex_positions.len(), Rgba32Unmul::WHITE);
         }
 
         if let Some(primitive_normals) = reader.read_normals() {

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -171,7 +171,7 @@ fn import_mesh(
         if let Some(primitive_normals) = reader.read_normals() {
             vertex_normals.extend(primitive_normals.map(glam::Vec3::from));
         } else {
-            anyhow::bail!("Gltf primitives must have normals");
+            vertex_normals.resize(vertex_positions.len(), glam::Vec3::ZERO);
         }
         if vertex_positions.len() != vertex_normals.len() {
             anyhow::bail!("Number of positions was not equal number of normals.");
@@ -246,7 +246,7 @@ fn import_mesh(
         anyhow::bail!("empty mesh");
     }
 
-    Ok(Mesh {
+    let mesh = Mesh {
         label: mesh.name().into(),
         indices,
         vertex_positions,
@@ -254,7 +254,11 @@ fn import_mesh(
         vertex_normals,
         vertex_texcoords,
         materials,
-    })
+    };
+
+    mesh.sanity_check()?;
+
+    Ok(mesh)
 }
 
 fn gather_instances_recursive(

--- a/crates/re_renderer/src/importer/obj.rs
+++ b/crates/re_renderer/src/importer/obj.rs
@@ -95,11 +95,8 @@ pub fn load_obj_from_buffer(
 
             mesh.sanity_check()?;
 
-            let gpu_mesh = ctx
-                .mesh_manager
-                .write()
-                .create(ctx, &mesh, lifetime)
-                .unwrap(); // TODO(andreas): Handle error
+            let gpu_mesh = ctx.mesh_manager.write().create(ctx, &mesh, lifetime)?;
+
             Ok(MeshInstance {
                 gpu_mesh,
                 mesh: Some(Arc::new(mesh)),

--- a/crates/re_renderer/src/importer/obj.rs
+++ b/crates/re_renderer/src/importer/obj.rs
@@ -7,7 +7,7 @@ use crate::{
     mesh::{Material, Mesh},
     renderer::MeshInstance,
     resource_managers::ResourceLifeTime,
-    RenderContext,
+    RenderContext, Rgba32Unmul,
 };
 
 /// Load a [Wavefront .obj file](https://en.wikipedia.org/wiki/Wavefront_.obj_file)
@@ -43,20 +43,19 @@ pub fn load_obj_from_buffer(
                 .map(|p| glam::vec3(p[0], p[1], p[2]))
                 .collect();
 
-            let mut vertex_colors: Vec<[u8; 4]> = mesh
+            let mut vertex_colors: Vec<Rgba32Unmul> = mesh
                 .vertex_color
                 .chunks_exact(3)
                 .map(|c| {
-                    [
+                    Rgba32Unmul::from_rgb(
                         // It is not specified if the color is in linear or gamma space, but gamma seems a safe bet.
                         (c[0] * 255.0).round() as u8,
                         (c[1] * 255.0).round() as u8,
                         (c[2] * 255.0).round() as u8,
-                        255,
-                    ]
+                    )
                 })
                 .collect();
-            vertex_colors.resize(vertex_positions.len(), [255, 255, 255, 255]);
+            vertex_colors.resize(vertex_positions.len(), Rgba32Unmul::WHITE);
 
             let mut vertex_normals: Vec<glam::Vec3> = mesh
                 .normals

--- a/crates/re_renderer/src/importer/obj.rs
+++ b/crates/re_renderer/src/importer/obj.rs
@@ -58,15 +58,12 @@ pub fn load_obj_from_buffer(
                 .collect();
             vertex_colors.resize(vertex_positions.len(), [255, 255, 255, 255]);
 
-            let vertex_normals: Vec<glam::Vec3> = mesh
+            let mut vertex_normals: Vec<glam::Vec3> = mesh
                 .normals
                 .chunks_exact(3)
                 .map(|n| glam::vec3(n[0], n[1], n[2]))
                 .collect();
-            anyhow::ensure!(
-                vertex_positions.len() == vertex_normals.len(),
-                "Missing normals"
-            );
+            vertex_normals.resize(vertex_positions.len(), glam::Vec3::ZERO);
 
             let mut vertex_texcoords: Vec<glam::Vec2> = mesh
                 .texcoords
@@ -95,6 +92,9 @@ pub fn load_obj_from_buffer(
                     albedo_multiplier: crate::Rgba::WHITE,
                 }],
             };
+
+            mesh.sanity_check()?;
+
             let gpu_mesh = ctx
                 .mesh_manager
                 .write()

--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -15,6 +15,7 @@ pub mod resource_managers;
 pub mod view_builder;
 
 mod allocator;
+mod color;
 mod colormap;
 mod context;
 mod debug_label;
@@ -26,6 +27,7 @@ mod size;
 mod wgpu_buffer_types;
 mod wgpu_resources;
 
+pub use color::Rgba32Unmul;
 pub use colormap::{
     colormap_inferno_srgb, colormap_magma_srgb, colormap_plasma_srgb, colormap_srgb,
     colormap_turbo_srgb, colormap_viridis_srgb, grayscale_srgb, ColorMap,

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -11,7 +11,7 @@ use crate::{
         BindGroupDesc, BindGroupEntry, BufferDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
         GpuBuffer,
     },
-    RenderContext,
+    RenderContext, Rgba32Unmul,
 };
 
 /// Defines how mesh vertices are built.
@@ -89,9 +89,9 @@ pub struct Mesh {
 
     pub vertex_positions: Vec<glam::Vec3>,
 
-    /// Per-vertex albedo color with unmulitplied/separate alpha.
+    /// Per-vertex albedo color.
     /// Must be equal in length to [`Self::vertex_positions`].
-    pub vertex_colors: Vec<[u8; 4]>,
+    pub vertex_colors: Vec<Rgba32Unmul>,
 
     /// Must be equal in length to [`Self::vertex_positions`].
     /// Use ZERO for unshaded.
@@ -238,7 +238,7 @@ impl GpuMesh {
 
         // TODO(andreas): Have a variant that gets this from a stack allocator.
         let vb_positions_size = (data.vertex_positions.len() * size_of::<glam::Vec3>()) as u64;
-        let vb_color_size = (data.vertex_normals.len() * size_of::<[u8; 4]>()) as u64;
+        let vb_color_size = (data.vertex_colors.len() * size_of::<Rgba32Unmul>()) as u64;
         let vb_normals_size = (data.vertex_normals.len() * size_of::<glam::Vec3>()) as u64;
         let vb_texcoords_size = (data.vertex_texcoords.len() * size_of::<glam::Vec2>()) as u64;
 

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -15,9 +15,6 @@ use crate::{
 };
 
 /// Defines how mesh vertices are built.
-///
-/// Mesh vertices consist of two vertex buffers right now.
-/// One for positions ([`glam::Vec3`]) and one for the rest, called [`mesh_vertices::MeshVertexData`] here
 pub mod mesh_vertices {
     use crate::wgpu_resources::VertexBufferLayout;
     use smallvec::smallvec;
@@ -87,19 +84,20 @@ pub mod mesh_vertices {
 pub struct Mesh {
     pub label: DebugLabel,
 
+    /// Length must be a multipel of three.
     pub indices: Vec<u32>, // TODO(andreas): different index formats?
 
     pub vertex_positions: Vec<glam::Vec3>,
 
     /// Per-vertex albedo color with unmulitplied/separate alpha.
-    /// Must be equal in length to [`vertex_positions`].
+    /// Must be equal in length to [`Self::vertex_positions`].
     pub vertex_colors: Vec<[u8; 4]>,
 
-    /// Must be equal in length to [`vertex_positions`].
+    /// Must be equal in length to [`Self::vertex_positions`].
     /// Use ZERO for unshaded.
     pub vertex_normals: Vec<glam::Vec3>,
 
-    /// Must be equal in length to [`vertex_positions`].
+    /// Must be equal in length to [`Self::vertex_positions`].
     pub vertex_texcoords: Vec<glam::Vec2>,
 
     pub materials: SmallVec<[Material; 1]>,

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -17,55 +17,21 @@ use crate::{
 /// Defines how mesh vertices are built.
 pub mod mesh_vertices {
     use crate::wgpu_resources::VertexBufferLayout;
-    use smallvec::smallvec;
 
     /// Vertex buffer layouts describing how vertex data should be laid out.
     ///
     /// Needs to be kept in sync with `mesh_vertex.wgsl`.
-    pub fn vertex_buffer_layouts() -> [VertexBufferLayout; 4] {
-        [
-            // Position:
-            VertexBufferLayout {
-                array_stride: std::mem::size_of::<glam::Vec3>() as _,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: smallvec![wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    shader_location: 0,
-                    offset: 0,
-                }],
-            },
-            // 32 bit color:
-            VertexBufferLayout {
-                array_stride: 4,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: smallvec![wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Unorm8x4,
-                    shader_location: 1,
-                    offset: 0,
-                }],
-            },
-            // TODO(andreas): Compress normals. Afaik Octahedral Mapping is the best by far, see https://jcgt.org/published/0003/02/01/
-            // Normal:
-            VertexBufferLayout {
-                array_stride: std::mem::size_of::<glam::Vec3>() as _,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: smallvec![wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    shader_location: 2,
-                    offset: 0,
-                }],
-            },
-            // Texcoord:
-            VertexBufferLayout {
-                array_stride: std::mem::size_of::<glam::Vec2>() as _,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: smallvec![wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x2,
-                    shader_location: 3,
-                    offset: 0,
-                }],
-            },
-        ]
+    pub fn vertex_buffer_layouts() -> smallvec::SmallVec<[VertexBufferLayout; 4]> {
+        // TODO(andreas): Compress normals. Afaik Octahedral Mapping is the best by far, see https://jcgt.org/published/0003/02/01/
+        VertexBufferLayout::from_formats(
+            [
+                wgpu::VertexFormat::Float32x3, // position
+                wgpu::VertexFormat::Unorm8x4,  // RGBA
+                wgpu::VertexFormat::Float32x3, // normal
+                wgpu::VertexFormat::Float32x2, // texcoord
+            ]
+            .into_iter(),
+        )
     }
 
     /// Next vertex attribute index that can be used for another vertex buffer.

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -89,10 +89,17 @@ pub struct Mesh {
 
     pub indices: Vec<u32>, // TODO(andreas): different index formats?
 
-    // These must be equal in length:
     pub vertex_positions: Vec<glam::Vec3>,
+
+    /// Per-vertex albedo color with unmulitplied/separate alpha.
+    /// Must be equal in length to [`vertex_positions`].
     pub vertex_colors: Vec<[u8; 4]>,
+
+    /// Must be equal in length to [`vertex_positions`].
+    /// Use ZERO for unshaded.
     pub vertex_normals: Vec<glam::Vec3>,
+
+    /// Must be equal in length to [`vertex_positions`].
     pub vertex_texcoords: Vec<glam::Vec2>,
 
     pub materials: SmallVec<[Material; 1]>,
@@ -160,9 +167,13 @@ impl GpuMesh {
         mesh_bind_group_layout: GpuBindGroupLayoutHandle,
         data: &Mesh,
     ) -> Result<Self, ResourceManagerError> {
-        assert_eq!(data.vertex_positions.len(), data.vertex_colors.len());
-        assert_eq!(data.vertex_positions.len(), data.vertex_normals.len());
-        assert_eq!(data.vertex_positions.len(), data.vertex_texcoords.len());
+        if data.vertex_positions.len() != data.vertex_colors.len()
+            || data.vertex_positions.len() != data.vertex_normals.len()
+            || data.vertex_positions.len() != data.vertex_texcoords.len()
+        {
+            return Err(ResourceManagerError::InvalidMesh);
+        }
+
         re_log::trace!(
             "uploading new mesh named {:?} with {} vertices and {} triangles",
             data.label.get(),

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -37,6 +37,16 @@ pub mod mesh_vertices {
                     offset: 0,
                 }],
             },
+            // 32 bit color:
+            VertexBufferLayout {
+                array_stride: 4,
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: smallvec![wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Unorm8x4,
+                    shader_location: 1,
+                    offset: 0,
+                }],
+            },
             // TODO(andreas): Compress normals. Afaik Octahedral Mapping is the best by far, see https://jcgt.org/published/0003/02/01/
             // Normal:
             VertexBufferLayout {
@@ -44,7 +54,7 @@ pub mod mesh_vertices {
                 step_mode: wgpu::VertexStepMode::Vertex,
                 attributes: smallvec![wgpu::VertexAttribute {
                     format: wgpu::VertexFormat::Float32x3,
-                    shader_location: 1,
+                    shader_location: 2,
                     offset: 0,
                 }],
             },
@@ -54,16 +64,6 @@ pub mod mesh_vertices {
                 step_mode: wgpu::VertexStepMode::Vertex,
                 attributes: smallvec![wgpu::VertexAttribute {
                     format: wgpu::VertexFormat::Float32x2,
-                    shader_location: 2,
-                    offset: 0,
-                }],
-            },
-            // 32 bit color:
-            VertexBufferLayout {
-                array_stride: 4,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: smallvec![wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Unorm8x4,
                     shader_location: 3,
                     offset: 0,
                 }],

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -432,10 +432,14 @@ impl Renderer for MeshRenderer {
             );
             pass.set_vertex_buffer(
                 2,
-                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_normals_range.clone()),
+                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_colors_range.clone()),
             );
             pass.set_vertex_buffer(
                 3,
+                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_normals_range.clone()),
+            );
+            pass.set_vertex_buffer(
+                4,
                 vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_texcoord_range.clone()),
             );
             pass.set_index_buffer(

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -432,7 +432,11 @@ impl Renderer for MeshRenderer {
             );
             pass.set_vertex_buffer(
                 2,
-                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_data_range.clone()),
+                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_normals_range.clone()),
+            );
+            pass.set_vertex_buffer(
+                3,
+                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_texcoord_range.clone()),
             );
             pass.set_index_buffer(
                 index_buffer.slice(mesh_batch.mesh.index_buffer_range.clone()),

--- a/crates/re_renderer/src/resource_managers/resource_manager.rs
+++ b/crates/re_renderer/src/resource_managers/resource_manager.rs
@@ -42,6 +42,9 @@ pub enum ResourceManagerError {
 
     #[error("Failed accessing resource pools")]
     ResourcePoolError(PoolError),
+
+    #[error("Invalid mesh given as input")]
+    InvalidMesh,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/re_renderer/src/resource_managers/resource_manager.rs
+++ b/crates/re_renderer/src/resource_managers/resource_manager.rs
@@ -26,7 +26,7 @@ pub enum ResourceHandle<InnerHandle: slotmap::Key> {
     Invalid,
 }
 
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug)]
 pub enum ResourceManagerError {
     #[error("The requested resource is no longer valid. It was valid for the frame index {current_frame_index}, but the current frame index is {valid_frame_index}")]
     ExpiredResource {
@@ -44,7 +44,7 @@ pub enum ResourceManagerError {
     ResourcePoolError(PoolError),
 
     #[error("Invalid mesh given as input")]
-    InvalidMesh,
+    InvalidMesh(#[from] crate::mesh::MeshError),
 }
 
 #[derive(Clone, Copy)]

--- a/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
@@ -26,6 +26,22 @@ pub struct VertexBufferLayout {
 }
 
 impl VertexBufferLayout {
+    /// Generates layouts with successive shader locations without gaps.
+    pub fn from_formats(formats: impl Iterator<Item = wgpu::VertexFormat>) -> SmallVec<[Self; 4]> {
+        formats
+            .enumerate()
+            .map(move |(location, format)| Self {
+                array_stride: format.size(),
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: smallvec::smallvec![wgpu::VertexAttribute {
+                    format,
+                    offset: 0,
+                    shader_location: location as u32,
+                }],
+            })
+            .collect()
+    }
+
     /// Generates attributes with successive shader locations without gaps
     pub fn attributes_from_formats(
         start_location: u32,

--- a/crates/re_viewer/src/misc/mesh_loader.rs
+++ b/crates/re_viewer/src/misc/mesh_loader.rs
@@ -99,7 +99,7 @@ impl LoadedMesh {
 
         let RawMesh3D {
             mesh_id: _,
-            positions,
+            vertex_positions,
             vertex_colors,
             vertex_normals,
             indices,
@@ -107,7 +107,7 @@ impl LoadedMesh {
         } = raw_mesh;
 
         let vertex_positions: Vec<glam::Vec3> =
-            bytemuck::try_cast_vec(positions.clone()).map_err(|(err, _)| anyhow!(err))?;
+            bytemuck::try_cast_vec(vertex_positions.clone()).map_err(|(err, _)| anyhow!(err))?;
         let num_positions = vertex_positions.len();
 
         let indices = if let Some(indices) = indices {

--- a/crates/re_viewer/src/misc/mesh_loader.rs
+++ b/crates/re_viewer/src/misc/mesh_loader.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use re_log_types::{EncodedMesh3D, Mesh3D, MeshFormat, RawMesh3D};
-use re_renderer::{resource_managers::ResourceLifeTime, RenderContext};
+use re_renderer::{resource_managers::ResourceLifeTime, RenderContext, Rgba32Unmul};
 
 pub struct LoadedMesh {
     name: String,
@@ -119,9 +119,14 @@ impl LoadedMesh {
         let num_indices = indices.len();
 
         let vertex_colors = if let Some(vertex_colors) = vertex_colors {
-            vertex_colors.iter().map(|c| c.to_array()).collect()
+            vertex_colors
+                .iter()
+                .map(|c| Rgba32Unmul::from_rgba_unmul_array(c.to_array()))
+                .collect()
         } else {
-            std::iter::repeat([255; 4]).take(num_positions).collect()
+            std::iter::repeat(Rgba32Unmul::WHITE)
+                .take(num_positions)
+                .collect()
         };
 
         let vertex_normals = if let Some(normals) = vertex_normals {

--- a/crates/re_viewer/src/misc/mesh_loader.rs
+++ b/crates/re_viewer/src/misc/mesh_loader.rs
@@ -131,7 +131,7 @@ impl LoadedMesh {
                 .collect::<Vec<_>>()
         } else {
             // TODO(andreas): Calculate normals
-            // TODO(cmc): support colored and/or textured raw meshes
+            // TODO(cmc): support textured raw meshes
             std::iter::repeat(glam::Vec3::ZERO)
                 .take(num_positions)
                 .collect()

--- a/crates/re_viewer/src/misc/mesh_loader.rs
+++ b/crates/re_viewer/src/misc/mesh_loader.rs
@@ -102,7 +102,7 @@ impl LoadedMesh {
             positions,
             vertex_colors,
             indices,
-            normals,
+            vertex_normals,
             albedo_factor,
         } = raw_mesh;
 
@@ -117,7 +117,7 @@ impl LoadedMesh {
         };
         let num_indices = indices.len();
 
-        let normals = if let Some(normals) = normals {
+        let normals = if let Some(normals) = vertex_normals {
             normals
                 .chunks_exact(3)
                 .map(|v| glam::Vec3::from([v[0], v[1], v[2]]))

--- a/crates/re_viewer/src/misc/mesh_loader.rs
+++ b/crates/re_viewer/src/misc/mesh_loader.rs
@@ -100,6 +100,7 @@ impl LoadedMesh {
         let RawMesh3D {
             mesh_id: _,
             positions,
+            vertex_colors,
             indices,
             normals,
             albedo_factor,

--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -105,6 +105,14 @@ def run_3d_points() -> None:
     )
 
 
+def raw_mesh() -> None:
+    rr.log_mesh(
+        "mesh_demo/triangle",
+        positions=[[0, 0, 0], [0, 0.7, 0], [1.0, 0.0, 0]],
+        vertex_colors=[[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+    )
+
+
 def run_rects() -> None:
     import random
 
@@ -274,6 +282,7 @@ def main() -> None:
         "2d_lines": run_2d_lines,
         "3d_points": run_3d_points,
         "log_cleared": run_log_cleared,
+        "raw_mesh": raw_mesh,
         "rects": run_rects,
         "segmentation": run_segmentation,
         "text": run_text_logs,

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -31,7 +31,7 @@ impl From<GltfPrimitive> for Mesh3D {
             albedo_factor,
             positions,
             indices,
-            normals,
+            vertex_normals,
             vertex_colors,
             texcoords: _, // TODO(cmc) support mesh texturing
         } = primitive;
@@ -41,7 +41,7 @@ impl From<GltfPrimitive> for Mesh3D {
             albedo_factor: albedo_factor.map(Vec4D),
             indices,
             positions: positions.into_iter().flatten().collect(),
-            normals: normals.map(|normals| normals.into_iter().flatten().collect()),
+            vertex_normals: vertex_normals.map(|normals| normals.into_iter().flatten().collect()),
             vertex_colors,
         };
 
@@ -213,7 +213,7 @@ struct GltfPrimitive {
     albedo_factor: Option<[f32; 4]>,
     positions: Vec<[f32; 3]>,
     indices: Option<Vec<u32>>,
-    normals: Option<Vec<[f32; 3]>>,
+    vertex_normals: Option<Vec<[f32; 3]>>,
     vertex_colors: Option<Vec<ColorRGBA>>,
     #[allow(dead_code)]
     texcoords: Option<Vec<[f32; 2]>>,
@@ -277,8 +277,8 @@ fn node_primitives<'data>(
             let indices = reader.read_indices();
             let indices = indices.map(|indices| indices.into_u32().into_iter().collect());
 
-            let normals = reader.read_normals();
-            let normals = normals.map(|normals| normals.collect());
+            let vertex_normals = reader.read_normals();
+            let vertex_normals = vertex_normals.map(|normals| normals.collect());
 
             let vertex_colors = reader.read_colors(0); // TODO(cmc): pick correct set
             let vertex_colors = vertex_colors.map(|colors| {
@@ -295,7 +295,7 @@ fn node_primitives<'data>(
                 albedo_factor,
                 positions,
                 indices,
-                normals,
+                vertex_normals,
                 vertex_colors,
                 texcoords,
             }

--- a/rerun_py/rerun_sdk/rerun/log/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/log/__init__.py
@@ -28,8 +28,8 @@ __all__ = [
 
 
 ColorDtype = Union[np.uint8, np.float32, np.float64]
-Colors = npt.NDArray[ColorDtype]
 Color = Union[npt.NDArray[ColorDtype], Sequence[Union[int, float]]]
+Colors = Union[Sequence[Color], npt.NDArray[ColorDtype]]
 
 OptionalClassIds = Optional[Union[int, npt.ArrayLike]]
 OptionalKeyPointIds = Optional[Union[int, npt.ArrayLike]]
@@ -42,7 +42,7 @@ def _to_sequence(array: Optional[npt.ArrayLike]) -> Optional[Sequence[float]]:
     return array  # type: ignore[return-value]
 
 
-def _normalize_colors(colors: Optional[npt.ArrayLike] = None) -> npt.NDArray[np.uint8]:
+def _normalize_colors(colors: Optional[Union[Color, Colors]] = None) -> npt.NDArray[np.uint8]:
     """Normalize flexible colors arrays."""
     if colors is None:
         # An empty array represents no colors.

--- a/rerun_py/rerun_sdk/rerun/log/file.py
+++ b/rerun_py/rerun_sdk/rerun/log/file.py
@@ -52,7 +52,7 @@ def log_mesh_file(
     """
     Log the contents of a mesh file (.gltf, .glb, .obj, …).
 
-    `transform` is an optional 3x4 affine transform matrix applied to the mesh.
+    You can also use [`rerun.log_mesh`] to log raw mesh data.
 
     Example:
     -------

--- a/rerun_py/rerun_sdk/rerun/log/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log/mesh.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -19,11 +19,11 @@ __all__ = [
 @log_decorator
 def log_mesh(
     entity_path: str,
-    positions: npt.ArrayLike,
+    positions: Any,
     *,
-    indices: Optional[npt.ArrayLike] = None,
-    normals: Optional[npt.ArrayLike] = None,
-    albedo_factor: Optional[npt.ArrayLike] = None,
+    indices: Optional[Any] = None,
+    normals: Optional[Any] = None,
+    albedo_factor: Optional[Any] = None,
     vertex_colors: Optional[Colors] = None,
     timeless: bool = False,
 ) -> None:

--- a/rerun_py/rerun_sdk/rerun/log/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log/mesh.py
@@ -59,7 +59,7 @@ def log_mesh(
         Path to the mesh in the space hierarchy
     positions:
         An array of 3D points.
-        If no `indices` are specified, then each triplet of positions is interpeted as a triangle.
+        If no `indices` are specified, then each triplet of positions is interpreted as a triangle.
     indices:
         If specified, is a flattened array of indices that describe the mesh's triangles,
         i.e. its length must be divisible by 3.

--- a/rerun_py/rerun_sdk/rerun/log/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log/mesh.py
@@ -25,16 +25,7 @@ def log_mesh(
     """
     Log a raw 3D mesh by specifying its vertex positions, and optionally indices, normals and albedo factor.
 
-    The data is _always_ interpreted as a triangle list:
-
-    * `positions` is a (potentially flattened) array of 3D points, i.e. the total number of elements must be divisible
-      by 3.
-    * `indices`, if specified, is a flattened array of indices that describe the mesh's faces,
-      i.e. its length must be divisible by 3.
-    * `normals`, if specified, is a (potentially flattened) array of 3D vectors that describe the normal for each
-      vertex, i.e. the total number of elements must be divisible by 3 and more importantly, `len(normals)` should be
-      equal to `len(positions)`.
-    * `albedo_factor`, if specified, is either a linear, unmultiplied, normalized RGB (vec3) or RGBA (vec4) value.
+    You can also use [`rerun.log_mesh_file`] to log .gltf, .glb, .obj, etc.
 
     Example:
     -------
@@ -62,13 +53,17 @@ def log_mesh(
     entity_path:
         Path to the mesh in the space hierarchy
     positions:
-        An array of 3D points
+        An array of 3D points.
+        If no `indices` are specified, then each triplet of positions is interpeted as a triangle.
     indices:
-        Optional array of indices that describe the mesh's faces
+        If specified, is a flattened array of indices that describe the mesh's triangles,
+        i.e. its length must be divisible by 3.
     normals:
-        Optional array of 3D vectors that describe the normal of each vertices
+        If specified, is a (potentially flattened) array of 3D vectors that describe the normal for each
+        vertex, i.e. the total number of elements must be divisible by 3 and more importantly, `len(normals)` should be
+        equal to `len(positions)`.
     albedo_factor:
-        Optional RGB(A) color for the albedo factor of the mesh, aka base color factor.
+        Optional color multiplier of the mesh using RGB or unmuliplied RGBA in linear 0-1 space.
     timeless:
         If true, the mesh will be timeless (default: False)
 

--- a/rerun_py/rerun_sdk/rerun/log/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log/mesh.py
@@ -90,7 +90,7 @@ def log_mesh(
     bindings.log_meshes(
         entity_path,
         position_buffers=[positions.flatten()],
-        vertex_color_buffers=[vertex_colors.flatten()],
+        vertex_color_buffers=[vertex_colors],
         index_buffers=[indices],
         normal_buffers=[normals],
         albedo_factors=[albedo_factor],

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -12,7 +12,6 @@ use pyo3::{
 };
 
 use rerun::{
-    external::re_viewer::external::eframe::wgpu::Color,
     log::{LogMsg, MsgBundle, MsgId, PathOp},
     time::{Time, TimeInt, TimePoint, TimeType, Timeline},
     ApplicationId, EntityPath, RecordingId,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -606,7 +606,7 @@ fn log_meshes(
 
     let mut meshes = Vec::with_capacity(position_buffers.len());
 
-    for (positions, vertex_colors, indices, normals, albedo_factor) in izip!(
+    for (vertex_positions, vertex_colors, indices, normals, albedo_factor) in izip!(
         position_buffers,
         vertex_color_buffers,
         index_buffers,
@@ -655,7 +655,7 @@ fn log_meshes(
 
         let raw = RawMesh3D {
             mesh_id: MeshId::random(),
-            positions: positions.as_array().to_vec(),
+            vertex_positions: vertex_positions.as_array().to_vec(),
             vertex_colors,
             indices: indices.map(|indices| indices.as_array().to_vec()),
             vertex_normals: normals.map(|normals| normals.as_array().to_vec()),

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -654,7 +654,7 @@ fn log_meshes(
             positions: positions.as_array().to_vec(),
             vertex_colors,
             indices: indices.map(|indices| indices.as_array().to_vec()),
-            normals: normals.map(|normals| normals.as_array().to_vec()),
+            vertex_normals: normals.map(|normals| normals.as_array().to_vec()),
             albedo_factor,
         };
         raw.sanity_check()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -634,7 +634,7 @@ fn log_meshes(
                 [_, 3] => Some(
                     slice_from_np_array(&vertex_colors)
                         .chunks_exact(3)
-                        .map(|c| ColorRGBA::from_unmultiplied_rgba(c[0], c[1], c[2], 255))
+                        .map(|c| ColorRGBA::from_rgb(c[0], c[1], c[2]))
                         .collect(),
                 ),
                 [_, 4] => Some(

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -575,6 +575,7 @@ enum TensorDataMeaning {
 fn log_meshes(
     entity_path_str: &str,
     position_buffers: Vec<numpy::PyReadonlyArray1<'_, f32>>,
+    vertex_color_buffers: Vec<Option<numpy::PyReadonlyArray1<'_, u8>>>,
     index_buffers: Vec<Option<numpy::PyReadonlyArray1<'_, u32>>>,
     normal_buffers: Vec<Option<numpy::PyReadonlyArray1<'_, f32>>>,
     albedo_factors: Vec<Option<numpy::PyReadonlyArray1<'_, f32>>>,
@@ -583,14 +584,16 @@ fn log_meshes(
     let entity_path = parse_entity_path(entity_path_str)?;
 
     // Make sure we have as many position buffers as index buffers, etc.
-    if position_buffers.len() != index_buffers.len()
+    if position_buffers.len() != vertex_color_buffers.len()
+        || position_buffers.len() != index_buffers.len()
         || position_buffers.len() != normal_buffers.len()
         || position_buffers.len() != albedo_factors.len()
     {
         return Err(PyTypeError::new_err(format!(
             "Top-level position/index/normal/albedo buffer arrays must be same the length, \
-                got positions={}, indices={}, normals={}, albedo={} instead",
+                got positions={}, vertex_colors={}, indices={}, normals={}, albedo={} instead",
             position_buffers.len(),
+            vertex_color_buffers.len(),
             index_buffers.len(),
             normal_buffers.len(),
             albedo_factors.len(),


### PR DESCRIPTION
Works with `rr.log_mesh` and with any vertex colors found n GLB/GLTF or OBJ files.

Test: `just py-build && examples/python/api_demo/main.py --demo raw_mesh`

![image](https://user-images.githubusercontent.com/1148717/226951878-1cca928e-ce58-4ffc-a2ea-8455d481c225.png)

![mesh-vertex-colors](https://user-images.githubusercontent.com/1148717/226952487-f6cec2cd-6f86-4b5d-8621-04209fce94f4.gif)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
