### PR TITLE
Improve the depth backprojection feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Unreleased
 [Commits since latest release](https://github.com/rerun-io/rerun/compare/latest...HEAD)
 
+* Fixed a bug in the image hover code, causing the wrong RGBA values to be printed 😬 [#1690](https://github.com/rerun-io/rerun/pull/1356)
+* Fixed a bug that caused points to be render too large [#1690](https://github.com/rerun-io/rerun/pull/1690)
 
 ## 0.3.1 - Remove potentially sensitive analytics
 [Commits](https://github.com/rerun-io/rerun/compare/v0.3.1...v0.3.0)

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -72,8 +72,6 @@ pub struct EntityProperties {
     pub depth_from_world_scale: EditableAutoValue<f32>,
 
     /// Used to scale the radii of the points in the resulting point cloud.
-    ///
-    /// Default is 1.0.
     pub backproject_radius_scale: EditableAutoValue<f32>,
 }
 
@@ -122,7 +120,7 @@ impl Default for EntityProperties {
             backproject_depth: false,
             backproject_pinhole_ent_path: None,
             depth_from_world_scale: EditableAutoValue::default(),
-            backproject_radius_scale: EditableAutoValue::Auto(1.0),
+            backproject_radius_scale: EditableAutoValue::Auto(2.0), // Lower values leads to too much Moiré
         }
     }
 }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -72,6 +72,8 @@ pub struct EntityProperties {
     pub backproject_depth_meter: EditableAutoValue<f32>,
 
     /// Used to scale the radii of the points in the resulting point cloud.
+    ///
+    /// Default is 1.0.
     pub backproject_radius_scale: EditableAutoValue<f32>,
 }
 
@@ -120,7 +122,7 @@ impl Default for EntityProperties {
             backproject_depth: false,
             backproject_pinhole_ent_path: None,
             backproject_depth_meter: EditableAutoValue::default(),
-            backproject_radius_scale: EditableAutoValue::default(),
+            backproject_radius_scale: EditableAutoValue::Auto(1.0),
         }
     }
 }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -66,8 +66,10 @@ pub struct EntityProperties {
     /// `None` means backprojection is disabled.
     pub backproject_pinhole_ent_path: Option<EntityPath>,
 
-    /// Used to scale the resulting point cloud.
-    pub backproject_scale: EditableAutoValue<f32>,
+    /// How many depth units per world-space unit. e.g. 1000 for millimeters.
+    ///
+    /// This corresponds to [`Tensor::meter`].
+    pub backproject_depth_meter: EditableAutoValue<f32>,
 
     /// Used to scale the radii of the points in the resulting point cloud.
     pub backproject_radius_scale: EditableAutoValue<f32>,
@@ -94,7 +96,10 @@ impl EntityProperties {
                 .backproject_pinhole_ent_path
                 .clone()
                 .or(child.backproject_pinhole_ent_path.clone()),
-            backproject_scale: self.backproject_scale.or(&child.backproject_scale).clone(),
+            backproject_depth_meter: self
+                .backproject_depth_meter
+                .or(&child.backproject_depth_meter)
+                .clone(),
             backproject_radius_scale: self
                 .backproject_radius_scale
                 .or(&child.backproject_radius_scale)
@@ -114,7 +119,7 @@ impl Default for EntityProperties {
             pinhole_image_plane_distance: EditableAutoValue::default(),
             backproject_depth: false,
             backproject_pinhole_ent_path: None,
-            backproject_scale: EditableAutoValue::default(),
+            backproject_depth_meter: EditableAutoValue::default(),
             backproject_radius_scale: EditableAutoValue::default(),
         }
     }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -69,7 +69,7 @@ pub struct EntityProperties {
     /// How many depth units per world-space unit. e.g. 1000 for millimeters.
     ///
     /// This corresponds to [`re_log_types::component_types::Tensor::meter`].
-    pub backproject_depth_meter: EditableAutoValue<f32>,
+    pub depth_from_world_scale: EditableAutoValue<f32>,
 
     /// Used to scale the radii of the points in the resulting point cloud.
     ///
@@ -98,9 +98,9 @@ impl EntityProperties {
                 .backproject_pinhole_ent_path
                 .clone()
                 .or(child.backproject_pinhole_ent_path.clone()),
-            backproject_depth_meter: self
-                .backproject_depth_meter
-                .or(&child.backproject_depth_meter)
+            depth_from_world_scale: self
+                .depth_from_world_scale
+                .or(&child.depth_from_world_scale)
                 .clone(),
             backproject_radius_scale: self
                 .backproject_radius_scale
@@ -121,7 +121,7 @@ impl Default for EntityProperties {
             pinhole_image_plane_distance: EditableAutoValue::default(),
             backproject_depth: false,
             backproject_pinhole_ent_path: None,
-            backproject_depth_meter: EditableAutoValue::default(),
+            depth_from_world_scale: EditableAutoValue::default(),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),
         }
     }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -68,7 +68,7 @@ pub struct EntityProperties {
 
     /// How many depth units per world-space unit. e.g. 1000 for millimeters.
     ///
-    /// This corresponds to [`Tensor::meter`].
+    /// This corresponds to [`re_log_types::component_types::Tensor::meter`].
     pub backproject_depth_meter: EditableAutoValue<f32>,
 
     /// Used to scale the radii of the points in the resulting point cloud.

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -120,7 +120,7 @@ impl Default for EntityProperties {
             backproject_depth: false,
             backproject_pinhole_ent_path: None,
             depth_from_world_scale: EditableAutoValue::default(),
-            backproject_radius_scale: EditableAutoValue::Auto(2.0), // Lower values leads to too much Moiré
+            backproject_radius_scale: EditableAutoValue::Auto(1.0),
         }
     }
 }

--- a/crates/re_log_types/src/data.rs
+++ b/crates/re_log_types/src/data.rs
@@ -94,6 +94,10 @@ impl TensorDataType {
         }
     }
 
