### PR TITLE
Swap overlay order of selection & hover outlines

### DIFF
--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -335,12 +335,12 @@ impl SelectionState {
         let mut next_selection_mask = || {
             // We don't expect to overflow u8, but if we do, don't use the "background mask".
             selection_mask_index = selection_mask_index.wrapping_add(1).at_least(1);
-            OutlineMaskPreference::some(selection_mask_index, 0)
+            OutlineMaskPreference::some(0, selection_mask_index)
         };
         let mut next_hover_mask = || {
             // We don't expect to overflow u8, but if we do, don't use the "background mask".
             hover_mask_index = hover_mask_index.wrapping_add(1).at_least(1);
-            OutlineMaskPreference::some(0, hover_mask_index)
+            OutlineMaskPreference::some(hover_mask_index, 0)
         };
 
         for current_selection in self.selection.iter() {

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -644,7 +644,7 @@ pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
 
     OutlineConfig {
         outline_radius_pixel: (gui_ctx.pixels_per_point() * 1.5).at_least(0.5),
-        color_layer_a: selection_outline_color,
-        color_layer_b: hover_outline_color,
+        color_layer_a: hover_outline_color,
+        color_layer_b: selection_outline_color,
     }
 }


### PR DESCRIPTION
This causes selected things to no longer to be overwritten by hover outlines - Fixes #1597.


https://user-images.githubusercontent.com/1220815/227471730-b87380f1-a0c0-4e04-92e1-e564099ecbcb.mov


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
