### PR TITLE
Better handle scroll-to-zoom in 3D views

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -288,7 +288,8 @@ pub fn view_3d(
         state
             .state_3d
             .update_eye(&response, &state.scene_bbox_accum, &scene.space_cameras);
-    let did_interact_with_eye = orbit_eye.interact(&response, orbit_eye_drag_threshold);
+    let did_interact_with_eye =
+        orbit_eye.interact(&response, orbit_eye_drag_threshold, &state.scene_bbox_accum);
 
     let orbit_eye = *orbit_eye;
     let eye = orbit_eye.to_eye();


### PR DESCRIPTION
Problem: when radius shrinks, scrolling no longer does much. This makes the user think something is broken.

Solution: switch to dolly when radius is small enough. That way scrolling will always move you closer, one way or another.

Closes https://github.com/rerun-io/rerun/issues/965 (but does not address os-specific scroll/zoom speed problems)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
