### PR TITLE
Track changed state in nav mode combo box

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -315,24 +315,29 @@ impl ViewSpatialState {
                 .on_hover_text("The virtual camera which controls what is shown on screen.");
             ui.vertical(|ui| {
                 let mut nav_mode = *self.nav_mode.get();
-                let nav_mode_response =  egui::ComboBox::from_id_source("nav_mode")
+                let changed =  egui::ComboBox::from_id_source("nav_mode")
                     .selected_text(nav_mode)
                     .show_ui(ui, |ui| {
                         ui.style_mut().wrap = Some(false);
                         ui.set_min_width(64.0);
 
-                        ui.selectable_value(
+                        let mut changed = false;
+
+                        changed |= ui.selectable_value(
                             &mut nav_mode,
                             SpatialNavigationMode::TwoD,
                             SpatialNavigationMode::TwoD,
-                        );
-                        ui.selectable_value(
+                        ).changed();
+
+                        changed |= ui.selectable_value(
                             &mut nav_mode,
                             SpatialNavigationMode::ThreeD,
                             SpatialNavigationMode::ThreeD,
-                        );
-                    }).response;
-                    if nav_mode_response.changed() {
+                        ).changed();
+
+                        changed
+                    }).inner.unwrap_or(false);
+                    if changed {
                         self.nav_mode = EditableAutoValue::UserEdited(nav_mode);
                     }
 


### PR DESCRIPTION
It doesn't seem like the `.changed()` response of the combo box does what we expected. Maybe I'm missing something?

I confirmed this works.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
