### PR TITLE
Show the git commit in the about section in pre-release builds

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Patch Cargo.toml for pre-release
         if: github.ref == 'refs/heads/main'
-        # After patching the pre-release version, run cargo check.
+        # After patching the pre-release version, run cargo update.
         # This updates the cargo.lock file with the new version numbers and keeps the wheel build from failing
         run: |
           python3 scripts/version_util.py --patch_prerelease

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -296,7 +296,7 @@ jobs:
           parent: false
 
       - name: "Upload RRD (prerelease)"
-        if: github.ref == 'refs/heads/main'
+        if: "!startsWith(github.ref , 'refs/tags/v')"
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "rrd"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -269,7 +269,7 @@ jobs:
           save-if: ${{ github.event_name == 'push'}}
 
       - name: Patch Cargo.toml for pre-release
-        if: github.ref == 'refs/heads/main'
+        if: "!startsWith(github.ref , 'refs/tags/v')"
         # After patching the pre-release version, run cargo update.
         # This updates the cargo.lock file with the new version numbers and keeps the wheel build from failing
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -268,6 +268,14 @@ jobs:
           # See: https://github.com/rerun-io/rerun/pull/497
           save-if: ${{ github.event_name == 'push'}}
 
+      - name: Patch Cargo.toml for pre-release
+        if: github.ref == 'refs/heads/main'
+        # After patching the pre-release version, run cargo update.
+        # This updates the cargo.lock file with the new version numbers and keeps the wheel build from failing
+        run: |
+          python3 scripts/version_util.py --patch_prerelease
+          cargo update -w
+
       - name: Build web-viewer (release)
         uses: actions-rs/cargo@v1
         with:

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1188,13 +1188,13 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
     };
 
     let maybe_git_hash = if version.is_prerelease() {
-        git_hash
+        format!("({})", &git_hash[..std::cmp::min(git_hash.len(), 7)])
     } else {
-        ""
+        String::new()
     };
 
     ui.label(format!(
-        "{crate_name} {version}{maybe_git_hash}\n\
+        "{crate_name} {version} {maybe_git_hash}\n\
         {target_triple}\n\
         rustc {rustc_version}\n\
         LLVM {llvm_version}\n\

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1166,7 +1166,7 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
         version,
         rustc_version,
         llvm_version,
-        git_hash: _,
+        git_hash,
         git_branch: _,
         is_in_rerun_workspace: _,
         target_triple,
@@ -1187,8 +1187,14 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
         llvm_version
     };
 
+    let maybe_git_hash = if version.is_prerelease() {
+        git_hash
+    } else {
+        ""
+    };
+
     ui.label(format!(
-        "{crate_name} {version}\n\
+        "{crate_name} {version}{maybe_git_hash}\n\
         {target_triple}\n\
         rustc {rustc_version}\n\
         LLVM {llvm_version}\n\

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1187,14 +1187,10 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
         llvm_version
     };
 
-    let maybe_git_hash = if version.is_prerelease() {
-        format!("({})", &git_hash[..std::cmp::min(git_hash.len(), 7)])
-    } else {
-        String::new()
-    };
+    let short_git_hash = &git_hash[..std::cmp::min(git_hash.len(), 7)];
 
     ui.label(format!(
-        "{crate_name} {version} {maybe_git_hash}\n\
+        "{crate_name} {version} ({short_git_hash})\n\
         {target_triple}\n\
         rustc {rustc_version}\n\
         LLVM {llvm_version}\n\


### PR DESCRIPTION
We do this version-patching on the wheels, so it makes sense to do it on the web-build as well. This is particularly important now that we have https://github.com/rerun-io/rerun/pull/1676 since there is no other easy way of telling which commit app.rerun.io/prerelease is running from.

As it turns out this was a bit more involved than I expected because we were throwing away the prerelease information in `crate_version.rs`. We now track an extra bit indicator of whether this was a real release build or a prerelease `+` version, and use that to include the git-commit in the about section.

Before:
![image](https://user-images.githubusercontent.com/3312232/227042525-70293f5e-2219-4118-88b6-3378a09bb3ee.png)

After:
![image](https://user-images.githubusercontent.com/3312232/227064308-a478af26-1797-4f25-8fd0-c1a221ed12cc.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
