### PR TITLE
Fix compilation of `rerun` without native_viewer feature

### DIFF
--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -263,7 +263,14 @@ async fn run_impl(
     let rx = if let Some(url_or_path) = args.url_or_path.clone() {
         match categorize_argument(url_or_path) {
             ArgumentCategory::RrdHttpUrl(url) => {
-                re_viewer::stream_rrd_from_http::stream_rrd_from_http_to_channel(url)
+                #[cfg(feature = "native_viewer")]
+                {
+                    re_viewer::stream_rrd_from_http::stream_rrd_from_http_to_channel(url)
+                }
+                #[cfg(not(feature = "native_viewer"))]
+                {
+                    anyhow::bail!("Can't start viewer - rerun was compiled without the 'native_viewer' feature");
+                }
             }
             ArgumentCategory::RrdFilePath(path) => {
                 re_log::info!("Loading {path:?}…");


### PR DESCRIPTION
Fix build with `--no-default-features --features sdk`. This should have been caught by the CI but wasn't. Is this related to `--locked`?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
