### PR TITLE
Remove the redundant costly transform check during categorization

### DIFF
--- a/crates/re_viewer/src/ui/view_category.rs
+++ b/crates/re_viewer/src/ui/view_category.rs
@@ -1,5 +1,5 @@
 use re_arrow_store::{LatestAtQuery, TimeInt};
-use re_data_store::{query_latest_single, EntityPath, LogDb, Timeline};
+use re_data_store::{EntityPath, LogDb, Timeline};
 use re_log_types::{
     component_types::{
         Box3D, LineStrip2D, LineStrip3D, Point2D, Point3D, Rect2D, Scalar, Tensor, TensorTrait,
@@ -70,18 +70,6 @@ pub fn categorize_entity_path(
     crate::profile_function!();
 
     let mut set = ViewCategorySet::default();
-
-    // If it has a transform we might want to visualize it in space
-    // (as of writing we do that only for projections, i.e. cameras, but visualizations for rigid transforms may be added)
-    if query_latest_single::<Transform>(
-        &log_db.entity_db,
-        entity_path,
-        &LatestAtQuery::new(timeline, TimeInt::MAX),
-    )
-    .is_some()
-    {
-        set.insert(ViewCategory::Spatial);
-    }
 
     for component in log_db
         .entity_db


### PR DESCRIPTION
As far as I can tell this check is redundant and the overhead adds up when we have a large number of transforms.

This shaves about 6ms off of `all_possible_space_views` in the raw_mesh example.

Before:
![image](https://user-images.githubusercontent.com/3312232/227285031-15d7717f-0ffa-4e2d-bdab-b88acb3a3297.png)


After:
![image](https://user-images.githubusercontent.com/3312232/227285913-db79b4d5-035f-4fb5-a3ea-dfe9ff6f996f.png)


### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
