### PR TITLE
End-to-end testing of python logging -> store ingestion

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -216,6 +216,9 @@ jobs:
       - name: Run tests
         run: cd rerun_py/tests && pytest
 
+      - name: Run e2e test
+        run: scripts/run_python_e2e_test.py
+
       - name: Unpack the wheel
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
  "re_analytics",
  "re_build_build_info",
  "re_build_info",
+ "re_data_store",
  "re_format",
  "re_log",
  "re_log_encoding",

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -158,7 +158,8 @@ async fn run_client(
         let msg = crate::decode_log_msg(&packet)?;
 
         if matches!(msg, LogMsg::Goodbye(_)) {
-            re_log::debug!("Client sent goodbye message.");
+            re_log::debug!("Received goodbye message.");
+            tx.send(msg)?;
             return Ok(());
         }
 

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -64,6 +64,7 @@ web_viewer = [
 
 [dependencies]
 re_build_info.workspace = true
+re_data_store.workspace = true
 re_format.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 re_log_types.workspace = true

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -36,45 +36,9 @@ use crate::web_viewer::host_web_viewer;
 #[derive(Debug, clap::Parser)]
 #[clap(author, about)]
 struct Args {
-    /// Print version and quit
-    #[clap(long)]
-    version: bool,
-
-    /// Either a path to a `.rrd` file to load, an http url to an `.rrd` file,
-    /// or a websocket url to a Rerun Server from which to read data
-    ///
-    /// If none is given, a server will be hosted which the Rerun SDK can connect to.
-    url_or_path: Option<String>,
-
-    /// What TCP port do we listen to (for SDK:s to connect to)?
-    #[cfg(feature = "server")]
-    #[clap(long, default_value_t = re_sdk_comms::DEFAULT_SERVER_PORT)]
-    port: u16,
-
-    /// Start the viewer in the browser (instead of locally).
-    /// Requires Rerun to have been compiled with the 'web_viewer' feature.
-    #[clap(long)]
-    web_viewer: bool,
-
-    /// Stream incoming log events to an .rrd file at the given path.
-    #[clap(long)]
-    save: Option<String>,
-
-    /// Start with the puffin profiler running.
-    #[clap(long)]
-    profile: bool,
-
-    /// Exit with a non-zero exit code if any warning or error is logged. Useful for tests.
-    #[clap(long)]
-    strict: bool,
-
-    /// An upper limit on how much memory the Rerun Viewer should use.
-    ///
-    /// When this limit is used, Rerun will purge the oldest data.
-    ///
-    /// Example: `16GB`
-    #[clap(long)]
-    memory_limit: Option<String>,
+    // Note: arguments are sorted lexicographically for nicer `--help` message:
+    #[command(subcommand)]
+    commands: Option<Commands>,
 
     /// Set a maximum input latency, e.g. "200ms" or "10s".
     ///
@@ -86,8 +50,45 @@ struct Args {
     #[clap(long)]
     drop_at_latency: Option<String>,
 
-    #[command(subcommand)]
-    commands: Option<Commands>,
+    /// An upper limit on how much memory the Rerun Viewer should use.
+    ///
+    /// When this limit is used, Rerun will purge the oldest data.
+    ///
+    /// Example: `16GB`
+    #[clap(long)]
+    memory_limit: Option<String>,
+
+    /// What TCP port do we listen to (for SDK:s to connect to)?
+    #[cfg(feature = "server")]
+    #[clap(long, default_value_t = re_sdk_comms::DEFAULT_SERVER_PORT)]
+    port: u16,
+
+    /// Start with the puffin profiler running.
+    #[clap(long)]
+    profile: bool,
+
+    /// Stream incoming log events to an .rrd file at the given path.
+    #[clap(long)]
+    save: Option<String>,
+
+    /// Exit with a non-zero exit code if any warning or error is logged. Useful for tests.
+    #[clap(long)]
+    strict: bool,
+
+    /// Either a path to a `.rrd` file to load, an http url to an `.rrd` file,
+    /// or a websocket url to a Rerun Server from which to read data
+    ///
+    /// If none is given, a server will be hosted which the Rerun SDK can connect to.
+    url_or_path: Option<String>,
+
+    /// Print version and quit
+    #[clap(long)]
+    version: bool,
+
+    /// Start the viewer in the browser (instead of locally).
+    /// Requires Rerun to have been compiled with the 'web_viewer' feature.
+    #[clap(long)]
+    web_viewer: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/justfile
+++ b/justfile
@@ -38,14 +38,15 @@ py-run-all: py-build
     fd main.py | xargs -I _ sh -c "echo _ && python3 _"
 
 # Build and install the package into the venv
-py-build:
+py-build *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     unset CONDA_PREFIX && \
         source venv/bin/activate && \
         maturin develop \
             -m rerun_py/Cargo.toml \
-            --extras="tests"
+            --extras="tests" \
+            {{ARGS}}
 
 # Run autoformatting
 py-format:

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -20,7 +20,7 @@ import time
 def main() -> None:
     build_env = os.environ.copy()
     if "RUST_LOG" in build_env:
-        del build_env["RUST_LOG"] # The user likely only meant it for the actual tests; not the setup
+        del build_env["RUST_LOG"]  # The user likely only meant it for the actual tests; not the setup
 
     print("----------------------------------------------------------")
     print("Building rerun-sdk…")
@@ -31,6 +31,7 @@ def main() -> None:
     print("")
 
     examples = [
+        # Trivial examples that don't require weird dependencies, or downloading data
         "examples/python/api_demo/main.py",
         "examples/python/car/main.py",
         "examples/python/multithreading/main.py",

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -67,10 +67,12 @@ def run_example(example: str) -> None:
     python_process = subprocess.Popen([python_executable, example, "--connect", "--addr", f"127.0.0.1:{port}"])
 
     print("Waiting for python process to finish…")
-    python_process.wait(timeout=30)
+    returncode = python_process.wait(timeout=30)
+    assert returncode == 0, f"python process exited with error code {returncode}"
 
     print("Waiting for rerun process to finish…")
-    rerun_process.wait(timeout=30)
+    returncode = rerun_process.wait(timeout=30)
+    assert returncode == 0, f"rerun process exited with error code {returncode}"
 
 
 if __name__ == "__main__":

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+"""
+Run some of our python exeamples, piping their log stream to the rerun process.
+
+This is an end-to-end test for testing:
+* Our Python API
+* LogMsg encoding/decoding
+* Arrow encoding/decoding
+* TCP connection
+* Data store ingestion
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+
+def main() -> None:
+    build_env = os.environ.copy()
+    if "RUST_LOG" in build_env:
+        del build_env["RUST_LOG"] # The user likely only meant it for the actual tests; not the setup
+
+    print("----------------------------------------------------------")
+    print("Building rerun-sdk…")
+    start_time = time.time()
+    subprocess.Popen(["just", "py-build", "--quiet"], env=build_env).wait()
+    elapsed = time.time() - start_time
+    print(f"rerun-sdk built in {elapsed:.1f} seconds")
+    print("")
+
+    print("----------------------------------------------------------")
+    print("Building rerun…")
+    start_time = time.time()
+    subprocess.Popen(["cargo", "build", "-p", "rerun", "--quiet"], env=build_env).wait()
+    elapsed = time.time() - start_time
+    print(f"rerun built in {elapsed:.1f} seconds")
+    print("")
+
+    examples = [
+        "examples/python/api_demo/main.py",
+        "examples/python/car/main.py",
+        "examples/python/multithreading/main.py",
+        "examples/python/plots/main.py",
+        "examples/python/text_logging/main.py",
+    ]
+    for example in examples:
+        print("----------------------------------------------------------")
+        print(f"Testing {example}…\n")
+        start_time = time.time()
+        run_example(example)
+        elapsed = time.time() - start_time
+        print(f"{example} done in {elapsed:.1f} seconds")
+        print()
+
+    print()
+    print("All tests passed successfully!")
+
+
+def run_example(example: str) -> None:
+    port = 9752
+
+    rerun_process = subprocess.Popen(
+        ["cargo", "run", "-p", "rerun", "--", "--port", str(port), "--strict", "--test-receive"]
+    )
+    time.sleep(0.3)  # Wait for rerun server to start to remove a logged warning
+
+    # sys.executable: the absolute path of the executable binary for the Python interpreter
+    python_executable = sys.executable
+    if python_executable is None:
+        python_executable = "python3"
+
+    python_process = subprocess.Popen([python_executable, example, "--connect", "--addr", f"127.0.0.1:{port}"])
+
+    print("Waiting for python process to finish…")
+    python_process.wait(timeout=30)
+
+    print("Waiting for rerun process to finish…")
+    rerun_process.wait(timeout=30)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -30,14 +30,6 @@ def main() -> None:
     print(f"rerun-sdk built in {elapsed:.1f} seconds")
     print("")
 
-    print("----------------------------------------------------------")
-    print("Building rerun…")
-    start_time = time.time()
-    subprocess.Popen(["cargo", "build", "-p", "rerun", "--quiet"], env=build_env).wait()
-    elapsed = time.time() - start_time
-    print(f"rerun built in {elapsed:.1f} seconds")
-    print("")
-
     examples = [
         "examples/python/api_demo/main.py",
         "examples/python/car/main.py",
@@ -61,15 +53,15 @@ def main() -> None:
 def run_example(example: str) -> None:
     port = 9752
 
-    rerun_process = subprocess.Popen(
-        ["cargo", "run", "-p", "rerun", "--", "--port", str(port), "--strict", "--test-receive"]
-    )
-    time.sleep(0.3)  # Wait for rerun server to start to remove a logged warning
-
     # sys.executable: the absolute path of the executable binary for the Python interpreter
     python_executable = sys.executable
     if python_executable is None:
         python_executable = "python3"
+
+    rerun_process = subprocess.Popen(
+        [python_executable, "-m", "rerun", "--port", str(port), "--strict", "--test-receive"]
+    )
+    time.sleep(0.3)  # Wait for rerun server to start to remove a logged warning
 
     python_process = subprocess.Popen([python_executable, example, "--connect", "--addr", f"127.0.0.1:{port}"])
 


### PR DESCRIPTION
Part of #1483

Try it with: `scripts/run_python_e2e_test.py` (must be in the correct venv).

This tests:
* Our Python API
* `LogMsg` encoding/decoding
* Arrow encoding/decoding
* TCP connection
* Data store ingestion

~This is not yet run on CI.~ I've also added it to CI (waiting to see how that turns out…)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
