### PR TITLE
Don't run 3rd party bench suites on CI

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -27,7 +27,7 @@ polars = ["dep:polars-core", "dep:polars-ops"]
 
 ## When set, disables costly benchmark suites that measure the performance of third-party
 ## libraries.
-## Commonly set implictly by --all-features, e.g. on CI.
+## Commonly set implicitly by --all-features, e.g. on CI.
 dont_bench_third_party = []
 
 

--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -25,6 +25,11 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 ## Integration with `polars`, to efficiently use the datastore with dataframes.
 polars = ["dep:polars-core", "dep:polars-ops"]
 
+## When set, disables costly benchmark suites that measure the performance of third-party
+## libraries.
+## Commonly set implictly by --all-features, e.g. on CI.
+dont_bench_third_party = []
+
 
 [dependencies]
 # Rerun dependencies:

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -9,7 +9,7 @@ use arrow2::{
     array::{Array, PrimitiveArray, StructArray, UnionArray},
     compute::aggregate::estimated_bytes_size,
 };
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use itertools::Itertools;
 use re_log_types::{
     component_types::{InstanceKey, Point2D, Rect2D},
@@ -23,7 +23,7 @@ use re_log_types::{
 criterion_group!(benches, erased_clone, estimated_size_bytes);
 
 #[cfg(not(feature = "dont_bench_third_party"))]
-criterion_main!(benches);
+criterion::criterion_main!(benches);
 
 // Don't run these benchmarks on CI: they measure the performance of third-party libraries.
 #[cfg(feature = "dont_bench_third_party")]

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -21,7 +21,13 @@ use re_log_types::{
 // ---
 
 criterion_group!(benches, erased_clone, estimated_size_bytes);
+
+#[cfg(not(feature = "dont_bench_third_party"))]
 criterion_main!(benches);
+
+// Don't run these benchmarks on CI: they measure the performance of third-party libraries.
+#[cfg(feature = "dont_bench_third_party")]
+fn main() {}
 
 // ---
 

--- a/crates/re_arrow_store/benches/arrow2_convert.rs
+++ b/crates/re_arrow_store/benches/arrow2_convert.rs
@@ -4,7 +4,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use arrow2::{array::PrimitiveArray, datatypes::PhysicalType, types::PrimitiveType};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use re_log_types::{
     component_types::InstanceKey, external::arrow2_convert::deserialize::TryIntoCollection,
     Component as _, DataCell,
@@ -15,7 +15,7 @@ use re_log_types::{
 criterion_group!(benches, serialize, deserialize);
 
 #[cfg(not(feature = "dont_bench_third_party"))]
-criterion_main!(benches);
+criterion::criterion_main!(benches);
 
 // Don't run these benchmarks on CI: they measure the performance of third-party libraries.
 #[cfg(feature = "dont_bench_third_party")]

--- a/crates/re_arrow_store/benches/arrow2_convert.rs
+++ b/crates/re_arrow_store/benches/arrow2_convert.rs
@@ -13,7 +13,13 @@ use re_log_types::{
 // ---
 
 criterion_group!(benches, serialize, deserialize);
+
+#[cfg(not(feature = "dont_bench_third_party"))]
 criterion_main!(benches);
+
+// Don't run these benchmarks on CI: they measure the performance of third-party libraries.
+#[cfg(feature = "dont_bench_third_party")]
+fn main() {}
 
 // ---
 

--- a/crates/re_arrow_store/benches/vectors.rs
+++ b/crates/re_arrow_store/benches/vectors.rs
@@ -3,7 +3,7 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 
 use smallvec::SmallVec;
 use tinyvec::TinyVec;
@@ -13,7 +13,7 @@ use tinyvec::TinyVec;
 criterion_group!(benches, sort, split, swap, swap_opt);
 
 #[cfg(not(feature = "dont_bench_third_party"))]
-criterion_main!(benches);
+criterion::criterion_main!(benches);
 
 // Don't run these benchmarks on CI: they measure the performance of third-party libraries.
 #[cfg(feature = "dont_bench_third_party")]

--- a/crates/re_arrow_store/benches/vectors.rs
+++ b/crates/re_arrow_store/benches/vectors.rs
@@ -8,8 +8,16 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use smallvec::SmallVec;
 use tinyvec::TinyVec;
 
+// ---
+
 criterion_group!(benches, sort, split, swap, swap_opt);
+
+#[cfg(not(feature = "dont_bench_third_party"))]
 criterion_main!(benches);
+
+// Don't run these benchmarks on CI: they measure the performance of third-party libraries.
+#[cfg(feature = "dont_bench_third_party")]
+fn main() {}
 
 // ---
 


### PR DESCRIPTION
Disables heavy benchmark suites that are only meant to check the performance of third-party libraries when running on CI.

Save :clock1: and :dollar: 