### PR TITLE
Don't initialize an SDK session if we are only going to be launching the app

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -306,9 +306,14 @@ def spawn(port: int = 9876, connect: bool = True) -> None:
         print("Rerun is disabled - spawn() call ignored")
         return
 
+    import os
     import subprocess
     import sys
     from time import sleep
+
+    # Let the spawned rerun process know it's just an app
+    new_env = os.environ.copy()
+    new_env["RERUN_APP_ONLY"] = "true"
 
     # sys.executable: the absolute path of the executable binary for the Python interpreter
     python_executable = sys.executable
@@ -317,7 +322,7 @@ def spawn(port: int = 9876, connect: bool = True) -> None:
 
     # start_new_session=True ensures the spawned process does NOT die when
     # we hit ctrl-c in the terminal running the parent Python process.
-    subprocess.Popen([python_executable, "-m", "rerun", "--port", str(port)], start_new_session=True)
+    subprocess.Popen([python_executable, "-m", "rerun", "--port", str(port)], env=new_env, start_new_session=True)
 
     # TODO(emilk): figure out a way to postpone connecting until the rerun viewer is listening.
     # For example, wait until it prints "Hosting a SDK server over TCP at …"


### PR DESCRIPTION
This is a bit hacky but solves some of the gratuitous session initialization stuff that normally happens on import of rerun but is otherwise totally unnecessary if we are just calling through to `bindings.main()`.

Resolves:
 - https://github.com/rerun-io/rerun/issues/1649

A better way to do this might be to instead bundle a pure rust binary with the python package and run that via Subprocess instead of going through the python library indirection logic.

This now only prints a single message about session initialization:
```
$ RERUN=on python points.py 
[2023-04-04T16:01:04Z INFO  re_sdk] Rerun Logging is enabled by the 'RERUN' environment variable.
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
