### PR TITLE
Add typing_extensions to requirements-doc.txt

### DIFF
--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -7,3 +7,4 @@ mkdocs-redirects
 mkdocstrings
 mkdocstrings-python
 mike
+typing_extensions # uncaptured dep for mkdocstrings (https://github.com/mkdocstrings/mkdocstrings/issues/548)


### PR DESCRIPTION
Looks like this is a recent regression in mkdocstrings: https://github.com/mkdocstrings/mkdocstrings/issues/548

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
