### PR TITLE
Always send recording_id as part of LogMsg

### DIFF
--- a/crates/re_data_store/examples/memory_usage.rs
+++ b/crates/re_data_store/examples/memory_usage.rs
@@ -48,7 +48,7 @@ fn live_bytes() -> usize {
 
 // ----------------------------------------------------------------------------
 
-use re_log_types::{entity_path, DataRow, MsgId};
+use re_log_types::{entity_path, DataRow, MsgId, RecordingId};
 
 fn main() {
     log_messages();
@@ -91,6 +91,7 @@ fn log_messages() {
 
     const NUM_POINTS: usize = 1_000;
 
+    let recording_id = RecordingId::random();
     let timeline = Timeline::new_sequence("frame_nr");
     let mut time_point = TimePoint::default();
     time_point.insert(timeline, TimeInt::from(0));
@@ -116,7 +117,10 @@ fn log_messages() {
             .into_table(),
         );
         let table_bytes = live_bytes() - used_bytes_start;
-        let log_msg = Box::new(LogMsg::ArrowMsg(ArrowMsg::try_from(&*table).unwrap()));
+        let log_msg = Box::new(LogMsg::ArrowMsg(
+            recording_id,
+            ArrowMsg::try_from(&*table).unwrap(),
+        ));
         let log_msg_bytes = live_bytes() - used_bytes_start;
         println!("Arrow payload containing a Pos2 uses {table_bytes} bytes in RAM");
         let encoded = encode_log_msg(&log_msg);
@@ -139,7 +143,10 @@ fn log_messages() {
             .into_table(),
         );
         let table_bytes = live_bytes() - used_bytes_start;
-        let log_msg = Box::new(LogMsg::ArrowMsg(ArrowMsg::try_from(&*table).unwrap()));
+        let log_msg = Box::new(LogMsg::ArrowMsg(
+            recording_id,
+            ArrowMsg::try_from(&*table).unwrap(),
+        ));
         let log_msg_bytes = live_bytes() - used_bytes_start;
         println!("Arrow payload containing a Pos2 uses {table_bytes} bytes in RAM");
         let encoded = encode_log_msg(&log_msg);

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -235,7 +235,7 @@ impl LogDb {
 
         match &msg {
             LogMsg::BeginRecordingMsg(msg) => self.add_begin_recording_msg(msg),
-            LogMsg::EntityPathOpMsg(msg) => {
+            LogMsg::EntityPathOpMsg(_, msg) => {
                 let EntityPathOpMsg {
                     msg_id,
                     time_point,
@@ -243,7 +243,7 @@ impl LogDb {
                 } = msg;
                 self.entity_db.add_path_op(*msg_id, time_point, path_op);
             }
-            LogMsg::ArrowMsg(inner) => self.entity_db.try_add_arrow_msg(inner)?,
+            LogMsg::ArrowMsg(_, inner) => self.entity_db.try_add_arrow_msg(inner)?,
             LogMsg::Goodbye(_) => {}
         }
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -206,26 +206,7 @@ impl LogMsg {
     }
 }
 
-impl From<BeginRecordingMsg> for LogMsg {
-    #[inline]
-    fn from(value: BeginRecordingMsg) -> Self {
-        Self::BeginRecordingMsg(value)
-    }
-}
-
-impl From<(RecordingId, EntityPathOpMsg)> for LogMsg {
-    #[inline]
-    fn from(value: (RecordingId, EntityPathOpMsg)) -> Self {
-        Self::EntityPathOpMsg(value.0, value.1)
-    }
-}
-
-impl From<(RecordingId, ArrowMsg)> for LogMsg {
-    #[inline]
-    fn from(value: (RecordingId, ArrowMsg)) -> Self {
-        Self::ArrowMsg(value.0, value.1)
-    }
-}
+impl_into_enum!(BeginRecordingMsg, LogMsg, BeginRecordingMsg);
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -1,12 +1,13 @@
+use std::borrow::Borrow;
+
 use re_log_types::{component_types::InstanceKey, DataRow, DataTableError, RecordingId};
 
 use crate::{
     components::Transform,
     log::{DataCell, LogMsg, MsgId},
-    session::RecordingLogSink,
     sink::LogSink,
     time::{Time, TimeInt, TimePoint, Timeline},
-    Component, EntityPath, SerializableComponent,
+    Component, EntityPath, SerializableComponent, Session,
 };
 
 // TODO(#1619): Rust SDK batching
@@ -230,8 +231,8 @@ impl MsgSender {
 
     /// Consumes, packs, sanity checks and finally sends the message to the currently configured
     /// target of the SDK.
-    pub fn send(self, sink: &impl RecordingLogSink) -> Result<(), DataTableError> {
-        self.send_to_sink(sink.get_recording_id(), sink.borrow())
+    pub fn send(self, session: &Session) -> Result<(), DataTableError> {
+        self.send_to_sink(session.recording_id(), session.borrow())
     }
 
     /// Consumes, packs, sanity checks and finally sends the message to the currently configured

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -305,6 +305,7 @@ impl std::borrow::Borrow<dyn LogSink> for Session {
     }
 }
 
+/// Trait to expose [`RecordingId`] from a session
 pub trait HasRecordingId {
     fn get_recording_id(&self) -> RecordingId;
 }
@@ -317,5 +318,7 @@ impl HasRecordingId for Session {
     }
 }
 
+/// Composite trait for accessing [`LogSink`] and [`RecordingId`] from session-like objects
 pub trait RecordingLogSink: std::borrow::Borrow<dyn LogSink> + HasRecordingId {}
+
 impl<T: std::borrow::Borrow<dyn LogSink> + HasRecordingId> RecordingLogSink for T {}

--- a/crates/re_sdk/src/session.rs
+++ b/crates/re_sdk/src/session.rs
@@ -287,7 +287,7 @@ impl Session {
         path_op: re_log_types::PathOp,
     ) {
         self.send(LogMsg::EntityPathOpMsg(
-            self.get_recording_id(),
+            self.recording_id(),
             re_log_types::EntityPathOpMsg {
                 msg_id: re_log_types::MsgId::random(),
                 time_point: time_point.clone(),
@@ -299,6 +299,11 @@ impl Session {
     /// Drain all buffered [`LogMsg`]es and return them.
     pub fn drain_backlog(&self) -> Vec<LogMsg> {
         self.sink.drain_backlog()
+    }
+
+    /// The current [`RecordingId`].
+    pub fn recording_id(&self) -> RecordingId {
+        self.recording_info.recording_id
     }
 }
 
@@ -313,19 +318,3 @@ impl std::borrow::Borrow<dyn LogSink> for Session {
         self.sink.as_ref()
     }
 }
-
-/// Trait to expose [`RecordingId`] from a session
-pub trait HasRecordingId {
-    fn get_recording_id(&self) -> RecordingId;
-}
-
-impl HasRecordingId for Session {
-    fn get_recording_id(&self) -> RecordingId {
-        self.recording_info.recording_id
-    }
-}
-
-/// Composite trait for accessing [`LogSink`] and [`RecordingId`] from session-like objects
-pub trait RecordingLogSink: std::borrow::Borrow<dyn LogSink> + HasRecordingId {}
-
-impl<T: std::borrow::Borrow<dyn LogSink> + HasRecordingId> RecordingLogSink for T {}

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -209,9 +209,11 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::BeginRecordingMsg(_) | LogMsg::EntityPathOpMsg(_) | LogMsg::Goodbye(_) => true,
+            LogMsg::BeginRecordingMsg(_) | LogMsg::EntityPathOpMsg(_, _) | LogMsg::Goodbye(_) => {
+                true
+            }
 
-            LogMsg::ArrowMsg(arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
+            LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }
     }
 

--- a/crates/re_viewer/src/ui/data_ui/log_msg.rs
+++ b/crates/re_viewer/src/ui/data_ui/log_msg.rs
@@ -16,8 +16,8 @@ impl DataUi for LogMsg {
     ) {
         match self {
             LogMsg::BeginRecordingMsg(msg) => msg.data_ui(ctx, ui, verbosity, query),
-            LogMsg::EntityPathOpMsg(msg) => msg.data_ui(ctx, ui, verbosity, query),
-            LogMsg::ArrowMsg(msg) => msg.data_ui(ctx, ui, verbosity, query),
+            LogMsg::EntityPathOpMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
+            LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
             LogMsg::Goodbye(_) => {
                 ui.label("Goodbye");
             }

--- a/crates/re_viewer/src/ui/event_log_view.rs
+++ b/crates/re_viewer/src/ui/event_log_view.rs
@@ -141,7 +141,7 @@ fn table_row(
                 ui.monospace(format!("{application_id} - {recording_id:?}"));
             });
         }
-        LogMsg::EntityPathOpMsg(msg) => {
+        LogMsg::EntityPathOpMsg(_, msg) => {
             let EntityPathOpMsg {
                 msg_id,
                 time_point,
@@ -176,7 +176,7 @@ fn table_row(
         // NOTE: This really only makes sense because we don't yet have batches with more than a
         // single row at the moment... and by the time we do, the event log view will have
         // disappeared entirely.
-        LogMsg::ArrowMsg(msg) => match DataTable::try_from(msg) {
+        LogMsg::ArrowMsg(_, msg) => match DataTable::try_from(msg) {
             Ok(table) => {
                 for datarow in table.as_rows() {
                     row.col(|ui| {

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -81,7 +81,7 @@ pub fn get_registered_component_names(py: pyo3::Python<'_>) -> PyResult<&PyDict>
 }
 
 /// Build a [`DataTable`] given a '**kwargs'-style dictionary of component arrays.
-pub fn build_chunk_from_components(
+pub fn build_data_table_from_components(
     entity_path: &EntityPath,
     components: &PyDict,
     time_point: &TimePoint,

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -80,8 +80,7 @@ pub fn get_registered_component_names(py: pyo3::Python<'_>) -> PyResult<&PyDict>
     Ok(fields.into_py_dict(py))
 }
 
-/// Build a [`LogMsg`] and vector of [`Field`] given a '**kwargs'-style dictionary of
-/// component arrays.
+/// Build a [`DataTable`] given a '**kwargs'-style dictionary of component arrays.
 pub fn build_chunk_from_components(
     entity_path: &EntityPath,
     components: &PyDict,

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -9,9 +9,7 @@ use pyo3::{
     types::{IntoPyDict, PyString},
     PyAny, PyResult,
 };
-use re_log_types::{
-    component_types, DataCell, DataRow, DataTableError, EntityPath, LogMsg, MsgId, TimePoint,
-};
+use re_log_types::{component_types, DataCell, DataRow, DataTable, EntityPath, MsgId, TimePoint};
 
 /// Perform conversion between a pyarrow array to arrow2 types.
 ///
@@ -88,7 +86,7 @@ pub fn build_chunk_from_components(
     entity_path: &EntityPath,
     components: &PyDict,
     time_point: &TimePoint,
-) -> PyResult<LogMsg> {
+) -> PyResult<DataTable> {
     let (arrays, fields): (Vec<Box<dyn Array>>, Vec<Field>) = itertools::process_results(
         components.iter().map(|(name, array)| {
             let name = name.downcast::<PyString>()?.to_str()?;
@@ -112,9 +110,7 @@ pub fn build_chunk_from_components(
         cells,
     );
 
-    let msg = (&row.into_table())
-        .try_into()
-        .map_err(|err: DataTableError| PyValueError::new_err(err.to_string()))?;
+    let data_table = row.into_table();
 
-    Ok(LogMsg::ArrowMsg(msg))
+    Ok(data_table)
 }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -980,7 +980,7 @@ fn log_arrow_msg(entity_path: &str, components: &PyDict, timeless: bool) -> PyRe
     // the API we call to back through pyarrow temporarily releases the GIL, which can cause
     // cause a deadlock.
     let data_table =
-        crate::arrow::build_chunk_from_components(&entity_path, components, &time(timeless))?;
+        crate::arrow::build_data_table_from_components(&entity_path, components, &time(timeless))?;
 
     let mut session = python_session();
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -243,10 +243,13 @@ fn main(py: Python<'_>, argv: Vec<String>) -> PyResult<u8> {
 
 #[pyfunction]
 fn get_recording_id() -> PyResult<String> {
-    python_session()
-        .recording_id()
-        .ok_or_else(|| PyTypeError::new_err("module has not been initialized"))
-        .map(|recording_id| recording_id.to_string())
+    let recording_id = python_session().recording_id();
+
+    if recording_id == RecordingId::ZERO {
+        Err(PyTypeError::new_err("module has not been initialized"))
+    } else {
+        Ok(recording_id.to_string())
+    }
 }
 
 #[pyfunction]

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -209,6 +209,12 @@ impl PythonSession {
         if !self.has_sent_begin_recording_msg {
             let info = self.recording_meta_data.to_recording_info();
 
+            // This shouldn't happen, but at least log an error if it does.
+            // See: https://github.com/rerun-io/rerun/issues/1792
+            if info.recording_id == RecordingId::ZERO {
+                re_log::error_once!("RecordingId was still ZERO when sent to server. This is a python initialization bug.");
+            }
+
             re_log::debug!(
                 "Beginning new recording with application_id {:?} and recording id {}",
                 info.application_id.0,

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -118,7 +118,7 @@ impl PythonSession {
         }
     }
 
-    /// The current [`RecordingId`], if set.
+    /// The current [`RecordingId`].
     pub fn recording_id(&self) -> RecordingId {
         self.recording_meta_data.recording_id
     }

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use re_log_types::{
-    ApplicationId, BeginRecordingMsg, LogMsg, MsgId, PathOp, RecordingId, RecordingInfo,
+    ApplicationId, ArrowMsg, BeginRecordingMsg, LogMsg, MsgId, PathOp, RecordingId, RecordingInfo,
     RecordingSource, Time, TimePoint,
 };
 
@@ -226,12 +226,20 @@ impl PythonSession {
         self.sink.send(log_msg);
     }
 
+    pub fn send_arrow_msg(&mut self, arrow_msg: ArrowMsg) {
+        let recording_id = self.recording_id().unwrap_or_default();
+        self.send(LogMsg::ArrowMsg(recording_id, arrow_msg));
+    }
+
     /// Send a [`PathOp`].
     pub fn send_path_op(&mut self, time_point: &TimePoint, path_op: PathOp) {
-        self.send(LogMsg::EntityPathOpMsg(re_log_types::EntityPathOpMsg {
-            msg_id: MsgId::random(),
-            time_point: time_point.clone(),
-            path_op,
-        }));
+        self.send(LogMsg::EntityPathOpMsg(
+            self.recording_id().unwrap_or_default(),
+            re_log_types::EntityPathOpMsg {
+                msg_id: MsgId::random(),
+                time_point: time_point.clone(),
+                path_op,
+            },
+        ));
     }
 }


### PR DESCRIPTION
Our comms were previously somewhat stateful -- we assumed all messages received after a BeginRecording belonged to that recording. However, smart channels (as well as rrd files, web sockets, etc.) allow many sessions, including those with different recording_ids, to become interlaced, introducing ambiguity as to which recording a given message belonged to.

This adds some additional overhead to the LogMsg by sending RecordingId per-message. 

Before:
```
Arrow payload containing a Pos2 uses 4493 bytes in RAM
Arrow LogMsg containing a Pos2 uses 10821-15418 bytes in RAM, and 805 bytes encoded
Arrow payload containing a Pos2 uses 27904 bytes in RAM
Arrow LogMsg containing 1000x Pos2 uses 34797-38829 bytes in RAM, and 8091 bytes encoded
```

After:
```
Arrow payload containing a Pos2 uses 4493 bytes in RAM
Arrow LogMsg containing a Pos2 uses 10821-15418 bytes in RAM, and 827 bytes encoded
Arrow payload containing a Pos2 uses 27904 bytes in RAM
Arrow LogMsg containing 1000x Pos2 uses 34797-38829 bytes in RAM, and 8121 bytes encoded
```

Performance benches seem to be in the noise:
```
group                                                 main                                     send_recording_id
-----                                                 ----                                     -----------------
batch_points_arrow/decode_log_msg                     1.00    198.1±4.83µs 48.1 MElem/sec      1.01    200.8±6.73µs 47.5 MElem/sec
batch_points_arrow/decode_message_bundles             1.01  1168.7±27.88ns  8.0 GElem/sec      1.00  1154.9±24.84ns  8.1 GElem/sec
batch_points_arrow/decode_total                       1.00    203.1±6.74µs 46.9 MElem/sec      1.00    203.3±8.41µs 46.9 MElem/sec
batch_points_arrow/encode_log_msg                     1.00    200.6±4.14µs 47.5 MElem/sec      1.07    215.2±3.51µs 44.3 MElem/sec
batch_points_arrow/encode_total                       1.00    367.8±6.64µs 25.9 MElem/sec      1.03   379.8±10.91µs 25.1 MElem/sec
batch_points_arrow/generate_message_bundles           1.01    154.3±2.79µs 61.8 MElem/sec      1.00    153.5±2.24µs 62.1 MElem/sec
batch_points_arrow/generate_messages                  1.00      3.0±0.06µs  3.1 GElem/sec      1.01      3.0±0.03µs  3.1 GElem/sec
mono_points_arrow/decode_log_msg                      1.01    108.3±1.07ms 90.1 KElem/sec      1.00    107.4±2.19ms 91.0 KElem/sec
mono_points_arrow/decode_message_bundles              1.03     30.2±0.41ms 322.9 KElem/sec     1.00     29.5±0.44ms 331.2 KElem/sec
mono_points_arrow/decode_total                        1.01    140.4±0.82ms 69.6 KElem/sec      1.00    139.3±1.51ms 70.1 KElem/sec
mono_points_arrow/encode_log_msg                      1.02     81.2±1.16ms 120.3 KElem/sec     1.00     79.5±0.90ms 122.8 KElem/sec
mono_points_arrow/encode_total                        1.01    167.1±1.07ms 58.4 KElem/sec      1.00    166.2±2.00ms 58.8 KElem/sec
mono_points_arrow/generate_message_bundles            1.03     22.3±1.80ms 438.7 KElem/sec     1.00     21.6±0.40ms 451.8 KElem/sec
mono_points_arrow/generate_messages                   1.00     65.4±0.76ms 149.2 KElem/sec     1.03     67.4±4.63ms 144.8 KElem/sec
mono_points_arrow_batched/decode_log_msg              1.03   441.0±18.96µs 21.6 MElem/sec      1.00   429.1±13.29µs 22.2 MElem/sec
mono_points_arrow_batched/decode_message_bundles      1.01      6.2±0.12ms 1582.3 KElem/sec    1.00      6.1±0.29ms 1600.5 KElem/sec
mono_points_arrow_batched/decode_total                1.03      6.9±0.17ms 1407.7 KElem/sec    1.00      6.8±0.17ms 1445.0 KElem/sec
mono_points_arrow_batched/encode_log_msg              1.01   780.2±11.06µs 12.2 MElem/sec      1.00   773.8±15.92µs 12.3 MElem/sec
mono_points_arrow_batched/encode_total                1.00     25.2±0.49ms 387.9 KElem/sec     1.01     25.4±1.41ms 385.1 KElem/sec
mono_points_arrow_batched/generate_message_bundles    1.04     19.0±0.31ms 515.0 KElem/sec     1.00     18.2±0.34ms 537.7 KElem/sec
mono_points_arrow_batched/generate_messages           1.05      4.9±0.17ms 1973.2 KElem/sec    1.00      4.7±0.19ms  2.0 MElem/sec
```

However, this overhead will be substantially mitigated by the new batching logic.

Resolves: https://github.com/rerun-io/rerun/issues/903

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
