### PR TITLE
chore: change utc time to local time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,9 +630,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -3898,6 +3898,7 @@ dependencies = [
  "arrow2",
  "arrow2_convert",
  "bytemuck",
+ "chrono",
  "criterion",
  "document-features",
  "ecolor",

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -98,6 +98,7 @@ rand = { version = "0.8", optional = true }
 rmp-serde = { version = "1", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 serde_bytes = { version = "0.11", optional = true }
+chrono = "0.4.24"
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/re_log_types/src/time_point/mod.rs
+++ b/crates/re_log_types/src/time_point/mod.rs
@@ -1,3 +1,4 @@
+use chrono::{Local, TimeZone as _};
 use std::collections::{btree_map, BTreeMap};
 
 mod time_int;
@@ -129,6 +130,22 @@ impl TimeType {
             self.format(time_range.min),
             self.format(time_range.max)
         )
+    }
+
+    pub fn format_to_local_time(&self, time_int: TimeInt) -> String {
+        if time_int <= TimeInt::BEGINNING {
+            "-∞".into()
+        } else if time_int >= TimeInt::MAX {
+            "+∞".into()
+        } else {
+            match self {
+                Self::Time => Local
+                    .timestamp_nanos(time_int.0)
+                    .format("%H:%M:%S%.3f")
+                    .to_string(),
+                Self::Sequence => format!("#{}", time_int.0),
+            }
+        }
     }
 }
 

--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -716,7 +716,7 @@ fn current_time_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
         let timeline = ctx.rec_cfg.time_ctrl.timeline();
         if is_time_safe_to_show(ctx.log_db, timeline, time_int.into()) {
             let time_type = ctx.rec_cfg.time_ctrl.time_type();
-            ui.monospace(time_type.format(time_int));
+            ui.monospace(time_type.format_to_local_time(time_int));
         }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/rerun-io/rerun/issues/1714

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

--- 

**!! Added new crate !!**

I've added `Chrono` crate to `re_log_type`. 

Reason: 
1. I search for Chrono in the repository and found that `Arrow2` already depends on `Chrono`. I'm not sure if it's a right idea, but I thought if `Arrow2` already depends on `Chrono` it would be safe to add it to `re_log_type` as well. 
2. This is my first PR here and thought of getting used to the code instead of making drastic changes from start. I'm open for feedback and would implement a solution which doesn't involve `chrono`.

---

**Changes made:**

Added a Method on `TypeType` with name `format_to_local_time` which takes in `TimeInt` and returns a formatted string.

Alternatively, Could've implemented it directly on the `Time`. Open for suggestions here.

<img width="629" alt="Screenshot 2023-04-06 at 9 32 54 AM" src="https://user-images.githubusercontent.com/42001064/230269222-263b2b44-cda1-4e92-be3c-d06a53579885.png">