### PR TITLE
Fix web crash on missing uniform buffer padding

### DIFF
--- a/crates/re_renderer/shader/lines.wgsl
+++ b/crates/re_renderer/shader/lines.wgsl
@@ -13,6 +13,11 @@ var position_data_texture: texture_2d<u32>;
 
 struct DrawDataUniformBuffer {
     size_boost_in_points: f32,
+    // In actuality there is way more padding than this since we align all our uniform buffers to
+    // 256bytes in order to allow them to be buffer-suballocations.
+    // However, wgpu doesn't know this at this point and therefore requires `DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED`
+    // if we wouldn't add padding here, which isn't available on WebGL.
+    _padding: Vec4,
 };
 @group(1) @binding(2)
 var<uniform> draw_data: DrawDataUniformBuffer;

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -12,6 +12,11 @@ var color_texture: texture_2d<f32>;
 
 struct DrawDataUniformBuffer {
     size_boost_in_points: f32,
+    // In actuality there is way more padding than this since we align all our uniform buffers to
+    // 256bytes in order to allow them to be buffer-suballocations.
+    // However, wgpu doesn't know this at this point and therefore requires `DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED`
+    // if we wouldn't add padding here, which isn't available on WebGL.
+    _padding: Vec4,
 };
 @group(1) @binding(2)
 var<uniform> draw_data: DrawDataUniformBuffer;


### PR DESCRIPTION
The alignment is actually already there, but wgpu/Naga doesn't see it at this point.

Fixes  #1697

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
