### PR TITLE
Add `minimal_options` example for Rust SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minimal_options"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "clap 4.1.4",
+ "glam",
+ "rerun",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "minimal_options"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+rerun = { workspace = true, features = ["web_viewer"] }
+
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+glam.workspace = true

--- a/examples/rust/minimal_options/src/main.rs
+++ b/examples/rust/minimal_options/src/main.rs
@@ -1,0 +1,66 @@
+//! Demonstrates how to accept arguments and connect to running rerun servers.
+//!
+//! Usage:
+//! ```
+//!  cargo run -p minimal_options -- --help
+//! ```
+
+use rerun::components::{ColorRGBA, Point3D};
+use rerun::time::{TimeType, Timeline};
+use rerun::{external::re_log, MsgSender, Session};
+
+use rerun::demo_util::grid;
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[command(flatten)]
+    rerun: rerun::clap::RerunArgs,
+
+    #[clap(long, default_value = "10")]
+    num_points_per_axis: usize,
+
+    #[clap(long, default_value = "5.0")]
+    radius: f32,
+}
+
+fn run(session: &Session, args: &Args) -> anyhow::Result<()> {
+    let timeline_keyframe = Timeline::new("keyframe", TimeType::Sequence);
+
+    let points = grid(
+        glam::Vec3::splat(-args.radius),
+        glam::Vec3::splat(args.radius),
+        args.num_points_per_axis,
+    )
+    .map(Point3D::from)
+    .collect::<Vec<_>>();
+    let colors = grid(
+        glam::Vec3::ZERO,
+        glam::Vec3::splat(255.0),
+        args.num_points_per_axis,
+    )
+    .map(|v| ColorRGBA::from_rgb(v.x as u8, v.y as u8, v.z as u8))
+    .collect::<Vec<_>>();
+
+    MsgSender::new("my_points")
+        .with_component(&points)?
+        .with_component(&colors)?
+        .with_time(timeline_keyframe, 0)
+        .send(session)?;
+
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    re_log::setup_native_logging();
+
+    use clap::Parser as _;
+    let args = Args::parse();
+
+    let default_enabled = true;
+    args.rerun
+        .clone()
+        .run("minimal_options", default_enabled, move |session| {
+            run(&session, &args).unwrap();
+        })
+}


### PR DESCRIPTION
This is just the minimal example, with a couple of command line arguments (--num-points and --radius).

Note, this tends to crash a rerun server, with for example 200^3 points:
cargo run -p minimal_options -- --connect --num-points=200 --radius=10.0

Although I believe this is a known limitation/issue:  #1136, I thought perhaps this PR would fix this: #959

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
