### PR TITLE
Always create the log_time timeline

### DIFF
--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -40,7 +40,6 @@ impl TimeHistogramPerTimeline {
 // ----------------------------------------------------------------------------
 
 /// Number of messages per time per timeline
-#[derive(Default)]
 pub struct TimesPerTimeline(BTreeMap<Timeline, BTreeSet<TimeInt>>);
 
 impl TimesPerTimeline {
@@ -76,6 +75,13 @@ impl TimesPerTimeline {
         &mut self,
     ) -> impl ExactSizeIterator<Item = (&Timeline, &mut BTreeSet<TimeInt>)> {
         self.0.iter_mut()
+    }
+}
+
+// Always ensure we have a default "log_time" timeline.
+impl Default for TimesPerTimeline {
+    fn default() -> Self {
+        Self(BTreeMap::from([(Timeline::log_time(), Default::default())]))
     }
 }
 

--- a/crates/re_viewer/src/misc/time_control.rs
+++ b/crates/re_viewer/src/misc/time_control.rs
@@ -501,11 +501,11 @@ impl TimeControl {
 }
 
 fn min(values: &BTreeSet<TimeInt>) -> TimeInt {
-    *values.iter().next().unwrap()
+    *values.iter().next().unwrap_or(&TimeInt::BEGINNING)
 }
 
 fn max(values: &BTreeSet<TimeInt>) -> TimeInt {
-    *values.iter().rev().next().unwrap()
+    *values.iter().rev().next().unwrap_or(&TimeInt::BEGINNING)
 }
 
 fn range(values: &BTreeSet<TimeInt>) -> TimeRange {


### PR DESCRIPTION
This gives us a valid timeline on which to view timeless data if no other data is logged.

Resolves:
 - https://github.com/rerun-io/rerun/issues/1175

Known issues: the timeline view still does not show the data:
![image](https://user-images.githubusercontent.com/3312232/229809686-22ce343b-0358-4544-bbe4-07801ea364c8.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
