### PR TITLE
`arrow2_convert` primitive (de)serialization benchmarks

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -111,3 +111,7 @@ required-features = ["polars"]
 [[bench]]
 name = "data_store"
 harness = false
+
+[[bench]]
+name = "arrow2_convert"
+harness = false

--- a/crates/re_arrow_store/benches/arrow2_convert.rs
+++ b/crates/re_arrow_store/benches/arrow2_convert.rs
@@ -41,6 +41,7 @@ fn serialize(c: &mut Criterion) {
                     cell.datatype().to_physical_type(),
                     PhysicalType::Primitive(PrimitiveType::UInt64)
                 );
+                cell
             });
         });
     }
@@ -55,6 +56,7 @@ fn serialize(c: &mut Criterion) {
                     cell.datatype().to_physical_type(),
                     PhysicalType::Primitive(PrimitiveType::UInt64)
                 );
+                cell
             });
         });
     }
@@ -62,6 +64,11 @@ fn serialize(c: &mut Criterion) {
     {
         group.bench_function("arrow2/from_vec", |b| {
             b.iter(|| {
+                // NOTE: We do the `collect()` here on purpose!
+                //
+                // All of these APIs have to allocate an array under the hood, except `from_vec`
+                // which is O(1) (it just unsafely reuses the vec's data pointer).
+                // We need to measure the collection in order to have a leveled playing field.
                 let values = PrimitiveArray::from_vec((0..NUM_INSTANCES as u64).collect()).boxed();
                 let cell = crate::DataCell::from_arrow(InstanceKey::name(), values);
                 assert_eq!(NUM_INSTANCES as u32, cell.num_instances());
@@ -69,6 +76,7 @@ fn serialize(c: &mut Criterion) {
                     cell.datatype().to_physical_type(),
                     PhysicalType::Primitive(PrimitiveType::UInt64)
                 );
+                cell
             });
         });
     }
@@ -92,6 +100,7 @@ fn deserialize(c: &mut Criterion) {
                     InstanceKey(NUM_INSTANCES as u64 / 2),
                     keys[NUM_INSTANCES / 2]
                 );
+                keys
             });
         });
     }
@@ -109,6 +118,7 @@ fn deserialize(c: &mut Criterion) {
                     InstanceKey(NUM_INSTANCES as u64 / 2),
                     keys[NUM_INSTANCES / 2]
                 );
+                keys
             });
         });
     }
@@ -124,6 +134,7 @@ fn deserialize(c: &mut Criterion) {
                     InstanceKey(NUM_INSTANCES as u64 / 2),
                     keys[NUM_INSTANCES / 2]
                 );
+                keys
             });
         });
     }

--- a/crates/re_arrow_store/benches/arrow2_convert.rs
+++ b/crates/re_arrow_store/benches/arrow2_convert.rs
@@ -1,0 +1,130 @@
+//! Keeping track of performance issues/regressions in `arrow2_convert` that directly affect us.
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use arrow2::{array::PrimitiveArray, datatypes::PhysicalType, types::PrimitiveType};
+use criterion::{criterion_group, criterion_main, Criterion};
+use re_log_types::{
+    component_types::InstanceKey, external::arrow2_convert::deserialize::TryIntoCollection,
+    Component as _, DataCell,
+};
+
+// ---
+
+criterion_group!(benches, serialize, deserialize);
+criterion_main!(benches);
+
+// ---
+
+#[cfg(not(debug_assertions))]
+const NUM_INSTANCES: usize = 100_000;
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+const NUM_INSTANCES: usize = 1;
+
+// ---
+
+fn serialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!(
+        "arrow2_convert/serialize/primitive/instances={NUM_INSTANCES}"
+    ));
+    group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+    {
+        group.bench_function("arrow2_convert", |b| {
+            b.iter(|| {
+                let cell = DataCell::from_component::<InstanceKey>(0..NUM_INSTANCES as u64);
+                assert_eq!(NUM_INSTANCES as u32, cell.num_instances());
+                assert_eq!(
+                    cell.datatype().to_physical_type(),
+                    PhysicalType::Primitive(PrimitiveType::UInt64)
+                );
+            });
+        });
+    }
+
+    {
+        group.bench_function("arrow2/from_values", |b| {
+            b.iter(|| {
+                let values = PrimitiveArray::from_values(0..NUM_INSTANCES as u64).boxed();
+                let cell = crate::DataCell::from_arrow(InstanceKey::name(), values);
+                assert_eq!(NUM_INSTANCES as u32, cell.num_instances());
+                assert_eq!(
+                    cell.datatype().to_physical_type(),
+                    PhysicalType::Primitive(PrimitiveType::UInt64)
+                );
+            });
+        });
+    }
+
+    {
+        group.bench_function("arrow2/from_vec", |b| {
+            b.iter(|| {
+                let values = PrimitiveArray::from_vec((0..NUM_INSTANCES as u64).collect()).boxed();
+                let cell = crate::DataCell::from_arrow(InstanceKey::name(), values);
+                assert_eq!(NUM_INSTANCES as u32, cell.num_instances());
+                assert_eq!(
+                    cell.datatype().to_physical_type(),
+                    PhysicalType::Primitive(PrimitiveType::UInt64)
+                );
+            });
+        });
+    }
+}
+
+fn deserialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!(
+        "arrow2_convert/deserialize/primitive/instances={NUM_INSTANCES}"
+    ));
+    group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+    let cell = DataCell::from_component::<InstanceKey>(0..NUM_INSTANCES as u64);
+    let data = cell.as_arrow();
+
+    {
+        group.bench_function("arrow2_convert", |b| {
+            b.iter(|| {
+                let keys: Vec<InstanceKey> = data.as_ref().try_into_collection().unwrap();
+                assert_eq!(NUM_INSTANCES, keys.len());
+                assert_eq!(
+                    InstanceKey(NUM_INSTANCES as u64 / 2),
+                    keys[NUM_INSTANCES / 2]
+                );
+            });
+        });
+    }
+
+    {
+        group.bench_function("arrow2/validity_checks", |b| {
+            b.iter(|| {
+                let data = data.as_any().downcast_ref::<PrimitiveArray<u64>>().unwrap();
+                let keys: Vec<InstanceKey> = data
+                    .into_iter()
+                    .filter_map(|v| v.copied().map(InstanceKey))
+                    .collect();
+                assert_eq!(NUM_INSTANCES, keys.len());
+                assert_eq!(
+                    InstanceKey(NUM_INSTANCES as u64 / 2),
+                    keys[NUM_INSTANCES / 2]
+                );
+            });
+        });
+    }
+
+    {
+        group.bench_function("arrow2/validity_bypass", |b| {
+            b.iter(|| {
+                let data = data.as_any().downcast_ref::<PrimitiveArray<u64>>().unwrap();
+                assert!(data.validity().is_none());
+                let keys: Vec<InstanceKey> = data.values_iter().copied().map(InstanceKey).collect();
+                assert_eq!(NUM_INSTANCES, keys.len());
+                assert_eq!(
+                    InstanceKey(NUM_INSTANCES as u64 / 2),
+                    keys[NUM_INSTANCES / 2]
+                );
+            });
+        });
+    }
+}


