### PR TITLE
Update wgpu to v0.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,6 +3978,7 @@ dependencies = [
  "web-sys",
  "wgpu",
  "wgpu-core",
+ "wgpu-hal",
  "winit",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,15 +1944,15 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434618454f74b63f9b39328298097256977c41ea0ba9d75a47238b77790b6163"
+checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
 dependencies = [
  "backtrace",
  "log",
  "thiserror",
  "winapi",
- "windows 0.43.0",
+ "windows",
 ]
 
 [[package]]
@@ -2381,9 +2381,9 @@ checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4330,7 +4330,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.44.0",
+ "windows",
 ]
 
 [[package]]
@@ -5492,9 +5492,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5685,9 +5685,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5737,9 +5737,9 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14c6bfcf3b10f4273f522a95994553c0a5f2934976e62e61a720ae4bc2eb8f2"
+checksum = "d745a1b6d91d85c33defbb29f0eee0450e1d2614d987e14bf6baf26009d132d7"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5761,9 +5761,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f61be28e557a6ecb2506cac06c63fae3b6d302a006f38195a7a80995abeb9"
+checksum = "7131408d940e335792645a98f03639573b0480e9e2e7cddbbab74f7c6d9f3fff"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5784,9 +5784,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.15.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95792925fe3d58950b9a5c2a191caa145e2bc570e2d233f0d7320f6a8e814"
+checksum = "bdcf61a283adc744bb5453dd88ea91f3f86d5ca6b027661c6c73c7734ae0288b"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5826,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf8cfcbf98f94cc8bd5981544c687140cf9d3948e2ab83849367ead2cd737cf"
+checksum = "32444e121b0bd00cb02c0de32fde457a9491bd44e03e7a5db6df9b1da2f6f110"
 dependencies = [
  "bitflags",
  "js-sys",
@@ -5891,21 +5891,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,9 @@ puffin = "0.14"
 thiserror = "1.0"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tokio = "1.24"
-wgpu = { version = "0.15", default-features = false }
-wgpu-core = { version = "0.15", default-features = false }
+wgpu = { version = "0.15.1", default-features = false }
+wgpu-core = { version = "0.15.1", default-features = false }
+wgpu-hal = { version = "0.15.4", default-features = false }
 
 
 [profile.dev]

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -77,6 +77,7 @@ notify = "5.0"
 puffin.workspace = true
 wgpu = { workspace = true, default-features = false, features = ["wgsl"] }
 wgpu-core.workspace = true
+wgpu-hal.workspace = true
 
 # wasm
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/re_renderer/src/config.rs
+++ b/crates/re_renderer/src/config.rs
@@ -14,15 +14,6 @@ pub enum HardwareTier {
 }
 
 impl HardwareTier {
-    /// Temporary workaround until [this GL state leaking fix](https://github.com/gfx-rs/wgpu/pull/3589) is landed.
-    /// All our target platforms should support alpha to coverage.
-    pub fn support_alpha_to_coverage(&self) -> bool {
-        match self {
-            HardwareTier::Basic => false,
-            HardwareTier::Native => true,
-        }
-    }
-
     /// Whether the current hardware tier supports sampling from textures with a sample count higher than 1.
     pub fn support_sampling_msaa_texture(&self) -> bool {
         match self {

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -394,10 +394,7 @@ impl Renderer for DepthCloudRenderer {
             multisample: wgpu::MultisampleState {
                 // We discard pixels to do the round cutout, therefore we need to
                 // calculate our own sampling mask.
-                alpha_to_coverage_enabled: shared_data
-                    .config
-                    .hardware_tier
-                    .support_alpha_to_coverage(),
+                alpha_to_coverage_enabled: true,
                 ..ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE
             },
         };

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -742,10 +742,7 @@ impl Renderer for LineRenderer {
                 depth_stencil: ViewBuilder::MAIN_TARGET_DEFAULT_DEPTH_STATE,
                 multisample: wgpu::MultisampleState {
                     // We discard pixels to do the round cutout, therefore we need to calculate our own sampling mask.
-                    alpha_to_coverage_enabled: shared_data
-                        .config
-                        .hardware_tier
-                        .support_alpha_to_coverage(),
+                    alpha_to_coverage_enabled: true,
                     ..ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE
                 },
             },

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -556,10 +556,7 @@ impl Renderer for PointCloudRenderer {
             multisample: wgpu::MultisampleState {
                 // We discard pixels to do the round cutout, therefore we need to calculate
                 // our own sampling mask.
-                alpha_to_coverage_enabled: shared_data
-                    .config
-                    .hardware_tier
-                    .support_alpha_to_coverage(),
+                alpha_to_coverage_enabled: true,
                 ..ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE
             },
         };


### PR DESCRIPTION
Fixes #1620 (meshes don't show up on windows chrome)
Removes need for alpha-to-coverage workaround.

Tested raw_mesh & colmap on Windows Firefox & Chrome.

Yes, the v0.15.3 tag of wgpu is a range of versions of its different crates, ironically none of which is marked with 0.15.3 due to a previous publishing mistake

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
