### PR TITLE
Datastore: revamp bench suite

### DIFF
--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -51,6 +51,8 @@ fn insert(c: &mut Criterion) {
                         DataStoreConfig {
                             index_bucket_nb_rows: num_rows_per_bucket,
                             component_bucket_nb_rows: num_rows_per_bucket,
+                            index_bucket_size_bytes: u64::MAX,
+                            component_bucket_size_bytes: u64::MAX,
                             ..Default::default()
                         },
                         InstanceKey::name(),
@@ -83,6 +85,8 @@ fn latest_at(c: &mut Criterion) {
                 DataStoreConfig {
                     index_bucket_nb_rows: num_rows_per_bucket,
                     component_bucket_nb_rows: num_rows_per_bucket,
+                    index_bucket_size_bytes: u64::MAX,
+                    component_bucket_size_bytes: u64::MAX,
                     ..Default::default()
                 },
                 InstanceKey::name(),
@@ -146,6 +150,8 @@ fn latest_at_missing(c: &mut Criterion) {
                 DataStoreConfig {
                     index_bucket_nb_rows: num_rows_per_bucket,
                     component_bucket_nb_rows: num_rows_per_bucket,
+                    index_bucket_size_bytes: u64::MAX,
+                    component_bucket_size_bytes: u64::MAX,
                     ..Default::default()
                 },
                 InstanceKey::name(),
@@ -190,6 +196,8 @@ fn range(c: &mut Criterion) {
                 DataStoreConfig {
                     index_bucket_nb_rows: num_rows_per_bucket,
                     component_bucket_nb_rows: num_rows_per_bucket,
+                    index_bucket_size_bytes: u64::MAX,
+                    component_bucket_size_bytes: u64::MAX,
                     ..Default::default()
                 },
                 InstanceKey::name(),

--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -70,7 +70,6 @@ fn latest_at(c: &mut Criterion) {
         group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 
         let table = build_table(NUM_INSTANCES as usize, packed);
-        let store = insert_table(Default::default(), InstanceKey::name(), &table);
 
         // Default config
         group.bench_function("default", |b| {
@@ -80,6 +79,15 @@ fn latest_at(c: &mut Criterion) {
         // Emulate more or less buckets
         let num_rows_per_bucket = [0, 2, 32, 2048];
         for num_rows_per_bucket in num_rows_per_bucket {
+            let store = insert_table(
+                DataStoreConfig {
+                    index_bucket_nb_rows: num_rows_per_bucket,
+                    component_bucket_nb_rows: num_rows_per_bucket,
+                    ..Default::default()
+                },
+                InstanceKey::name(),
+                &table,
+            );
             group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
                 b.iter(|| {
                     let results = latest_data_at(&store, Rect2D::name(), &[Rect2D::name()]);
@@ -104,9 +112,9 @@ fn latest_at_missing(c: &mut Criterion) {
         group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 
         let table = build_table(NUM_INSTANCES as usize, packed);
-        let store = insert_table(Default::default(), InstanceKey::name(), &table);
 
         // Default config
+        let store = insert_table(Default::default(), InstanceKey::name(), &table);
         group.bench_function("primary/default", |b| {
             b.iter(|| {
                 let results =
@@ -134,6 +142,15 @@ fn latest_at_missing(c: &mut Criterion) {
         // Emulate more or less buckets
         let num_rows_per_bucket = [0, 2, 32, 2048];
         for num_rows_per_bucket in num_rows_per_bucket {
+            let store = insert_table(
+                DataStoreConfig {
+                    index_bucket_nb_rows: num_rows_per_bucket,
+                    component_bucket_nb_rows: num_rows_per_bucket,
+                    ..Default::default()
+                },
+                InstanceKey::name(),
+                &table,
+            );
             group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
                 b.iter(|| {
                     let results = latest_data_at(&store, Rect2D::name(), &[Rect2D::name()]);
@@ -160,7 +177,6 @@ fn range(c: &mut Criterion) {
         ));
 
         let table = build_table(NUM_INSTANCES as usize, packed);
-        let store = insert_table(Default::default(), InstanceKey::name(), &table);
 
         // Default config
         group.bench_function("default", |b| {
@@ -170,6 +186,15 @@ fn range(c: &mut Criterion) {
         // Emulate more or less buckets
         let num_rows_per_bucket = [0, 2, 32, 2048];
         for num_rows_per_bucket in num_rows_per_bucket {
+            let store = insert_table(
+                DataStoreConfig {
+                    index_bucket_nb_rows: num_rows_per_bucket,
+                    component_bucket_nb_rows: num_rows_per_bucket,
+                    ..Default::default()
+                },
+                InstanceKey::name(),
+                &table,
+            );
             group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
                 b.iter(|| {
                     let msgs = range_data(&store, [Rect2D::name()]);

--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -177,7 +177,7 @@ fn latest_at_missing(c: &mut Criterion) {
                     assert!(results[0].is_none());
                 });
             });
-            group.bench_function("secondaries/bucketsz={num_rows_per_bucket}", |b| {
+            group.bench_function(format!("secondaries/bucketsz={num_rows_per_bucket}"), |b| {
                 b.iter(|| {
                     let results = latest_data_at(
                         &store,

--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -8,88 +8,113 @@ use re_arrow_store::{DataStore, DataStoreConfig, LatestAtQuery, RangeQuery, Time
 use re_log_types::{
     component_types::{InstanceKey, Rect2D},
     datagen::{build_frame_nr, build_some_instances, build_some_rects},
-    Component as _, ComponentName, DataRow, EntityPath, MsgId, TimeType, Timeline,
+    Component as _, ComponentName, DataRow, DataTable, EntityPath, MsgId, TimeType, Timeline,
 };
 
 // ---
 
 #[cfg(not(debug_assertions))]
-const NUM_FRAMES: i64 = 100;
+const NUM_ROWS: i64 = 1_000;
 #[cfg(not(debug_assertions))]
-const NUM_RECTS: i64 = 100;
+const NUM_INSTANCES: i64 = 1_000;
 
 // `cargo test` also runs the benchmark setup code, so make sure they run quickly:
 #[cfg(debug_assertions)]
-const NUM_FRAMES: i64 = 1;
+const NUM_ROWS: i64 = 1;
 #[cfg(debug_assertions)]
-const NUM_RECTS: i64 = 1;
+const NUM_INSTANCES: i64 = 1;
 
 // --- Benchmarks ---
 
-// TODO(cmc): need additional benches for full tables
-
 fn insert(c: &mut Criterion) {
-    {
-        let rows = build_rows(NUM_RECTS as usize);
-        let mut group = c.benchmark_group("datastore/insert/batch/rects");
-        group.throughput(criterion::Throughput::Elements(
-            (NUM_RECTS * NUM_FRAMES) as _,
+    for packed in [false, true] {
+        let mut group = c.benchmark_group(format!(
+            "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/insert"
         ));
-        group.bench_function("insert", |b| {
-            b.iter(|| insert_rows(Default::default(), InstanceKey::name(), rows.iter()));
-        });
-    }
-}
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_INSTANCES * NUM_ROWS) as _,
+        ));
 
-fn latest_at_batch(c: &mut Criterion) {
-    {
-        let rows = build_rows(NUM_RECTS as usize);
-        let store = insert_rows(Default::default(), InstanceKey::name(), rows.iter());
-        let mut group = c.benchmark_group("datastore/latest_at/batch/rects");
-        group.throughput(criterion::Throughput::Elements(NUM_RECTS as _));
-        group.bench_function("query", |b| {
-            b.iter(|| {
-                let results = latest_data_at(&store, Rect2D::name(), &[Rect2D::name()]);
-                let rects = results[0]
-                    .as_ref()
-                    .unwrap()
-                    .as_any()
-                    .downcast_ref::<UnionArray>()
-                    .unwrap();
-                assert_eq!(NUM_RECTS as usize, rects.len());
+        let table = build_table(NUM_INSTANCES as usize, packed);
+
+        // Default config
+        group.bench_function("default", |b| {
+            b.iter(|| insert_table(Default::default(), InstanceKey::name(), &table));
+        });
+
+        // Emulate more or less buckets
+        let num_rows_per_bucket = [0, 2, 32, 2048];
+        for num_rows_per_bucket in num_rows_per_bucket {
+            group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
+                b.iter(|| {
+                    insert_table(
+                        DataStoreConfig {
+                            index_bucket_nb_rows: num_rows_per_bucket,
+                            component_bucket_nb_rows: num_rows_per_bucket,
+                            ..Default::default()
+                        },
+                        InstanceKey::name(),
+                        &table,
+                    )
+                });
             });
-        });
+        }
     }
 }
 
-fn latest_at_missing_components(c: &mut Criterion) {
-    // Simulate the worst possible case: many many buckets.
-    let config = DataStoreConfig {
-        index_bucket_size_bytes: 0,
-        index_bucket_nb_rows: 0,
-        ..Default::default()
-    };
+fn latest_at(c: &mut Criterion) {
+    for packed in [false, true] {
+        let mut group = c.benchmark_group(format!(
+            "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/latest_at"
+        ));
+        group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 
-    {
-        let msgs = build_rows(NUM_RECTS as usize);
-        let store = insert_rows(config.clone(), InstanceKey::name(), msgs.iter());
-        let mut group = c.benchmark_group("datastore/latest_at/missing_components");
-        group.throughput(criterion::Throughput::Elements(NUM_RECTS as _));
-        group.bench_function("primary", |b| {
+        let table = build_table(NUM_INSTANCES as usize, packed);
+        let store = insert_table(Default::default(), InstanceKey::name(), &table);
+
+        // Default config
+        group.bench_function("default", |b| {
+            b.iter(|| insert_table(Default::default(), InstanceKey::name(), &table));
+        });
+
+        // Emulate more or less buckets
+        let num_rows_per_bucket = [0, 2, 32, 2048];
+        for num_rows_per_bucket in num_rows_per_bucket {
+            group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
+                b.iter(|| {
+                    let results = latest_data_at(&store, Rect2D::name(), &[Rect2D::name()]);
+                    let rects = results[0]
+                        .as_ref()
+                        .unwrap()
+                        .as_any()
+                        .downcast_ref::<UnionArray>()
+                        .unwrap();
+                    assert_eq!(NUM_INSTANCES as usize, rects.len());
+                });
+            });
+        }
+    }
+}
+
+fn latest_at_missing(c: &mut Criterion) {
+    for packed in [false, true] {
+        let mut group = c.benchmark_group(format!(
+            "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/latest_at_missing"
+        ));
+        group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+        let table = build_table(NUM_INSTANCES as usize, packed);
+        let store = insert_table(Default::default(), InstanceKey::name(), &table);
+
+        // Default config
+        group.bench_function("primary/default", |b| {
             b.iter(|| {
                 let results =
                     latest_data_at(&store, "non_existing_component".into(), &[Rect2D::name()]);
                 assert!(results[0].is_none());
             });
         });
-    }
-
-    {
-        let msgs = build_rows(NUM_RECTS as usize);
-        let store = insert_rows(config, InstanceKey::name(), msgs.iter());
-        let mut group = c.benchmark_group("datastore/latest_at/missing_components");
-        group.throughput(criterion::Throughput::Elements(NUM_RECTS as _));
-        group.bench_function("secondaries", |b| {
+        group.bench_function("secondaries/default", |b| {
             b.iter(|| {
                 let results = latest_data_at(
                     &store,
@@ -105,51 +130,76 @@ fn latest_at_missing_components(c: &mut Criterion) {
                 assert!(results[2].is_none());
             });
         });
-    }
-}
 
-fn range_batch(c: &mut Criterion) {
-    {
-        let msgs = build_rows(NUM_RECTS as usize);
-        let store = insert_rows(Default::default(), InstanceKey::name(), msgs.iter());
-        let mut group = c.benchmark_group("datastore/range/batch/rects");
-        group.throughput(criterion::Throughput::Elements(
-            (NUM_RECTS * NUM_FRAMES) as _,
-        ));
-        group.bench_function("query", |b| {
-            b.iter(|| {
-                let msgs = range_data(&store, [Rect2D::name()]);
-                for (cur_time, (time, results)) in msgs.enumerate() {
-                    let time = time.unwrap();
-                    assert_eq!(cur_time as i64, time.as_i64());
-
+        // Emulate more or less buckets
+        let num_rows_per_bucket = [0, 2, 32, 2048];
+        for num_rows_per_bucket in num_rows_per_bucket {
+            group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
+                b.iter(|| {
+                    let results = latest_data_at(&store, Rect2D::name(), &[Rect2D::name()]);
                     let rects = results[0]
                         .as_ref()
                         .unwrap()
                         .as_any()
                         .downcast_ref::<UnionArray>()
                         .unwrap();
-                    assert_eq!(NUM_RECTS as usize, rects.len());
-                }
+                    assert_eq!(NUM_INSTANCES as usize, rects.len());
+                });
             });
-        });
+        }
     }
 }
 
-criterion_group!(
-    benches,
-    insert,
-    latest_at_batch,
-    latest_at_missing_components,
-    range_batch,
-);
+fn range(c: &mut Criterion) {
+    for packed in [false, true] {
+        let mut group = c.benchmark_group(format!(
+            "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/range"
+        ));
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_INSTANCES * NUM_ROWS) as _,
+        ));
+
+        let table = build_table(NUM_INSTANCES as usize, packed);
+        let store = insert_table(Default::default(), InstanceKey::name(), &table);
+
+        // Default config
+        group.bench_function("default", |b| {
+            b.iter(|| insert_table(Default::default(), InstanceKey::name(), &table));
+        });
+
+        // Emulate more or less buckets
+        let num_rows_per_bucket = [0, 2, 32, 2048];
+        for num_rows_per_bucket in num_rows_per_bucket {
+            group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
+                b.iter(|| {
+                    let msgs = range_data(&store, [Rect2D::name()]);
+                    for (cur_time, (time, results)) in msgs.enumerate() {
+                        let time = time.unwrap();
+                        assert_eq!(cur_time as i64, time.as_i64());
+
+                        let rects = results[0]
+                            .as_ref()
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<UnionArray>()
+                            .unwrap();
+                        assert_eq!(NUM_INSTANCES as usize, rects.len());
+                    }
+                });
+            });
+        }
+    }
+}
+
+criterion_group!(benches, insert, latest_at, latest_at_missing, range);
 criterion_main!(benches);
 
 // --- Helpers ---
 
-fn build_rows(n: usize) -> Vec<DataRow> {
-    (0..NUM_FRAMES)
-        .map(move |frame_idx| {
+fn build_table(n: usize, packed: bool) -> DataTable {
+    let mut table = DataTable::from_rows(
+        MsgId::ZERO,
+        (0..NUM_ROWS).map(move |frame_idx| {
             DataRow::from_cells2(
                 MsgId::random(),
                 "rects",
@@ -157,17 +207,25 @@ fn build_rows(n: usize) -> Vec<DataRow> {
                 n as _,
                 (build_some_instances(n), build_some_rects(n)),
             )
-        })
-        .collect()
+        }),
+    );
+
+    // Do a serialization roundtrip to pack everything in contiguous memory.
+    if packed {
+        let (schema, columns) = table.serialize().unwrap();
+        table = DataTable::deserialize(MsgId::ZERO, &schema, &columns).unwrap();
+    }
+
+    table
 }
 
-fn insert_rows<'a>(
+fn insert_table(
     config: DataStoreConfig,
     cluster_key: ComponentName,
-    rows: impl Iterator<Item = &'a DataRow>,
+    table: &DataTable,
 ) -> DataStore {
     let mut store = DataStore::new(cluster_key, config);
-    rows.for_each(|row| store.insert_row(row).unwrap());
+    store.insert_table(table).unwrap();
     store
 }
 
@@ -177,7 +235,7 @@ fn latest_data_at<const N: usize>(
     secondaries: &[ComponentName; N],
 ) -> [Option<Box<dyn Array>>; N] {
     let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
-    let timeline_query = LatestAtQuery::new(timeline_frame_nr, (NUM_FRAMES / 2).into());
+    let timeline_query = LatestAtQuery::new(timeline_frame_nr, (NUM_ROWS / 2).into());
     let ent_path = EntityPath::from("rects");
 
     let row_indices = store
@@ -191,10 +249,7 @@ fn range_data<const N: usize>(
     components: [ComponentName; N],
 ) -> impl Iterator<Item = (Option<TimeInt>, [Option<Box<dyn Array>>; N])> + '_ {
     let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
-    let query = RangeQuery::new(
-        timeline_frame_nr,
-        TimeRange::new(0.into(), NUM_FRAMES.into()),
-    );
+    let query = RangeQuery::new(timeline_frame_nr, TimeRange::new(0.into(), NUM_ROWS.into()));
     let ent_path = EntityPath::from("rects");
 
     store


### PR DESCRIPTION
This reworks the datastore benchmark suite to actually cover all of the important stuff, and make it scalable to more parameters in the future (without breaking existing graphs).
This is a prerequisite for #1619 and in particular #1727 and its upcoming follow ups.

Needs to be merged in separately as it breaks existing benchmarks.

---

| Benchmark suite | Current: 29626cd4595c55fcda792a46ec16a1352b773c32 |
|-|-|
| `datastore/num_rows=1000/num_instances=1000/packed=false/insert/default` | `12625677` ns/iter (`± 607274`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/insert/bucketsz=0` | `14646870` ns/iter (`± 1133610`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/insert/bucketsz=2` | `13995839` ns/iter (`± 782248`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/insert/bucketsz=32` | `13002161` ns/iter (`± 984171`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/insert/bucketsz=2048` | `12813783` ns/iter (`± 906175`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/insert/default` | `12206704` ns/iter (`± 599724`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/insert/bucketsz=0` | `14043694` ns/iter (`± 609431`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/insert/bucketsz=2` | `13270571` ns/iter (`± 772281`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/insert/bucketsz=32` | `11689675` ns/iter (`± 452193`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/insert/bucketsz=2048` | `11165205` ns/iter (`± 474775`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at/default` | `1856` ns/iter (`± 20`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at/bucketsz=0` | `1873` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at/bucketsz=2` | `1865` ns/iter (`± 1`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at/bucketsz=32` | `1867` ns/iter (`± 2`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at/bucketsz=2048` | `1854` ns/iter (`± 33`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at/default` | `1869` ns/iter (`± 18`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at/bucketsz=0` | `1877` ns/iter (`± 2`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at/bucketsz=2` | `1872` ns/iter (`± 6`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at/bucketsz=32` | `1885` ns/iter (`± 3`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at/bucketsz=2048` | `1883` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/primary/default` | `286` ns/iter (`± 1`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/secondaries/default` | `438` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/primary/bucketsz=0` | `281` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/secondaries/bucketsz=0` | `444` ns/iter (`± 6`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/primary/bucketsz=2` | `280` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/secondaries/bucketsz=2` | `443` ns/iter (`± 1`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/primary/bucketsz=32` | `282` ns/iter (`± 1`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/secondaries/bucketsz=32` | `443` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/primary/bucketsz=2048` | `282` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/latest_at_missing/secondaries/bucketsz=2048` | `439` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/primary/default` | `281` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/secondaries/default` | `437` ns/iter (`± 1`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/primary/bucketsz=0` | `280` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/secondaries/bucketsz=0` | `444` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/primary/bucketsz=2` | `281` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/secondaries/bucketsz=2` | `447` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/primary/bucketsz=32` | `281` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/secondaries/bucketsz=32` | `444` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/primary/bucketsz=2048` | `282` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/latest_at_missing/secondaries/bucketsz=2048` | `438` ns/iter (`± 0`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/range/default` | `12517856` ns/iter (`± 924973`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/range/bucketsz=0` | `2216396` ns/iter (`± 9037`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/range/bucketsz=2` | `2188885` ns/iter (`± 10207`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/range/bucketsz=32` | `1957717` ns/iter (`± 8345`) |
| `datastore/num_rows=1000/num_instances=1000/packed=false/range/bucketsz=2048` | `1864529` ns/iter (`± 6538`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/range/default` | `12318758` ns/iter (`± 392622`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/range/bucketsz=0` | `2212547` ns/iter (`± 6209`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/range/bucketsz=2` | `2178050` ns/iter (`± 7677`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/range/bucketsz=32` | `1920285` ns/iter (`± 12660`) |
| `datastore/num_rows=1000/num_instances=1000/packed=true/range/bucketsz=2048` | `1857672` ns/iter (`± 4359`) |
