### PR TITLE
Fix logging meshes without colors

### DIFF
--- a/examples/python/raw_mesh/requirements.txt
+++ b/examples/python/raw_mesh/requirements.txt
@@ -2,3 +2,4 @@ numpy
 requests==2.28.1
 rerun-sdk
 trimesh==3.15.2
+pillow

--- a/rerun_py/rerun_sdk/rerun/log/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log/mesh.py
@@ -84,7 +84,8 @@ def log_mesh(
         normals = np.asarray(normals, dtype=np.float32).flatten()
     if albedo_factor is not None:
         albedo_factor = np.asarray(albedo_factor, dtype=np.float32).flatten()
-    vertex_colors = _normalize_colors(vertex_colors)
+    if vertex_colors is not None:
+        vertex_colors = _normalize_colors(vertex_colors)
 
     # Mesh arrow handling happens inside the python bridge
     bindings.log_meshes(


### PR DESCRIPTION
This broke the `raw_mesh` demo since `_normalize_colors` outputs an empty np array when passed `None` and the other side expects a certain dimensionality

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
