### PR TITLE
Hover rays for tracked 3D cameras

### DIFF
--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -3,7 +3,7 @@ use egui::NumExt;
 use lazy_static::lazy_static;
 use nohash_hasher::IntMap;
 
-use re_data_store::{EntityPath, LogDb};
+use re_data_store::{EntityPath, InstancePath, InstancePathHash, LogDb};
 use re_log_types::{component_types::InstanceKey, EntityPathHash};
 use re_renderer::OutlineMaskPreference;
 
@@ -29,8 +29,15 @@ pub enum HoveredSpace {
         /// The 3D space with the camera(s)
         space_3d: EntityPath,
 
-        /// 2D spaces and pixel coordinates (with Z=depth)
-        target_spaces: Vec<(EntityPath, Option<glam::Vec3>)>,
+        /// The point in 3D space that is hovered, if any.
+        pos: Option<glam::Vec3>,
+
+        /// Path of a space camera, this 3D space is viewed through.
+        /// (None for a free floating Eye)
+        tracked_space_camera: Option<InstancePath>,
+
+        /// Corresponding 2D spaces and pixel coordinates (with Z=depth)
+        point_in_space_cameras: Vec<(InstancePathHash, Option<glam::Vec3>)>,
     },
 }
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -232,7 +232,7 @@ impl SceneSpatial {
         if self
             .space_cameras
             .iter()
-            .any(|camera| &camera.entity_path != space_info_path)
+            .any(|camera| camera.instance_path_hash.entity_path_hash != space_info_path.hash())
         {
             return SpatialNavigationMode::ThreeD;
         }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -89,7 +89,6 @@ impl CamerasPart {
         let frustum_length = *props.pinhole_image_plane_distance.get();
 
         scene.space_cameras.push(SpaceCamera3D {
-            entity_path: entity_path.clone(),
             instance_path_hash,
             view_coordinates,
             world_from_camera,

--- a/crates/re_viewer/src/ui/view_spatial/space_camera_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/space_camera_3d.rs
@@ -1,18 +1,15 @@
 use glam::{vec3, Affine3A, Mat3, Quat, Vec2, Vec3};
 use macaw::{IsoTransform, Ray3};
 
-use re_data_store::{EntityPath, InstancePathHash};
+use re_data_store::InstancePathHash;
 use re_log_types::ViewCoordinates;
 
 /// A logged camera that connects spaces.
 #[derive(Clone)]
 pub struct SpaceCamera3D {
-    /// Path to the entity which has the projection (pinhole, ortho or otherwise) transforms.
+    /// Path to the instance which has the projection (pinhole, ortho or otherwise) transforms.
     ///
-    /// We expect the camera transform to apply to this entity and every path below it.
-    pub entity_path: EntityPath,
-
-    /// The instance that has the projection.
+    /// We expect the camera transform to apply to this instance and every path below it.
     pub instance_path_hash: InstancePathHash,
 
     /// The coordinate system of the camera ("view-space").
@@ -49,7 +46,7 @@ impl SpaceCamera3D {
         match from_rub_quat(self.view_coordinates) {
             Ok(from_rub) => Some(self.world_from_camera * IsoTransform::from_quat(from_rub)),
             Err(err) => {
-                re_log::warn_once!("Camera {:?}: {err}", self.entity_path);
+                re_log::warn_once!("Camera {:?}: {err}", self.instance_path_hash);
                 None
             }
         }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -581,9 +581,13 @@ fn show_projections_from_3d_space(
     ui_from_space: &RectTransform,
 ) -> Vec<Shape> {
     let mut shapes = Vec::new();
-    if let HoveredSpace::ThreeD { target_spaces, .. } = ctx.selection_state().hovered_space() {
+    if let HoveredSpace::ThreeD {
+        point_in_space_cameras: target_spaces,
+        ..
+    } = ctx.selection_state().hovered_space()
+    {
         for (space_2d, pos_2d) in target_spaces {
-            if space_2d == space {
+            if space_2d.entity_path_hash == space.hash() {
                 if let Some(pos_2d) = pos_2d {
                     // User is hovering a 2D point inside a 3D view.
                     let pos_in_ui = ui_from_space.transform_pos(pos2(pos_2d.x, pos_2d.y));


### PR DESCRIPTION
Tracked 3D cameras lead now to on-hover rays in other space views that show the same camera but don't track it.

https://user-images.githubusercontent.com/1220815/229366523-75b708ad-72a8-4e88-87a6-0eb1be00f60e.mov


In the same way as a 2D scene causes a on-hover ray in all space views that contain the space camera at which the 2D view "sits".

Arguably a small piece of #1025 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
