### PR TITLE
Central GpuReadback handling for re_viewer, experimental space view screenshots

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
         "nyud",
         "objectron",
         "Readback",
+        "readbacks",
         "Skybox",
         "smallvec",
         "swapchain",

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -180,6 +180,7 @@ impl Default for TargetConfiguration {
     }
 }
 
+#[derive(Clone)]
 pub struct ScheduledScreenshot {
     pub identifier: GpuReadbackBufferIdentifier,
     pub width: u32,

--- a/crates/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/re_renderer/src/wgpu_resources/mod.rs
@@ -115,6 +115,7 @@ impl WgpuResourcePools {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct TextureRowDataInfo {
     /// How many bytes per row contain actual data.
     pub bytes_per_row_unpadded: u32,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1635,6 +1635,14 @@ fn options_menu_ui(ui: &mut egui::Ui, frame: &mut eframe::Frame, options: &mut A
         ui.close_menu();
     }
 
+    if ui
+        .checkbox(&mut options.experimental_space_view_screenshots, "(experimental) Space View screenshots")
+        .on_hover_text("Allow taking screenshots of 2D & 3D space views via their context menu. Does not contain labels.")
+        .clicked()
+    {
+        ui.close_menu();
+    }
+
     #[cfg(debug_assertions)]
     {
         ui.separator();

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1635,12 +1635,15 @@ fn options_menu_ui(ui: &mut egui::Ui, frame: &mut eframe::Frame, options: &mut A
         ui.close_menu();
     }
 
-    if ui
-        .checkbox(&mut options.experimental_space_view_screenshots, "(experimental) Space View screenshots")
-        .on_hover_text("Allow taking screenshots of 2D & 3D space views via their context menu. Does not contain labels.")
-        .clicked()
+    #[cfg(not(target_arch = "wasm32"))]
     {
-        ui.close_menu();
+        if ui
+            .checkbox(&mut options.experimental_space_view_screenshots, "(experimental) Space View screenshots")
+            .on_hover_text("Allow taking screenshots of 2D & 3D space views via their context menu. Does not contain labels.")
+            .clicked()
+        {
+            ui.close_menu();
+        }
     }
 
     #[cfg(debug_assertions)]

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -424,7 +424,7 @@ impl App {
                     } => {
                         if let Some(blueprint) = self.state.blueprints.get_mut(application_id) {
                             blueprint.viewport.save_spaceview_screenshot(
-                                screenshot,
+                                &screenshot,
                                 data,
                                 space_view_id,
                             );
@@ -577,8 +577,7 @@ impl eframe::App for App {
                         self.state.show(
                             ui,
                             render_ctx,
-                            &mut self
-                                .scheduled_gpu_readbacks_per_application
+                            self.scheduled_gpu_readbacks_per_application
                                 .entry(selected_app_id)
                                 .or_default(),
                             log_db,
@@ -982,6 +981,7 @@ struct AppState {
 }
 
 impl AppState {
+    #[allow(clippy::too_many_arguments)]
     fn show(
         &mut self,
         ui: &mut egui::Ui,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -421,12 +421,14 @@ impl App {
                     ScheduledGpuReadback::SpaceViewScreenshot {
                         screenshot,
                         space_view_id,
+                        mode,
                     } => {
                         if let Some(blueprint) = self.state.blueprints.get_mut(application_id) {
                             blueprint.viewport.save_spaceview_screenshot(
                                 &screenshot,
                                 data,
                                 space_view_id,
+                                mode,
                             );
                         }
                     }

--- a/crates/re_viewer/src/misc/app_options.rs
+++ b/crates/re_viewer/src/misc/app_options.rs
@@ -20,6 +20,7 @@ pub struct AppOptions {
     pub zoom_factor: f32,
 
     /// Enable the experimental feature for space view screenshots.
+    #[cfg(not(target_arch = "wasm32"))]
     pub experimental_space_view_screenshots: bool,
 }
 
@@ -36,6 +37,7 @@ impl Default for AppOptions {
             #[cfg(not(target_arch = "wasm32"))]
             zoom_factor: 1.0,
 
+            #[cfg(not(target_arch = "wasm32"))]
             experimental_space_view_screenshots: false,
         }
     }

--- a/crates/re_viewer/src/misc/app_options.rs
+++ b/crates/re_viewer/src/misc/app_options.rs
@@ -18,6 +18,9 @@ pub struct AppOptions {
     /// (Since this is serialized, even between sessions!)
     #[cfg(not(target_arch = "wasm32"))]
     pub zoom_factor: f32,
+
+    /// Enable the experimental feature for space view screenshots.
+    pub experimental_space_view_screenshots: bool,
 }
 
 impl Default for AppOptions {
@@ -32,6 +35,8 @@ impl Default for AppOptions {
 
             #[cfg(not(target_arch = "wasm32"))]
             zoom_factor: 1.0,
+
+            experimental_space_view_screenshots: false,
         }
     }
 }

--- a/crates/re_viewer/src/misc/gpu_readbacks.rs
+++ b/crates/re_viewer/src/misc/gpu_readbacks.rs
@@ -3,6 +3,7 @@ use re_renderer::ScheduledScreenshot;
 use crate::ui::SpaceViewId;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
+#[allow(dead_code)] // Not used on the web.
 pub enum ScreenshotMode {
     /// The screenshot will be saved to disc and copied to the clipboard.
     SaveAndCopyToClipboard,

--- a/crates/re_viewer/src/misc/gpu_readbacks.rs
+++ b/crates/re_viewer/src/misc/gpu_readbacks.rs
@@ -2,11 +2,21 @@ use re_renderer::ScheduledScreenshot;
 
 use crate::ui::SpaceViewId;
 
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum ScreenshotMode {
+    /// The screenshot will be saved to disc and copied to the clipboard.
+    SaveAndCopyToClipboard,
+
+    /// The screenshot will be copied to the clipboard.
+    CopyToClipboard,
+}
+
 /// A previously scheduled GPU readback, waiting for getting the result.
 pub enum ScheduledGpuReadback {
     SpaceViewScreenshot {
         screenshot: ScheduledScreenshot,
         space_view_id: SpaceViewId,
+        mode: ScreenshotMode,
     },
     // Picking {
     //     picking: ScheduledPicking,

--- a/crates/re_viewer/src/misc/gpu_readbacks.rs
+++ b/crates/re_viewer/src/misc/gpu_readbacks.rs
@@ -1,0 +1,15 @@
+use re_renderer::ScheduledScreenshot;
+
+use crate::ui::SpaceViewId;
+
+/// A previously scheduled GPU readback, waiting for getting the result.
+pub enum ScheduledGpuReadback {
+    SpaceViewScreenshot {
+        screenshot: ScheduledScreenshot,
+        space_view_id: SpaceViewId,
+    },
+    // Picking {
+    //     picking: ScheduledPicking,
+    //     space_view_id: SpaceViewId,
+    // },
+}

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -36,7 +36,7 @@ pub use {
 };
 
 mod gpu_readbacks;
-pub use gpu_readbacks::ScheduledGpuReadback;
+pub use gpu_readbacks::{ScheduledGpuReadback, ScreenshotMode};
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -35,6 +35,9 @@ pub use {
     },
 };
 
+mod gpu_readbacks;
+pub use gpu_readbacks::ScheduledGpuReadback;
+
 // ----------------------------------------------------------------------------
 
 pub fn help_hover_button(ui: &mut egui::Ui) -> egui::Response {

--- a/crates/re_viewer/src/misc/viewer_context.rs
+++ b/crates/re_viewer/src/misc/viewer_context.rs
@@ -1,5 +1,7 @@
+use ahash::HashMap;
 use re_data_store::{log_db::LogDb, InstancePath};
 use re_log_types::{ComponentPath, EntityPath, MsgId, TimeInt, Timeline};
+use re_renderer::GpuReadbackBufferIdentifier;
 
 use crate::ui::{
     data_ui::{ComponentUiRegistry, DataUi},
@@ -8,7 +10,7 @@ use crate::ui::{
 
 use super::{
     item::{Item, ItemCollection},
-    HoverHighlight,
+    HoverHighlight, ScheduledGpuReadback,
 };
 
 /// Common things needed by many parts of the viewer.
@@ -32,6 +34,9 @@ pub struct ViewerContext<'a> {
     pub re_ui: &'a re_ui::ReUi,
 
     pub render_ctx: &'a mut re_renderer::RenderContext,
+
+    /// List of all data we're currently waiting for from the GPU.
+    pub scheduled_gpu_readbacks: &'a mut HashMap<GpuReadbackBufferIdentifier, ScheduledGpuReadback>,
 }
 
 impl<'a> ViewerContext<'a> {

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -622,12 +622,12 @@ pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
 }
 
 pub fn screenshot_context_menu(
-    ctx: &ViewerContext<'_>,
+    _ctx: &ViewerContext<'_>,
     response: egui::Response,
 ) -> (egui::Response, bool) {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        if ctx.app_options.experimental_space_view_screenshots {
+        if _ctx.app_options.experimental_space_view_screenshots {
             let mut take_screenshot = false;
             let response = response.context_menu(|ui| {
                 if ui.button("Take screenshot").clicked() {

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -9,7 +9,8 @@ use re_renderer::renderer::OutlineConfig;
 
 use crate::{
     misc::{
-        space_info::query_view_coordinates, SelectionHighlight, SpaceViewHighlights, ViewerContext,
+        space_info::query_view_coordinates, ScreenshotMode, SelectionHighlight,
+        SpaceViewHighlights, ViewerContext,
     },
     ui::{data_blueprint::DataBlueprintTree, view_spatial::UiLabelTarget, SpaceViewId},
 };
@@ -624,24 +625,27 @@ pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
 pub fn screenshot_context_menu(
     _ctx: &ViewerContext<'_>,
     response: egui::Response,
-) -> (egui::Response, bool) {
+) -> (egui::Response, Option<ScreenshotMode>) {
     #[cfg(not(target_arch = "wasm32"))]
     {
         if _ctx.app_options.experimental_space_view_screenshots {
-            let mut take_screenshot = false;
+            let mut take_screenshot = None;
             let response = response.context_menu(|ui| {
-                if ui.button("Take screenshot").clicked() {
-                    take_screenshot = true;
+                if ui.button("Screenshot (save to disk)").clicked() {
+                    take_screenshot = Some(ScreenshotMode::SaveAndCopyToClipboard);
+                    ui.close_menu();
+                } else if ui.button("Screenshot (clipboard only)").clicked() {
+                    take_screenshot = Some(ScreenshotMode::CopyToClipboard);
                     ui.close_menu();
                 }
             });
             (response, take_screenshot)
         } else {
-            (response, false)
+            (response, None)
         }
     }
     #[cfg(target_arch = "wasm32")]
     {
-        (response, false)
+        (response, None)
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -5,7 +5,7 @@ use re_format::format_f32;
 use egui::{NumExt, WidgetText};
 use macaw::BoundingBox;
 use re_log_types::component_types::{Tensor, TensorDataMeaning};
-use re_renderer::{renderer::OutlineConfig, view_builder::ScheduledScreenshot};
+use re_renderer::renderer::OutlineConfig;
 
 use crate::{
     misc::{
@@ -77,9 +77,6 @@ pub struct ViewSpatialState {
 
     /// Size of automatically sized objects. None if it wasn't configured.
     auto_size_config: re_renderer::AutoSizeConfig,
-
-    #[serde(skip)]
-    pub scheduled_screenshots: Vec<ScheduledScreenshot>,
 }
 
 impl Default for ViewSpatialState {
@@ -95,7 +92,6 @@ impl Default for ViewSpatialState {
                 point_radius: re_renderer::Size::AUTO, // let re_renderer decide
                 line_radius: re_renderer::Size::AUTO,  // let re_renderer decide
             },
-            scheduled_screenshots: Vec::new(),
         }
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -620,3 +620,21 @@ pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
         color_layer_b: selection_outline_color,
     }
 }
+
+pub fn screenshot_context_menu(
+    ctx: &ViewerContext<'_>,
+    response: egui::Response,
+) -> (egui::Response, bool) {
+    if ctx.app_options.experimental_space_view_screenshots {
+        let mut take_screenshot = false;
+        let response = response.context_menu(|ui| {
+            if ui.button("Take screenshot").clicked() {
+                take_screenshot = true;
+                ui.close_menu();
+            }
+        });
+        (response, take_screenshot)
+    } else {
+        (response, false)
+    }
+}

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -5,7 +5,7 @@ use re_format::format_f32;
 use egui::{NumExt, WidgetText};
 use macaw::BoundingBox;
 use re_log_types::component_types::{Tensor, TensorDataMeaning};
-use re_renderer::renderer::OutlineConfig;
+use re_renderer::{renderer::OutlineConfig, view_builder::ScheduledScreenshot};
 
 use crate::{
     misc::{
@@ -77,6 +77,9 @@ pub struct ViewSpatialState {
 
     /// Size of automatically sized objects. None if it wasn't configured.
     auto_size_config: re_renderer::AutoSizeConfig,
+
+    #[serde(skip)]
+    pub scheduled_screenshots: Vec<ScheduledScreenshot>,
 }
 
 impl Default for ViewSpatialState {
@@ -92,6 +95,7 @@ impl Default for ViewSpatialState {
                 point_radius: re_renderer::Size::AUTO, // let re_renderer decide
                 line_radius: re_renderer::Size::AUTO,  // let re_renderer decide
             },
+            scheduled_screenshots: Vec::new(),
         }
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -625,16 +625,23 @@ pub fn screenshot_context_menu(
     ctx: &ViewerContext<'_>,
     response: egui::Response,
 ) -> (egui::Response, bool) {
-    if ctx.app_options.experimental_space_view_screenshots {
-        let mut take_screenshot = false;
-        let response = response.context_menu(|ui| {
-            if ui.button("Take screenshot").clicked() {
-                take_screenshot = true;
-                ui.close_menu();
-            }
-        });
-        (response, take_screenshot)
-    } else {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if ctx.app_options.experimental_space_view_screenshots {
+            let mut take_screenshot = false;
+            let response = response.context_menu(|ui| {
+                if ui.button("Take screenshot").clicked() {
+                    take_screenshot = true;
+                    ui.close_menu();
+                }
+            });
+            (response, take_screenshot)
+        } else {
+            (response, false)
+        }
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
         (response, false)
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -12,7 +12,7 @@ use super::{
     ViewSpatialState,
 };
 use crate::{
-    misc::{HoveredSpace, Item, SpaceViewHighlights},
+    misc::{HoveredSpace, Item, ScheduledGpuReadback, SpaceViewHighlights},
     ui::{
         data_ui::{self, DataUi},
         view_spatial::{
@@ -20,7 +20,7 @@ use crate::{
             ui_renderer_bridge::{create_scene_paint_callback, get_viewport, ScreenBackground},
             SceneSpatial,
         },
-        SpaceViewId, UiVerbosity,
+        SpaceView, SpaceViewId, UiVerbosity,
     },
     ViewerContext,
 };
@@ -453,7 +453,7 @@ fn view_2d_scrollable(
             return response;
         };
 
-        let Ok((callback, scheduled_screenshot)) = create_scene_paint_callback(
+        let Ok((callback, screenshot)) = create_scene_paint_callback(
             ctx.render_ctx,
             target_config, painter.clip_rect(),
             scene.primitives,
@@ -462,7 +462,15 @@ fn view_2d_scrollable(
         ) else {
             return response;
         };
-        state.scheduled_screenshots.extend(scheduled_screenshot);
+        if let Some(screenshot) = screenshot {
+            ctx.scheduled_gpu_readbacks.insert(
+                screenshot.identifier,
+                ScheduledGpuReadback::SpaceViewScreenshot {
+                    space_view_id,
+                    screenshot,
+                },
+            );
+        }
 
         painter.add(callback);
     }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -8,8 +8,10 @@ use re_log_types::component_types::TensorTrait;
 use re_renderer::view_builder::TargetConfiguration;
 
 use super::{
-    eye::Eye, scene::AdditionalPickingInfo, ui::create_labels, SpatialNavigationMode,
-    ViewSpatialState,
+    eye::Eye,
+    scene::AdditionalPickingInfo,
+    ui::{create_labels, screenshot_context_menu},
+    SpatialNavigationMode, ViewSpatialState,
 };
 use crate::{
     misc::{HoveredSpace, Item, ScheduledGpuReadback, SpaceViewHighlights},
@@ -427,13 +429,7 @@ fn view_2d_scrollable(
 
     // ------------------------------------------------------------------------
 
-    let mut take_screenshot = false;
-    let response = response.context_menu(|ui| {
-        if ui.button("Take screenshot").clicked() {
-            take_screenshot = true;
-            ui.close_menu();
-        }
-    });
+    let (response, take_screenshot) = screenshot_context_menu(ctx, response);
 
     // Draw a re_renderer driven view.
     // Camera & projection are configured to ingest space coordinates directly.

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -20,7 +20,7 @@ use crate::{
             ui_renderer_bridge::{create_scene_paint_callback, get_viewport, ScreenBackground},
             SceneSpatial,
         },
-        SpaceView, SpaceViewId, UiVerbosity,
+        SpaceViewId, UiVerbosity,
     },
     ViewerContext,
 };

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -429,7 +429,7 @@ fn view_2d_scrollable(
 
     // ------------------------------------------------------------------------
 
-    let (response, take_screenshot) = screenshot_context_menu(ctx, response);
+    let (response, screenshot_action) = screenshot_context_menu(ctx, response);
 
     // Draw a re_renderer driven view.
     // Camera & projection are configured to ingest space coordinates directly.
@@ -454,16 +454,17 @@ fn view_2d_scrollable(
             target_config, painter.clip_rect(),
             scene.primitives,
             &ScreenBackground::ClearColor(parent_ui.visuals().extreme_bg_color.into()),
-            take_screenshot,
+            screenshot_action.is_some(),
         ) else {
             return response;
         };
-        if let Some(screenshot) = screenshot {
+        if let (Some(screenshot), Some(screenshot_action)) = (screenshot, screenshot_action) {
             ctx.scheduled_gpu_readbacks.insert(
                 screenshot.identifier,
                 ScheduledGpuReadback::SpaceViewScreenshot {
                     space_view_id,
                     screenshot,
+                    mode: screenshot_action,
                 },
             );
         }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -427,6 +427,14 @@ fn view_2d_scrollable(
 
     // ------------------------------------------------------------------------
 
+    let mut take_screenshot = false;
+    let response = response.context_menu(|ui| {
+        if ui.button("Take screenshot").clicked() {
+            take_screenshot = true;
+            ui.close_menu();
+        }
+    });
+
     // Draw a re_renderer driven view.
     // Camera & projection are configured to ingest space coordinates directly.
     {
@@ -445,14 +453,16 @@ fn view_2d_scrollable(
             return response;
         };
 
-        let Ok(callback) = create_scene_paint_callback(
+        let Ok((callback, scheduled_screenshot)) = create_scene_paint_callback(
             ctx.render_ctx,
             target_config, painter.clip_rect(),
             scene.primitives,
             &ScreenBackground::ClearColor(parent_ui.visuals().extreme_bg_color.into()),
+            take_screenshot,
         ) else {
             return response;
         };
+        state.scheduled_screenshots.extend(scheduled_screenshot);
 
         painter.add(callback);
     }

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -11,7 +11,7 @@ use re_renderer::{
 };
 
 use crate::{
-    misc::{HoveredSpace, Item, SpaceViewHighlights},
+    misc::{HoveredSpace, Item, ScheduledGpuReadback, SpaceViewHighlights},
     ui::{
         data_ui::{self, DataUi},
         view_spatial::{
@@ -504,7 +504,7 @@ pub fn view_3d(
         }
     });
 
-    let scheduled_screenshot = paint_view(
+    let screenshot = paint_view(
         ui,
         eye,
         rect,
@@ -514,7 +514,15 @@ pub fn view_3d(
         state.auto_size_config(),
         take_screenshot,
     );
-    state.scheduled_screenshots.extend(scheduled_screenshot);
+    if let Some(screenshot) = screenshot {
+        ctx.scheduled_gpu_readbacks.insert(
+            screenshot.identifier,
+            ScheduledGpuReadback::SpaceViewScreenshot {
+                space_view_id,
+                screenshot,
+            },
+        );
+    }
 
     // Add egui driven labels on top of re_renderer content.
     let painter = ui.painter().with_clip_rect(ui.max_rect());

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -16,7 +16,7 @@ use crate::{
         data_ui::{self, DataUi},
         view_spatial::{
             scene::AdditionalPickingInfo,
-            ui::{create_labels, outline_config},
+            ui::{create_labels, outline_config, screenshot_context_menu},
             ui_renderer_bridge::{create_scene_paint_callback, get_viewport, ScreenBackground},
             SceneSpatial, SpaceCamera3D, SpatialNavigationMode,
         },
@@ -496,13 +496,7 @@ pub fn view_3d(
         }
     }
 
-    let mut take_screenshot = false;
-    response.context_menu(|ui| {
-        if ui.button("Take screenshot").clicked() {
-            take_screenshot = true;
-            ui.close_menu();
-        }
-    });
+    let (_, take_screenshot) = screenshot_context_menu(ctx, response);
 
     let screenshot = paint_view(
         ui,

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -496,7 +496,7 @@ pub fn view_3d(
         }
     }
 
-    let (_, take_screenshot) = screenshot_context_menu(ctx, response);
+    let (_, screenshot_action) = screenshot_context_menu(ctx, response);
 
     let screenshot = paint_view(
         ui,
@@ -506,14 +506,15 @@ pub fn view_3d(
         ctx.render_ctx,
         &space.to_string(),
         state.auto_size_config(),
-        take_screenshot,
+        screenshot_action.is_some(),
     );
-    if let Some(screenshot) = screenshot {
+    if let (Some(screenshot), Some(screenshot_action)) = (screenshot, screenshot_action) {
         ctx.scheduled_gpu_readbacks.insert(
             screenshot.identifier,
             ScheduledGpuReadback::SpaceViewScreenshot {
                 space_view_id,
                 screenshot,
+                mode: screenshot_action,
             },
         );
     }

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -572,6 +572,11 @@ impl Viewport {
             );
         }
 
+        // Set to clipboard.
+        crate::misc::Clipboard::with(|clipboard| {
+            clipboard.set_image([screenshot.width as _, screenshot.height as _], &buffer);
+        });
+
         // Get next available file name.
         let safe_space_view_name =
             space_view_display_name.replace(|c: char| !c.is_alphanumeric() && c != ' ', "");
@@ -594,7 +599,7 @@ impl Viewport {
         ) {
             Ok(_) => {
                 re_log::info!(
-                    "Saved screenshot to {:?}",
+                    "Saved screenshot to {:?} and copied to clipboard.",
                     filename.canonicalize().unwrap_or(filename.to_path_buf())
                 );
             }

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -573,6 +573,7 @@ impl Viewport {
         }
 
         // Set to clipboard.
+        #[cfg(not(target_arch = "wasm32"))]
         crate::misc::Clipboard::with(|clipboard| {
             clipboard.set_image([screenshot.width as _, screenshot.height as _], &buffer);
         });

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -549,7 +549,7 @@ impl Viewport {
 
     pub fn save_spaceview_screenshot(
         &self,
-        screenshot: ScheduledScreenshot,
+        screenshot: &ScheduledScreenshot,
         data: &[u8],
         space_view_id: SpaceViewId,
     ) {

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -9,7 +9,9 @@ use re_data_store::EntityPath;
 use re_renderer::ScheduledScreenshot;
 
 use crate::{
-    misc::{space_info::SpaceInfoCollection, Item, SpaceViewHighlights, ViewerContext},
+    misc::{
+        space_info::SpaceInfoCollection, Item, ScreenshotMode, SpaceViewHighlights, ViewerContext,
+    },
     ui::space_view_heuristics::default_created_space_views,
 };
 
@@ -552,6 +554,7 @@ impl Viewport {
         screenshot: &ScheduledScreenshot,
         data: &[u8],
         space_view_id: SpaceViewId,
+        mode: ScreenshotMode,
     ) {
         let Some(space_view_display_name) = self.space_views
             .get(&space_view_id)
@@ -577,6 +580,9 @@ impl Viewport {
         crate::misc::Clipboard::with(|clipboard| {
             clipboard.set_image([screenshot.width as _, screenshot.height as _], &buffer);
         });
+        if mode == ScreenshotMode::CopyToClipboard {
+            return;
+        }
 
         // Get next available file name.
         let safe_space_view_name =
@@ -600,7 +606,7 @@ impl Viewport {
         ) {
             Ok(_) => {
                 re_log::info!(
-                    "Saved screenshot to {:?} and copied to clipboard.",
+                    "Saved screenshot to {:?}.",
                     filename.canonicalize().unwrap_or(filename.to_path_buf())
                 );
             }

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -392,11 +392,13 @@ impl Viewport {
                             .display_name
                             .replace(|c: char| !c.is_alphanumeric() && c != ' ', "");
                         let mut i = 1;
-                        let mut filename = format!("Screenshot {safe_space_view_name}.png");
-                        while std::path::Path::new(&filename).exists() {
-                            filename = format!("Screenshot {safe_space_view_name} ({i}).png");
+                        let filename = loop {
+                            let filename = format!("Screenshot {safe_space_view_name} - {i}.png");
+                            if !std::path::Path::new(&filename).exists() {
+                                break filename;
+                            }
                             i += 1;
-                        }
+                        };
                         let filename = std::path::Path::new(&filename);
 
                         image::save_buffer(

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -360,6 +360,63 @@ impl Viewport {
     ) {
         crate::profile_function!();
 
+        ctx.render_ctx
+            .gpu_readback_belt
+            .lock()
+            .receive_data(|data, identifier| {
+                for space_view in self.space_views.values_mut() {
+                    let scheduled_screenshots =
+                        &mut space_view.view_state.state_spatial.scheduled_screenshots;
+
+                    if let Some(index) = scheduled_screenshots
+                        .iter()
+                        .position(|s| s.identifier == identifier)
+                    {
+                        let screenshot = scheduled_screenshots.swap_remove(index);
+
+                        // Need to do a memcpy to remove the padding.
+                        // TODO(andreas): This should be a utility in the render crate.
+                        let row_info = screenshot.row_info;
+                        let mut buffer = Vec::with_capacity(
+                            (row_info.bytes_per_row_unpadded * screenshot.height) as usize,
+                        );
+                        for row in 0..screenshot.height {
+                            let offset = (row_info.bytes_per_row_padded * row) as usize;
+                            buffer.extend_from_slice(
+                                &data[offset..(offset + row_info.bytes_per_row_unpadded as usize)],
+                            );
+                        }
+
+                        // Get next available file name.
+                        let safe_space_view_name = space_view
+                            .display_name
+                            .replace(|c: char| !c.is_alphanumeric() && c != ' ', "");
+                        let mut i = 1;
+                        let mut filename = format!("Screenshot {safe_space_view_name}.png");
+                        while std::path::Path::new(&filename).exists() {
+                            filename = format!("Screenshot {safe_space_view_name} ({i}).png");
+                            i += 1;
+                        }
+                        let filename = std::path::Path::new(&filename);
+
+                        image::save_buffer(
+                            filename,
+                            &buffer,
+                            screenshot.width,
+                            screenshot.height,
+                            image::ColorType::Rgba8,
+                        )
+                        .expect("Failed to save screenshot"); // TODO: Graceful error handling DONT CRASH COME ON
+
+                        re_log::info!(
+                            "Saved screenshot to {:?}",
+                            filename.canonicalize().unwrap_or(filename.to_path_buf())
+                        );
+                        break;
+                    }
+                }
+            });
+
         for space_view in self.space_views.values_mut() {
             space_view.on_frame_start(ctx, spaces_info);
         }


### PR DESCRIPTION
https://user-images.githubusercontent.com/1220815/227952111-405b8827-2838-40bb-8f6b-24eb444171d6.mov

Created the embryo of handling readback data in a generalized & robust fashion across the viewer. Using this to implement screenshot functionality on 2d/3d space views - since it's limited to those & doesn't include egui rendered labels, I put this behind a feature flag.
Note that this is force-disabled on the Web.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
