### PR TITLE
benchmarks for common vector ops across `smallvec`/`tinyvec`/std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,8 +3802,10 @@ dependencies = [
  "re_format",
  "re_log",
  "re_log_types",
+ "smallvec",
  "static_assertions",
  "thiserror",
+ "tinyvec",
 ]
 
 [[package]]

--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -81,6 +81,8 @@ polars-core = { workspace = true, features = [
   "sort_multiple",
 ] }
 rand = "0.8"
+smallvec = { version = "1.0", features = ["const_generics", "union"] }
+tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 
 
 [lib]
@@ -114,4 +116,8 @@ harness = false
 
 [[bench]]
 name = "arrow2_convert"
+harness = false
+
+[[bench]]
+name = "vectors"
 harness = false

--- a/crates/re_arrow_store/benches/vectors.rs
+++ b/crates/re_arrow_store/benches/vectors.rs
@@ -1,0 +1,311 @@
+//! Keeping track of performance issues/regressions for common vector operations.
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use smallvec::SmallVec;
+use tinyvec::TinyVec;
+
+criterion_group!(benches, sort, split, swap, swap_opt);
+criterion_main!(benches);
+
+// ---
+
+#[cfg(not(debug_assertions))]
+const NUM_INSTANCES: usize = 10_000;
+#[cfg(not(debug_assertions))]
+const SMALLVEC_SIZE: usize = 4;
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+const NUM_INSTANCES: usize = 1;
+#[cfg(debug_assertions)]
+const SMALLVEC_SIZE: usize = 1;
+
+// --- Benchmarks ---
+
+fn split(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("vector_ops/split_off/instances={NUM_INSTANCES}"));
+    group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+    {
+        fn split_off<T: Copy, const N: usize>(
+            data: &mut SmallVec<[T; N]>,
+            split_idx: usize,
+        ) -> SmallVec<[T; N]> {
+            if split_idx >= data.len() {
+                return SmallVec::default();
+            }
+
+            let second_half = SmallVec::from_slice(&data[split_idx..]);
+            data.truncate(split_idx);
+            second_half
+        }
+
+        let data: SmallVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).collect();
+
+        group.bench_function(format!("smallvec/n={SMALLVEC_SIZE}/manual"), |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                let second_half = split_off(&mut data, NUM_INSTANCES / 2);
+                assert_eq!(NUM_INSTANCES, data.len() + second_half.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, second_half[0]);
+                (data, second_half)
+            });
+        });
+    }
+
+    {
+        let data: TinyVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).collect();
+
+        group.bench_function(format!("tinyvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                let second_half = data.split_off(NUM_INSTANCES / 2);
+                assert_eq!(NUM_INSTANCES, data.len() + second_half.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, second_half[0]);
+                (data, second_half)
+            });
+        });
+    }
+
+    {
+        fn split_off<T: Default + Copy, const N: usize>(
+            data: &mut TinyVec<[T; N]>,
+            split_idx: usize,
+        ) -> TinyVec<[T; N]> {
+            if split_idx >= data.len() {
+                return TinyVec::default();
+            }
+
+            let second_half = TinyVec::from(&data[split_idx..]);
+            data.truncate(split_idx);
+            second_half
+        }
+
+        let data: TinyVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).collect();
+
+        group.bench_function(format!("tinyvec/n={SMALLVEC_SIZE}/manual"), |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                let second_half = split_off(&mut data, NUM_INSTANCES / 2);
+                assert_eq!(NUM_INSTANCES, data.len() + second_half.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, second_half[0]);
+                (data, second_half)
+            });
+        });
+    }
+
+    {
+        let data: Vec<i64> = (0..NUM_INSTANCES as i64).collect();
+
+        group.bench_function("vec", |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                let second_half = data.split_off(NUM_INSTANCES / 2);
+                assert_eq!(NUM_INSTANCES, data.len() + second_half.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, second_half[0]);
+                (data, second_half)
+            });
+        });
+    }
+
+    {
+        fn split_off<T: Copy>(data: &mut Vec<T>, split_idx: usize) -> Vec<T> {
+            if split_idx >= data.len() {
+                return Vec::default();
+            }
+
+            let second_half = Vec::from(&data[split_idx..]);
+            data.truncate(split_idx);
+            second_half
+        }
+
+        let data: Vec<i64> = (0..NUM_INSTANCES as i64).collect();
+
+        group.bench_function("vec/manual", |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                let second_half = split_off(&mut data, NUM_INSTANCES / 2);
+                assert_eq!(NUM_INSTANCES, data.len() + second_half.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, second_half[0]);
+                (data, second_half)
+            });
+        });
+    }
+}
+
+fn sort(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("vector_ops/sort/instances={NUM_INSTANCES}"));
+    group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+    {
+        let data: SmallVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).rev().collect();
+
+        group.bench_function(format!("smallvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                data.sort_unstable();
+                assert_eq!(NUM_INSTANCES, data.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, data[NUM_INSTANCES / 2]);
+                data
+            });
+        });
+    }
+
+    {
+        let data: TinyVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).rev().collect();
+
+        group.bench_function(format!("tinyvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                data.sort_unstable();
+                assert_eq!(NUM_INSTANCES, data.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, data[NUM_INSTANCES / 2]);
+                data
+            });
+        });
+    }
+
+    {
+        let data: Vec<i64> = (0..NUM_INSTANCES as i64).rev().collect();
+
+        group.bench_function("vec", |b| {
+            b.iter(|| {
+                let mut data = data.clone();
+                data.sort_unstable();
+                assert_eq!(NUM_INSTANCES, data.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2, data[NUM_INSTANCES / 2]);
+                data
+            });
+        });
+    }
+}
+
+fn swap(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("vector_ops/swap/instances={NUM_INSTANCES}"));
+    group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+    {
+        let data: SmallVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).collect();
+        let swaps: SmallVec<[usize; SMALLVEC_SIZE]> = (0..NUM_INSTANCES).rev().collect();
+
+        group.bench_function(format!("smallvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data1 = data.clone();
+                let data2 = data.clone();
+                for &swap in &swaps {
+                    data1[NUM_INSTANCES - swap - 1] = data2[swap];
+                }
+                assert_eq!(NUM_INSTANCES, data1.len());
+                assert_eq!(NUM_INSTANCES, data2.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2 - 1, data1[NUM_INSTANCES / 2]);
+                (data1, data2)
+            });
+        });
+    }
+
+    {
+        let data: TinyVec<[i64; SMALLVEC_SIZE]> = (0..NUM_INSTANCES as i64).collect();
+        let swaps: TinyVec<[usize; SMALLVEC_SIZE]> = (0..NUM_INSTANCES).rev().collect();
+
+        group.bench_function(format!("tinyvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data1 = data.clone();
+                let data2 = data.clone();
+                for &swap in &swaps {
+                    data1[NUM_INSTANCES - swap - 1] = data2[swap];
+                }
+                assert_eq!(NUM_INSTANCES, data1.len());
+                assert_eq!(NUM_INSTANCES, data2.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2 - 1, data1[NUM_INSTANCES / 2]);
+                (data1, data2)
+            });
+        });
+    }
+
+    {
+        let data: Vec<i64> = (0..NUM_INSTANCES as i64).collect();
+        let swaps: Vec<usize> = (0..NUM_INSTANCES).rev().collect();
+
+        group.bench_function("vec", |b| {
+            b.iter(|| {
+                let mut data1 = data.clone();
+                let data2 = data.clone();
+                for &swap in &swaps {
+                    data1[NUM_INSTANCES - swap - 1] = data2[swap];
+                }
+                assert_eq!(NUM_INSTANCES, data1.len());
+                assert_eq!(NUM_INSTANCES, data2.len());
+                assert_eq!(NUM_INSTANCES as i64 / 2 - 1, data1[NUM_INSTANCES / 2]);
+                (data1, data2)
+            });
+        });
+    }
+}
+
+fn swap_opt(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("vector_ops/swap_opt/instances={NUM_INSTANCES}"));
+    group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
+
+    {
+        let data: SmallVec<[Option<i64>; SMALLVEC_SIZE]> =
+            (0..NUM_INSTANCES as i64).map(Some).collect();
+        let swaps: SmallVec<[usize; SMALLVEC_SIZE]> = (0..NUM_INSTANCES).rev().collect();
+
+        group.bench_function(format!("smallvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data1 = data.clone();
+                let mut data2 = data.clone();
+                for &swap in &swaps {
+                    data1[NUM_INSTANCES - swap - 1] = data2[swap].take();
+                }
+                assert_eq!(NUM_INSTANCES, data1.len());
+                assert_eq!(NUM_INSTANCES, data2.len());
+                assert_eq!(Some(NUM_INSTANCES as i64 / 2 - 1), data1[NUM_INSTANCES / 2]);
+                (data1, data2)
+            });
+        });
+    }
+
+    {
+        let data: TinyVec<[Option<i64>; SMALLVEC_SIZE]> =
+            (0..NUM_INSTANCES as i64).map(Some).collect();
+        let swaps: TinyVec<[usize; SMALLVEC_SIZE]> = (0..NUM_INSTANCES).rev().collect();
+
+        group.bench_function(format!("tinyvec/n={SMALLVEC_SIZE}"), |b| {
+            b.iter(|| {
+                let mut data1 = data.clone();
+                let mut data2 = data.clone();
+                for &swap in &swaps {
+                    data1[NUM_INSTANCES - swap - 1] = data2[swap].take();
+                }
+                assert_eq!(NUM_INSTANCES, data1.len());
+                assert_eq!(NUM_INSTANCES, data2.len());
+                assert_eq!(Some(NUM_INSTANCES as i64 / 2 - 1), data1[NUM_INSTANCES / 2]);
+                (data1, data2)
+            });
+        });
+    }
+
+    {
+        let data: Vec<Option<i64>> = (0..NUM_INSTANCES as i64).map(Some).collect();
+        let swaps: Vec<usize> = (0..NUM_INSTANCES).rev().collect();
+
+        group.bench_function("vec", |b| {
+            b.iter(|| {
+                let mut data1 = data.clone();
+                let mut data2 = data.clone();
+                for &swap in &swaps {
+                    data1[NUM_INSTANCES - swap - 1] = data2[swap].take();
+                }
+                assert_eq!(NUM_INSTANCES, data1.len());
+                assert_eq!(NUM_INSTANCES, data2.len());
+                assert_eq!(Some(NUM_INSTANCES as i64 / 2 - 1), data1[NUM_INSTANCES / 2]);
+                (data1, data2)
+            });
+        });
+    }
+}

