### PR TITLE
Add banner about mobile browsers being unsupported

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1012,10 +1012,12 @@ impl AppState {
     }
 }
 
-fn warning_panel(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
-    // We have some bugs when running the web viewer on Windows.
-    // See https://github.com/rerun-io/rerun/issues/1206
-    if frame.is_web() && ui.ctx().os() == egui::os::OperatingSystem::Windows {
+fn warning_panel(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    // We have not yet optimized the UI experience for mobile. Show a warning banner
+    // with a link to the tracking issue.
+    if ui.ctx().os() == egui::os::OperatingSystem::IOS
+        || ui.ctx().os() == egui::os::OperatingSystem::Android
+    {
         let frame = egui::Frame {
             fill: ui.visuals().panel_fill,
             ..re_ui.bottom_panel_frame()
@@ -1027,9 +1029,9 @@ fn warning_panel(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, frame: &mut eframe::Fra
             .show_inside(ui, |ui| {
                 ui.centered_and_justified(|ui| {
                     let text = re_ui.warning_text(
-                        "The web viewer has some known issues on Windows. Click for details.",
+                        "Web view on mobile is not yet supported. Click for details.",
                     );
-                    ui.hyperlink_to(text, "https://github.com/rerun-io/rerun/issues/1206");
+                    ui.hyperlink_to(text, "https://github.com/rerun-io/rerun/issues/1672");
                 });
             });
     }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1028,9 +1028,8 @@ fn warning_panel(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, _frame: &mut eframe::Fr
             .frame(frame)
             .show_inside(ui, |ui| {
                 ui.centered_and_justified(|ui| {
-                    let text = re_ui.warning_text(
-                        "Web view on mobile is not yet supported. Click for details.",
-                    );
+                    let text =
+                        re_ui.warning_text("Mobile OSes are not yet supported. Click for details.");
                     ui.hyperlink_to(text, "https://github.com/rerun-io/rerun/issues/1672");
                 });
             });


### PR DESCRIPTION
If a user decides to click through, make sure we still show a notification about the fact that mobile is not yet actually supported with a link to the tracking issue.

Also remove the windows banner since windows now generally works.

Tracking issue:
 - https://github.com/rerun-io/rerun/issues/1672

![image](https://user-images.githubusercontent.com/3312232/227005678-53e2adaf-9be9-40ab-9d7d-c6b7420ec794.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
