### PR TITLE
Improve dealing with raw buffers for texture read/write

### DIFF
--- a/crates/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/re_renderer/src/wgpu_resources/mod.rs
@@ -117,9 +117,9 @@ impl WgpuResourcePools {
     }
 }
 
-/// Utility for dealing with rows of raw texture data.
-#[derive(Clone, Copy)]
-pub struct TextureRowDataInfo {
+/// Utility for dealing with buffers containing raw 2D texture data.
+#[derive(Clone)]
+pub struct Texture2DBufferInfo {
     /// How many bytes per row contain actual data.
     pub bytes_per_row_unpadded: u32,
 
@@ -127,34 +127,57 @@ pub struct TextureRowDataInfo {
     ///
     /// Padding bytes are always at the end of a row.
     pub bytes_per_row_padded: u32,
+
+    /// Size required for an unpadded buffer.
+    pub buffer_size_unpadded: wgpu::BufferAddress,
+
+    /// Size required for a padded buffer as it is read/written from/to the GPU.
+    pub buffer_size_padded: wgpu::BufferAddress,
 }
 
-impl TextureRowDataInfo {
-    pub fn new(format: wgpu::TextureFormat, width: u32) -> Self {
+impl Texture2DBufferInfo {
+    #[inline]
+    pub fn new(format: wgpu::TextureFormat, extent: glam::UVec2) -> Self {
         let format_info = format.describe();
-        let width_blocks = width / format_info.block_dimensions.0 as u32;
-        let bytes_per_row_unaligned = width_blocks * format_info.block_size as u32;
+
+        let width_blocks = extent.x / format_info.block_dimensions.0 as u32;
+        let height_blocks = extent.y / format_info.block_dimensions.1 as u32;
+
+        let bytes_per_row_unpadded = width_blocks * format_info.block_size as u32;
+        let bytes_per_row_padded =
+            wgpu::util::align_to(bytes_per_row_unpadded, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
 
         Self {
-            bytes_per_row_unpadded: bytes_per_row_unaligned,
-            bytes_per_row_padded: wgpu::util::align_to(
-                bytes_per_row_unaligned,
-                wgpu::COPY_BYTES_PER_ROW_ALIGNMENT,
-            ),
+            bytes_per_row_unpadded,
+            bytes_per_row_padded,
+            buffer_size_unpadded: (bytes_per_row_unpadded * height_blocks) as wgpu::BufferAddress,
+            buffer_size_padded: (bytes_per_row_padded * height_blocks) as wgpu::BufferAddress,
         }
     }
 
+    #[inline]
+    pub fn num_rows(&self) -> u32 {
+        self.buffer_size_padded as u32 / self.bytes_per_row_padded
+    }
+
     /// Removes the padding from a buffer containing gpu texture data.
+    ///
+    /// The buffer have the expected size for a padded buffer to hold the texture data.
+    ///
+    /// Note that if you're passing in gpu data, there no alignment guarantees on the returned slice,
+    /// do NOT convert it using [`bytemuck`]. Use [`Texture2DBufferInfo::remove_padding_and_convert`] instead.
     pub fn remove_padding<'a>(&self, buffer: &'a [u8]) -> Cow<'a, [u8]> {
+        crate::profile_function!();
+
+        assert!(buffer.len() as wgpu::BufferAddress == self.buffer_size_padded);
+
         if self.bytes_per_row_padded == self.bytes_per_row_unpadded {
             return Cow::Borrowed(buffer);
         }
 
-        let height = (buffer.len() as u32) / self.bytes_per_row_padded;
-        let mut unpadded_buffer =
-            Vec::with_capacity((self.bytes_per_row_unpadded * height) as usize);
+        let mut unpadded_buffer = Vec::with_capacity(self.buffer_size_unpadded as _);
 
-        for row in 0..height {
+        for row in 0..self.num_rows() {
             let offset = (self.bytes_per_row_padded * row) as usize;
             unpadded_buffer.extend_from_slice(
                 &buffer[offset..(offset + self.bytes_per_row_unpadded as usize)],
@@ -162,5 +185,41 @@ impl TextureRowDataInfo {
         }
 
         unpadded_buffer.into()
+    }
+
+    /// Removes the padding from a buffer containing gpu texture data and remove convert to a given type.
+    ///
+    /// The buffer have the expected size for a padded buffer to hold the texture data.
+    ///
+    /// The unpadded row size is expected to be a multiple of the size of the target type.
+    /// (Which means that, while uncommon, it technically doesn't need to be as big as a block in the pixel - this can be useful for e.g. packing wide bitfields)
+    pub fn remove_padding_and_convert<T: bytemuck::Pod>(&self, buffer: &[u8]) -> Vec<T> {
+        crate::profile_function!();
+
+        assert!(buffer.len() as wgpu::BufferAddress == self.buffer_size_padded);
+        assert!(self.bytes_per_row_unpadded % std::mem::size_of::<T>() as u32 == 0);
+
+        // Due to https://github.com/gfx-rs/wgpu/issues/3508 the data might be completely unaligned,
+        // so much, that we can't even interpret it as e.g. a u32 slice.
+        // Therefore, we have to do a copy of the data regardless of whether it's padded or not.
+
+        let mut unpadded_buffer: Vec<T> = vec![
+            T::zeroed();
+            (self.num_rows() * self.bytes_per_row_unpadded / std::mem::size_of::<T>() as u32)
+                as usize
+        ]; // Consider using unsafe set_len() instead of vec![] to avoid zeroing the memory.
+        let unpaadded_buffer_u8 = bytemuck::cast_slice_mut(&mut unpadded_buffer);
+
+        for row in 0..self.num_rows() {
+            let offset_padded = (self.bytes_per_row_padded * row) as usize;
+            let offset_unpadded = (self.bytes_per_row_unpadded * row) as usize;
+            unpaadded_buffer_u8
+                [offset_unpadded..(offset_unpadded + self.bytes_per_row_unpadded as usize)]
+                .copy_from_slice(
+                    &buffer[offset_padded..(offset_padded + self.bytes_per_row_unpadded as usize)],
+                );
+        }
+
+        unpadded_buffer
     }
 }


### PR DESCRIPTION
Replace TextureRowDataInfo with the more versatile Texture2DBufferInfo
Split this out of ongoing work to read back depth values.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
