### PR TITLE
New API to reset_time

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -484,3 +484,19 @@ def set_time_nanos(timeline: str, nanos: Optional[int]) -> None:
         return
 
     bindings.set_time_nanos(timeline, nanos)
+
+
+def reset_time() -> None:
+    """
+    Clear all timeline information on this thread.
+
+    This is the same as calling `set_time_*` with `None` for all of the active timelines.
+
+    Used for all subsequent logging on the same thread,
+    until the next call to [`rerun.set_time_nanos`][] or [`rerun.set_time_seconds`][].
+    """
+
+    if not bindings.is_enabled():
+        return
+
+    bindings.reset_time()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -59,6 +59,10 @@ impl ThreadInfo {
         Self::with(|ti| ti.set_time(timeline, time_int));
     }
 
+    pub fn reset_thread_time() {
+        Self::with(|ti| ti.reset_time());
+    }
+
     /// Get access to the thread-local [`ThreadInfo`].
     fn with<R>(f: impl FnOnce(&mut ThreadInfo) -> R) -> R {
         use std::cell::RefCell;
@@ -85,6 +89,10 @@ impl ThreadInfo {
         } else {
             self.time_point.remove(&timeline);
         }
+    }
+
+    fn reset_time(&mut self) {
+        self.time_point = TimePoint::default();
     }
 }
 
@@ -144,6 +152,7 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_time_sequence, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_seconds, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_nanos, m)?)?;
+    m.add_function(wrap_pyfunction!(reset_time, m)?)?;
 
     m.add_function(wrap_pyfunction!(log_unknown_transform, m)?)?;
     m.add_function(wrap_pyfunction!(log_rigid3, m)?)?;
@@ -402,6 +411,11 @@ fn set_time_nanos(timeline: &str, ns: Option<i64>) {
         Timeline::new(timeline, TimeType::Time),
         ns.map(|ns| Time::from_ns_since_epoch(ns).into()),
     );
+}
+
+#[pyfunction]
+fn reset_time() {
+    ThreadInfo::reset_thread_time();
 }
 
 fn convert_color(color: Vec<u8>) -> PyResult<[u8; 4]> {


### PR DESCRIPTION
It's helpful to be able to reset the timepoint state without knowing the names of all the timelines.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
