### PR TITLE
Gpu readback belt for fast & easy data readback from gpu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
         "memoffset",
         "nyud",
         "objectron",
+        "Readback",
         "Skybox",
         "smallvec",
         "swapchain",

--- a/crates/re_renderer/examples/multiview.rs
+++ b/crates/re_renderer/examples/multiview.rs
@@ -197,7 +197,7 @@ impl Multiview {
 
     fn handle_incoming_screenshots(&mut self, re_ctx: &mut RenderContext) {
         re_ctx
-            .gpu_write_cpu_read_belt
+            .gpu_readback_belt
             .lock()
             .receive_data(|data, identifier| {
                 if let Some(index) = self

--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -303,6 +303,8 @@ impl CpuWriteGpuReadBelt {
     ) -> CpuWriteGpuReadBuffer<T> {
         crate::profile_function!();
 
+        debug_assert!(num_elements > 0, "Cannot allocate zero-sized buffer");
+
         // Potentially overestimate alignment with Self::MIN_ALIGNMENT, see Self::MIN_ALIGNMENT doc string.
         let alignment = (std::mem::align_of::<T>() as wgpu::BufferAddress).max(Self::MIN_ALIGNMENT);
         // Pad out the size of the used buffer to a multiple of Self::MIN_ALIGNMENT.

--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -425,7 +425,7 @@ impl CpuWriteGpuReadBelt {
 
 impl std::fmt::Debug for CpuWriteGpuReadBelt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StagingBelt")
+        f.debug_struct("CpuWriteGpuReadBelt")
             .field("chunk_size", &self.chunk_size)
             .field("active_chunks", &self.active_chunks.len())
             .field("closed_chunks", &self.closed_chunks.len())

--- a/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
@@ -1,8 +1,4 @@
-use std::{
-    num::NonZeroU32,
-    ops::{DerefMut, Range},
-    sync::mpsc,
-};
+use std::{num::NonZeroU32, ops::Range, sync::mpsc};
 
 use crate::wgpu_resources::{BufferDesc, GpuBuffer, GpuBufferPool};
 
@@ -18,7 +14,7 @@ pub struct GpuWriteCpuReadBuffer {
 
 impl GpuWriteCpuReadBuffer {
     /// Populates the buffer with data from a texture.
-    pub fn from_texture(
+    pub fn read_texture(
         self,
         encoder: &mut wgpu::CommandEncoder,
         source: wgpu::ImageCopyTexture<'_>,
@@ -43,7 +39,7 @@ impl GpuWriteCpuReadBuffer {
     }
 
     /// Populates the buffer with data from a buffer.
-    pub fn from_buffer(
+    pub fn read_buffer(
         self,
         encoder: &mut wgpu::CommandEncoder,
         source: &GpuBuffer,
@@ -223,7 +219,7 @@ impl GpuWriteCpuReadBelt {
                         // This should never happen. Drop the chunk and report.
                         re_log::error_once!("Failed to map staging buffer for reading");
                     } else {
-                        sender.send(chunk);
+                        let _ = sender.send(chunk);
                     }
                 });
         }

--- a/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
@@ -183,7 +183,7 @@ impl GpuWriteCpuReadBelt {
                         label: "GpuWriteCpuReadBelt buffer".into(),
                         size: size_in_bytes,
                         usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-                        mapped_at_creation: true,
+                        mapped_at_creation: false,
                     },
                 );
 
@@ -236,7 +236,7 @@ impl GpuWriteCpuReadBelt {
     /// After this call, internal chunks can be re-used.
     pub fn receive_data(
         &mut self,
-        on_data_received: impl Fn(&[u8], GpuWriteCpuReadBufferIdentifier),
+        mut on_data_received: impl FnMut(&[u8], GpuWriteCpuReadBufferIdentifier),
     ) {
         crate::profile_function!();
 

--- a/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
@@ -1,0 +1,276 @@
+use std::{
+    num::NonZeroU32,
+    ops::{DerefMut, Range},
+    sync::mpsc,
+};
+
+use crate::wgpu_resources::{BufferDesc, GpuBuffer, GpuBufferPool};
+
+pub type GpuWriteCpuReadBufferIdentifier = u32;
+
+/// TODO: Docstring
+pub struct GpuWriteCpuReadBuffer {
+    chunk_buffer: GpuBuffer,
+    byte_offset_in_chunk_buffer: wgpu::BufferAddress,
+    size_in_bytes: wgpu::BufferAddress,
+    identifier: GpuWriteCpuReadBufferIdentifier,
+}
+
+impl GpuWriteCpuReadBuffer {
+    /// Populates the buffer with data from a texture.
+    pub fn from_texture(
+        self,
+        encoder: &mut wgpu::CommandEncoder,
+        source: wgpu::ImageCopyTexture<'_>,
+        bytes_per_row: Option<NonZeroU32>,
+        rows_per_image: Option<NonZeroU32>,
+        copy_size: wgpu::Extent3d,
+    ) -> GpuWriteCpuReadBufferIdentifier {
+        // TODO: validate that stay within the slice.
+        encoder.copy_texture_to_buffer(
+            source,
+            wgpu::ImageCopyBuffer {
+                buffer: &self.chunk_buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: self.byte_offset_in_chunk_buffer,
+                    bytes_per_row,
+                    rows_per_image,
+                },
+            },
+            copy_size,
+        );
+        self.identifier
+    }
+
+    /// Populates the buffer with data from a buffer.
+    pub fn from_buffer(
+        self,
+        encoder: &mut wgpu::CommandEncoder,
+        source: &GpuBuffer,
+        source_offset: wgpu::BufferAddress,
+    ) -> GpuWriteCpuReadBufferIdentifier {
+        encoder.copy_buffer_to_buffer(
+            source,
+            source_offset,
+            &self.chunk_buffer,
+            self.byte_offset_in_chunk_buffer,
+            self.size_in_bytes,
+        );
+        self.identifier
+    }
+}
+
+/// Internal chunk of the staging belt.
+struct Chunk {
+    buffer: GpuBuffer,
+    /// All ranges that are currently in use, i.e. there is a GPU write to it scheduled.
+    ranges_in_use: Vec<(Range<wgpu::BufferAddress>, GpuWriteCpuReadBufferIdentifier)>,
+}
+
+impl Chunk {
+    fn unused_offset(&self) -> wgpu::BufferAddress {
+        self.ranges_in_use.last().map_or(0, |(range, _)| range.end)
+    }
+
+    fn remaining_capacity(&self) -> wgpu::BufferAddress {
+        self.buffer.size() - self.unused_offset()
+    }
+
+    /// Caller needs to make sure that there is enough space.
+    fn allocate(
+        &mut self,
+        size_in_bytes: wgpu::BufferAddress,
+        identifier: GpuWriteCpuReadBufferIdentifier,
+    ) -> GpuWriteCpuReadBuffer {
+        debug_assert!(size_in_bytes <= self.remaining_capacity());
+
+        let start_offset = self.unused_offset();
+        self.ranges_in_use
+            .push((start_offset..start_offset + size_in_bytes, identifier));
+
+        GpuWriteCpuReadBuffer {
+            chunk_buffer: self.buffer.clone(),
+            byte_offset_in_chunk_buffer: start_offset,
+            size_in_bytes,
+            identifier,
+        }
+    }
+}
+
+/// Efficiently performs many buffer reads by sharing and reusing temporary buffers.
+///
+/// Internally it uses a ring-buffer of staging buffers that are sub-allocated.
+pub struct GpuWriteCpuReadBelt {
+    /// Minimum size for new buffers.
+    chunk_size: u64,
+
+    /// Chunks which the GPU writes are scheduled, but we haven't mapped them yet.
+    active_chunks: Vec<Chunk>,
+
+    /// Chunks that have been mapped by the CPU and are
+    free_chunks: Vec<Chunk>,
+
+    /// When a chunk mapping is successful, it is moved to this sender to be read by the CPU.
+    sender: mpsc::Sender<Chunk>,
+
+    /// Chunks are received here are ready to be read by the CPU.
+    receiver: mpsc::Receiver<Chunk>,
+
+    next_identifier: GpuWriteCpuReadBufferIdentifier,
+}
+
+impl GpuWriteCpuReadBelt {
+    /// All allocations of this allocator will be aligned to at least this size.
+    ///
+    /// Buffer mappings however are currently NOT guaranteed to be aligned to this size!
+    /// See this issue on [Alignment guarantees for mapped buffers](https://github.com/gfx-rs/wgpu/issues/3508).
+    const MIN_ALIGNMENT: u64 = wgpu::MAP_ALIGNMENT; //wgpu::COPY_BUFFER_ALIGNMENT.max(wgpu::MAP_ALIGNMENT);
+
+    /// Create a gpu-write & cpu-read staging belt.
+    ///
+    /// The `chunk_size` is the unit of internal buffer allocation; writes will be
+    /// sub-allocated within each chunk. Therefore, for optimal use of memory, the
+    /// chunk size should be:
+    ///
+    /// * larger than the largest single [`GpuWriteCpuReadBelt::allocate`] operation;
+    /// * 1-4 times less than the total amount of data uploaded per submission
+    ///   (per [`GpuWriteCpuReadBelt::before_queue_submit()`]); and
+    /// * bigger is better, within these bounds.
+    ///
+    /// TODO(andreas): Adaptive chunk sizes
+    /// TODO(andreas): Shrinking after usage spikes?
+    pub fn new(chunk_size: wgpu::BufferSize) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        GpuWriteCpuReadBelt {
+            chunk_size: wgpu::util::align_to(chunk_size.get(), Self::MIN_ALIGNMENT),
+            active_chunks: Vec::new(),
+            free_chunks: Vec::new(),
+            sender,
+            receiver,
+            next_identifier: 0,
+        }
+    }
+
+    /// Allocates a Gpu writable buffer & cpu readable buffer with a given size.
+    pub fn allocate(
+        &mut self,
+        device: &wgpu::Device,
+        buffer_pool: &GpuBufferPool,
+        size_in_bytes: wgpu::BufferSize,
+    ) -> GpuWriteCpuReadBuffer {
+        crate::profile_function!();
+
+        let size_in_bytes = wgpu::util::align_to(size_in_bytes.get(), Self::MIN_ALIGNMENT);
+
+        // Try to find space in any of the active chunks first.
+        let mut chunk = if let Some(index) = self
+            .active_chunks
+            .iter_mut()
+            .position(|chunk| chunk.remaining_capacity() >= size_in_bytes)
+        {
+            self.active_chunks.swap_remove(index)
+        } else {
+            // Use a free chunk if possible, fall back to creating a new one if necessary.
+            if let Some(index) = self
+                .free_chunks
+                .iter()
+                .position(|chunk| chunk.remaining_capacity() >= size_in_bytes)
+            {
+                self.free_chunks.swap_remove(index)
+            } else {
+                // Happens relatively rarely, this is a noteworthy event!
+                re_log::debug!("Allocating new GpuWriteCpuReadBelt chunk of size {size_in_bytes}");
+                let buffer = buffer_pool.alloc(
+                    device,
+                    &BufferDesc {
+                        label: "GpuWriteCpuReadBelt buffer".into(),
+                        size: size_in_bytes,
+                        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                        mapped_at_creation: true,
+                    },
+                );
+
+                Chunk {
+                    buffer,
+                    ranges_in_use: Vec::new(),
+                }
+            }
+        };
+
+        let buffer_slice = chunk.allocate(size_in_bytes, self.next_identifier);
+        self.active_chunks.push(chunk);
+
+        self.next_identifier += 1;
+
+        buffer_slice
+    }
+
+    /// Prepare used buffers for CPU read.
+    ///
+    /// This should be called before the command encoder(s) used in [`GpuWriteCpuReadBuffer`] copy operations are submitted.
+    ///
+    /// At this point, all the partially used staging buffers are closed until the GPU write operation is done and the CPU has read them.
+    pub fn before_queue_submit(&mut self) {
+        crate::profile_function!();
+        for chunk in self.active_chunks.drain(..) {
+            let sender = self.sender.clone();
+            chunk
+                .buffer
+                .clone()
+                .slice(..chunk.unused_offset())
+                .map_async(wgpu::MapMode::Read, move |result| {
+                    if result.is_err() {
+                        // This should never happen. Drop the chunk and report.
+                        re_log::error_once!("Failed to map staging buffer for reading");
+                    } else {
+                        sender.send(chunk);
+                    }
+                });
+        }
+    }
+
+    /// Receive all buffers that have been written by the GPU and are ready to be read by the CPU.
+    ///
+    /// ATTENTION: Do NOT assume any alignment on the slice passed to `on_data_received`.
+    /// See this issue on [Alignment guarantees for mapped buffers](https://github.com/gfx-rs/wgpu/issues/3508).
+    ///
+    /// This should be called every frame to ensure that we're not accumulating too many buffers.
+    /// After this call, internal chunks can be re-used.
+    pub fn receive_data(
+        &mut self,
+        on_data_received: impl Fn(&[u8], GpuWriteCpuReadBufferIdentifier),
+    ) {
+        crate::profile_function!();
+
+        while let Ok(mut chunk) = self.receiver.try_recv() {
+            {
+                let buffer_view = chunk
+                    .buffer
+                    .slice(..chunk.unused_offset())
+                    .get_mapped_range();
+
+                for (range, identifier) in chunk.ranges_in_use.drain(..) {
+                    on_data_received(
+                        &buffer_view[range.start as usize..range.end as usize],
+                        identifier,
+                    );
+                }
+            }
+
+            // Ready for re-use!
+            chunk.buffer.unmap();
+            self.free_chunks.push(chunk);
+        }
+    }
+}
+
+impl std::fmt::Debug for GpuWriteCpuReadBelt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GpuWriteCpuReadBelt")
+            .field("chunk_size", &self.chunk_size)
+            .field("active_chunks", &self.active_chunks.len())
+            .field("free_chunks", &self.free_chunks.len())
+            .field("next_identifier", &self.next_identifier)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/gpu_write_cpu_read_belt.rs
@@ -175,13 +175,15 @@ impl GpuWriteCpuReadBelt {
             {
                 self.free_chunks.swap_remove(index)
             } else {
+                // Allocation might be bigger than a chunk!
+                let buffer_size = self.chunk_size.max(size_in_bytes);
                 // Happens relatively rarely, this is a noteworthy event!
-                re_log::debug!("Allocating new GpuWriteCpuReadBelt chunk of size {size_in_bytes}");
+                re_log::debug!("Allocating new GpuWriteCpuReadBelt chunk of size {buffer_size}");
                 let buffer = buffer_pool.alloc(
                     device,
                     &BufferDesc {
                         label: "GpuWriteCpuReadBelt buffer".into(),
-                        size: size_in_bytes,
+                        size: buffer_size,
                         usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
                         mapped_at_creation: false,
                     },

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -4,6 +4,7 @@
 //! follows some more complex strategy for efficient re-use and sub-allocation of wgpu resources.
 
 mod cpu_write_gpu_read_belt;
+mod gpu_write_cpu_read_belt;
 mod uniform_buffer_fill;
 
 pub use cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -8,6 +8,9 @@ mod gpu_write_cpu_read_belt;
 mod uniform_buffer_fill;
 
 pub use cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};
+pub use gpu_write_cpu_read_belt::{
+    GpuWriteCpuReadBelt, GpuWriteCpuReadBuffer, GpuWriteCpuReadBufferIdentifier,
+};
 pub use uniform_buffer_fill::{
     create_and_fill_uniform_buffer, create_and_fill_uniform_buffer_batch,
 };

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -4,13 +4,11 @@
 //! follows some more complex strategy for efficient re-use and sub-allocation of wgpu resources.
 
 mod cpu_write_gpu_read_belt;
-mod gpu_write_cpu_read_belt;
+mod gpu_readback_belt;
 mod uniform_buffer_fill;
 
 pub use cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};
-pub use gpu_write_cpu_read_belt::{
-    GpuWriteCpuReadBelt, GpuWriteCpuReadBuffer, GpuWriteCpuReadBufferIdentifier,
-};
+pub use gpu_readback_belt::{GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackBufferIdentifier};
 pub use uniform_buffer_fill::{
     create_and_fill_uniform_buffer, create_and_fill_uniform_buffer_batch,
 };

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -76,7 +76,11 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod>(
         num_buffers as _,
     );
     staging_buffer.extend(content);
-    staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(), &buffer, 0);
+    staging_buffer.copy_to_buffer(
+        ctx.active_frame.before_view_builder_encoder.lock().get(),
+        &buffer,
+        0,
+    );
 
     (0..num_buffers)
         .map(|i| BindGroupEntry::Buffer {

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -262,18 +262,6 @@ impl RenderContext {
         // Map all read staging buffers.
         self.gpu_readback_belt.lock().after_queue_submit();
 
-        // TODO: We need a safety mechanism like this. But just draining here might discard brand new buffers that just came in.
-        //          Instead, brandmark buffers with a frame index and only drain those that are older than the current frame index.
-        // To err on the safe side, drain all unused mapped staging buffers.
-        // self.gpu_write_cpu_read_belt
-        //     .lock()
-        //     .receive_data(|_data, identifier| {
-        //         log::warn_once!(
-        //             "Discarding read buffer with identifier {:?} as it was unused.",
-        //             identifier
-        //         );
-        //     });
-
         self.active_frame = ActiveFrameContext {
             before_view_builder_encoder: Mutex::new(FrameGlobalCommandEncoder::new(&self.device)),
             frame_index: self.active_frame.frame_index + 1,

--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -27,6 +27,7 @@ mod size;
 mod wgpu_buffer_types;
 mod wgpu_resources;
 
+pub use allocator::{GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackBufferIdentifier};
 pub use color::Rgba32Unmul;
 pub use colormap::{
     colormap_inferno_srgb, colormap_magma_srgb, colormap_plasma_srgb, colormap_srgb,
@@ -38,7 +39,7 @@ pub use depth_offset::DepthOffset;
 pub use line_strip_builder::{LineStripBuilder, LineStripSeriesBuilder};
 pub use point_cloud_builder::{PointCloudBatchBuilder, PointCloudBuilder};
 pub use size::Size;
-pub use view_builder::AutoSizeConfig;
+pub use view_builder::{AutoSizeConfig, ScheduledScreenshot};
 pub use wgpu_resources::WgpuResourcePoolStatistics;
 
 mod file_system;

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -235,7 +235,7 @@ impl GpuMesh {
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_normals));
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_texcoords));
             staging_buffer.copy_to_buffer(
-                ctx.active_frame.encoder.lock().get(),
+                ctx.active_frame.before_view_builder_encoder.lock().get(),
                 &vertex_buffer_combined,
                 0,
             );
@@ -260,7 +260,11 @@ impl GpuMesh {
                 data.indices.len(),
             );
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.indices));
-            staging_buffer.copy_to_buffer(ctx.active_frame.encoder.lock().get(), &index_buffer, 0);
+            staging_buffer.copy_to_buffer(
+                ctx.active_frame.before_view_builder_encoder.lock().get(),
+                &index_buffer,
+                0,
+            );
             index_buffer
         };
 

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -254,7 +254,7 @@ fn create_and_upload_texture<T: bytemuck::Pod>(
         .alloc(&ctx.device, &depth_texture_desc);
 
     let TextureRowDataInfo {
-        bytes_per_row_unaligned,
+        bytes_per_row_unpadded: bytes_per_row_unaligned,
         bytes_per_row_padded,
     } = texture_row_data_info(depth_texture_desc.format, depth_texture_desc.size.width);
 

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -21,9 +21,9 @@ use crate::{
     resource_managers::ResourceManagerError,
     view_builder::ViewBuilder,
     wgpu_resources::{
-        BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
-        GpuRenderPipelineHandle, GpuTexture, PipelineLayoutDesc, RenderPipelineDesc,
-        ShaderModuleDesc, TextureDesc,
+        texture_row_data_info, BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup,
+        GpuBindGroupLayoutHandle, GpuRenderPipelineHandle, GpuTexture, PipelineLayoutDesc,
+        RenderPipelineDesc, ShaderModuleDesc, TextureDesc, TextureRowDataInfo,
     },
     ColorMap,
 };
@@ -253,52 +253,53 @@ fn create_and_upload_texture<T: bytemuck::Pod>(
         .textures
         .alloc(&ctx.device, &depth_texture_desc);
 
-    let format_info = depth_texture_desc.format.describe();
-    let width_blocks = depth_cloud.depth_dimensions.x / format_info.block_dimensions.0 as u32;
-    let height_blocks = depth_cloud.depth_dimensions.y / format_info.block_dimensions.1 as u32;
-    let bytes_per_row_unaligned = width_blocks * format_info.block_size as u32;
+    let TextureRowDataInfo {
+        bytes_per_row_unaligned,
+        bytes_per_row_padded,
+    } = texture_row_data_info(depth_texture_desc.format, depth_texture_desc.size.width);
+
+    // Not supporting compressed formats here.
+    debug_assert!(depth_texture_desc.format.describe().block_dimensions == (1, 1));
 
     // TODO(andreas): CpuGpuWriteBelt should make it easier to do this.
-    let bytes_per_row_aligned =
-        wgpu::util::align_to(bytes_per_row_unaligned, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
-    let bytes_padding_per_row = (bytes_per_row_aligned - bytes_per_row_unaligned) as usize;
+    let bytes_padding_per_row = (bytes_per_row_padded - bytes_per_row_unaligned) as usize;
     // Sanity check the padding size. If this happens something is seriously wrong, as it would imply
     // that we can't express the required alignment with the block size.
     debug_assert!(
         bytes_padding_per_row % std::mem::size_of::<T>() == 0,
         "Padding is not a multiple of pixel size. Can't correctly pad the texture data"
     );
-    let blocks_padding_per_row = bytes_padding_per_row / std::mem::size_of::<T>();
+    let num_pixel_padding_per_row = bytes_padding_per_row / std::mem::size_of::<T>();
 
     let mut depth_texture_staging = ctx.cpu_write_gpu_read_belt.lock().allocate::<T>(
         &ctx.device,
         &ctx.gpu_resources.buffers,
-        data.len() + blocks_padding_per_row * height_blocks as usize,
+        data.len() + num_pixel_padding_per_row * depth_texture_desc.size.height as usize,
     );
 
     // Fill with a single copy if possible, otherwise do multiple, filling in padding.
-    if blocks_padding_per_row == 0 {
+    if num_pixel_padding_per_row == 0 {
         depth_texture_staging.extend_from_slice(data);
     } else {
         let row_padding = std::iter::repeat(T::zeroed())
-            .take(blocks_padding_per_row)
+            .take(num_pixel_padding_per_row)
             .collect::<Vec<_>>();
 
-        for row in data.chunks(width_blocks as usize) {
+        for row in data.chunks(depth_texture_desc.size.width as usize) {
             depth_texture_staging.extend_from_slice(row);
             depth_texture_staging.extend_from_slice(&row_padding);
         }
     }
 
     depth_texture_staging.copy_to_texture(
-        ctx.active_frame.encoder.lock().get(),
+        ctx.active_frame.before_view_builder_encoder.lock().get(),
         wgpu::ImageCopyTexture {
             texture: &depth_texture.inner.texture,
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,
         },
-        Some(NonZeroU32::new(bytes_per_row_aligned).expect("invalid bytes per row")),
+        Some(NonZeroU32::new(bytes_per_row_padded).expect("invalid bytes per row")),
         None,
         depth_texture_size,
     );

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -252,7 +252,7 @@ impl MeshDrawData {
             }
             assert_eq!(num_processed_instances, instances.len());
             instance_buffer_staging.copy_to_buffer(
-                ctx.active_frame.encoder.lock().get(),
+                ctx.active_frame.before_view_builder_encoder.lock().get(),
                 &instance_buffer,
                 0,
             );

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -98,6 +98,10 @@ pub enum DrawPhase {
 
     /// Drawn when compositing with the main target.
     Compositing,
+
+    /// Drawn when compositing with the main target, but for screenshots.
+    /// This is a separate phase primarily because screenshots may be rendered with a different texture format.
+    CompositingScreenshot,
 }
 
 /// Gets or creates a vertex shader module for drawing a screen filling triangle.

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -303,7 +303,7 @@ impl PointCloudDrawData {
         }
 
         builder.color_buffer.copy_to_texture(
-            ctx.active_frame.encoder.lock().get(),
+            ctx.active_frame.before_view_builder_encoder.lock().get(),
             wgpu::ImageCopyTexture {
                 texture: &color_texture.texture,
                 mip_level: 0,

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -577,7 +577,7 @@ impl ViewBuilder {
         //
         // This comes with the perk that we can do extra things here if we want!
         //
-        // TODO(andreas): Like more antialiasing!
+        // TODO(andreas): One thing to add would be more anti-aliasing!
         // We could render the same image with subpixel moved camera in order to get super-sampling without hitting texture size limitations.
         // Or alternatively try to render the images in several tiles 🤔. In any case this would greatly improve quality!
         if let Some(screenshot_target_buffer) = self.scheduled_screenshot.take() {
@@ -616,12 +616,7 @@ impl ViewBuilder {
                 self.draw_phase(ctx, DrawPhase::CompositingScreenshot, &mut pass);
             }
 
-            let bytes_per_row = texture_row_data_info(
-                screenshot_texture.texture.format(),
-                screenshot_texture.texture.width(),
-            )
-            .bytes_per_row_padded;
-            screenshot_target_buffer.read_texture(
+            screenshot_target_buffer.read_texture2d(
                 &mut encoder,
                 wgpu::ImageCopyTexture {
                     texture: &screenshot_texture.texture,
@@ -629,9 +624,8 @@ impl ViewBuilder {
                     origin: wgpu::Origin3d::ZERO,
                     aspect: wgpu::TextureAspect::All,
                 },
-                std::num::NonZeroU32::new(bytes_per_row),
-                None,
-                screenshot_texture.texture.size(),
+                screenshot_texture.texture.width(),
+                screenshot_texture.texture.height(),
             );
         }
 

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -640,10 +640,23 @@ impl ViewBuilder {
 
     /// Schedules the taking of a screenshot.
     ///
-    /// Needs to be called after setup.
+    /// Needs to be called after [`ViewBuilder::setup_view`] and before [`ViewBuilder::draw`].
     /// Returns screenshot data properties for convenience.
     ///
-    /// TODO: Document how to get the data
+    /// Data from the screenshot needs to be retrieved from the [`crate::GpuReadbackBelt`] on [`RenderContext`].
+    /// For this the user needs to store the returned scheduled screenshot like so:
+    /// ```no_run
+    /// use re_renderer::{RenderContext, ScheduledScreenshot};
+    /// fn handle_readback_data(ctx: &RenderContext, scheduled_screenshot: ScheduledScreenshot) {
+    ///     ctx.gpu_readback_belt.lock().receive_data(|data, identifier| {
+    ///         if identifier == scheduled_screenshot.identifier {
+    ///             // Do something with the screenshot data.
+    ///         } else {
+    ///            re_log::warn_once!("Unknown readback buffer identifier {:?}", identifier);
+    ///         }
+    ///     });
+    /// }
+    /// ```
     pub fn schedule_screenshot(
         &mut self,
         ctx: &RenderContext,

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -3,9 +3,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::{
-    allocator::{
-        create_and_fill_uniform_buffer, GpuWriteCpuReadBuffer, GpuWriteCpuReadBufferIdentifier,
-    },
+    allocator::{create_and_fill_uniform_buffer, GpuReadbackBuffer, GpuReadbackBufferIdentifier},
     context::RenderContext,
     global_bindings::FrameUniformBuffer,
     renderer::{
@@ -44,7 +42,7 @@ pub struct ViewBuilder {
     // TODO(andreas): Consider making "render processors" a "thing" by establishing a form of hardcoded/limited-flexibility render-graph
     outline_mask_processor: Option<OutlineMaskProcessor>,
 
-    scheduled_screenshot: Option<GpuWriteCpuReadBuffer>,
+    scheduled_screenshot: Option<GpuReadbackBuffer>,
 }
 
 struct ViewTargetSetup {
@@ -174,7 +172,7 @@ impl Default for TargetConfiguration {
 }
 
 pub struct ScheduledScreenshot {
-    pub identifier: GpuWriteCpuReadBufferIdentifier,
+    pub identifier: GpuReadbackBufferIdentifier,
     pub width: u32,
     pub height: u32,
     pub row_info: TextureRowDataInfo,
@@ -662,7 +660,7 @@ impl ViewBuilder {
         let row_info =
             texture_row_data_info(Self::SCREENSHOT_COLOR_FORMAT, setup.resolution_in_pixel[0]);
         let buffer_size = row_info.bytes_per_row_padded * setup.resolution_in_pixel[1];
-        let screenshot_buffer = ctx.gpu_write_cpu_read_belt.lock().allocate(
+        let screenshot_buffer = ctx.gpu_readback_belt.lock().allocate(
             &ctx.device,
             &ctx.gpu_resources.buffers,
             buffer_size as u64,

--- a/crates/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/re_renderer/src/wgpu_resources/mod.rs
@@ -114,3 +114,25 @@ impl WgpuResourcePools {
         }
     }
 }
+
+pub struct TextureRowDataInfo {
+    /// How many bytes per row contain actual data.
+    pub bytes_per_row_unaligned: u32,
+    /// How many bytes per row are required to be allocated in total.
+    pub bytes_per_row_padded: u32,
+}
+
+/// Returns the number of required bytes per row of a texture with the given format and width.
+pub fn texture_row_data_info(format: wgpu::TextureFormat, width: u32) -> TextureRowDataInfo {
+    let format_info = format.describe();
+    let width_blocks = width / format_info.block_dimensions.0 as u32;
+    let bytes_per_row_unaligned = width_blocks * format_info.block_size as u32;
+
+    TextureRowDataInfo {
+        bytes_per_row_unaligned,
+        bytes_per_row_padded: wgpu::util::align_to(
+            bytes_per_row_unaligned,
+            wgpu::COPY_BYTES_PER_ROW_ALIGNMENT,
+        ),
+    }
+}

--- a/crates/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/re_renderer/src/wgpu_resources/mod.rs
@@ -117,7 +117,7 @@ impl WgpuResourcePools {
 
 pub struct TextureRowDataInfo {
     /// How many bytes per row contain actual data.
-    pub bytes_per_row_unaligned: u32,
+    pub bytes_per_row_unpadded: u32,
     /// How many bytes per row are required to be allocated in total.
     pub bytes_per_row_padded: u32,
 }
@@ -129,7 +129,7 @@ pub fn texture_row_data_info(format: wgpu::TextureFormat, width: u32) -> Texture
     let bytes_per_row_unaligned = width_blocks * format_info.block_size as u32;
 
     TextureRowDataInfo {
-        bytes_per_row_unaligned,
+        bytes_per_row_unpadded: bytes_per_row_unaligned,
         bytes_per_row_padded: wgpu::util::align_to(
             bytes_per_row_unaligned,
             wgpu::COPY_BYTES_PER_ROW_ALIGNMENT,


### PR DESCRIPTION
Tested on `multiview` - you can now make screenshot with the keys 1/2/3/4 on native and get a screenshot file out of the first/second/.. view respectively.

Draft notes:
* [ ] test on web
* [ ] check again with debug log if allocatoing behavior is as expected
* [ ] self-review

Part of #1615 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
