### PR TITLE
Use copilot markers in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 ### WHAT
 copilot:summary
 ​
-copilot:poem
 
 ### WHY
 <!-- author to complete -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,14 @@
+### WHAT
+copilot:summary
+​
+copilot:poem
+
+### WHY
+<!-- author to complete -->
+
+### HOW
+copilot:walkthrough
+
 ### Checklist
 * [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
 * [ ] I've included a screenshot or gif (if applicable)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56babe5</samp>

This pull request adds a pull request template to the `.github` folder of the rerun-io/rerun repository. The template uses GitHub Copilot to generate a summary, a poem, and a walkthrough of the changes.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 56babe5</samp>

> _`rerun` gets a template_
> _Copilot writes summary and poem_
> _Autumn of code review_

### WHY
We are now part of the copilot beta for PR:s

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56babe5</samp>

* Add a pull request template to the repository ([link](https://github.com/rerun-io/rerun/pull/1784/files?diff=unified&w=0#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R11))

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
