### PR TITLE
Always upload latest prerelease to a dedicated prefix

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -286,7 +286,7 @@ jobs:
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: "Upload RRD"
         uses: google-github-actions/upload-cloud-storage@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -295,6 +295,14 @@ jobs:
           destination: "rerun-example-rrd/commit/${{env.SHORT_SHA}}"
           parent: false
 
+      - name: "Upload RRD (prerelease)"
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "rrd"
+          destination: "rerun-example-rrd/prerelease"
+          parent: false
+
       - name: "Upload RRD (tagged)"
         if: startsWith(github.ref, 'refs/tags/v')
         uses: google-github-actions/upload-cloud-storage@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -291,6 +291,14 @@ jobs:
           destination: "rerun-web-viewer/commit/${{env.SHORT_SHA}}"
           parent: false
 
+      - name: "Upload web-viewer (prerelease)"
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "web_viewer"
+          destination: "rerun-web-viewer/prerelease"
+          parent: false
+
       - name: "Upload web-viewer (tagged)"
         if: startsWith(github.ref, 'refs/tags/v')
         uses: google-github-actions/upload-cloud-storage@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -282,7 +282,7 @@ jobs:
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: "Upload web-viewer"
         uses: google-github-actions/upload-cloud-storage@v1


### PR DESCRIPTION
This way: app.rerun.io/prerelease will always be the latest goodness to land on main.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