--- a/crates/re_arrow_store/benches/vectors.rs
+++ b/crates/re_arrow_store/benches/vectors.rs
@@ -201,7 +201,10 @@ fn swap(c: &mut Criterion) {
                 }
                 assert_eq!(NUM_INSTANCES, data1.len());
                 assert_eq!(NUM_INSTANCES, data2.len());
-                assert_eq!(NUM_INSTANCES as i64 / 2 - 1, data1[NUM_INSTANCES / 2]);
+                assert_eq!(
+                    (NUM_INSTANCES as i64 / 2).max(1) - 1,
+                    data1[NUM_INSTANCES / 2]
+                );
                 (data1, data2)
             });
         });
@@ -220,7 +223,10 @@ fn swap(c: &mut Criterion) {
                 }
                 assert_eq!(NUM_INSTANCES, data1.len());
                 assert_eq!(NUM_INSTANCES, data2.len());
-                assert_eq!(NUM_INSTANCES as i64 / 2 - 1, data1[NUM_INSTANCES / 2]);
+                assert_eq!(
+                    (NUM_INSTANCES as i64 / 2).max(1) - 1,
+                    data1[NUM_INSTANCES / 2]
+                );
                 (data1, data2)
             });
         });
@@ -239,7 +245,10 @@ fn swap(c: &mut Criterion) {
                 }
                 assert_eq!(NUM_INSTANCES, data1.len());
                 assert_eq!(NUM_INSTANCES, data2.len());
