### PR TITLE
Only show the mobile OS warning banner on web

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1012,11 +1012,16 @@ impl AppState {
     }
 }
 
-fn warning_panel(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+fn warning_panel(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
     // We have not yet optimized the UI experience for mobile. Show a warning banner
     // with a link to the tracking issue.
-    if ui.ctx().os() == egui::os::OperatingSystem::IOS
-        || ui.ctx().os() == egui::os::OperatingSystem::Android
+
+    // Although this banner is applicable to IOS / Android generically without limit to web
+    // There is a small issue in egui where Windows native currently reports as android.
+    // TODO(jleibs): Remove the is_web gate once https://github.com/emilk/egui/pull/2832 has landed.
+    if frame.is_web()
+        && (ui.ctx().os() == egui::os::OperatingSystem::IOS
+            || ui.ctx().os() == egui::os::OperatingSystem::Android)
     {
         let frame = egui::Frame {
             fill: ui.visuals().panel_fill,


### PR DESCRIPTION
A silly bug in egui means windows currently reports as android. Work-around by limiting the banner to web for now.

Fixed here:
- https://github.com/emilk/egui/pull/2832

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
