### PR TITLE
Fix e2e test on CI: Don't try to re-build rerun-sdk

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -217,7 +217,7 @@ jobs:
         run: cd rerun_py/tests && pytest
 
       - name: Run e2e test
-        run: scripts/run_python_e2e_test.py
+        run: scripts/run_python_e2e_test.py --no-build # rerun-sdk is already built and installed
 
       - name: Unpack the wheel
         shell: bash

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -11,6 +11,7 @@ This is an end-to-end test for testing:
 * Data store ingestion
 """
 
+import argparse
 import os
 import subprocess
 import sys
@@ -18,17 +19,23 @@ import time
 
 
 def main() -> None:
-    build_env = os.environ.copy()
-    if "RUST_LOG" in build_env:
-        del build_env["RUST_LOG"]  # The user likely only meant it for the actual tests; not the setup
+    parser = argparse.ArgumentParser(description="Logs Objectron data using the Rerun SDK.")
+    parser.add_argument("--no-build", action="store_true", help="Skip building rerun-sdk")
 
-    print("----------------------------------------------------------")
-    print("Building rerun-sdk…")
-    start_time = time.time()
-    subprocess.Popen(["just", "py-build", "--quiet"], env=build_env).wait()
-    elapsed = time.time() - start_time
-    print(f"rerun-sdk built in {elapsed:.1f} seconds")
-    print("")
+    if parser.parse_args().no_build:
+        print("Skipping building rerun-sdk - assuming it is already built and up-to-date!")
+    else:
+        build_env = os.environ.copy()
+        if "RUST_LOG" in build_env:
+            del build_env["RUST_LOG"]  # The user likely only meant it for the actual tests; not the setup
+
+        print("----------------------------------------------------------")
+        print("Building rerun-sdk…")
+        start_time = time.time()
+        subprocess.Popen(["just", "py-build", "--quiet"], env=build_env).wait()
+        elapsed = time.time() - start_time
+        print(f"rerun-sdk built in {elapsed:.1f} seconds")
+        print("")
 
     examples = [
         # Trivial examples that don't require weird dependencies, or downloading data


### PR DESCRIPTION
Follow-up to https://github.com/rerun-io/rerun/pull/1817

`just` isn't available on CI, but also, as @jleibs already pointed out, we don't need to re-build `rerun-sdk` on the CI anyways.

Unfortunately we need to merge this to test it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
