### PR TITLE
Turn on depth cloud backprojection by default

### DIFF
--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -86,7 +86,7 @@ impl EntityProperties {
                 .or(&child.pinhole_image_plane_distance)
                 .clone(),
 
-            backproject_depth: self.backproject_depth || child.backproject_depth,
+            backproject_depth: self.backproject_depth && child.backproject_depth,
             depth_from_world_scale: self
                 .depth_from_world_scale
                 .or(&child.depth_from_world_scale)

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -57,9 +57,10 @@ pub struct EntityProperties {
 
     /// Should the depth texture be backprojected into a point cloud?
     ///
-    /// Only applies to tensors with meaning=depth that are affected by a pinhole transform when
-    /// in a spatial view, using 3D navigation.
-    pub backproject_depth: bool,
+    /// Only applies to tensors with meaning=depth that are affected by a pinhole transform.
+    ///
+    /// The default for 3D views is `true`, but for 2D views it is `false`.
+    pub backproject_depth: EditableAutoValue<bool>,
 
     /// How many depth units per world-space unit. e.g. 1000 for millimeters.
     ///
@@ -86,7 +87,7 @@ impl EntityProperties {
                 .or(&child.pinhole_image_plane_distance)
                 .clone(),
 
-            backproject_depth: self.backproject_depth && child.backproject_depth,
+            backproject_depth: self.backproject_depth.or(&child.backproject_depth).clone(),
             depth_from_world_scale: self
                 .depth_from_world_scale
                 .or(&child.depth_from_world_scale)
@@ -108,7 +109,7 @@ impl Default for EntityProperties {
             interactive: true,
             color_mapper: EditableAutoValue::default(),
             pinhole_image_plane_distance: EditableAutoValue::default(),
-            backproject_depth: true,
+            backproject_depth: EditableAutoValue::Auto(true),
             depth_from_world_scale: EditableAutoValue::default(),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),
         }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -61,11 +61,6 @@ pub struct EntityProperties {
     /// in a spatial view, using 3D navigation.
     pub backproject_depth: bool,
 
-    /// Entity path of the pinhole transform used for the backprojection.
-    ///
-    /// `None` means backprojection is disabled.
-    pub backproject_pinhole_ent_path: Option<EntityPath>,
-
     /// How many depth units per world-space unit. e.g. 1000 for millimeters.
     ///
     /// This corresponds to [`re_log_types::component_types::Tensor::meter`].
@@ -92,10 +87,6 @@ impl EntityProperties {
                 .clone(),
 
             backproject_depth: self.backproject_depth || child.backproject_depth,
-            backproject_pinhole_ent_path: self
-                .backproject_pinhole_ent_path
-                .clone()
-                .or(child.backproject_pinhole_ent_path.clone()),
             depth_from_world_scale: self
                 .depth_from_world_scale
                 .or(&child.depth_from_world_scale)
@@ -118,7 +109,6 @@ impl Default for EntityProperties {
             color_mapper: EditableAutoValue::default(),
             pinhole_image_plane_distance: EditableAutoValue::default(),
             backproject_depth: true,
-            backproject_pinhole_ent_path: None,
             depth_from_world_scale: EditableAutoValue::default(),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),
         }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -117,7 +117,7 @@ impl Default for EntityProperties {
             interactive: true,
             color_mapper: EditableAutoValue::default(),
             pinhole_image_plane_distance: EditableAutoValue::default(),
-            backproject_depth: false,
+            backproject_depth: true,
             backproject_pinhole_ent_path: None,
             depth_from_world_scale: EditableAutoValue::default(),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -3,6 +3,7 @@ pub mod caches;
 pub mod format_time;
 mod item;
 pub(crate) mod mesh_loader;
+pub mod queries;
 mod selection_state;
 pub(crate) mod space_info;
 pub(crate) mod time_control;

--- a/crates/re_viewer/src/misc/queries.rs
+++ b/crates/re_viewer/src/misc/queries.rs
@@ -1,0 +1,27 @@
+use re_arrow_store::LatestAtQuery;
+use re_data_store::{query_latest_single, EntityPath};
+use re_log_types::Transform;
+
+use super::ViewerContext;
+
+/// Find closest entity with a pinhole transform.
+pub fn closest_pinhole_transform(
+    ctx: &ViewerContext<'_>,
+    entity_path: &EntityPath,
+    query: &LatestAtQuery,
+) -> Option<EntityPath> {
+    crate::profile_function!();
+
+    let mut pinhole_ent_path = None;
+    let mut cur_path = Some(entity_path.clone());
+    while let Some(path) = cur_path {
+        if let Some(Transform::Pinhole(_)) =
+            query_latest_single::<Transform>(&ctx.log_db.entity_db, &path, query)
+        {
+            pinhole_ent_path = Some(path);
+            break;
+        }
+        cur_path = path.parent();
+    }
+    pinhole_ent_path
+}

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -488,14 +488,15 @@ fn depth_props_ui(
     entity_path: &EntityPath,
     entity_props: &mut EntityProperties,
 ) -> Option<()> {
-    let query = ctx.current_query();
-    let pinhole_ent_path =
-        crate::misc::queries::closest_pinhole_transform(ctx, entity_path, &query)?;
-    let tensor = query_latest_single::<Tensor>(&ctx.log_db.entity_db, entity_path, &query)?;
+    crate::profile_function!();
 
+    let query = ctx.current_query();
+    let tensor = query_latest_single::<Tensor>(&ctx.log_db.entity_db, entity_path, &query)?;
     if tensor.meaning != TensorDataMeaning::Depth {
         return Some(());
     }
+    let pinhole_ent_path =
+        crate::misc::queries::closest_pinhole_transform(ctx, entity_path, &query)?;
 
     ui.checkbox(&mut entity_props.backproject_depth, "Backproject Depth")
         .on_hover_text(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -498,14 +498,21 @@ fn depth_props_ui(
     let pinhole_ent_path =
         crate::misc::queries::closest_pinhole_transform(ctx, entity_path, &query)?;
 
-    ui.checkbox(&mut entity_props.backproject_depth, "Backproject Depth")
+    let mut backproject_depth = *entity_props.backproject_depth.get();
+
+    if ui
+        .checkbox(&mut backproject_depth, "Backproject Depth")
         .on_hover_text(
             "If enabled, the depth texture will be backprojected into a point cloud rather \
                 than simply displayed as an image.",
-        );
+        )
+        .changed()
+    {
+        entity_props.backproject_depth = EditableAutoValue::UserEdited(backproject_depth);
+    }
     ui.end_row();
 
-    if entity_props.backproject_depth {
+    if backproject_depth {
         ui.label("Pinhole");
         ctx.entity_path_button(ui, None, &pinhole_ent_path)
             .on_hover_text(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -489,14 +489,13 @@ fn depth_props_ui(
     entity_props: &mut EntityProperties,
 ) -> Option<()> {
     let query = ctx.current_query();
-    let pinhole_ent_path = closest_pinhole_transform(ctx, entity_path, &query)?;
+    let pinhole_ent_path =
+        crate::misc::queries::closest_pinhole_transform(ctx, entity_path, &query)?;
     let tensor = query_latest_single::<Tensor>(&ctx.log_db.entity_db, entity_path, &query)?;
 
     if tensor.meaning != TensorDataMeaning::Depth {
         return Some(());
     }
-
-    entity_props.backproject_pinhole_ent_path = Some(pinhole_ent_path.clone());
 
     ui.checkbox(&mut entity_props.backproject_depth, "Backproject Depth")
         .on_hover_text(
@@ -520,31 +519,9 @@ fn depth_props_ui(
         // TODO(cmc): This should apply to the depth map entity as a whole, but for that we
         // need to get the current hardcoded colormapping out of the image cache first.
         colormap_props_ui(ui, entity_props);
-    } else {
-        entity_props.backproject_pinhole_ent_path = None;
     }
 
     Some(())
-}
-
-/// Find closest entity with a pinhole transform.
-fn closest_pinhole_transform(
-    ctx: &ViewerContext<'_>,
-    entity_path: &EntityPath,
-    query: &re_arrow_store::LatestAtQuery,
-) -> Option<EntityPath> {
-    let mut pinhole_ent_path = None;
-    let mut cur_path = Some(entity_path.clone());
-    while let Some(path) = cur_path {
-        if let Some(re_log_types::Transform::Pinhole(_)) =
-            query_latest_single::<Transform>(&ctx.log_db.entity_db, &path, query)
-        {
-            pinhole_ent_path = Some(path);
-            break;
-        }
-        cur_path = path.parent();
-    }
-    pinhole_ent_path
 }
 
 fn depth_from_world_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoValue<f32>) {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -487,55 +487,64 @@ fn depth_props_ui(
     ui: &mut egui::Ui,
     entity_path: &EntityPath,
     entity_props: &mut EntityProperties,
-) {
+) -> Option<()> {
     let query = ctx.current_query();
+    let pinhole_ent_path = closest_pinhole_transform(ctx, entity_path, &query)?;
+    let tensor = query_latest_single::<Tensor>(&ctx.log_db.entity_db, entity_path, &query)?;
 
-    // Find closest pinhole transform, if any.
+    if tensor.meaning != TensorDataMeaning::Depth {
+        return Some(());
+    }
+
+    entity_props.backproject_pinhole_ent_path = Some(pinhole_ent_path.clone());
+
+    ui.checkbox(&mut entity_props.backproject_depth, "Backproject Depth")
+        .on_hover_text(
+            "If enabled, the depth texture will be backprojected into a point cloud rather \
+                than simply displayed as an image.",
+        );
+    ui.end_row();
+
+    if entity_props.backproject_depth {
+        ui.label("Pinhole");
+        ctx.entity_path_button(ui, None, &pinhole_ent_path)
+            .on_hover_text(
+                "The entity path of the pinhole transform being used to do the backprojection.",
+            );
+        ui.end_row();
+
+        depth_from_world_scale_ui(ui, &mut entity_props.depth_from_world_scale);
+
+        backproject_radius_scale_ui(ui, &mut entity_props.backproject_radius_scale);
+
+        // TODO(cmc): This should apply to the depth map entity as a whole, but for that we
+        // need to get the current hardcoded colormapping out of the image cache first.
+        colormap_props_ui(ui, entity_props);
+    } else {
+        entity_props.backproject_pinhole_ent_path = None;
+    }
+
+    Some(())
+}
+
+/// Find closest entity with a pinhole transform.
+fn closest_pinhole_transform(
+    ctx: &ViewerContext<'_>,
+    entity_path: &EntityPath,
+    query: &re_arrow_store::LatestAtQuery,
+) -> Option<EntityPath> {
     let mut pinhole_ent_path = None;
     let mut cur_path = Some(entity_path.clone());
     while let Some(path) = cur_path {
         if let Some(re_log_types::Transform::Pinhole(_)) =
-            query_latest_single::<Transform>(&ctx.log_db.entity_db, &path, &query)
+            query_latest_single::<Transform>(&ctx.log_db.entity_db, &path, query)
         {
             pinhole_ent_path = Some(path);
             break;
         }
         cur_path = path.parent();
     }
-
-    // Early out if there's no pinhole transform upwards in the tree.
-    let Some(pinhole_ent_path) = pinhole_ent_path else { return; };
-
-    entity_props.backproject_pinhole_ent_path = Some(pinhole_ent_path.clone());
-
-    let tensor = query_latest_single::<Tensor>(&ctx.log_db.entity_db, entity_path, &query);
-    if tensor.as_ref().map(|t| t.meaning) == Some(TensorDataMeaning::Depth) {
-        ui.checkbox(&mut entity_props.backproject_depth, "Backproject Depth")
-            .on_hover_text(
-                "If enabled, the depth texture will be backprojected into a point cloud rather \
-                than simply displayed as an image.",
-            );
-        ui.end_row();
-
-        if entity_props.backproject_depth {
-            ui.label("Pinhole");
-            ctx.entity_path_button(ui, None, &pinhole_ent_path)
-                .on_hover_text(
-                    "The entity path of the pinhole transform being used to do the backprojection.",
-                );
-            ui.end_row();
-
-            depth_from_world_scale_ui(ui, &mut entity_props.depth_from_world_scale);
-
-            backproject_radius_scale_ui(ui, &mut entity_props.backproject_radius_scale);
-
-            // TODO(cmc): This should apply to the depth map entity as a whole, but for that we
-            // need to get the current hardcoded colormapping out of the image cache first.
-            colormap_props_ui(ui, entity_props);
-        } else {
-            entity_props.backproject_pinhole_ent_path = None;
-        }
-    }
+    pinhole_ent_path
 }
 
 fn depth_from_world_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoValue<f32>) {

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -153,9 +153,12 @@ impl ImagesPart {
 
                 let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
-                if tensor.meaning == TensorDataMeaning::Depth {
-                    if let Some(pinhole_ent_path) = properties.backproject_pinhole_ent_path.as_ref()
-                    {
+                if properties.backproject_depth && tensor.meaning == TensorDataMeaning::Depth {
+                    let query = ctx.current_query();
+                    let pinhole_ent_path =
+                        crate::misc::queries::closest_pinhole_transform(ctx, ent_path, &query);
+
+                    if let Some(pinhole_ent_path) = pinhole_ent_path {
                         // NOTE: we don't pass in `world_from_obj` because this corresponds to the
                         // transform of the projection plane, which is of no use to us here.
                         // What we want are the extrinsics of the depth camera!
@@ -165,7 +168,7 @@ impl ImagesPart {
                             transforms,
                             properties,
                             &tensor,
-                            pinhole_ent_path,
+                            &pinhole_ent_path,
                             entity_highlight,
                         );
                         return Ok(());


### PR DESCRIPTION
Closes #1586

Or rather: turn it on by default for 3D views, but off by default for 2D views.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