+    pub fn is_integer(&self) -> bool {
+        !self.is_float()
+    }
+
     pub fn is_float(&self) -> bool {
         match self {
             Self::U8

--- a/crates/re_log_types/src/data.rs
+++ b/crates/re_log_types/src/data.rs
@@ -94,10 +94,12 @@ impl TensorDataType {
         }
     }
 
+    #[inline]
     pub fn is_integer(&self) -> bool {
         !self.is_float()
     }
 
+    #[inline]
     pub fn is_float(&self) -> bool {
         match self {
             Self::U8
@@ -112,6 +114,7 @@ impl TensorDataType {
         }
     }
 
+    #[inline]
     pub fn max_value(&self) -> f64 {
         match self {
             Self::U8 => u8::MAX as _,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -47,7 +47,7 @@ struct RenderDepthClouds {
     albedo_handle: GpuTexture2DHandle,
 
     scale: f32,
-    radius_scale: f32,
+    point_radius_from_world_depth: f32,
     intrinsics: glam::Mat3,
 
     camera_control: CameraControl,
@@ -72,7 +72,7 @@ impl RenderDepthClouds {
         let Self {
             depth,
             scale,
-            radius_scale,
+            point_radius_from_world_depth,
             intrinsics,
             ..
         } = self;
@@ -93,7 +93,7 @@ impl RenderDepthClouds {
                     (
                         pos_in_world * *scale,
                         Color32::from_gray((linear_depth * 255.0) as u8),
-                        Size(linear_depth * *radius_scale),
+                        Size(linear_depth * *point_radius_from_world_depth),
                     )
                 })
                 .multiunzip();
@@ -163,7 +163,7 @@ impl RenderDepthClouds {
         let Self {
             depth,
             scale,
-            radius_scale,
+            point_radius_from_world_depth,
             intrinsics,
             ..
         } = self;
@@ -175,7 +175,8 @@ impl RenderDepthClouds {
             &[DepthCloud {
                 depth_camera_extrinsics: world_from_obj,
                 depth_camera_intrinsics: *intrinsics,
-                point_radius_from_normalized_depth: *radius_scale,
+                world_depth_from_data_depth: 1.0,
+                point_radius_from_world_depth: *point_radius_from_world_depth,
                 depth_dimensions: depth.dimensions,
                 depth_data: depth.data.clone(),
                 colormap: re_renderer::ColorMap::ColorMapTurbo,
@@ -246,7 +247,7 @@ impl framework::Example for RenderDepthClouds {
         );
 
         let scale = 50.0;
-        let radius_scale = 0.1;
+        let point_radius_from_world_depth = 0.1;
 
         // hardcoded intrinsics for nyud dataset
         let focal_length = depth.dimensions.x as f32 * 0.7;
@@ -264,7 +265,7 @@ impl framework::Example for RenderDepthClouds {
             albedo_handle,
 
             scale,
-            radius_scale,
+            point_radius_from_world_depth,
             intrinsics,
 
             camera_control: CameraControl::RotateAroundCenter,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -173,7 +173,7 @@ impl RenderDepthClouds {
         let depth_cloud_draw_data = DepthCloudDrawData::new(
             re_ctx,
             &[DepthCloud {
-                depth_camera_extrinsics: world_from_obj,
+                world_from_obj,
                 depth_camera_intrinsics: *intrinsics,
                 world_depth_from_data_depth: 1.0,
                 point_radius_from_world_depth: *point_radius_from_world_depth,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -175,7 +175,7 @@ impl RenderDepthClouds {
             &[DepthCloud {
                 depth_camera_extrinsics: world_from_obj,
                 depth_camera_intrinsics: *intrinsics,
-                radius_scale: *radius_scale,
+                point_radius_from_normalized_depth: *radius_scale,
                 depth_dimensions: depth.dimensions,
                 depth_data: depth.data.clone(),
                 colormap: re_renderer::ColorMap::ColorMapTurbo,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -177,6 +177,7 @@ impl RenderDepthClouds {
                 depth_camera_intrinsics: *intrinsics,
                 world_depth_from_data_depth: 1.0,
                 point_radius_from_world_depth: *point_radius_from_world_depth,
+                max_depth: 5.0,
                 depth_dimensions: depth.dimensions,
                 depth_data: depth.data.clone(),
                 colormap: re_renderer::ColorMap::ColorMapTurbo,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -177,7 +177,7 @@ impl RenderDepthClouds {
                 depth_camera_intrinsics: *intrinsics,
                 world_depth_from_data_depth: 1.0,
                 point_radius_from_world_depth: *point_radius_from_world_depth,
-                max_depth: 5.0,
+                max_depth_in_world: 5.0,
                 depth_dimensions: depth.dimensions,
                 depth_data: depth.data.clone(),
                 colormap: re_renderer::ColorMap::ColorMapTurbo,

--- a/crates/re_renderer/shader/colormap.wgsl
+++ b/crates/re_renderer/shader/colormap.wgsl
@@ -9,6 +9,9 @@ const COLORMAP_PLASMA:  u32 = 3u;
 const COLORMAP_MAGMA:   u32 = 4u;
 const COLORMAP_INFERNO: u32 = 5u;
 
+/// Returns a gamma-space sRGB in 0-1 range.
+///
+/// The input will be saturated to [0, 1] range.
 fn colormap_srgb(which: u32, t: f32) -> Vec3 {
     if which == COLORMAP_TURBO {
         return colormap_turbo_srgb(t);
@@ -25,6 +28,13 @@ fn colormap_srgb(which: u32, t: f32) -> Vec3 {
     }
 }
 
+/// Returns a linear-space sRGB in 0-1 range.
+///
+/// The input will be saturated to [0, 1] range.
+fn colormap_linear(which: u32, t: f32) -> Vec3 {
+    return linear_from_srgb(colormap_srgb(which, t));
+}
+
 // --- Turbo color map ---
 
 // Polynomial approximation in GLSL for the Turbo colormap.
@@ -38,7 +48,8 @@ fn colormap_srgb(which: u32, t: f32) -> Vec3 {
 //   Colormap Design: Anton Mikhailov (mikhailov@google.com)
 //   GLSL Approximation: Ruofei Du (ruofei@google.com)
 
-/// Returns a normalized sRGB polynomial approximation from Turbo color map, assuming `t` is
+/// Returns a gamma-space sRGB in 0-1 range.
+/// This is a polynomial approximation from Turbo color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
 fn colormap_turbo_srgb(t: f32) -> Vec3 {
     let r4 = Vec4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
@@ -73,7 +84,8 @@ fn colormap_turbo_srgb(t: f32) -> Vec3 {
 //
 // Data fitted from https://github.com/BIDS/colormap/blob/master/colormaps.py (CC0).
 
-/// Returns a normalized sRGB polynomial approximation from Viridis color map, assuming `t` is
+/// Returns a gamma-space sRGB in 0-1 range.
+/// This is a polynomial approximation from Viridis color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
 fn colormap_viridis_srgb(t: f32) -> Vec3 {
     let c0 = Vec3(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
@@ -87,7 +99,8 @@ fn colormap_viridis_srgb(t: f32) -> Vec3 {
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
-/// Returns a normalized sRGB polynomial approximation from Plasma color map, assuming `t` is
+/// Returns a gamma-space sRGB in 0-1 range.
+/// This is a polynomial approximation from Plasma color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
 fn colormap_plasma_srgb(t: f32) -> Vec3 {
     let c0 = Vec3(0.05873234392399702, 0.02333670892565664, 0.5433401826748754);
@@ -101,7 +114,8 @@ fn colormap_plasma_srgb(t: f32) -> Vec3 {
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
-/// Returns a normalized sRGB polynomial approximation from Magma color map, assuming `t` is
+/// Returns a gamma-space sRGB in 0-1 range.
+/// This is a polynomial approximation from Magma color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
 fn colormap_magma_srgb(t: f32) -> Vec3 {
     let c0 = Vec3(-0.002136485053939582, -0.000749655052795221, -0.005386127855323933);
@@ -115,7 +129,8 @@ fn colormap_magma_srgb(t: f32) -> Vec3 {
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
-/// Returns a normalized sRGB polynomial approximation from Inferno color map, assuming `t` is
+/// Returns a gamma-space sRGB in 0-1 range.
+/// This is a polynomial approximation from Inferno color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
 fn colormap_inferno_srgb(t: f32) -> Vec3 {
     let c0 = Vec3(0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -28,7 +28,7 @@ fn compute_point_data(quad_idx: i32) -> PointData {
     let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;
 
     // TODO(cmc): albedo textures
-    let color = Vec4(colormap_linear(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth), 1.0);
+    let color = Vec4(colormap_linear(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth_in_world), 1.0);
 
     // TODO(cmc): This assumes a pinhole camera; need to support other kinds at some point.
     let intrinsics = depth_cloud_info.depth_camera_intrinsics;
@@ -71,8 +71,8 @@ struct DepthCloudInfo {
     /// Point radius is calculated as world-space depth times this value.
     point_radius_from_world_depth: f32,
 
-    /// The maximum depth value, for use with the colormap.
-    max_depth: f32,
+    /// The maximum depth value in world-space, for use with the colormap.
+    max_depth_in_world: f32,
 
     /// Configures color mapping mode, see `colormap.wgsl`.
     colormap: u32,

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -27,10 +27,8 @@ fn compute_point_data(quad_idx: i32) -> PointData {
     // TODO(cmc): expose knobs to linearize/normalize/flip/cam-to-plane depth.
     let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;
 
-    let max_depth = 10.0; // TODO: get from uniform buffer
-
     // TODO(cmc): albedo textures
-    let color = Vec4(colormap_srgb(depth_cloud_info.colormap, world_space_depth / max_depth), 1.0);
+    let color = Vec4(colormap_srgb(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth), 1.0);
 
     // TODO(cmc): This assumes a pinhole camera; need to support other kinds at some point.
     let intrinsics = depth_cloud_info.depth_camera_intrinsics;
@@ -72,6 +70,9 @@ struct DepthCloudInfo {
 
     /// Point radius is calculated as world-space depth times this value.
     point_radius_from_world_depth: f32,
+
+    /// The maximum depth value, for use with the colormap.
+    max_depth: f32,
 
     /// Configures color mapping mode, see `colormap.wgsl`.
     colormap: u32,

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -42,7 +42,7 @@ fn compute_point_data(quad_idx: i32) -> PointData {
         world_space_depth,
     );
 
-    let pos_in_world = depth_cloud_info.extrinsincs * Vec4(pos_in_obj, 1.0);
+    let pos_in_world = depth_cloud_info.world_from_obj * Vec4(pos_in_obj, 1.0);
 
     var data: PointData;
     data.pos_in_world = pos_in_world.xyz;
@@ -57,7 +57,7 @@ fn compute_point_data(quad_idx: i32) -> PointData {
 /// Keep in sync with `DepthCloudInfoUBO` in `depth_cloud.rs`.
 struct DepthCloudInfo {
     /// The extrinsincs of the camera used for the projection.
-    extrinsincs: Mat4,
+    world_from_obj: Mat4,
 
     /// The intrinsics of the camera used for the projection.
     ///

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -52,6 +52,7 @@ fn compute_point_data(quad_idx: i32) -> PointData {
 
 // ---
 
+/// Keep in sync with `DepthCloudInfoUBO` in `depth_cloud.rs`.
 struct DepthCloudInfo {
     /// The extrinsincs of the camera used for the projection.
     extrinsincs: Mat4,

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -28,7 +28,7 @@ fn compute_point_data(quad_idx: i32) -> PointData {
     let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;
 
     // TODO(cmc): albedo textures
-    let color = Vec4(colormap_srgb(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth), 1.0);
+    let color = Vec4(colormap_linear(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth), 1.0);
 
     // TODO(cmc): This assumes a pinhole camera; need to support other kinds at some point.
     let intrinsics = depth_cloud_info.depth_camera_intrinsics;

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -44,7 +44,7 @@ fn compute_point_data(quad_idx: i32) -> PointData {
 
     var data: PointData;
     data.pos_in_world = pos_in_world.xyz;
-    data.unresolved_radius = norm_linear_depth * depth_cloud_info.radius_scale;
+    data.unresolved_radius = depth_cloud_info.point_radius_from_normalized_depth * norm_linear_depth;
     data.color = color;
 
     return data;
@@ -61,8 +61,8 @@ struct DepthCloudInfo {
     /// Only supports pinhole cameras at the moment.
     depth_camera_intrinsics: Mat3,
 
-    /// The scale to apply to the radii of the backprojected points.
-    radius_scale: f32,
+    /// Point radius is calculated as normalized depth times this value.
+    point_radius_from_normalized_depth: f32,
 
     /// Configures color mapping mode, see `colormap.wgsl`.
     colormap: u32,
@@ -70,6 +70,7 @@ struct DepthCloudInfo {
     /// Outline mask id for the outline mask pass.
     outline_mask_id: UVec2,
 };
+
 @group(1) @binding(0)
 var<uniform> depth_cloud_info: DepthCloudInfo;
 

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -25,10 +25,12 @@ fn compute_point_data(quad_idx: i32) -> PointData {
     let texcoords = IVec2(quad_idx % wh.x, quad_idx / wh.x);
 
     // TODO(cmc): expose knobs to linearize/normalize/flip/cam-to-plane depth.
-    let norm_linear_depth = textureLoad(depth_texture, texcoords, 0).x;
+    let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;
+
+    let max_depth = 10.0; // TODO: get from uniform buffer
 
     // TODO(cmc): albedo textures
-    let color = Vec4(colormap_srgb(depth_cloud_info.colormap, norm_linear_depth), 1.0);
+    let color = Vec4(colormap_srgb(depth_cloud_info.colormap, world_space_depth / max_depth), 1.0);
 
     // TODO(cmc): This assumes a pinhole camera; need to support other kinds at some point.
     let intrinsics = depth_cloud_info.depth_camera_intrinsics;
@@ -36,15 +38,15 @@ fn compute_point_data(quad_idx: i32) -> PointData {
     let offset = Vec2(intrinsics[2][0], intrinsics[2][1]);
 
     let pos_in_obj = Vec3(
-        (Vec2(texcoords) - offset) * norm_linear_depth / focal_length,
-        norm_linear_depth,
+        (Vec2(texcoords) - offset) * world_space_depth / focal_length,
+        world_space_depth,
     );
 
     let pos_in_world = depth_cloud_info.extrinsincs * Vec4(pos_in_obj, 1.0);
 
     var data: PointData;
     data.pos_in_world = pos_in_world.xyz;
-    data.unresolved_radius = depth_cloud_info.point_radius_from_normalized_depth * norm_linear_depth;
+    data.unresolved_radius = depth_cloud_info.point_radius_from_world_depth * world_space_depth;
     data.color = color;
 
     return data;
@@ -62,14 +64,17 @@ struct DepthCloudInfo {
     /// Only supports pinhole cameras at the moment.
     depth_camera_intrinsics: Mat3,
 
-    /// Point radius is calculated as normalized depth times this value.
-    point_radius_from_normalized_depth: f32,
+    /// Outline mask id for the outline mask pass.
+    outline_mask_id: UVec2,
+
+    /// Multiplier to get world-space depth from whatever is in the texture.
+    world_depth_from_texture_value: f32,
+
+    /// Point radius is calculated as world-space depth times this value.
+    point_radius_from_world_depth: f32,
 
     /// Configures color mapping mode, see `colormap.wgsl`.
     colormap: u32,
-
-    /// Outline mask id for the outline mask pass.
-    outline_mask_id: UVec2,
 };
 
 @group(1) @binding(0)

--- a/crates/re_renderer/shader/utils/sphere_quad.wgsl
+++ b/crates/re_renderer/shader/utils/sphere_quad.wgsl
@@ -106,6 +106,6 @@ fn sphere_quad_coverage(world_position: Vec3, radius: f32, point_center: Vec3) -
     let distance_to_surface_in_pixels = distance_to_sphere_surface / pixel_world_size;
 
     // At the surface we have 50% coverage, and it decreases with distance.
-    // Not that we have signed distances to the sphere surface.
+    // Note that we have signed distances to the sphere surface.
     return saturate(0.5 - distance_to_surface_in_pixels);
 }

--- a/crates/re_renderer/shader/utils/sphere_quad.wgsl
+++ b/crates/re_renderer/shader/utils/sphere_quad.wgsl
@@ -27,9 +27,9 @@ fn sphere_quad_span_perspective(
     let camera_offset = radius_sq * distance_to_camera_inv;
     var modified_radius = point_radius * distance_to_camera_inv * sqrt(distance_to_camera_sq - radius_sq);
 
-    // We're computing a coverage mask in the fragment shader - make sure the quad doesn't cut off our antialiasing.
+    // Add half a pixel of margin for the feathering we do for antialiasing the spheres.
     // It's fairly subtle but if we don't do this our spheres look slightly squarish
-    modified_radius += frame.pixel_world_size_from_camera_distance * camera_distance;
+    modified_radius += 0.5 * frame.pixel_world_size_from_camera_distance * camera_distance;
 
     return point_pos + pos_in_quad * modified_radius + camera_offset * quad_normal;
 
@@ -48,9 +48,9 @@ fn sphere_quad_span_orthographic(point_pos: Vec3, point_radius: f32, top_bottom:
     let quad_up = cross(quad_right, quad_normal);
     let pos_in_quad = top_bottom * quad_up + left_right * quad_right;
 
-    // We're computing a coverage mask in the fragment shader - make sure the quad doesn't cut off our antialiasing.
+    // Add half a pixel of margin for the feathering we do for antialiasing the spheres.
     // It's fairly subtle but if we don't do this our spheres look slightly squarish
-    let radius = point_radius + frame.pixel_world_size_from_camera_distance;
+    let radius = point_radius + 0.5 * frame.pixel_world_size_from_camera_distance;
 
     return point_pos + pos_in_quad * radius;
 }

--- a/crates/re_renderer/shader/utils/sphere_quad.wgsl
+++ b/crates/re_renderer/shader/utils/sphere_quad.wgsl
@@ -99,9 +99,13 @@ fn sphere_quad_coverage(world_position: Vec3, radius: f32, point_center: Vec3) -
     // https://www.shadertoy.com/view/MsSSWV
     // (but rearranged and labeled to it's easier to understand!)
     let d = ray_sphere_distance(ray, point_center, radius);
-    let smallest_distance_to_sphere = d.x;
+    let distance_to_sphere_surface = d.x;
     let closest_ray_dist = d.y;
     let pixel_world_size = approx_pixel_world_size_at(closest_ray_dist);
 
-    return 1.0 - saturate(smallest_distance_to_sphere / pixel_world_size);
+    let distance_to_surface_in_pixels = distance_to_sphere_surface / pixel_world_size;
+
+    // At the surface we have 50% coverage, and it decreases with distance.
+    // Not that we have signed distances to the sphere surface.
+    return saturate(0.5 - distance_to_surface_in_pixels);
 }

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -54,8 +54,11 @@ mod gpu_data {
         /// Point radius is calculated as world-space depth times this value.
         pub point_radius_from_world_depth: f32,
 
+        /// The maximum depth value, for use with the colormap.
+        pub max_depth: f32,
+
         pub colormap: u32,
-        pub row_pad: [u32; 3],
+        pub row_pad: [u32; 2],
 
         pub end_padding: [crate::wgpu_buffer_types::PaddingRow; 16 - 4 - 3 - 1 - 1],
     }
@@ -67,6 +70,7 @@ mod gpu_data {
                 depth_camera_intrinsics,
                 world_depth_from_data_depth,
                 point_radius_from_world_depth,
+                max_depth,
                 depth_dimensions: _,
                 depth_data,
                 colormap,
@@ -86,6 +90,7 @@ mod gpu_data {
                 outline_mask_id: outline_mask_id.0.unwrap_or_default().into(),
                 world_depth_from_texture_value,
                 point_radius_from_world_depth: *point_radius_from_world_depth,
+                max_depth: *max_depth,
                 colormap: *colormap as u32,
                 row_pad: Default::default(),
                 end_padding: Default::default(),
@@ -134,6 +139,9 @@ pub struct DepthCloud {
 
     /// Point radius is calculated as world-space depth times this value.
     pub point_radius_from_world_depth: f32,
+
+    /// The maximum depth value, for use with the colormap.
+    pub max_depth: f32,
 
     /// The dimensions of the depth texture in pixels.
     pub depth_dimensions: glam::UVec2,

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -134,7 +134,7 @@ pub struct DepthCloud {
     /// Only supports pinhole cameras at the moment.
     pub depth_camera_intrinsics: glam::Mat3,
 
-    /// Multiplier to get world-space depth from whatever is in [`depth_data`].
+    /// Multiplier to get world-space depth from whatever is in [`Self::depth_data`].
     pub world_depth_from_data_depth: f32,
 
     /// Point radius is calculated as world-space depth times this value.

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -229,8 +229,7 @@ impl DepthCloudDrawData {
                             wgpu::TextureFormat::R32Float,
                         )
                     } else {
-                        // Native: We use Depth16Unorm over R16Unorm because the latter is behind a feature flag,
-                        // and not available on OpenGL backends.
+                        // Native: We use Depth16Unorm over R16Unorm because the latter is behind a feature flag and doesn't work on WebGPU.
                         create_and_upload_texture(
                             ctx,
                             depth_cloud,

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -54,8 +54,8 @@ mod gpu_data {
         /// Point radius is calculated as world-space depth times this value.
         pub point_radius_from_world_depth: f32,
 
-        /// The maximum depth value, for use with the colormap.
-        pub max_depth: f32,
+        /// The maximum depth value in world-space, for use with the colormap.
+        pub max_depth_in_world: f32,
 
         pub colormap: u32,
         pub row_pad: [u32; 2],
@@ -70,7 +70,7 @@ mod gpu_data {
                 depth_camera_intrinsics,
                 world_depth_from_data_depth,
                 point_radius_from_world_depth,
-                max_depth,
+                max_depth_in_world,
                 depth_dimensions: _,
                 depth_data,
                 colormap,
@@ -90,7 +90,7 @@ mod gpu_data {
                 outline_mask_id: outline_mask_id.0.unwrap_or_default().into(),
                 world_depth_from_texture_value,
                 point_radius_from_world_depth: *point_radius_from_world_depth,
-                max_depth: *max_depth,
+                max_depth_in_world: *max_depth_in_world,
                 colormap: *colormap as u32,
                 row_pad: Default::default(),
                 end_padding: Default::default(),
@@ -140,8 +140,8 @@ pub struct DepthCloud {
     /// Point radius is calculated as world-space depth times this value.
     pub point_radius_from_world_depth: f32,
 
-    /// The maximum depth value, for use with the colormap.
-    pub max_depth: f32,
+    /// The maximum depth value in world-space, for use with the colormap.
+    pub max_depth_in_world: f32,
 
     /// The dimensions of the depth texture in pixels.
     pub depth_dimensions: glam::UVec2,

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -44,7 +44,8 @@ mod gpu_data {
         pub depth_camera_extrinsics: crate::wgpu_buffer_types::Mat4,
         pub depth_camera_intrinsics: crate::wgpu_buffer_types::Mat3,
 
-        pub radius_scale: f32,
+        /// Point radius is calculated as depth times this value.
+        pub point_radius_from_normalized_depth: f32,
         pub colormap: u32,
         pub outline_mask_id: crate::wgpu_buffer_types::UVec2,
 
@@ -84,8 +85,8 @@ pub struct DepthCloud {
     /// Only supports pinhole cameras at the moment.
     pub depth_camera_intrinsics: glam::Mat3,
 
-    /// The scale to apply to the radii of the backprojected points.
-    pub radius_scale: f32,
+    /// Point radius is calculated as depth times this value.
+    pub point_radius_from_normalized_depth: f32,
 
     /// The dimensions of the depth texture in pixels.
     pub depth_dimensions: glam::UVec2,
@@ -107,7 +108,7 @@ impl Default for DepthCloud {
         Self {
             depth_camera_extrinsics: glam::Mat4::IDENTITY,
             depth_camera_intrinsics: glam::Mat3::IDENTITY,
-            radius_scale: 1.0,
+            point_radius_from_normalized_depth: 1e-3,
             depth_dimensions: glam::UVec2::ZERO,
             depth_data: DepthCloudDepthData::default(),
             colormap: ColorMap::ColorMapTurbo,
@@ -162,7 +163,7 @@ impl DepthCloudDrawData {
             depth_clouds.iter().map(|info| gpu_data::DepthCloudInfoUBO {
                 depth_camera_extrinsics: info.depth_camera_extrinsics.into(),
                 depth_camera_intrinsics: info.depth_camera_intrinsics.into(),
-                radius_scale: info.radius_scale,
+                point_radius_from_normalized_depth: info.point_radius_from_normalized_depth,
                 colormap: info.colormap as u32,
                 outline_mask_id: info.outline_mask_id.0.unwrap_or_default().into(),
                 end_padding: Default::default(),

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -41,7 +41,8 @@ mod gpu_data {
     #[repr(C, align(256))]
     #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct DepthCloudInfoUBO {
-        pub depth_camera_extrinsics: crate::wgpu_buffer_types::Mat4,
+        /// The extrinsics of the camera used for the projection.
+        pub world_from_obj: crate::wgpu_buffer_types::Mat4,
 
         pub depth_camera_intrinsics: crate::wgpu_buffer_types::Mat3,
 
@@ -62,7 +63,7 @@ mod gpu_data {
     impl DepthCloudInfoUBO {
         pub fn from_depth_cloud(depth_cloud: &super::DepthCloud) -> Self {
             let super::DepthCloud {
-                depth_camera_extrinsics,
+                world_from_obj,
                 depth_camera_intrinsics,
                 world_depth_from_data_depth,
                 point_radius_from_world_depth,
@@ -80,7 +81,7 @@ mod gpu_data {
                 world_depth_from_data_depth * user_depth_from_texture_value;
 
             Self {
-                depth_camera_extrinsics: (*depth_camera_extrinsics).into(),
+                world_from_obj: (*world_from_obj).into(),
                 depth_camera_intrinsics: (*depth_camera_intrinsics).into(),
                 outline_mask_id: outline_mask_id.0.unwrap_or_default().into(),
                 world_depth_from_texture_value,
@@ -121,7 +122,7 @@ impl Default for DepthCloudDepthData {
 
 pub struct DepthCloud {
     /// The extrinsics of the camera used for the projection.
-    pub depth_camera_extrinsics: glam::Mat4,
+    pub world_from_obj: glam::Mat4,
 
     /// The intrinsics of the camera used for the projection.
     ///

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -185,8 +185,8 @@ impl DepthCloudDrawData {
                             wgpu::TextureFormat::R32Float,
                         )
                     } else {
-                        // Native: We use Depth16Unorm over R16Unorm beacuse the latter is behind a feature flag,
-                        // and not avilable on OpenGL backends.
+                        // Native: We use Depth16Unorm over R16Unorm because the latter is behind a feature flag,
+                        // and not available on OpenGL backends.
                         create_and_upload_texture(
                             ctx,
                             depth_cloud,

--- a/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
+++ b/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
@@ -461,6 +461,8 @@ fn depth_tensor_as_color_image(tensor: &Tensor) -> anyhow::Result<ColorImage> {
         "Depth image had non-finite values"
     );
 
+    min = min.min(0.0); // Depth ususally start at zero.
+
     if min == max {
         // Uniform image. We can't remap it to a 0-1 range, so do whatever:
         min = 0.0;

--- a/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
+++ b/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
@@ -461,7 +461,7 @@ fn depth_tensor_as_color_image(tensor: &Tensor) -> anyhow::Result<ColorImage> {
         "Depth image had non-finite values"
     );
 
-    min = min.min(0.0); // Depth ususally start at zero.
+    min = min.min(0.0); // Depth usually start at zero.
 
     if min == max {
         // Uniform image. We can't remap it to a 0-1 range, so do whatever:

--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -390,16 +390,16 @@ pub fn show_zoomed_image_region(
                 let tensor = tensor_view.tensor;
 
                 let text = match tensor.num_dim() {
-                    2 => tensor.get(&[x, y]).map(|v| format!("Val: {v}")),
+                    2 => tensor.get(&[y, x]).map(|v| format!("Val: {v}")),
                     3 => match tensor.shape()[2].size {
                         0 => Some("Cannot preview 0-size channel".to_owned()),
-                        1 => tensor.get(&[x, y, 0]).map(|v| format!("Val: {v}")),
+                        1 => tensor.get(&[y, x, 0]).map(|v| format!("Val: {v}")),
                         3 => {
                             // TODO(jleibs): Track RGB ordering somehow -- don't just assume it
                             if let (Some(r), Some(g), Some(b)) = (
-                                tensor_view.tensor.get(&[x, y, 0]),
-                                tensor_view.tensor.get(&[x, y, 1]),
-                                tensor_view.tensor.get(&[x, y, 2]),
+                                tensor_view.tensor.get(&[y, x, 0]),
+                                tensor_view.tensor.get(&[y, x, 1]),
+                                tensor_view.tensor.get(&[y, x, 2]),
                             ) {
                                 match (r, g, b) {
                                     (
@@ -420,10 +420,10 @@ pub fn show_zoomed_image_region(
                         4 => {
                             // TODO(jleibs): Track RGB ordering somehow -- don't just assume it
                             if let (Some(r), Some(g), Some(b), Some(a)) = (
-                                tensor_view.tensor.get(&[x, y, 0]),
-                                tensor_view.tensor.get(&[x, y, 1]),
-                                tensor_view.tensor.get(&[x, y, 2]),
-                                tensor_view.tensor.get(&[x, y, 3]),
+                                tensor_view.tensor.get(&[y, x, 0]),
+                                tensor_view.tensor.get(&[y, x, 1]),
+                                tensor_view.tensor.get(&[y, x, 2]),
+                                tensor_view.tensor.get(&[y, x, 3]),
                             ) {
                                 match (r, g, b, a) {
                                     (

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -572,8 +572,9 @@ fn backproject_radius_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoVal
         )
         .on_hover_text(
             "Scales the radii of the points in the backprojected point cloud.\n\
-            With a scale of one, adjacent pixels at the same depth are sized so that they are just touching.\
-            \nDouble-click to reset.",
+            This is a factor of the projected pixel diameter. \
+            This means a scale of 0.5 will leave adjacent pixels at the same depth value jsut touching.\n\
+            Double-click to reset.",
         );
     if response.double_clicked() {
         *property = EditableAutoValue::Auto(2.0);

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -548,8 +548,8 @@ fn depth_from_world_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoValue
             .clamp_range(0.0..=1.0e8)
             .speed(speed),
     )
-    .on_hover_text("How many steps in the depth image correspond to one world-space unit. For instance, 1000 means millimeters.\
-                                \nDouble-click to reset.");
+    .on_hover_text("How many steps in the depth image correspond to one world-space unit. For instance, 1000 means millimeters.\n\
+                    Double-click to reset.");
     if response.double_clicked() {
         // reset to auto - the exact value will be restored somewhere else
         *property = EditableAutoValue::Auto(value);
@@ -572,11 +572,11 @@ fn backproject_radius_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoVal
         )
         .on_hover_text(
             "Scales the radii of the points in the backprojected point cloud.\n\
-                        With a scale of one, diagonally adjacent pixels at the same depth are sized so that they are just touching, leaving no gaps.\
-                        \nDouble-click to reset.",
+            With a scale of one, adjacent pixels at the same depth are sized so that they are just touching.\
+            \nDouble-click to reset.",
         );
     if response.double_clicked() {
-        *property = EditableAutoValue::Auto(1.0);
+        *property = EditableAutoValue::Auto(2.0);
         response.surrender_focus();
     } else if response.changed() {
         *property = EditableAutoValue::UserEdited(value);

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -573,7 +573,7 @@ fn backproject_radius_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoVal
         .on_hover_text(
             "Scales the radii of the points in the backprojected point cloud.\n\
             This is a factor of the projected pixel diameter. \
-            This means a scale of 0.5 will leave adjacent pixels at the same depth value jsut touching.\n\
+            This means a scale of 0.5 will leave adjacent pixels at the same depth value just touching.\n\
             Double-click to reset.",
         );
     if response.double_clicked() {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -525,52 +525,9 @@ fn depth_props_ui(
                 );
             ui.end_row();
 
-            {
-                ui.label("Backproject meter");
-                let mut meter = *entity_props.backproject_depth_meter.get();
-                let speed = (meter * 0.05).at_least(0.01);
-                let response = ui
-                .add(
-                    egui::DragValue::new(&mut meter)
-                        .clamp_range(0.0..=1.0e8)
-                        .speed(speed),
-                )
-                .on_hover_text("How many depth values correspond to one work-space unit. For instance, 1000 means millimeters.\
-                                \nDouble-click to reset.");
-                if response.double_clicked() {
-                    // reset to auto - the exact value will be restored somewhere else
-                    entity_props.backproject_depth_meter = EditableAutoValue::Auto(meter);
-                    response.surrender_focus();
-                } else if response.changed() {
-                    entity_props.backproject_depth_meter = EditableAutoValue::UserEdited(meter);
-                }
-                ui.end_row();
-            }
+            depth_from_world_scale_ui(ui, &mut entity_props.depth_from_world_scale);
 
-            {
-                ui.label("Backproject radius scale");
-                let mut radius_scale = *entity_props.backproject_radius_scale.get();
-                let speed = (radius_scale * 0.01).at_least(0.001);
-                let response = ui
-                    .add(
-                        egui::DragValue::new(&mut radius_scale)
-                            .clamp_range(0.0..=1.0e8)
-                            .speed(speed),
-                    )
-                    .on_hover_text(
-                        "Scales the radii of the points in the backprojected point cloud.\n\
-                        With a scale of one, diagonally adjacent pixels at the same depth are sized so that they are just touching, leaving no gaps.\
-                        \nDouble-click to reset.",
-                    );
-                if response.double_clicked() {
-                    entity_props.backproject_radius_scale = EditableAutoValue::Auto(1.0);
-                    response.surrender_focus();
-                } else if response.changed() {
-                    entity_props.backproject_radius_scale =
-                        EditableAutoValue::UserEdited(radius_scale);
-                }
-                ui.end_row();
-            }
+            backproject_radius_scale_ui(ui, &mut entity_props.backproject_radius_scale);
 
             // TODO(cmc): This should apply to the depth map entity as a whole, but for that we
             // need to get the current hardcoded colormapping out of the image cache first.
@@ -579,4 +536,50 @@ fn depth_props_ui(
             entity_props.backproject_pinhole_ent_path = None;
         }
     }
+}
+
+fn depth_from_world_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoValue<f32>) {
+    ui.label("Backproject meter");
+    let mut value = *property.get();
+    let speed = (value * 0.05).at_least(0.01);
+    let response = ui
+    .add(
+        egui::DragValue::new(&mut value)
+            .clamp_range(0.0..=1.0e8)
+            .speed(speed),
+    )
+    .on_hover_text("How many steps in the depth image correspond to one world-space unit. For instance, 1000 means millimeters.\
+                                \nDouble-click to reset.");
+    if response.double_clicked() {
+        // reset to auto - the exact value will be restored somewhere else
+        *property = EditableAutoValue::Auto(value);
+        response.surrender_focus();
+    } else if response.changed() {
+        *property = EditableAutoValue::UserEdited(value);
+    }
+    ui.end_row();
+}
+
+fn backproject_radius_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoValue<f32>) {
+    ui.label("Backproject radius scale");
+    let mut value = *property.get();
+    let speed = (value * 0.01).at_least(0.001);
+    let response = ui
+        .add(
+            egui::DragValue::new(&mut value)
+                .clamp_range(0.0..=1.0e8)
+                .speed(speed),
+        )
+        .on_hover_text(
+            "Scales the radii of the points in the backprojected point cloud.\n\
+                        With a scale of one, diagonally adjacent pixels at the same depth are sized so that they are just touching, leaving no gaps.\
+                        \nDouble-click to reset.",
+        );
+    if response.double_clicked() {
+        *property = EditableAutoValue::Auto(1.0);
+        response.surrender_focus();
+    } else if response.changed() {
+        *property = EditableAutoValue::UserEdited(value);
+    }
+    ui.end_row();
 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -535,7 +535,8 @@ fn depth_props_ui(
                         .clamp_range(0.0..=1.0e8)
                         .speed(speed),
                 )
-                .on_hover_text("How many depth values correspond to one work-space unit. For instance, 1000 means millimeters. Double-click to reset.");
+                .on_hover_text("How many depth values correspond to one work-space unit. For instance, 1000 means millimeters.\
+                                \nDouble-click to reset.");
                 if response.double_clicked() {
                     // reset to auto - the exacy value will be restored somewhere else
                     entity_props.backproject_depth_meter = EditableAutoValue::Auto(meter);
@@ -557,7 +558,9 @@ fn depth_props_ui(
                             .speed(speed),
                     )
                     .on_hover_text(
-                        "Scales the radii of the points in the backprojected point cloud. Double-click to reset.",
+                        "Scales the radii of the points in the backprojected point cloud.\n\
+                        With a scale of one, diagonally adjacent pixels at the same depth are sized so that they are just touching, leaving no gaps.\
+                        \nDouble-click to reset.",
                     );
                 if response.double_clicked() {
                     entity_props.backproject_radius_scale = EditableAutoValue::Auto(1.0);

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -538,7 +538,7 @@ fn depth_props_ui(
                 .on_hover_text("How many depth values correspond to one work-space unit. For instance, 1000 means millimeters.\
                                 \nDouble-click to reset.");
                 if response.double_clicked() {
-                    // reset to auto - the exacy value will be restored somewhere else
+                    // reset to auto - the exact value will be restored somewhere else
                     entity_props.backproject_depth_meter = EditableAutoValue::Auto(meter);
                     response.surrender_focus();
                 } else if response.changed() {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -549,7 +549,7 @@ fn depth_props_ui(
             {
                 ui.label("Backproject radius scale");
                 let mut radius_scale = *entity_props.backproject_radius_scale.get();
-                let speed = (radius_scale * 0.001).at_least(0.001);
+                let speed = (radius_scale * 0.01).at_least(0.001);
                 let response = ui
                     .add(
                         egui::DragValue::new(&mut radius_scale)
@@ -560,8 +560,7 @@ fn depth_props_ui(
                         "Scales the radii of the points in the backprojected point cloud. Double-click to reset.",
                     );
                 if response.double_clicked() {
-                    // reset to auto - the exacy value will be restored somewhere else
-                    entity_props.backproject_radius_scale = EditableAutoValue::Auto(radius_scale);
+                    entity_props.backproject_radius_scale = EditableAutoValue::Auto(1.0);
                     response.surrender_focus();
                 } else if response.changed() {
                     entity_props.backproject_radius_scale =

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -525,37 +525,50 @@ fn depth_props_ui(
                 );
             ui.end_row();
 
-            ui.label("Backproject scale");
-            let mut scale = *entity_props.backproject_scale.get();
-            let speed = (scale * 0.05).at_least(0.01);
-            if ui
+            {
+                ui.label("Backproject meter");
+                let mut meter = *entity_props.backproject_depth_meter.get();
+                let speed = (meter * 0.05).at_least(0.01);
+                let response = ui
                 .add(
-                    egui::DragValue::new(&mut scale)
+                    egui::DragValue::new(&mut meter)
                         .clamp_range(0.0..=1.0e8)
                         .speed(speed),
                 )
-                .on_hover_text("Scales the backprojected point cloud")
-                .changed()
-            {
-                entity_props.backproject_scale = EditableAutoValue::UserEdited(scale);
+                .on_hover_text("How many depth values correspond to one work-space unit. For instance, 1000 means millimeters. Double-click to reset.");
+                if response.double_clicked() {
+                    // reset to auto - the exacy value will be restored somewhere else
+                    entity_props.backproject_depth_meter = EditableAutoValue::Auto(meter);
+                    response.surrender_focus();
+                } else if response.changed() {
+                    entity_props.backproject_depth_meter = EditableAutoValue::UserEdited(meter);
+                }
+                ui.end_row();
             }
-            ui.end_row();
 
-            ui.label("Backproject radius scale");
-            let mut radius_scale = *entity_props.backproject_radius_scale.get();
-            let speed = (radius_scale * 0.001).at_least(0.001);
-            if ui
-                .add(
-                    egui::DragValue::new(&mut radius_scale)
-                        .clamp_range(0.0..=1.0e8)
-                        .speed(speed),
-                )
-                .on_hover_text("Scales the radii of the points in the backprojected point cloud")
-                .changed()
             {
-                entity_props.backproject_radius_scale = EditableAutoValue::UserEdited(radius_scale);
+                ui.label("Backproject radius scale");
+                let mut radius_scale = *entity_props.backproject_radius_scale.get();
+                let speed = (radius_scale * 0.001).at_least(0.001);
+                let response = ui
+                    .add(
+                        egui::DragValue::new(&mut radius_scale)
+                            .clamp_range(0.0..=1.0e8)
+                            .speed(speed),
+                    )
+                    .on_hover_text(
+                        "Scales the radii of the points in the backprojected point cloud. Double-click to reset.",
+                    );
+                if response.double_clicked() {
+                    // reset to auto - the exacy value will be restored somewhere else
+                    entity_props.backproject_radius_scale = EditableAutoValue::Auto(radius_scale);
+                    response.surrender_focus();
+                } else if response.changed() {
+                    entity_props.backproject_radius_scale =
+                        EditableAutoValue::UserEdited(radius_scale);
+                }
+                ui.end_row();
             }
-            ui.end_row();
 
             // TODO(cmc): This should apply to the depth map entity as a whole, but for that we
             // need to get the current hardcoded colormapping out of the image cache first.

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -302,7 +302,7 @@ impl ImagesPart {
 
         let meter = *properties.backproject_depth_meter.get();
         let scale = match data {
-            // the GPU normalizes the u16 to [0, 1] during texture smapler:
+            // the GPU normalizes the u16 to [0, 1] during texture sampling:
             DepthCloudDepthData::U16(_) => u16::MAX as f32 / meter,
 
             DepthCloudDepthData::F32(_) => 1.0 / meter,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -342,7 +342,7 @@ impl ImagesPart {
             depth_camera_intrinsics: intrinsics.image_from_cam.into(),
             world_depth_from_data_depth,
             point_radius_from_world_depth,
-            max_depth: world_depth_from_data_depth * max_data_value,
+            max_depth_in_world: world_depth_from_data_depth * max_data_value,
             depth_dimensions: dimensions,
             depth_data: data,
             colormap,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -317,14 +317,13 @@ impl ImagesPart {
             },
         };
 
-        // By default, we assign a radius to each point so that each point becomes a ball
-        // that just barely touches its neighboring pixel-points.
-        // This means the point radius increases with distance.
-        // It also increases with the field of view, and decreases with the resolution.
+        // We want point radius to be defined in a scale where the radius of a point
+        // is a factor (`backproject_radius_scale`) of the diameter of a pixel projected
+        // at that distance.
         let fov_y = intrinsics.fov_y().unwrap_or(1.0);
-        let point_radius_from_depth = (0.5 * fov_y).tan() / (0.5 * h as f32);
+        let pixel_width_from_depth = (0.5 * fov_y).tan() / (0.5 * h as f32);
         let radius_scale = *properties.backproject_radius_scale.get();
-        let point_radius_from_world_depth = radius_scale * point_radius_from_depth;
+        let point_radius_from_world_depth = radius_scale * pixel_width_from_depth;
 
         let max_data_value = if let Some((_min, max)) = ctx.cache.tensor_stats(tensor).range {
             max as f32

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -299,7 +299,13 @@ impl ImagesPart {
             }
         };
 
-        let scale = *properties.backproject_scale.get();
+        let meter = *properties.backproject_depth_meter.get();
+        let scale = match data {
+            // the GPU normalizes the u16 to [0, 1] during texture smapler:
+            DepthCloudDepthData::U16(_) => u16::MAX as f32 / meter,
+
+            DepthCloudDepthData::F32(_) => 1.0 / meter,
+        };
         let radius_scale = *properties.backproject_radius_scale.get();
 
         let (h, w) = (tensor.shape()[0].size, tensor.shape()[1].size);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -328,12 +328,10 @@ impl ImagesPart {
         // that just barely touches its diagonally-neighboring pixel-point.
         // This means the point radius increases with distance.
         // It also increases with the field of view, and decreases with the resolution.
+        let fov_y = intrinsics.fov_y().unwrap_or(1.0);
+        let point_radius_from_depth = 0.5_f32.sqrt() * (0.5 * fov_y).tan() / (0.5 * h as f32);
         let radius_scale = *properties.backproject_radius_scale.get();
-        let point_radius_from_depth = 0.5_f32.sqrt() * intrinsics.fov_y().unwrap_or(1.0) / h as f32;
         let point_radius_from_normalized_depth = radius_scale * point_radius_from_depth * scale;
-
-        // TODO(emilk): we get gaps between diagonally adjacent points without this hack. WHY???
-        let point_radius_from_normalized_depth = 1.1 * point_radius_from_normalized_depth;
 
         scene.primitives.depth_clouds.push(DepthCloud {
             depth_camera_extrinsics: world_from_obj,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -329,7 +329,7 @@ impl ImagesPart {
             max as f32
         } else {
             // This could only happen for Jpegs, and we should never get here.
-            // TODO(emilk): refactor the code so that we can always clauclate a range for the tensor
+            // TODO(emilk): refactor the code so that we can always calculate a range for the tensor
             re_log::warn_once!("Couldn't calculate range for a depth tensor!?");
             match data {
                 DepthCloudDepthData::U16(_) => u16::MAX as f32,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -318,11 +318,11 @@ impl ImagesPart {
         };
 
         // By default, we assign a radius to each point so that each point becomes a ball
-        // that just barely touches its diagonally-neighboring pixel-point.
+        // that just barely touches its neighboring pixel-points.
         // This means the point radius increases with distance.
         // It also increases with the field of view, and decreases with the resolution.
         let fov_y = intrinsics.fov_y().unwrap_or(1.0);
-        let point_radius_from_depth = 0.5_f32.sqrt() * (0.5 * fov_y).tan() / (0.5 * h as f32);
+        let point_radius_from_depth = (0.5 * fov_y).tan() / (0.5 * h as f32);
         let radius_scale = *properties.backproject_radius_scale.get();
         let point_radius_from_world_depth = radius_scale * point_radius_from_depth;
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -278,10 +278,10 @@ impl ImagesPart {
         };
 
         // TODO(cmc): getting to those extrinsics is no easy task :|
-        let extrinsics = pinhole_ent_path
+        let world_from_obj = pinhole_ent_path
             .parent()
             .and_then(|ent_path| transforms.reference_from_entity(&ent_path));
-        let Some(extrinsics) = extrinsics else {
+        let Some(world_from_obj) = world_from_obj else {
             re_log::warn_once!("Couldn't fetch pinhole extrinsics at {pinhole_ent_path:?}");
             return;
         };
@@ -300,7 +300,7 @@ impl ImagesPart {
             }
         };
 
-        let meter = *properties.backproject_depth_meter.get();
+        let depth_from_world_scale = *properties.depth_from_world_scale.get();
 
         let (h, w) = (tensor.shape()[0].size, tensor.shape()[1].size);
         let dimensions = glam::UVec2::new(w as _, h as _);
@@ -326,9 +326,9 @@ impl ImagesPart {
         let point_radius_from_world_depth = radius_scale * point_radius_from_depth;
 
         scene.primitives.depth_clouds.push(DepthCloud {
-            depth_camera_extrinsics: extrinsics,
+            world_from_obj,
             depth_camera_intrinsics: intrinsics.image_from_cam.into(),
-            world_depth_from_data_depth: 1.0 / meter,
+            world_depth_from_data_depth: 1.0 / depth_from_world_scale,
             point_radius_from_world_depth,
             depth_dimensions: dimensions,
             depth_data: data,

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -175,13 +175,7 @@ impl ViewSpatialState {
                 &entity_path,
                 scene_size,
             );
-            Self::update_depth_cloud_property_heuristics(
-                ctx,
-                data_blueprint,
-                &query,
-                &entity_path,
-                scene_size,
-            );
+            Self::update_depth_cloud_property_heuristics(ctx, data_blueprint, &query, &entity_path);
         }
     }
 
@@ -221,7 +215,6 @@ impl ViewSpatialState {
         data_blueprint: &mut DataBlueprintTree,
         query: &re_arrow_store::LatestAtQuery,
         entity_path: &EntityPath,
-        scene_size: f32,
     ) {
         let tensor = query_latest_single::<Tensor>(&ctx.log_db.entity_db, entity_path, query);
         if tensor.as_ref().map(|t| t.meaning) == Some(TensorDataMeaning::Depth) {
@@ -241,12 +234,7 @@ impl ViewSpatialState {
             }
 
             if properties.backproject_radius_scale.is_auto() {
-                let auto = if scene_size.is_finite() && scene_size > 0.0 {
-                    f32::max(0.02, scene_size * 0.001)
-                } else {
-                    0.02
-                };
-                properties.backproject_radius_scale = EditableAutoValue::Auto(auto);
+                properties.backproject_radius_scale = EditableAutoValue::Auto(1.0);
             }
 
             data_blueprint

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -4,7 +4,7 @@ use re_format::format_f32;
 
 use egui::{NumExt, WidgetText};
 use macaw::BoundingBox;
-use re_log_types::component_types::{Tensor, TensorData, TensorDataMeaning};
+use re_log_types::component_types::{Tensor, TensorDataMeaning};
 use re_renderer::renderer::OutlineConfig;
 
 use crate::{
@@ -228,18 +228,16 @@ impl ViewSpatialState {
             let tensor = tensor.as_ref().unwrap();
 
             let mut properties = data_blueprint.data_blueprints_individual().get(entity_path);
-            if properties.backproject_scale.is_auto() {
-                let auto = tensor.meter.map_or_else(
-                    || match &tensor.data {
-                        TensorData::U16(_) => 1.0 / u16::MAX as f32,
-                        _ => 1.0,
-                    },
-                    |meter| match &tensor.data {
-                        TensorData::U16(_) => 1.0 / meter * u16::MAX as f32,
-                        _ => meter,
-                    },
-                );
-                properties.backproject_scale = EditableAutoValue::Auto(auto);
+            if properties.backproject_depth_meter.is_auto() {
+                let auto = tensor.meter.unwrap_or_else(|| {
+                    use re_log_types::component_types::TensorTrait as _;
+                    if tensor.dtype().is_integer() {
+                        1000.0
+                    } else {
+                        1.0
+                    }
+                });
+                properties.backproject_depth_meter = EditableAutoValue::Auto(auto);
             }
 
             if properties.backproject_radius_scale.is_auto() {

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -221,7 +221,7 @@ impl ViewSpatialState {
             let tensor = tensor.as_ref().unwrap();
 
             let mut properties = data_blueprint.data_blueprints_individual().get(entity_path);
-            if properties.backproject_depth_meter.is_auto() {
+            if properties.depth_from_world_scale.is_auto() {
                 let auto = tensor.meter.unwrap_or_else(|| {
                     use re_log_types::component_types::TensorTrait as _;
                     if tensor.dtype().is_integer() {
@@ -230,7 +230,7 @@ impl ViewSpatialState {
                         1.0
                     }
                 });
-                properties.backproject_depth_meter = EditableAutoValue::Auto(auto);
+                properties.depth_from_world_scale = EditableAutoValue::Auto(auto);
             }
 
             if properties.backproject_radius_scale.is_auto() {


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1587

A bunch of fixes:

* I fixed a bug that caused our points to always have a radius that was 0.5 pixels too much, making points too large.
* I fixed a bug in the image hover code, causing the wrong RGBA values to be printed 😬 
* I fixed the gamma of the depth cloud color map
* I fixed a bug in f32 depth maps
* I made the color map range of the depth cloud the same as that for the 2D depth maps
* The UI option is now for the same "meters" parameter as in the SDK. You can double-click it to reset it to what you logged.
* The point radius scale is defines so that `1.0` means that the radius is the same as a pixel projected at that distance. This means a value of `0.5` creates balls that just touch horizontally and diagonally. The default is `2.0` to avoid Moiré patterns.

![image](https://user-images.githubusercontent.com/1148717/227264824-db9556f3-5eac-4d0f-b0fa-9589d9937922.png)

The colors of the 2D depth visualization and the 3D backprojected depth now line up perfectly both for `u16` and `f32` depth maps:

![image](https://user-images.githubusercontent.com/1148717/227500131-4263cc03-3646-4848-acc3-6bd1a9f79035.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