-                assert_eq!(NUM_INSTANCES as i64 / 2 - 1, data1[NUM_INSTANCES / 2]);
+                assert_eq!(
+                    (NUM_INSTANCES as i64 / 2).max(1) - 1,
+                    data1[NUM_INSTANCES / 2]
+                );
                 (data1, data2)
             });
         });
@@ -264,7 +273,10 @@ fn swap_opt(c: &mut Criterion) {
                 }
                 assert_eq!(NUM_INSTANCES, data1.len());
                 assert_eq!(NUM_INSTANCES, data2.len());
-                assert_eq!(Some(NUM_INSTANCES as i64 / 2 - 1), data1[NUM_INSTANCES / 2]);
+                assert_eq!(
+                    Some((NUM_INSTANCES as i64 / 2).max(1) - 1),
+                    data1[NUM_INSTANCES / 2]
+                );
                 (data1, data2)
             });
         });
@@ -284,7 +296,10 @@ fn swap_opt(c: &mut Criterion) {
                 }
                 assert_eq!(NUM_INSTANCES, data1.len());
                 assert_eq!(NUM_INSTANCES, data2.len());
-                assert_eq!(Some(NUM_INSTANCES as i64 / 2 - 1), data1[NUM_INSTANCES / 2]);
+                assert_eq!(
+                    Some((NUM_INSTANCES as i64 / 2).max(1) - 1),
+                    data1[NUM_INSTANCES / 2]
+                );
                 (data1, data2)
             });
         });
