### PR TITLE
Add `rerun --strict`: crash if any warning or error is logged

### DIFF
--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -35,6 +35,11 @@ pub use {
     setup::*,
 };
 
+/// Re-exports of other crates.
+pub mod external {
+    pub use log;
+}
+
 /// Never log anything less serious than a `WARN` from these crates.
 const CRATES_AT_WARN_LEVEL: [&str; 3] = [
     // wgpu crates spam a lot on info level, which is really annoying

--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -23,7 +23,7 @@ fn install_panic_hook(_build_info: BuildInfo) {
     let previous_panic_hook = std::panic::take_hook();
 
     std::panic::set_hook(Box::new(move |panic_info: &std::panic::PanicInfo<'_>| {
-        let callstack = callstack_from("panicking::panic_fmt\n");
+        let callstack = callstack_from(&["panicking::panic_fmt\n"]);
 
         let file_line = panic_info.location().map(|location| {
             let file = anonymize_source_file_path(&std::path::PathBuf::from(location.file()));
@@ -210,21 +210,38 @@ fn install_signal_handler(build_info: BuildInfo) {
     }
 
     fn callstack() -> String {
-        callstack_from("install_signal_handler::signal_handler\n")
+        callstack_from(&["install_signal_handler::signal_handler\n"])
     }
 }
 
-fn callstack_from(start_pattern: &str) -> String {
+/// Get a nicely formatted callstack.
+///
+/// You can give this function a list of substrings to look for, e.g. names of functions.
+/// If any of these substrings matches, anything before that is removed from the callstack.
+/// For example:
+///
+/// ```
+/// fn print_callstack() {
+///     eprintln!("{}", callstack_from(&["print_callstack"]));
+/// }
+/// ```
+pub fn callstack_from(start_patterns: &[&str]) -> String {
     let backtrace = backtrace::Backtrace::new();
     let stack = backtrace_to_string(&backtrace);
 
     // Trim it a bit:
     let mut stack = stack.as_str();
 
+    let start_patterns = start_patterns
+        .iter()
+        .chain(std::iter::once(&"callstack_from"));
+
     // Trim the top (closest to the panic handler) to cut out some noise:
-    if let Some(offset) = stack.find(start_pattern) {
-        let prev_newline = stack[..offset].rfind('\n').map_or(0, |newline| newline + 1);
-        stack = &stack[prev_newline..];
+    for start_pattern in start_patterns {
+        if let Some(offset) = stack.find(start_pattern) {
+            let prev_newline = stack[..offset].rfind('\n').map_or(0, |newline| newline + 1);
+            stack = &stack[prev_newline..];
+        }
     }
 
     // Trim the bottom to cut out code that sets up the callstack:

--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -220,7 +220,7 @@ fn install_signal_handler(build_info: BuildInfo) {
 /// If any of these substrings matches, anything before that is removed from the callstack.
 /// For example:
 ///
-/// ```
+/// ```ignore
 /// fn print_callstack() {
 ///     eprintln!("{}", callstack_from(&["print_callstack"]));
 /// }


### PR DESCRIPTION
Part of <https://github.com/rerun-io/rerun/issues/1483>

Running  with an old `.rrd` file:

```
❯ cargo r -p rerun -- ../nyud.rrd --strict
   Compiling rerun v0.4.0 (/Users/emilk/code/rerun/rerun/crates/rerun)
    Finished dev [optimized + debuginfo] target(s) in 3.86s
     Running `target/debug/rerun ../nyud.rrd --strict`
[2023-04-11T11:58:21Z INFO  rerun::run] --strict mode: any warning or error will cause Rerun to panic.
[2023-04-11T11:58:21Z INFO  rerun::run] Loading "../nyud.rrd"…
[2023-04-11T11:58:21Z WARN  rerun::run] Failed to decode message in "../nyud.rrd": MsgPack error: invalid type: map, expected bytes
warning logged in --strict mode: Failed to decode message in "../nyud.rrd": MsgPack error: invalid type: map, expected bytes
   4: log::__private_api_log
             at log-0.4.17/src/lib.rs:1597:5
   5: rerun::run::load_file_to_channel::{{closure}}
             at rerun/src/run.rs:481:25
❯ 
```

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 511d411</samp>

This pull request refactors the `callstack_from` function and moves it to the `re_log` crate, adds a `--strict` mode to the `rerun` crate that exits on log warnings or errors, and re-exports the `log` crate in the `re_log` crate. These changes improve the error handling and logging capabilities of the `rerun` tool.
​
### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 511d411</samp>

*  Add `--strict` mode to `rerun` crate that panics on any warning or error logs ([link](https://github.com/rerun-io/rerun/pull/1812/files?diff=unified&w=0#diff-c836a3ff2909bd2461f1f6f62576bd006a10f5794ad8d866f7d4ffc77c7ad800R67-R70), [link](https://github.com/rerun-io/rerun/pull/1812/files?diff=unified&w=0#diff-c836a3ff2909bd2461f1f6f62576bd006a10f5794ad8d866f7d4ffc77c7ad800R194-R198), [link](https://github.com/rerun-io/rerun/pull/1812/files?diff=unified&w=0#diff-c836a3ff2909bd2461f1f6f62576bd006a10f5794ad8d866f7d4ffc77c7ad800R551-R582))
*  Refactor `callstack_from` function to take slice of strings

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
