### PR TITLE
`arrow2` estimated_bytes_size benchmarks

### DIFF
--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -5,18 +5,22 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::sync::Arc;
 
-use arrow2::array::{Array, PrimitiveArray, StructArray};
+use arrow2::{
+    array::{Array, PrimitiveArray, StructArray},
+    compute::aggregate::estimated_bytes_size,
+};
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use re_log_types::{
-    component_types::{InstanceKey, Point2D},
-    datagen::{build_some_instances, build_some_point2d},
-    DataCell,
+    component_types::{InstanceKey, Point2D, Rect2D},
+    datagen::{build_some_instances, build_some_point2d, build_some_rects},
+    external::arrow2_convert::serialize::TryIntoArrow,
+    DataCell, SerializableComponent,
 };
 
 // ---
 
-criterion_group!(benches, estimated_size_bytes);
+criterion_group!(benches, erased_clone, estimated_size_bytes);
 criterion_main!(benches);
 
 // ---
@@ -41,6 +45,9 @@ enum ArrayKind {
 
     /// E.g. an array of `Point2D`.
     Struct,
+
+    /// E.g. an array of `Rect2D`.
+    StructLarge,
 }
 
 impl std::fmt::Display for ArrayKind {
@@ -48,12 +55,128 @@ impl std::fmt::Display for ArrayKind {
         f.write_str(match self {
             ArrayKind::Primitive => "primitive",
             ArrayKind::Struct => "struct",
+            ArrayKind::StructLarge => "struct_large",
         })
     }
 }
 
+fn erased_clone(c: &mut Criterion) {
+    let kind = [
+        ArrayKind::Primitive,
+        ArrayKind::Struct,
+        ArrayKind::StructLarge,
+    ];
+
+    for kind in kind {
+        let mut group = c.benchmark_group(format!(
+            "arrow2/size_bytes/{kind}/rows={NUM_ROWS}/instances={NUM_INSTANCES}"
+        ));
+        group.throughput(criterion::Throughput::Elements(NUM_ROWS as _));
+
+        match kind {
+            ArrayKind::Primitive => {
+                let data = build_some_instances(NUM_INSTANCES);
+                bench_arrow(&mut group, data.as_slice());
+                bench_native(&mut group, data.as_slice());
+            }
+            ArrayKind::Struct => {
+                let data = build_some_point2d(NUM_INSTANCES);
+                bench_arrow(&mut group, data.as_slice());
+                bench_native(&mut group, data.as_slice());
+            }
+            ArrayKind::StructLarge => {
+                let data = build_some_rects(NUM_INSTANCES);
+                bench_arrow(&mut group, data.as_slice());
+                bench_native(&mut group, data.as_slice());
+            }
+        }
+    }
+
+    // TODO(cmc): Use cells once `cell.size_bytes()` has landed (#1727)
+    fn bench_arrow<T: SerializableComponent>(
+        group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+        data: &[T],
+    ) {
+        let arrays: Vec<Box<dyn Array>> = (0..NUM_ROWS)
+            .map(|_| TryIntoArrow::try_into_arrow(data).unwrap())
+            .collect_vec();
+
+        let total_size_bytes = arrays
+            .iter()
+            .map(|array| estimated_bytes_size(&**array) as u64)
+            .sum::<u64>();
+        assert!(total_size_bytes as usize >= NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>());
+
+        group.bench_function("array", |b| {
+            b.iter(|| {
+                let sz = arrays
+                    .iter()
+                    .map(|array| estimated_bytes_size(&**array) as u64)
+                    .sum::<u64>();
+                assert_eq!(total_size_bytes, sz);
+                sz
+            });
+        });
+    }
+
+    fn bench_native<T: Clone>(
+        group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+        data: &[T],
+    ) {
+        let vecs = (0..NUM_ROWS).map(|_| data.to_vec()).collect_vec();
+
+        let total_size_bytes = vecs
+            .iter()
+            .map(|vec| std::mem::size_of_val(vec.as_slice()) as u64)
+            .sum::<u64>();
+        assert!(total_size_bytes as usize >= NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>());
+
+        {
+            let vecs = (0..NUM_ROWS).map(|_| data.to_vec()).collect_vec();
+            group.bench_function("vec", |b| {
+                b.iter(|| {
+                    let sz = vecs
+                        .iter()
+                        .map(|vec| std::mem::size_of_val(vec.as_slice()) as u64)
+                        .sum::<u64>();
+                    assert_eq!(total_size_bytes, sz);
+                    sz
+                });
+            });
+        }
+
+        trait SizeOf {
+            fn size_of(&self) -> usize;
+        }
+
+        impl<T> SizeOf for Vec<T> {
+            fn size_of(&self) -> usize {
+                std::mem::size_of_val(self.as_slice())
+            }
+        }
+
+        {
+            let vecs: Vec<Box<dyn SizeOf>> = (0..NUM_ROWS)
+                .map(|_| Box::new(data.to_vec()) as Box<dyn SizeOf>)
+                .collect_vec();
+
+            group.bench_function("vec/erased", |b| {
+                b.iter(|| {
+                    let sz = vecs.iter().map(|vec| vec.size_of() as u64).sum::<u64>();
+                    assert_eq!(total_size_bytes, sz);
+                    sz
+                });
+            });
+        }
+    }
+}
+
 fn estimated_size_bytes(c: &mut Criterion) {
-    let kind = [ArrayKind::Primitive, ArrayKind::Struct];
+    let kind = [
+        ArrayKind::Primitive,
+        ArrayKind::Struct,
+        ArrayKind::StructLarge,
+    ];
 
     for kind in kind {
         let mut group = c.benchmark_group(format!(
@@ -68,6 +191,9 @@ fn estimated_size_bytes(c: &mut Criterion) {
                     .collect(),
                 ArrayKind::Struct => (0..NUM_ROWS)
                     .map(|_| DataCell::from_native(build_some_point2d(NUM_INSTANCES).as_slice()))
+                    .collect(),
+                ArrayKind::StructLarge => (0..NUM_ROWS)
+                    .map(|_| DataCell::from_native(build_some_rects(NUM_INSTANCES).as_slice()))
                     .collect(),
             }
         }
@@ -153,7 +279,7 @@ fn estimated_size_bytes(c: &mut Criterion) {
                         });
                     });
                 }
