### PR TITLE
Always flush when we remove a sink

### DIFF
--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -331,6 +331,8 @@ fn serve(open_browser: bool) -> PyResult<()> {
 #[pyfunction]
 fn shutdown(py: Python<'_>) {
     re_log::info!("Shutting down the Rerun SDK");
+    // Disconnect the current sink which ensures that
+    // it flushes and cleans up.
     disconnect(py);
 }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -330,7 +330,7 @@ fn serve(open_browser: bool) -> PyResult<()> {
 
 #[pyfunction]
 fn shutdown(py: Python<'_>) {
-    re_log::info!("Shutting down the Rerun SDK");
+    re_log::debug!("Shutting down the Rerun SDK");
     // Disconnect the current sink which ensures that
     // it flushes and cleans up.
     disconnect(py);

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -144,9 +144,23 @@ impl PythonSession {
     /// If the previous sink is [`rerun::sink::BufferedSink`] (the default),
     /// it will be drained and sent to the new sink.
     pub fn set_sink(&mut self, sink: Box<dyn LogSink>) {
+        // Capture the backlog (should only applies if this was a `BufferedSink`)
         let backlog = self.sink.drain_backlog();
+
+        // Before changing the sink, we set drop_if_disconnected and
+        // flush. This ensures that any messages that are currently
+        // buffered will be sent.
+        self.sink.drop_msgs_if_disconnected();
+        self.sink.flush();
         self.sink = sink;
-        self.sink.send_all(backlog);
+
+        if backlog.is_empty() {
+            // If we had no backlog, we need to send the `BeginRecording` message to the new sink.
+            self.has_sent_begin_recording_msg = false;
+        } else {
+            // Otherwise the backlog should have had the `BeginRecording` message in it already.
+            self.sink.send_all(backlog);
+        }
     }
 
     /// Send log data to a remote viewer/server.
@@ -191,11 +205,6 @@ impl PythonSession {
     /// Wait until all logged data have been sent to the remove server (if any).
     pub fn flush(&mut self) {
         self.sink.flush();
-    }
-
-    /// If the tcp session is disconnected, allow it to quit early and drop unsent messages
-    pub fn drop_msgs_if_disconnected(&mut self) {
-        self.sink.drop_msgs_if_disconnected();
     }
 
     /// Send a single [`DataRow`].

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -144,7 +144,7 @@ impl PythonSession {
     /// If the previous sink is [`rerun::sink::BufferedSink`] (the default),
     /// it will be drained and sent to the new sink.
     pub fn set_sink(&mut self, sink: Box<dyn LogSink>) {
-        // Capture the backlog (should only applies if this was a `BufferedSink`)
+        // Capture the backlog (should only apply if this was a `BufferedSink`)
         let backlog = self.sink.drain_backlog();
 
         // Before changing the sink, we set drop_if_disconnected and


### PR DESCRIPTION
Whenever we disconnect (or implicitly disconnect by swapping a sink) we should flush the pending messages.  Additionally disconnect and flush calls both require releasing the GIL (for the same reason as shutdown previously).

This also resolves:
 - https://github.com/rerun-io/rerun/issues/1781

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
