### PR TITLE
`arrow2` erased refcounted clones benchmarks

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -115,6 +115,10 @@ name = "data_store"
 harness = false
 
 [[bench]]
+name = "arrow2"
+harness = false
+
+[[bench]]
 name = "arrow2_convert"
 harness = false
 

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -38,6 +38,7 @@ const NUM_INSTANCES: usize = 1;
 enum ArrayKind {
     /// E.g. an array of `InstanceKey`.
     Primitive,
+
     /// E.g. an array of `Point2D`.
     Struct,
 }

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -1,0 +1,228 @@
+//! Keeping track of performance issues/regressions in `arrow2` that directly affect us.
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use std::sync::Arc;
+
+use arrow2::array::{Array, PrimitiveArray, StructArray};
+use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use re_log_types::{
+    component_types::{InstanceKey, Point2D},
+    datagen::{build_some_instances, build_some_point2d},
+    DataCell,
+};
+
+// ---
+
+criterion_group!(benches, estimated_size_bytes);
+criterion_main!(benches);
+
+// ---
+
+#[cfg(not(debug_assertions))]
+const NUM_ROWS: usize = 10_000;
+#[cfg(not(debug_assertions))]
+const NUM_INSTANCES: usize = 100;
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+const NUM_ROWS: usize = 1;
+#[cfg(debug_assertions)]
+const NUM_INSTANCES: usize = 1;
+
+// ---
+
+fn estimated_size_bytes(c: &mut Criterion) {
+    let kind = ["primitive", "struct"];
+
+    for kind in kind {
+        let mut group = c.benchmark_group(format!(
+            "arrow2/erased_clone/{kind}/rows={NUM_ROWS}/instances={NUM_INSTANCES}"
+        ));
+        group.throughput(criterion::Throughput::Elements(NUM_ROWS as _));
+
+        fn generate_cells(kind: &str) -> Vec<DataCell> {
+            match kind {
+                "primitive" => (0..NUM_ROWS)
+                    .map(|_| DataCell::from_native(build_some_instances(NUM_INSTANCES).as_slice()))
+                    .collect(),
+                "struct" => (0..NUM_ROWS)
+                    .map(|_| DataCell::from_native(build_some_point2d(NUM_INSTANCES).as_slice()))
+                    .collect(),
+                _ => unreachable!(),
+            }
+        }
+
+        {
+            {
+                let cells = generate_cells(kind);
+                let total_instances = cells.iter().map(|cell| cell.num_instances()).sum::<u32>();
+                assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                group.bench_function("cell/arc_erased", |b| {
+                    b.iter(|| {
+                        let cells = cells.clone();
+                        assert_eq!(
+                            total_instances,
+                            cells.iter().map(|cell| cell.num_instances()).sum::<u32>()
+                        );
+                        cells
+                    });
+                });
+            }
+
+            {
+                let cells = generate_cells(kind).into_iter().map(Arc::new).collect_vec();
+                let total_instances = cells.iter().map(|cell| cell.num_instances()).sum::<u32>();
+                assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                group.bench_function("cell/wrapped_in_arc", |b| {
+                    b.iter(|| {
+                        let cells = cells.clone();
+                        assert_eq!(
+                            total_instances,
+                            cells.iter().map(|cell| cell.num_instances()).sum::<u32>()
+                        );
+                        cells
+                    });
+                });
+            }
+
+            {
+                let cells = generate_cells(kind);
+                let arrays = cells.iter().map(|cell| cell.as_arrow()).collect_vec();
+                let total_instances = arrays.iter().map(|array| array.len() as u32).sum::<u32>();
+                assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                group.bench_function("array", |b| {
+                    b.iter(|| {
+                        let arrays = arrays.clone();
+                        assert_eq!(
+                            total_instances,
+                            arrays.iter().map(|array| array.len() as u32).sum::<u32>()
+                        );
+                        arrays
+                    });
+                });
+            }
+
+            match kind {
+                "primitive" => {
+                    let cells = generate_cells(kind);
+                    let arrays = cells
+                        .iter()
+                        .map(|cell| {
+                            cell.as_arrow_ref()
+                                .as_any()
+                                .downcast_ref::<PrimitiveArray<u64>>()
+                                .unwrap()
+                                .clone()
+                        })
+                        .collect_vec();
+                    let total_instances =
+                        arrays.iter().map(|array| array.len() as u32).sum::<u32>();
+                    assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                    group.bench_function("array/downcast_first", |b| {
+                        b.iter(|| {
+                            let arrays = arrays.clone();
+                            assert_eq!(
+                                total_instances,
+                                arrays.iter().map(|array| array.len() as u32).sum::<u32>()
+                            );
+                            arrays
+                        });
+                    });
+                }
+                "struct" => {
+                    let cells = generate_cells(kind);
+                    let arrays = cells
+                        .iter()
+                        .map(|cell| {
+                            cell.as_arrow_ref()
+                                .as_any()
+                                .downcast_ref::<StructArray>()
+                                .unwrap()
+                                .clone()
+                        })
+                        .collect_vec();
+                    let total_instances =
+                        arrays.iter().map(|array| array.len() as u32).sum::<u32>();
+                    assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                    group.bench_function("array/downcast_first", |b| {
+                        b.iter(|| {
+                            let arrays = arrays.clone();
+                            assert_eq!(
+                                total_instances,
+                                arrays.iter().map(|array| array.len() as u32).sum::<u32>()
+                            );
+                            arrays
+                        });
+                    });
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        {
+            fn generate_points() -> Vec<Vec<Point2D>> {
+                (0..NUM_ROWS)
+                    .map(|_| build_some_point2d(NUM_INSTANCES))
+                    .collect()
+            }
+            fn generate_keys() -> Vec<Vec<InstanceKey>> {
+                (0..NUM_ROWS)
+                    .map(|_| build_some_instances(NUM_INSTANCES))
+                    .collect()
+            }
+
+            match kind {
+                "primitive" => bench_std(&mut group, generate_keys()),
+                "struct" => bench_std(&mut group, generate_points()),
+                _ => unreachable!(),
+            }
+
+            fn bench_std<T: Clone>(
+                group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+                data: Vec<Vec<T>>,
+            ) {
+                {
+                    let vecs = data.clone();
+                    let total_instances = vecs.iter().map(|vec| vec.len() as u32).sum::<u32>();
+                    assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                    group.bench_function("vec/full_copy", |b| {
+                        b.iter(|| {
+                            let vecs = vecs.clone();
+                            assert_eq!(
+                                total_instances,
+                                vecs.iter().map(|vec| vec.len() as u32).sum::<u32>()
+                            );
+                            vecs
+                        });
+                    });
+                }
+
+                {
+                    let vecs = data.into_iter().map(Arc::new).collect_vec();
+                    let total_instances = vecs.iter().map(|vec| vec.len() as u32).sum::<u32>();
+                    assert_eq!(total_instances, (NUM_ROWS * NUM_INSTANCES) as u32);
+
+                    group.bench_function("vec/wrapped_in_arc", |b| {
+                        b.iter(|| {
+                            let vecs = vecs.clone();
+                            assert_eq!(
+                                total_instances,
+                                vecs.iter().map(|vec| vec.len() as u32).sum::<u32>()
+                            );
+                            vecs
+                        });
+                    });
+                }
+            }
+        }
+    }
+}

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -173,6 +173,7 @@ fn estimated_size_bytes(c: &mut Criterion) {
                     .map(|_| build_some_point2d(NUM_INSTANCES))
                     .collect()
             }
+
             fn generate_keys() -> Vec<Vec<InstanceKey>> {
                 (0..NUM_ROWS)
                     .map(|_| build_some_instances(NUM_INSTANCES))


### PR DESCRIPTION
Accompanying benchmarks for #1746.

Linux 5950x:
```
$ taskset -c 7 cargo bench --all-features -- arrow2/erased

arrow2/erased_clone/primitive/rows=10000/instances=100/cell/arc_erased
                        time:   [345.70 µs 346.16 µs 346.81 µs]
                        thrpt:  [28.834 Melem/s 28.889 Melem/s 28.927 Melem/s]
arrow2/erased_clone/primitive/rows=10000/instances=100/cell/wrapped_in_arc
                        time:   [66.321 µs 66.392 µs 66.472 µs]
                        thrpt:  [150.44 Melem/s 150.62 Melem/s 150.78 Melem/s]
arrow2/erased_clone/primitive/rows=10000/instances=100/array
                        time:   [333.01 µs 333.49 µs 334.08 µs]
                        thrpt:  [29.933 Melem/s 29.986 Melem/s 30.029 Melem/s]
arrow2/erased_clone/primitive/rows=10000/instances=100/array/downcast_first
                        time:   [131.87 µs 131.93 µs 132.01 µs]
                        thrpt:  [75.754 Melem/s 75.796 Melem/s 75.831 Melem/s]
arrow2/erased_clone/primitive/rows=10000/instances=100/vec/full_copy
                        time:   [379.46 µs 379.93 µs 380.44 µs]
                        thrpt:  [26.285 Melem/s 26.320 Melem/s 26.353 Melem/s]
arrow2/erased_clone/primitive/rows=10000/instances=100/vec/wrapped_in_arc
                        time:   [52.433 µs 52.515 µs 52.609 µs]
                        thrpt:  [190.08 Melem/s 190.42 Melem/s 190.72 Melem/s]

arrow2/erased_clone/struct/rows=10000/instances=100/cell/arc_erased
                        time:   [2.1752 ms 2.1793 ms 2.1842 ms]
                        thrpt:  [4.5783 Melem/s 4.5886 Melem/s 4.5973 Melem/s]
arrow2/erased_clone/struct/rows=10000/instances=100/cell/wrapped_in_arc
                        time:   [88.589 µs 88.690 µs 88.798 µs]
                        thrpt:  [112.62 Melem/s 112.75 Melem/s 112.88 Melem/s]
arrow2/erased_clone/struct/rows=10000/instances=100/array
                        time:   [2.1399 ms 2.1447 ms 2.1519 ms]
                        thrpt:  [4.6470 Melem/s 4.6626 Melem/s 4.6731 Melem/s]
arrow2/erased_clone/struct/rows=10000/instances=100/array/downcast_first
                        time:   [1.8545 ms 1.8562 ms 1.8584 ms]
                        thrpt:  [5.3811 Melem/s 5.3873 Melem/s 5.3922 Melem/s]
arrow2/erased_clone/struct/rows=10000/instances=100/vec/full_copy
                        time:   [720.77 µs 723.63 µs 727.00 µs]
                        thrpt:  [13.755 Melem/s 13.819 Melem/s 13.874 Melem/s]
arrow2/erased_clone/struct/rows=10000/instances=100/vec/wrapped_in_arc
                        time:   [51.734 µs 51.769 µs 51.814 µs]
                        thrpt:  [193.00 Melem/s 193.17 Melem/s 193.30 Melem/s]
```