### PR TITLE
Implement `re_tuid::Tuid::random()` on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "criterion",
  "document-features",
  "getrandom",
+ "instant",
  "once_cell",
  "serde",
 ]

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -28,16 +28,14 @@ serde = ["dep:serde"]
 
 [dependencies]
 document-features = "0.2"
+getrandom = "0.2"
+instant = "0.1"
 once_cell = "1.16"
 
 # Optional dependencies:
 arrow2 = { workspace = true, optional = true }                    # used by arrow2_convert
 arrow2_convert = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-
-# native dependencies:
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-getrandom = "0.2"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -134,7 +134,7 @@ fn nanos_since_epoch() -> u64 {
 #[inline]
 fn random_u64() -> u64 {
     let mut bytes = [0_u8; 8];
-    getrandom::getrandom(&mut bytes).expect("Couldn't get inc");
+    getrandom::getrandom(&mut bytes).expect("Couldn't get random bytes");
     u64::from_le_bytes(bytes)
 }
 


### PR DESCRIPTION
### WHAT
I fixed a long-standing TODO to get `re_tuid::Tuid::random()` working on the web, i.e. so we can produce Tuids in the browser.
​
### WHY
Sparked by https://github.com/rerun-io/rerun/pull/1791#discussion_r1160518770

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