@@ -303,7 +318,10 @@ fn swap_opt(c: &mut Criterion) {
                 }
                 assert_eq!(NUM_INSTANCES, data1.len());
                 assert_eq!(NUM_INSTANCES, data2.len());
-                assert_eq!(Some(NUM_INSTANCES as i64 / 2 - 1), data1[NUM_INSTANCES / 2]);
+                assert_eq!(
+                    Some((NUM_INSTANCES as i64 / 2).max(1) - 1),
+                    data1[NUM_INSTANCES / 2]
+                );
                 (data1, data2)
             });
         });


### PR DESCRIPTION
Accompanying benchmarks for #1748.

Linux 5950x:
```
$ taskset -c 7 cargo bench --all-features -- vector_ops

# unstable sort on a reversed vec
vector_ops/sort/instances=10000/smallvec/n=4
                        time:   [6.2326 µs 6.2442 µs 6.2631 µs]
                        thrpt:  [1.5967 Gelem/s 1.6015 Gelem/s 1.6045 Gelem/s]
vector_ops/sort/instances=10000/tinyvec/n=4
                        time:   [4.2937 µs 4.3093 µs 4.3357 µs]
                        thrpt:  [2.3064 Gelem/s 2.3205 Gelem/s 2.3290 Gelem/s]
vector_ops/sort/instances=10000/vec
                        time:   [4.2907 µs 4.2970 µs 4.3054 µs]
                        thrpt:  [2.3227 Gelem/s 2.3272 Gelem/s 2.3306 Gelem/s]

# split a vec at its mid point
vector_ops/split_off/instances=10000/smallvec/n=4/manual
                        time:   [3.6301 µs 3.6329 µs 3.6379 µs]
                        thrpt:  [2.7489 Gelem/s 2.7526 Gelem/s 2.7547 Gelem/s]
vector_ops/split_off/instances=10000/tinyvec/n=4
                        time:   [1.7345 µs 1.7366 µs 1.7400 µs]
                        thrpt:  [5.7471 Gelem/s 5.7584 Gelem/s 5.7655 Gelem/s]
vector_ops/split_off/instances=10000/tinyvec/n=4/manual
                        time:   [1.7348 µs 1.7356 µs 1.7366 µs]
                        thrpt:  [5.7583 Gelem/s 5.7617 Gelem/s 5.7644 Gelem/s]
vector_ops/split_off/instances=10000/vec
                        time:   [1.7957 µs 1.7964 µs 1.7971 µs]
                        thrpt:  [5.5645 Gelem/s 5.5665 Gelem/s 5.5687 Gelem/s]
vector_ops/split_off/instances=10000/vec/manual
                        time:   [1.7295 µs 1.7303 µs 1.7312 µs]
                        thrpt:  [5.7762 Gelem/s 5.7793 Gelem/s 5.7820 Gelem/s]

# swap data around between two vecs using indices from a third vec
vector_ops/swap/instances=10000/smallvec/n=4
                        time:   [15.647 µs 15.666 µs 15.694 µs]
                        thrpt:  [637.18 Melem/s 638.32 Melem/s 639.09 Melem/s]
vector_ops/swap/instances=10000/tinyvec/n=4
                        time:   [10.240 µs 10.256 µs 10.271 µs]
                        thrpt:  [973.64 Melem/s 975.01 Melem/s 976.53 Melem/s]
vector_ops/swap/instances=10000/vec
                        time:   [6.5017 µs 6.5132 µs 6.5347 µs]
                        thrpt:  [1.5303 Gelem/s 1.5353 Gelem/s 1.5381 Gelem/s]

# swap optional data around between two vecs (`take()`) using indices from a third vec
vector_ops/swap_opt/instances=10000/smallvec/n=4
                        time:   [23.426 µs 23.478 µs 23.560 µs]
                        thrpt:  [424.44 Melem/s 425.92 Melem/s 426.88 Melem/s]
vector_ops/swap_opt/instances=10000/tinyvec/n=4
                        time:   [20.870 µs 21.215 µs 21.674 µs]
                        thrpt:  [461.38 Melem/s 471.37 Melem/s 479.16 Melem/s]
vector_ops/swap_opt/instances=10000/vec
                        time:   [11.763 µs 11.864 µs 12.025 µs]
                        thrpt:  [831.59 Melem/s 842.92 Melem/s 850.12 Melem/s]
```