### PR DESCRIPTION
Accompanying code for #1712.

Linux 5950x:
```
$ taskset -c 7 cargo bench --all-features -- arrow2_convert

arrow2_convert/serialize/primitive/instances=100000/arrow2_convert
                        time:   [195.01 µs 195.55 µs 196.21 µs]
                        thrpt:  [509.67 Melem/s 511.39 Melem/s 512.79 Melem/s]
arrow2_convert/serialize/primitive/instances=100000/arrow2/from_values
                        time:   [11.408 µs 11.413 µs 11.418 µs]
                        thrpt:  [8.7579 Gelem/s 8.7621 Gelem/s 8.7658 Gelem/s]
arrow2_convert/serialize/primitive/instances=100000/arrow2/from_vec
                        time:   [11.473 µs 11.479 µs 11.485 µs]
                        thrpt:  [8.7071 Gelem/s 8.7118 Gelem/s 8.7161 Gelem/s]

arrow2_convert/deserialize/primitive/instances=100000/arrow2_convert
                        time:   [47.778 µs 47.860 µs 48.004 µs]
                        thrpt:  [2.0831 Gelem/s 2.0894 Gelem/s 2.0930 Gelem/s]
arrow2_convert/deserialize/primitive/instances=100000/arrow2/validity_checks
                        time:   [83.708 µs 83.782 µs 83.870 µs]
                        thrpt:  [1.1923 Gelem/s 1.1936 Gelem/s 1.1946 Gelem/s]
arrow2_convert/deserialize/primitive/instances=100000/arrow2/validity_bypass
                        time:   [13.386 µs 13.537 µs 13.672 µs]
                        thrpt:  [7.3143 Gelem/s 7.3871 Gelem/s 7.4708 Gelem/s]
```

M1 Max (courtesy of @Wumpf):
```
$ cargo bench --all-features -- arrow2_convert

arrow2_convert/serialize/primitive/instances=100000/arrow2_convert
                        time:   [246.11 µs 248.19 µs 250.93 µs]
                        thrpt:  [398.51 Melem/s 402.92 Melem/s 406.33 Melem/s]
arrow2_convert/serialize/primitive/instances=100000/arrow2/from_values
                        time:   [16.626 µs 16.672 µs 16.722 µs]
                        thrpt:  [5.9803 Gelem/s 5.9979 Gelem/s 6.0148 Gelem/s]
arrow2_convert/serialize/primitive/instances=100000/arrow2/from_vec
                        time:   [16.571 µs 16.611 µs 16.654 µs]
                        thrpt:  [6.0047 Gelem/s 6.0202 Gelem/s 6.0347 Gelem/s]

arrow2_convert/deserialize/primitive/instances=100000/arrow2_convert
                        time:   [148.41 µs 150.08 µs 151.84 µs]
                        thrpt:  [658.59 Melem/s 666.30 Melem/s 673.79 Melem/s]
arrow2_convert/deserialize/primitive/instances=100000/arrow2/validity_checks
                        time:   [144.92 µs 145.09 µs 145.26 µs]
                        thrpt:  [688.41 Melem/s 689.23 Melem/s 690.04 Melem/s]
arrow2_convert/deserialize/primitive/instances=100000/arrow2/validity_bypass
                        time:   [11.087 µs 11.173 µs 11.281 µs]
                        thrpt:  [8.8643 Gelem/s 8.9500 Gelem/s 9.0194 Gelem/s]
```