-                ArrayKind::Struct => {
+                ArrayKind::Struct | ArrayKind::StructLarge => {
                     let cells = generate_cells(kind);
                     let arrays = cells
                         .iter()
@@ -196,9 +322,16 @@ fn estimated_size_bytes(c: &mut Criterion) {
                     .collect()
             }
 
+            fn generate_rects() -> Vec<Vec<Rect2D>> {
+                (0..NUM_ROWS)
+                    .map(|_| build_some_rects(NUM_INSTANCES))
+                    .collect()
+            }
+
             match kind {
                 ArrayKind::Primitive => bench_std(&mut group, generate_keys()),
                 ArrayKind::Struct => bench_std(&mut group, generate_points()),
+                ArrayKind::StructLarge => bench_std(&mut group, generate_rects()),
             }
 
             fn bench_std<T: Clone>(


### PR DESCRIPTION
Accompanying code for #1738.

Linux 5950x:
```
$ taskset -c 7 cargo bench --all-features -- arrow2/size

arrow2/size_bytes/primitive/rows=10000/instances=100/array
                        time:   [98.184 µs 98.798 µs 99.337 µs]
                        thrpt:  [100.67 Melem/s 101.22 Melem/s 101.85 Melem/s]
arrow2/size_bytes/primitive/rows=10000/instances=100/vec
                        time:   [2.1324 µs 2.1517 µs 2.1765 µs]
                        thrpt:  [4.5946 Gelem/s 4.6475 Gelem/s 4.6895 Gelem/s]
arrow2/size_bytes/primitive/rows=10000/instances=100/vec/erased
                        time:   [10.582 µs 10.598 µs 10.629 µs]
                        thrpt:  [940.84 Melem/s 943.60 Melem/s 945.04 Melem/s]

arrow2/size_bytes/struct/rows=10000/instances=100/array
                        time:   [486.14 µs 486.86 µs 487.61 µs]
                        thrpt:  [20.508 Melem/s 20.540 Melem/s 20.570 Melem/s]
arrow2/size_bytes/struct/rows=10000/instances=100/vec
                        time:   [2.1577 µs 2.1774 µs 2.2022 µs]
                        thrpt:  [4.5409 Gelem/s 4.5927 Gelem/s 4.6345 Gelem/s]
arrow2/size_bytes/struct/rows=10000/instances=100/vec/erased
                        time:   [10.936 µs 10.960 µs 10.989 µs]
                        thrpt:  [910.01 Melem/s 912.41 Melem/s 914.44 Melem/s]

arrow2/size_bytes/struct_large/rows=10000/instances=100/array
                        time:   [1.6225 ms 1.6294 ms 1.6380 ms]
                        thrpt:  [6.1052 Melem/s 6.1372 Melem/s 6.1632 Melem/s]
arrow2/size_bytes/struct_large/rows=10000/instances=100/vec
                        time:   [4.1955 µs 4.2105 µs 4.2407 µs]
                        thrpt:  [2.3581 Gelem/s 2.3750 Gelem/s 2.3835 Gelem/s]
arrow2/size_bytes/struct_large/rows=10000/instances=100/vec/erased
                        time:   [12.668 µs 12.683 µs 12.710 µs]
                        thrpt:  [786.80 Melem/s 788.46 Melem/s 789.37 Melem/s]
```

M1 Max (courtesy of @Wumpf):
```
arrow2/size_bytes/primitive/rows=10000/instances=100/array
                        time:   [82.540 µs 82.740 µs 82.909 µs]
                        thrpt:  [120.61 Melem/s 120.86 Melem/s 121.15 Melem/s]
arrow2/size_bytes/primitive/rows=10000/instances=100/vec
                        time:   [2.8399 µs 2.8424 µs 2.8451 µs]
                        thrpt:  [3.5148 Gelem/s 3.5181 Gelem/s 3.5212 Gelem/s]
arrow2/size_bytes/primitive/rows=10000/instances=100/vec/erased
                        time:   [9.5346 µs 9.5436 µs 9.5541 µs]
                        thrpt:  [1.0467 Gelem/s 1.0478 Gelem/s 1.0488 Gelem/s]

arrow2/size_bytes/struct/rows=10000/instances=100/array
                        time:   [246.94 µs 247.16 µs 247.41 µs]
                        thrpt:  [40.419 Melem/s 40.460 Melem/s 40.495 Melem/s]
arrow2/size_bytes/struct/rows=10000/instances=100/vec
                        time:   [2.8394 µs 2.8417 µs 2.8439 µs]
                        thrpt:  [3.5163 Gelem/s 3.5190 Gelem/s 3.5218 Gelem/s]
arrow2/size_bytes/struct/rows=10000/instances=100/vec/erased
                        time:   [9.5506 µs 9.5646 µs 9.5813 µs]
                        thrpt:  [1.0437 Gelem/s 1.0455 Gelem/s 1.0471 Gelem/s]

arrow2/size_bytes/struct_large/rows=10000/instances=100/array
                        time:   [1.9156 ms 1.9295 ms 1.9454 ms]
                        thrpt:  [5.1403 Melem/s 5.1827 Melem/s 5.2203 Melem/s]
arrow2/size_bytes/struct_large/rows=10000/instances=100/vec
                        time:   [3.1762 µs 3.1791 µs 3.1823 µs]
                        thrpt:  [3.1424 Gelem/s 3.1455 Gelem/s 3.1484 Gelem/s]
arrow2/size_bytes/struct_large/rows=10000/instances=100/vec/erased
                        time:   [9.5468 µs 9.5551 µs 9.5645 µs]
                        thrpt:  [1.0455 Gelem/s 1.0466 Gelem/s 1.0475 Gelem/s]
```