### PR TITLE
Fix broken outlines (hover/select effect) for lines

### DIFF
--- a/crates/re_renderer/shader/lines.wgsl
+++ b/crates/re_renderer/shader/lines.wgsl
@@ -225,7 +225,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
         // Push out positions as well along the quad dir.
         // This is especially important if there's no miters on a line-strip (TODO(#829)),
         // as this would enhance gaps between lines otherwise.
-        center_position += quad_dir * (size_boost * select(-1.0, 1.0, is_right_triangle));
+        center_position += quad_dir * (size_boost * select(-1.0, 1.0, is_at_quad_end));
     }
 
     var active_radius = strip_radius;


### PR DESCRIPTION
Fixes a regression introduced earlier today, sadly just before the 0.4.0 cutoff 🤦 

Before (regressed):
<img width="332" alt="image" src="https://user-images.githubusercontent.com/1220815/228256093-47325c76-e479-45fc-a8c0-5993c759f067.png">

<img width="709" alt="image" src="https://user-images.githubusercontent.com/1220815/228256051-9f113fcb-4d81-4147-8495-0b99b82b6224.png">

After:

<img width="308" alt="image" src="https://user-images.githubusercontent.com/1220815/228255918-92d6e081-6407-489e-a82e-d0442b49db51.png">
<img width="798" alt="image" src="https://user-images.githubusercontent.com/1220815/228257499-ae1d32b0-0223-4c03-93db-0ac8cae3b05c.png">




### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
