### PR TITLE
Change roll-shortcut from ALT to SHIFT

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/eye.rs
+++ b/crates/re_viewer/src/ui/view_spatial/eye.rs
@@ -268,7 +268,7 @@ impl OrbitEye {
         if response.drag_delta().length() > drag_threshold {
             if response.dragged_by(egui::PointerButton::Middle)
                 || (response.dragged_by(egui::PointerButton::Primary)
-                    && response.ctx.input(|i| i.modifiers.alt))
+                    && response.ctx.input(|i| i.modifiers.shift))
             {
                 if let Some(pointer_pos) = response.ctx.pointer_latest_pos() {
                     self.roll(&response.rect, pointer_pos, response.drag_delta());

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -242,7 +242,7 @@ fn find_camera(space_cameras: &[SpaceCamera3D], needle: &InstancePathHash) -> Op
 
 pub const HELP_TEXT_3D: &str = "Drag to rotate.\n\
     Drag with secondary mouse button to pan.\n\
-    Drag with middle mouse button (or primary mouse button + holding Alt/⌥ key) to roll the view.\n\
+    Drag with middle mouse button (or primary mouse button + holding SHIFT) to roll the view.\n\
     Scroll to zoom.\n\
     \n\
     While hovering the 3D view, navigate with WSAD and QE.\n\


### PR DESCRIPTION
Closes [#1681](https://github.com/rerun-io/rerun/issues/1681)

Done to avoid the bug where ALT get stuck in down-state on ALT-tab on web: https://github.com/emilk/egui/issues/2847

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
