### PR TITLE
Allow url param override on app.rerun.io

### DIFF
--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -180,7 +180,13 @@
         }
 
         function determine_url() {
-            // If a 'url' is provided as a url_param, use it
+            // If a 'url' is provided as a url-param, use it.
+            // Although `web.rs` can also parse the url-param itself,
+            // it won't do so if we pass in a non-null url. We could
+            // arguably return null here instead and achieve the same
+            // behavior, but as long as we've queried it anyways, we
+            // may as well just pass it in for consistency.
+
             const url_params = new URLSearchParams(window.location.search);
 
             let url = url_params.get('url');

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -172,22 +172,34 @@
         function on_wasm_loaded() {
             console.debug("wasm loaded. starting app…");
 
-            // The expected data path is the current pathname relocated to inside of "/data" with the
-            // index.html stripped off if it's present.
-            // exa: 'https://app.rerun.io/version/v4.0.0/index.html' -> '/data/version/v4.0.0/'
-            let data_path = "/data" + window.location.pathname.replace(/index\.html$/, '');
-
-            const url_params = new URLSearchParams(window.location.search);
-            const rrd_file = url_params.get('file') || 'colmap_fiat.rrd';
-
-            // By default load an rrd file over http
-            let url = data_path + rrd_file; // you can use this to point to an .rrd file over http, or a WebSocket Rerun server.
-
             // This call installs a bunch of callbacks and then returns:
-            wasm_bindgen.start("the_canvas_id", url);
+            wasm_bindgen.start("the_canvas_id", determine_url());
 
             console.debug("app started.");
             document.getElementById("center_text").remove();
+        }
+
+        function determine_url() {
+            // If a 'url' is provided as a url_param, use it
+            const url_params = new URLSearchParams(window.location.search);
+
+            let url = url_params.get('url');
+
+            if (url) {
+                return url;
+            }
+
+            // Otherwise, look up an rrd in the data path.
+
+            // The expected data path is the current pathname relocated to inside of "/data" with the
+            // index.html stripped off if it's present.
+            // exa: 'https://app.rerun.io/version/v4.0.0/index.html' -> '/data/version/v4.0.0/'
+            let data_path = '/data/' + window.location.pathname.replace(/index\.html$/, '') + '/';
+
+            const rrd_file = url_params.get('file') || 'colmap_fiat.rrd';
+
+            // Normalize the extra slashes from the url
+            return (data_path + rrd_file).replace(/\/{2,}/g, '/');
         }
 
         function on_wasm_error(error) {


### PR DESCRIPTION
The logic to provide a default url from javascript was preventing the old ?url param behavior from working. If url param is provided we now pass that through directly.

The other option would be for `web.rs` to always default to the url param if provided, but I can imagine other cases where the hosting web app wants full control over the url-param, so I think this is the preferable way of solving the problem.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
