### PR TITLE
Fix `memory_usage` example relying on implicit recursive features

### DIFF
--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -49,6 +49,12 @@ puffin.workspace = true
 criterion = "0.4"
 mimalloc.workspace = true
 rand = "0.8"
+re_log_types = { workspace = true, features = ["load", "save"] }
 
 [lib]
 bench = false
+
+[[example]]
+name = "memory_usage"
+path = "examples/memory_usage.rs"
+required-features = ["re_log_types/load", "re_log_types/save"]


### PR DESCRIPTION
The usual: the example only compiles in some contexts because it silently inherits from recursive feature flags when compiled as part of a larger piece of the workspace... but when compiled on its own it fails and one is left very confused :sob: