### PR TITLE
auto_color class-ids if they are present

### DIFF
--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -43,7 +43,7 @@ def run_segmentation() -> None:
         class_ids=np.array([42], dtype=np.uint8),
     )
 
-    rr.log_text_entry("logs/seg_demo_log", "no rects, default colored points, a single point has a label")
+    rr.log_text_entry("logs/seg_demo_log", "default colored rects, default colored points, a single point has a label")
 
     # Log an initial segmentation map with arbitrary colors
     rr.set_time_seconds("sim_time", 2)


### PR DESCRIPTION
I noticed we have had a long-standing regression where segmentation images only get colors assigned to them if they are included in an explicitly logged annotation_context.

This changes the behavior to always use auto_color as long as a class-id was provided, even if annotation context is missing.

![image](https://user-images.githubusercontent.com/3312232/230139441-8a5e5606-b081-4b1b-a6b7-5ab58be54c4a.png)


Resolves: https://github.com/rerun-io/rerun/issues/1782

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
