### PR TITLE
Fix logged obb being displayed with half of the requested size

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
@@ -64,7 +64,7 @@ impl Boxes3DPart {
             let color =
                 annotation_info.color(color.map(move |c| c.to_array()).as_ref(), default_color);
 
-            let scale = glam::Vec3::from(half_size);
+            let scale = glam::Vec3::from(half_size) * 2.0;
             let rot = rotation.map(glam::Quat::from).unwrap_or_default();
             let tran = position.map_or(glam::Vec3::ZERO, glam::Vec3::from);
             let transform = glam::Affine3A::from_scale_rotation_translation(scale, rot, tran);

--- a/rerun_py/rerun_sdk/rerun/log/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log/bounding_box.py
@@ -72,7 +72,7 @@ def log_obb(
     splats: Dict[str, Any] = {}
 
     if half_size is not None:
-        size = np.require(half_size, dtype="float32")
+        size = np.require(half_size, dtype="float32") * 2.0
 
         if size.shape[0] == 3:
             instanced["rerun.box3d"] = Box3DArray.from_numpy(size.reshape(1, 3))

--- a/rerun_py/rerun_sdk/rerun/log/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log/bounding_box.py
@@ -72,7 +72,7 @@ def log_obb(
     splats: Dict[str, Any] = {}
 
     if half_size is not None:
-        size = np.require(half_size, dtype="float32") * 2.0
+        size = np.require(half_size, dtype="float32")
 
         if size.shape[0] == 3:
             instanced["rerun.box3d"] = Box3DArray.from_numpy(size.reshape(1, 3))


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
Fixing #1701
minimal test script
```
import rerun as rr

rr.spawn()
rr.log_obb("world/obb", [1, 2, 3], [0, 0, 0], None, color=[255, 0, 0])

expected_corners = [[d0, d1, d2] for d0 in (-1, 1) for d1 in (-2, 2) for d2 in (-3, 3)]
rr.log_points("world/corners", positions=expected_corners, colors=[0, 255, 0])
```
Output showing `oob` with correct verticies.

![Untitled](https://user-images.githubusercontent.com/11699155/229186395-57731894-fcfd-4abb-ac2b-7642c09ae47e.gif)


If this is a suitable fix I'll add tests and polish. This is my first rerun contribution - I hope this finds a home. Thanks for the great tool - I've had a lot of fun using it. 
