### PR TITLE
Refactor: categorize tensor data as either compressed or uncompressed

### DIFF
--- a/crates/re_log_types/src/component_types/mod.rs
+++ b/crates/re_log_types/src/component_types/mod.rs
@@ -63,7 +63,8 @@ pub use size::Size3D;
 #[cfg(feature = "image")]
 pub use tensor::TensorImageError;
 pub use tensor::{
-    Tensor, TensorCastError, TensorData, TensorDataMeaning, TensorDimension, TensorId, TensorTrait,
+    CompressedTensorData, Tensor, TensorCastError, TensorData, TensorDataMeaning, TensorDimension,
+    TensorId, TensorTrait, UncompressedTensorData,
 };
 pub use text_entry::TextEntry;
 pub use transform::{Pinhole, Rigid3, Transform};

--- a/crates/re_tensor_ops/tests/tensor_tests.rs
+++ b/crates/re_tensor_ops/tests/tensor_tests.rs
@@ -1,5 +1,6 @@
 use re_log_types::component_types::{
-    Tensor, TensorCastError, TensorData, TensorDataMeaning, TensorDimension, TensorId, TensorTrait,
+    Tensor, TensorCastError, TensorDataMeaning, TensorDimension, TensorId, TensorTrait,
+    UncompressedTensorData,
 };
 
 #[test]
@@ -11,7 +12,7 @@ fn convert_tensor_to_ndarray_u8() {
             TensorDimension::unnamed(4),
             TensorDimension::unnamed(5),
         ],
-        TensorData::U8(vec![0; 60].into()),
+        UncompressedTensorData::U8(vec![0; 60].into()).into(),
         TensorDataMeaning::Unknown,
         None,
     );
@@ -30,7 +31,7 @@ fn convert_tensor_to_ndarray_u16() {
             TensorDimension::unnamed(4),
             TensorDimension::unnamed(5),
         ],
-        TensorData::U16(vec![0_u16; 60].into()),
+        UncompressedTensorData::U16(vec![0_u16; 60].into()).into(),
         TensorDataMeaning::Unknown,
         None,
     );
@@ -49,7 +50,7 @@ fn convert_tensor_to_ndarray_f32() {
             TensorDimension::unnamed(4),
             TensorDimension::unnamed(5),
         ],
-        TensorData::F32(vec![0_f32; 60].into()),
+        UncompressedTensorData::F32(vec![0_f32; 60].into()).into(),
         TensorDataMeaning::Unknown,
         None,
     );
@@ -88,7 +89,7 @@ fn check_slices() {
             TensorDimension::unnamed(4),
             TensorDimension::unnamed(5),
         ],
-        TensorData::U16((0_u16..60).collect::<Vec<u16>>().into()),
+        UncompressedTensorData::U16((0_u16..60).collect::<Vec<u16>>().into()).into(),
         TensorDataMeaning::Unknown,
         None,
     );
@@ -130,7 +131,7 @@ fn check_tensor_shape_error() {
             TensorDimension::unnamed(4),
             TensorDimension::unnamed(5),
         ],
-        TensorData::U8(vec![0; 59].into()),
+        UncompressedTensorData::U8(vec![0; 59].into()).into(),
         TensorDataMeaning::Unknown,
         None,
     );
@@ -154,7 +155,7 @@ fn check_tensor_type_error() {
             TensorDimension::unnamed(4),
             TensorDimension::unnamed(5),
         ],
-        TensorData::U16(vec![0; 60].into()),
+        UncompressedTensorData::U16(vec![0; 60].into()).into(),
         TensorDataMeaning::Unknown,
         None,
     );

--- a/crates/re_viewer/src/ui/view_bar_chart/ui.rs
+++ b/crates/re_viewer/src/ui/view_bar_chart/ui.rs
@@ -4,7 +4,7 @@ use egui::util::hash;
 
 use re_data_store::EntityPath;
 use re_log::warn_once;
