### PR TITLE
Make CI publish `latest` tagged web-viewer to `app.rerun.io`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -312,7 +312,7 @@ jobs:
           destination: "rerun-example-rrd/version/${{github.ref_name}}"
           parent: false
 
-      - name: "Upload web-viewer (latest release)"
+      - name: "Upload RRD (latest release)"
         if: github.ref == 'latest'
         uses: google-github-actions/upload-cloud-storage@v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Add SHORT_SHA env property with commit short sha
         run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-7`" >> $GITHUB_ENV
 
-      - name: "Upload RRD"
+      - name: "Upload RRD (commit)"
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "rrd"
@@ -310,6 +310,14 @@ jobs:
         with:
           path: "rrd"
           destination: "rerun-example-rrd/version/${{github.ref_name}}"
+          parent: false
+
+      - name: "Upload web-viewer (latest release)"
+        if: github.ref == 'latest'
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "rrd"
+          destination: "rerun-example-rrd/web_viewer"
           parent: false
 
   # See https://github.com/ncipollo/release-action

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -317,7 +317,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "rrd"
-          destination: "rerun-example-rrd/web_viewer"
+          destination: "rerun-example-rrd/latest"
           parent: false
 
   # See https://github.com/ncipollo/release-action

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -326,7 +326,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "web_viewer"
-          destination: "rerun-web-viewer/web_viewer"
+          destination: "rerun-web-viewer/latest"
           parent: false
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Add SHORT_SHA env property with commit short sha
         run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-7`" >> $GITHUB_ENV
 
-      - name: "Upload web-viewer"
+      - name: "Upload web-viewer (commit)"
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "web_viewer"
@@ -319,6 +319,14 @@ jobs:
         with:
           path: "web_viewer"
           destination: "rerun-web-viewer/version/${{github.ref_name}}"
+          parent: false
+
+      - name: "Upload web-viewer (latest release)"
+        if: github.ref == 'latest'
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "web_viewer"
+          destination: "rerun-web-viewer/web_viewer"
           parent: false
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
I think the only way to test this is to merge it and then make a new releae

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