Mac M1 Max via @Wumpf
```
# unstable sort on a reversed vec
vector_ops/sort/instances=10000/smallvec/n=4
                        time:   [7.8960 µs 7.9257 µs 7.9601 µs]
                        thrpt:  [1.2563 Gelem/s 1.2617 Gelem/s 1.2665 Gelem/s]
vector_ops/sort/instances=10000/tinyvec/n=4
                        time:   [6.0100 µs 6.0230 µs 6.0374 µs]
                        thrpt:  [1.6563 Gelem/s 1.6603 Gelem/s 1.6639 Gelem/s]
vector_ops/sort/instances=10000/vec
                        time:   [5.9921 µs 5.9986 µs 6.0052 µs]
                        thrpt:  [1.6652 Gelem/s 1.6671 Gelem/s 1.6689 Gelem/s]

# split a vec at its mid point
vector_ops/split_off/instances=10000/smallvec/n=4/manual
                        time:   [5.2576 µs 5.2744 µs 5.2920 µs]
                        thrpt:  [1.8897 Gelem/s 1.8959 Gelem/s 1.9020 Gelem/s]
vector_ops/split_off/instances=10000/tinyvec/n=4
                        time:   [2.7618 µs 2.7778 µs 2.7955 µs]
                        thrpt:  [3.5772 Gelem/s 3.6000 Gelem/s 3.6208 Gelem/s]
vector_ops/split_off/instances=10000/tinyvec/n=4/manual
                        time:   [2.7181 µs 2.7404 µs 2.7642 µs]
                        thrpt:  [3.6177 Gelem/s 3.6492 Gelem/s 3.6791 Gelem/s]
vector_ops/split_off/instances=10000/vec
                        time:   [2.8072 µs 2.8486 µs 2.8906 µs]
                        thrpt:  [3.4595 Gelem/s 3.5105 Gelem/s 3.5623 Gelem/s]
vector_ops/split_off/instances=10000/vec/manual
                        time:   [2.6671 µs 2.6726 µs 2.6785 µs]
                        thrpt:  [3.7334 Gelem/s 3.7417 Gelem/s 3.7494 Gelem/s]


# swap data around between two vecs using indices from a third vec
vector_ops/swap/instances=10000/smallvec/n=4
                        time:   [19.064 µs 19.073 µs 19.083 µs]
                        thrpt:  [524.03 Melem/s 524.31 Melem/s 524.55 Melem/s]
vector_ops/swap/instances=10000/tinyvec/n=4
                        time:   [9.1657 µs 9.1680 µs 9.1702 µs]
                        thrpt:  [1.0905 Gelem/s 1.0907 Gelem/s 1.0910 Gelem/s]
vector_ops/swap/instances=10000/vec
                        time:   [7.9118 µs 7.9167 µs 7.9221 µs]
                        thrpt:  [1.2623 Gelem/s 1.2632 Gelem/s 1.2639 Gelem/s]

# swap optional data around between two vecs (`take()`) using indices from a third vec
vector_ops/swap_opt/instances=10000/smallvec/n=4
                        time:   [26.255 µs 26.262 µs 26.269 µs]
                        thrpt:  [380.68 Melem/s 380.78 Melem/s 380.88 Melem/s]
vector_ops/swap_opt/instances=10000/tinyvec/n=4
                        time:   [24.310 µs 24.315 µs 24.320 µs]
                        thrpt:  [411.19 Melem/s 411.27 Melem/s 411.35 Melem/s]
vector_ops/swap_opt/instances=10000/vec
                        time:   [24.180 µs 24.186 µs 24.193 µs]
                        thrpt:  [413.35 Melem/s 413.46 Melem/s 413.56 Melem/s]
```