-use re_log_types::component_types::{self, InstanceKey};
+use re_log_types::component_types::{self, InstanceKey, UncompressedTensorData};
 
 use crate::{misc::ViewerContext, ui::annotations::auto_color};
 
@@ -57,43 +57,45 @@ pub(crate) fn view_bar_chart(
 
             for ((ent_path, instance_key), tensor) in &scene.charts {
                 let chart = match &tensor.data {
-                    component_types::TensorData::U8(data) => {
-                        create_bar_chart(ent_path, instance_key, data.0.iter().copied())
-                    }
-                    component_types::TensorData::U16(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::U32(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::U64(data) => create_bar_chart(
-                        ent_path,
-                        instance_key,
-                        data.iter().copied().map(|v| v as f64),
-                    ),
-                    component_types::TensorData::I8(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::I16(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::I32(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::I64(data) => create_bar_chart(
-                        ent_path,
-                        instance_key,
-                        data.iter().copied().map(|v| v as f64),
-                    ),
-                    component_types::TensorData::F32(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::F64(data) => {
-                        create_bar_chart(ent_path, instance_key, data.iter().copied())
-                    }
-                    component_types::TensorData::JPEG(_) => {
+                    component_types::TensorData::Uncompressed(data) => match data {
+                        UncompressedTensorData::U8(data) => {
+                            create_bar_chart(ent_path, instance_key, data.0.iter().copied())
+                        }
+                        UncompressedTensorData::U16(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                        UncompressedTensorData::U32(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                        UncompressedTensorData::U64(data) => create_bar_chart(
+                            ent_path,
+                            instance_key,
+                            data.iter().copied().map(|v| v as f64),
+                        ),
+                        UncompressedTensorData::I8(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                        UncompressedTensorData::I16(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                        UncompressedTensorData::I32(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                        UncompressedTensorData::I64(data) => create_bar_chart(
+                            ent_path,
+                            instance_key,
+                            data.iter().copied().map(|v| v as f64),
+                        ),
+                        UncompressedTensorData::F32(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                        UncompressedTensorData::F64(data) => {
+                            create_bar_chart(ent_path, instance_key, data.iter().copied())
+                        }
+                    },
+                    component_types::TensorData::Compressed(_) => {
                         warn_once!(
-                            "trying to display JPEG data as a bar chart ({:?})",
+                            "Cannot display compressed tensor data as a bar chart ({:?})",
                             ent_path
                         );
                         continue;

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -840,7 +840,8 @@ fn log_image_file(
                 TensorDimension::width(w as _),
                 TensorDimension::depth(3),
             ],
-            data: re_log_types::component_types::TensorData::JPEG(img_bytes.into()),
+            data: re_log_types::component_types::CompressedTensorData::JPEG(img_bytes.into())
+                .into(),
             meaning: re_log_types::component_types::TensorDataMeaning::Unknown,
             meter: None,
         }]


### PR DESCRIPTION
This refactor sub-divides `enum TensorData` into two new enums:

``` rust
pub enum TensorData {
    Uncompressed(UncompressedTensorData),
    Compressed(CompressedTensorData),
}

pub enum UncompressedTensorData {
    U8(BinaryBuffer),
    U16(Buffer<u16>),
    U32(Buffer<u32>),
    U64(Buffer<u64>),
    I8(Buffer<i8>),
    I16(Buffer<i16>),
    I32(Buffer<i32>),
    I64(Buffer<i64>),
    F32(Buffer<f32>),
    F64(Buffer<f64>),
}

pub enum CompressedTensorData {
    JPEG(BinaryBuffer),
}
```

This will make it easier and less error-prone to add more compression/encoding schemes to tensors, such as PNG.

In the long term we probably want this split to be done higher up (`Tensor` vs `CompressedTensor`). Related:
* https://github.com/rerun-io/rerun/pull/1595

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
