### PR TITLE
ci: fix benchmarks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,11 @@ jobs:
         run: |
           cargo bench \
             --all-features \
-            --all \
+            -p re_arrow_store \
+            -p re_data_store \
+            -p re_log_encoding \
+            -p re_query \
+            -p re_tuid \
             -- --output-format=bencher | tee output.txt
 
       - name: Store benchmark result

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,11 +68,7 @@ jobs:
         run: |
           cargo bench \
             --all-features \
-            -p re_arrow_store \
-            -p re_data_store \
-            -p re_log_types \
-            -p re_query \
-            -p re_tuid \
+            --all \
             -- --output-format=bencher | tee output.txt
 
       - name: Store benchmark result

--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -25,10 +25,9 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 ## Integration with `polars`, to efficiently use the datastore with dataframes.
 polars = ["dep:polars-core", "dep:polars-ops"]
 
-## When set, disables costly benchmark suites that measure the performance of third-party
-## libraries.
+## When set, only run the core set of benchmark suites.
 ## Commonly set implicitly by --all-features, e.g. on CI.
-dont_bench_third_party = []
+core_benchmarks_only = []
 
 
 [dependencies]

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -22,11 +22,11 @@ use re_log_types::{
 
 criterion_group!(benches, erased_clone, estimated_size_bytes);
 
-#[cfg(not(feature = "dont_bench_third_party"))]
+#[cfg(not(feature = "core_benchmarks_only"))]
 criterion::criterion_main!(benches);
 
 // Don't run these benchmarks on CI: they measure the performance of third-party libraries.
-#[cfg(feature = "dont_bench_third_party")]
+#[cfg(feature = "core_benchmarks_only")]
 fn main() {}
 
 // ---

--- a/crates/re_arrow_store/benches/arrow2_convert.rs
+++ b/crates/re_arrow_store/benches/arrow2_convert.rs
@@ -14,11 +14,11 @@ use re_log_types::{
 
 criterion_group!(benches, serialize, deserialize);
 
-#[cfg(not(feature = "dont_bench_third_party"))]
+#[cfg(not(feature = "core_benchmarks_only"))]
 criterion::criterion_main!(benches);
 
 // Don't run these benchmarks on CI: they measure the performance of third-party libraries.
-#[cfg(feature = "dont_bench_third_party")]
+#[cfg(feature = "core_benchmarks_only")]
 fn main() {}
 
 // ---

--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -27,10 +27,32 @@ const NUM_ROWS: i64 = 1;
 #[cfg(debug_assertions)]
 const NUM_INSTANCES: i64 = 1;
 
+fn packed() -> &'static [bool] {
+    #[cfg(feature = "core_benchmarks_only")]
+    {
+        &[false]
+    }
+    #[cfg(not(feature = "core_benchmarks_only"))]
+    {
+        &[false, true]
+    }
+}
+
+fn num_rows_per_bucket() -> &'static [u64] {
+    #[cfg(feature = "core_benchmarks_only")]
+    {
+        &[]
+    }
+    #[cfg(not(feature = "core_benchmarks_only"))]
+    {
+        &[0, 2, 32, 2048]
+    }
+}
+
 // --- Benchmarks ---
 
 fn insert(c: &mut Criterion) {
-    for packed in [false, true] {
+    for &packed in packed() {
         let mut group = c.benchmark_group(format!(
             "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/insert"
         ));
@@ -45,9 +67,8 @@ fn insert(c: &mut Criterion) {
             b.iter(|| insert_table(Default::default(), InstanceKey::name(), &table));
         });
 
-        // Emulate more or less buckets
-        let num_rows_per_bucket = [0, 2, 32, 2048];
-        for num_rows_per_bucket in num_rows_per_bucket {
+        // Emulate more or less bucket
+        for &num_rows_per_bucket in num_rows_per_bucket() {
             group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
                 b.iter(|| {
                     insert_table(
@@ -68,7 +89,7 @@ fn insert(c: &mut Criterion) {
 }
 
 fn latest_at(c: &mut Criterion) {
-    for packed in [false, true] {
+    for &packed in packed() {
         let mut group = c.benchmark_group(format!(
             "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/latest_at"
         ));
@@ -92,8 +113,7 @@ fn latest_at(c: &mut Criterion) {
         });
 
         // Emulate more or less buckets
-        let num_rows_per_bucket = [0, 2, 32, 2048];
-        for num_rows_per_bucket in num_rows_per_bucket {
+        for &num_rows_per_bucket in num_rows_per_bucket() {
             let store = insert_table(
                 DataStoreConfig {
                     index_bucket_nb_rows: num_rows_per_bucket,
@@ -122,7 +142,7 @@ fn latest_at(c: &mut Criterion) {
 }
 
 fn latest_at_missing(c: &mut Criterion) {
-    for packed in [false, true] {
+    for &packed in packed() {
         let mut group = c.benchmark_group(format!(
             "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/latest_at_missing"
         ));
@@ -157,8 +177,7 @@ fn latest_at_missing(c: &mut Criterion) {
         });
 
         // Emulate more or less buckets
-        let num_rows_per_bucket = [0, 2, 32, 2048];
-        for num_rows_per_bucket in num_rows_per_bucket {
+        for &num_rows_per_bucket in num_rows_per_bucket() {
             let store = insert_table(
                 DataStoreConfig {
                     index_bucket_nb_rows: num_rows_per_bucket,
@@ -198,7 +217,7 @@ fn latest_at_missing(c: &mut Criterion) {
 }
 
 fn range(c: &mut Criterion) {
-    for packed in [false, true] {
+    for &packed in packed() {
         let mut group = c.benchmark_group(format!(
             "datastore/num_rows={NUM_ROWS}/num_instances={NUM_INSTANCES}/packed={packed}/range"
         ));
@@ -214,8 +233,7 @@ fn range(c: &mut Criterion) {
         });
 
         // Emulate more or less buckets
-        let num_rows_per_bucket = [0, 2, 32, 2048];
-        for num_rows_per_bucket in num_rows_per_bucket {
+        for &num_rows_per_bucket in num_rows_per_bucket() {
             let store = insert_table(
                 DataStoreConfig {
                     index_bucket_nb_rows: num_rows_per_bucket,

--- a/crates/re_arrow_store/benches/vectors.rs
+++ b/crates/re_arrow_store/benches/vectors.rs
@@ -12,11 +12,11 @@ use tinyvec::TinyVec;
 
 criterion_group!(benches, sort, split, swap, swap_opt);
 
-#[cfg(not(feature = "dont_bench_third_party"))]
+#[cfg(not(feature = "core_benchmarks_only"))]
 criterion::criterion_main!(benches);
 
 // Don't run these benchmarks on CI: they measure the performance of third-party libraries.
-#[cfg(feature = "dont_bench_third_party")]
+#[cfg(feature = "core_benchmarks_only")]
 fn main() {}
 
 // ---


### PR DESCRIPTION
Benchmarks are broken on `main` due to the way the workflow is defined:
```yaml
      - name: Run benchmark
        # Use bash shell so we get pipefail behavior with tee
        shell: bash
        run: |
          cargo bench \
            --all-features \
            -p re_arrow_store \
            -p re_data_store \
            -p re_log_types \
            -p re_query \
            -p re_tuid \
            -- --output-format=bencher | tee output.txt
```
`re_log_types` doesn't have benchmarks on `main` anymore since #1772, so the command above fails.

- Bench `re_log_encoding` instead
- Skip some more costly benchmarks in `re_arrow_store` when run on CI, using the mechanism introduced in #1787 