### PR TITLE
setup_web.sh supports pacman package manager

### DIFF
--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -28,6 +28,7 @@ elif [ -x "$(command -v dnf)" ];     then sudo dnf install $packagesNeeded
 elif [ -x "$(command -v zypper)" ];  then sudo zypper install $packagesNeeded
 elif [ -x "$(command -v apk)" ];     then sudo apk add --no-cache $packagesNeeded
 elif [ -x "$(command -v winget)" ];  then sudo winget add --no-cache $packagesNeeded
+elif [ -x "$(command -v pacman)" ];  then sudo pacman -S $packagesNeeded
 else
     echo "FAILED TO INSTALL PACKAGE: Package manager not found. You must manually install: $packagesNeeded">&2;
     exit 1


### PR DESCRIPTION
### WHAT
setup_web.sh script can now install required packages using the [pacman](https://wiki.archlinux.org/title/pacman) package manager.

### WHY
I tried to set up the repository by following the BUILD.md guide. The setup_dev.sh script failed to the following error:
`FAILED TO INSTALL PACKAGE: Package manager not found. You must manually install: binaryen`.
Arch-based Linux distributions are quite popular, so I figured `pacman` would be a good addition here.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)