### PR TITLE
GPU colormapping, first step

### DIFF
--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -140,7 +140,8 @@ impl ExtraQueryHistory {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum ColorMap {
+pub enum Colormap {
+    /// Perceptually even
     Grayscale,
     #[default]
     Turbo,
@@ -150,15 +151,15 @@ pub enum ColorMap {
     Inferno,
 }
 
-impl std::fmt::Display for ColorMap {
+impl std::fmt::Display for Colormap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            ColorMap::Grayscale => "Grayscale",
-            ColorMap::Turbo => "Turbo",
-            ColorMap::Viridis => "Viridis",
-            ColorMap::Plasma => "Plasma",
-            ColorMap::Magma => "Magma",
-            ColorMap::Inferno => "Inferno",
+            Colormap::Grayscale => "Grayscale",
+            Colormap::Turbo => "Turbo",
+            Colormap::Viridis => "Viridis",
+            Colormap::Plasma => "Plasma",
+            Colormap::Magma => "Magma",
+            Colormap::Inferno => "Inferno",
         })
     }
 }
@@ -167,7 +168,7 @@ impl std::fmt::Display for ColorMap {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ColorMapper {
     /// Use a well-known color map, pre-implemented as a wgsl module.
-    ColorMap(ColorMap),
+    Colormap(Colormap),
     // TODO(cmc): support textures.
     // TODO(cmc): support custom transfer functions.
 }
@@ -175,7 +176,7 @@ pub enum ColorMapper {
 impl std::fmt::Display for ColorMapper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ColorMapper::ColorMap(colormap) => colormap.fmt(f),
+            ColorMapper::Colormap(colormap) => colormap.fmt(f),
         }
     }
 }
@@ -183,7 +184,7 @@ impl std::fmt::Display for ColorMapper {
 impl Default for ColorMapper {
     #[inline]
     fn default() -> Self {
-        Self::ColorMap(ColorMap::default())
+        Self::Colormap(Colormap::default())
     }
 }
 

--- a/crates/re_log_types/src/component_types/tensor.rs
+++ b/crates/re_log_types/src/component_types/tensor.rs
@@ -369,6 +369,23 @@ impl Tensor {
         self.shape.len()
     }
 
+    /// If this tensor is shaped as an image, return the height, width, and depth of it.
+    pub fn image_height_width_depth(&self) -> Option<[u64; 3]> {
+        if self.shape.len() == 2 {
+            Some([self.shape[0].size, self.shape[1].size, 1])
+        } else if self.shape.len() == 3 {
+            let depth = self.shape[2].size;
+            // gray, rgb, rgba
+            if matches!(depth, 1 | 3 | 4) {
+                Some([self.shape[0].size, self.shape[1].size, depth])
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn is_shaped_like_an_image(&self) -> bool {
         self.num_dim() == 2
             || self.num_dim() == 3 && {

--- a/crates/re_log_types/src/component_types/tensor.rs
+++ b/crates/re_log_types/src/component_types/tensor.rs
@@ -369,15 +369,15 @@ impl Tensor {
         self.shape.len()
     }
 
-    /// If this tensor is shaped as an image, return the height, width, and depth of it.
-    pub fn image_height_width_depth(&self) -> Option<[u64; 3]> {
+    /// If this tensor is shaped as an image, return the height, width, and channels/depth of it.
+    pub fn image_height_width_channels(&self) -> Option<[u64; 3]> {
         if self.shape.len() == 2 {
             Some([self.shape[0].size, self.shape[1].size, 1])
         } else if self.shape.len() == 3 {
-            let depth = self.shape[2].size;
+            let channels = self.shape[2].size;
             // gray, rgb, rgba
-            if matches!(depth, 1 | 3 | 4) {
-                Some([self.shape[0].size, self.shape[1].size, depth])
+            if matches!(channels, 1 | 3 | 4) {
+                Some([self.shape[0].size, self.shape[1].size, channels])
             } else {
                 None
             }

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -197,7 +197,7 @@ impl framework::Example for Render2D {
                     top_left_corner_position: glam::vec3(500.0, 120.0, -0.05),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    colormapped_texture: ColormappedTexture::from_srgba_unorm(
+                    colormapped_texture: ColormappedTexture::from_unorm_srgba(
                         self.rerun_logo_texture.clone(),
                     ),
                     texture_filter_magnification: TextureFilterMag::Nearest,
@@ -213,7 +213,7 @@ impl framework::Example for Render2D {
                     ),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    colormapped_texture: ColormappedTexture::from_srgba_unorm(
+                    colormapped_texture: ColormappedTexture::from_unorm_srgba(
                         self.rerun_logo_texture.clone(),
                     ),
                     texture_filter_magnification: TextureFilterMag::Linear,

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -39,7 +39,7 @@ impl framework::Example for Render2D {
             &mut re_ctx.gpu_resources.textures,
             &Texture2DCreationDesc {
                 label: "rerun logo".into(),
-                data: &image_data,
+                data: image_data.into(),
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
                 width: rerun_logo.width(),
                 height: rerun_logo.height(),

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -1,7 +1,8 @@
 use ecolor::Hsva;
 use re_renderer::{
     renderer::{
-        LineStripFlags, RectangleDrawData, TextureFilterMag, TextureFilterMin, TexturedRect,
+        ColormappedTexture, LineStripFlags, RectangleDrawData, TextureFilterMag, TextureFilterMin,
+        TexturedRect,
     },
     resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc},
     view_builder::{self, Projection, TargetConfiguration, ViewBuilder},
@@ -196,7 +197,9 @@ impl framework::Example for Render2D {
                     top_left_corner_position: glam::vec3(500.0, 120.0, -0.05),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    texture: self.rerun_logo_texture.clone(),
+                    colormapped_texture: ColormappedTexture::from_srgba(
+                        self.rerun_logo_texture.clone(),
+                    ),
                     texture_filter_magnification: TextureFilterMag::Nearest,
                     texture_filter_minification: TextureFilterMin::Linear,
                     ..Default::default()
@@ -210,7 +213,9 @@ impl framework::Example for Render2D {
                     ),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    texture: self.rerun_logo_texture.clone(),
+                    colormapped_texture: ColormappedTexture::from_srgba(
+                        self.rerun_logo_texture.clone(),
+                    ),
                     texture_filter_magnification: TextureFilterMag::Linear,
                     texture_filter_minification: TextureFilterMin::Linear,
                     depth_offset: 1,

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -197,7 +197,7 @@ impl framework::Example for Render2D {
                     top_left_corner_position: glam::vec3(500.0, 120.0, -0.05),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    colormapped_texture: ColormappedTexture::from_srgba(
+                    colormapped_texture: ColormappedTexture::from_srgba_unorm(
                         self.rerun_logo_texture.clone(),
                     ),
                     texture_filter_magnification: TextureFilterMag::Nearest,
@@ -213,7 +213,7 @@ impl framework::Example for Render2D {
                     ),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    colormapped_texture: ColormappedTexture::from_srgba(
+                    colormapped_texture: ColormappedTexture::from_srgba_unorm(
                         self.rerun_logo_texture.clone(),
                     ),
                     texture_filter_magnification: TextureFilterMag::Linear,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -243,7 +243,7 @@ impl framework::Example for RenderDepthClouds {
             &mut re_ctx.gpu_resources.textures,
             &Texture2DCreationDesc {
                 label: "albedo".into(),
-                data: bytemuck::cast_slice(&albedo.rgba8),
+                data: bytemuck::cast_slice(&albedo.rgba8).into(),
                 format: wgpu::TextureFormat::Rgba8UnormSrgb,
                 width: albedo.dimensions.x,
                 height: albedo.dimensions.y,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -20,8 +20,8 @@ use itertools::Itertools;
 use macaw::IsoTransform;
 use re_renderer::{
     renderer::{
-        DepthCloud, DepthCloudDepthData, DepthCloudDrawData, DepthClouds, DrawData,
-        GenericSkyboxDrawData, RectangleDrawData, TexturedRect,
+        ColormappedTexture, DepthCloud, DepthCloudDepthData, DepthCloudDrawData, DepthClouds,
+        DrawData, GenericSkyboxDrawData, RectangleDrawData, TexturedRect,
     },
     resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc},
     view_builder::{self, Projection, ViewBuilder},
@@ -329,7 +329,7 @@ impl framework::Example for RenderDepthClouds {
                     .transform_point3(glam::Vec3::new(1.0, 1.0, 0.0)),
                 extent_u: world_from_model.transform_vector3(-glam::Vec3::X),
                 extent_v: world_from_model.transform_vector3(-glam::Vec3::Y),
-                texture: albedo_handle.clone(),
+                colormapped_texture: ColormappedTexture::from_srgba(albedo_handle.clone()),
                 texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                 texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
                 multiplicative_tint: Rgba::from_white_alpha(0.5),

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -329,7 +329,7 @@ impl framework::Example for RenderDepthClouds {
                     .transform_point3(glam::Vec3::new(1.0, 1.0, 0.0)),
                 extent_u: world_from_model.transform_vector3(-glam::Vec3::X),
                 extent_v: world_from_model.transform_vector3(-glam::Vec3::Y),
-                colormapped_texture: ColormappedTexture::from_srgba(albedo_handle.clone()),
+                colormapped_texture: ColormappedTexture::from_srgba_unorm(albedo_handle.clone()),
                 texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                 texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
                 multiplicative_tint: Rgba::from_white_alpha(0.5),

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -329,7 +329,7 @@ impl framework::Example for RenderDepthClouds {
                     .transform_point3(glam::Vec3::new(1.0, 1.0, 0.0)),
                 extent_u: world_from_model.transform_vector3(-glam::Vec3::X),
                 extent_v: world_from_model.transform_vector3(-glam::Vec3::Y),
-                colormapped_texture: ColormappedTexture::from_srgba_unorm(albedo_handle.clone()),
+                colormapped_texture: ColormappedTexture::from_unorm_srgba(albedo_handle.clone()),
                 texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                 texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
                 multiplicative_tint: Rgba::from_white_alpha(0.5),

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -181,7 +181,7 @@ impl RenderDepthClouds {
                     max_depth_in_world: 5.0,
                     depth_dimensions: depth.dimensions,
                     depth_data: depth.data.clone(),
-                    colormap: re_renderer::ColorMap::ColorMapTurbo,
+                    colormap: re_renderer::Colormap::Turbo,
                     outline_mask_id: Default::default(),
                 }],
                 radius_boost_in_ui_points_for_outlines: 2.5,

--- a/crates/re_renderer/shader/colormap.wgsl
+++ b/crates/re_renderer/shader/colormap.wgsl
@@ -2,18 +2,20 @@
 #import <./utils/srgb.wgsl>
 
 // NOTE: Keep in sync with `colormap.rs`!
-const GRAYSCALE:        u32 = 0u;
-const COLORMAP_TURBO:   u32 = 1u;
-const COLORMAP_VIRIDIS: u32 = 2u;
-const COLORMAP_PLASMA:  u32 = 3u;
-const COLORMAP_MAGMA:   u32 = 4u;
-const COLORMAP_INFERNO: u32 = 5u;
+const COLORMAP_GRAYSCALE: u32 = 1u;
+const COLORMAP_TURBO:     u32 = 2u;
+const COLORMAP_VIRIDIS:   u32 = 3u;
+const COLORMAP_PLASMA:    u32 = 4u;
+const COLORMAP_MAGMA:     u32 = 5u;
+const COLORMAP_INFERNO:   u32 = 6u;
 
 /// Returns a gamma-space sRGB in 0-1 range.
 ///
 /// The input will be saturated to [0, 1] range.
 fn colormap_srgb(which: u32, t: f32) -> Vec3 {
-    if which == COLORMAP_TURBO {
+    if which == COLORMAP_GRAYSCALE {
+        return linear_from_srgb(Vec3(t));
+    } else if which == COLORMAP_TURBO {
         return colormap_turbo_srgb(t);
     } else if which == COLORMAP_VIRIDIS {
         return colormap_viridis_srgb(t);
@@ -23,8 +25,8 @@ fn colormap_srgb(which: u32, t: f32) -> Vec3 {
         return colormap_magma_srgb(t);
     } else if which == COLORMAP_INFERNO {
         return colormap_inferno_srgb(t);
-    } else { // assume grayscale
-        return linear_from_srgb(Vec3(t));
+    } else {
+        return ERROR_RGBA.rgb;
     }
 }
 

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -87,7 +87,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     // Sample the main texture:
     var sampled_value: Vec4;
     if rect_info.sample_type == SAMPLE_TYPE_FLOAT {
-        sampled_value = textureSample(texture_float, texture_sampler, in.texcoord);
+        sampled_value = textureSampleLevel(texture_float, texture_sampler, in.texcoord, 0.0); // TODO(emilk): support mipmaps
     } else if rect_info.sample_type == SAMPLE_TYPE_SINT {
         let icoords = IVec2(in.texcoord * Vec2(textureDimensions(texture_sint).xy));
         sampled_value = Vec4(textureLoad(texture_sint, icoords, 0));

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -43,6 +43,10 @@ struct UniformBuffer {
     range_min_max: Vec2,
 
     color_mapper: u32,
+
+    /// Exponent to raise the normalized texture value.
+    /// Inverse brightness.
+    gamma: f32,
 };
 
 @group(1) @binding(0)
@@ -100,9 +104,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
 
     // Normalize the sample:
     let range = rect_info.range_min_max;
-    let normalized_value: Vec4 = (sampled_value - range.x) / (range.y - range.x);
+    var normalized_value: Vec4 = (sampled_value - range.x) / (range.y - range.x);
 
-    // TODO(emilk): apply a user-specified gamma-curve here
+    // Apply gamma:
+    normalized_value = vec4(pow(normalized_value.rgb, vec3(rect_info.gamma)), normalized_value.a); // TODO(emilk): handle premultiplied alpha
 
     // Apply colormap, if any:
     var texture_color: Vec4;

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -3,13 +3,17 @@
 #import <./global_bindings.wgsl>
 #import <./utils/depth_offset.wgsl>
 
-const SAMPLE_TYPE_FLOAT = 1u;
-const SAMPLE_TYPE_SINT = 2u;
-const SAMPLE_TYPE_UINT = 3u;
+// Keep in sync with mirror in rectangle.rs
 
-const COLOR_MAPPER_OFF = 1u;
+// Which texture to read from?
+const SAMPLE_TYPE_FLOAT = 1u;
+const SAMPLE_TYPE_SINT  = 2u;
+const SAMPLE_TYPE_UINT  = 3u;
+
+// How do we do colormapping?
+const COLOR_MAPPER_OFF      = 1u;
 const COLOR_MAPPER_FUNCTION = 2u;
-const COLOR_MAPPER_TEXTURE = 3u;
+const COLOR_MAPPER_TEXTURE  = 3u;
 
 struct UniformBuffer {
     /// Top left corner position in world space.
@@ -83,7 +87,6 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     let icoords = IVec2(in.texcoord * Vec2(textureDimensions(texture_uint).xy));
 
     // Sample the main texture:
-
     var sampled_value: Vec4;
     if rect_info.sample_type == SAMPLE_TYPE_FLOAT {
         sampled_value = textureSample(texture_float, texture_sampler, in.texcoord);
@@ -103,7 +106,6 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
 
     // Apply colormap, if any:
     var texture_color: Vec4;
-
     if rect_info.color_mapper == COLOR_MAPPER_OFF {
         texture_color = normalized_value;
     } else if rect_info.color_mapper == COLOR_MAPPER_FUNCTION {

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -3,6 +3,10 @@
 #import <./global_bindings.wgsl>
 #import <./utils/depth_offset.wgsl>
 
+const SAMPLE_TYPE_FLOAT = 1u;
+const SAMPLE_TYPE_SINT = 2u;
+const SAMPLE_TYPE_UINT = 3u;
+
 struct UniformBuffer {
     /// Top left corner position in world space.
     top_left_corner_position: Vec3,
@@ -12,7 +16,8 @@ struct UniformBuffer {
     /// Vector that spans up the rectangle from its top left corner along the u axis of the texture.
     extent_u: Vec3,
 
-    sample_type: u32, // 1=float, 2=depth, 3=sint, 4=uint
+    /// Which texture sample to use
+    sample_type: u32,
 
     /// Vector that spans up the rectangle from its top left corner along the v axis of the texture.
     extent_v: Vec3,
@@ -73,13 +78,11 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     // Sample the main texture:
 
     var sampled_value: Vec4;
-    if rect_info.sample_type == 1u {
-        // float
+    if rect_info.sample_type == SAMPLE_TYPE_FLOAT {
         sampled_value = textureSample(texture_float, texture_sampler, in.texcoord);
-    } else if rect_info.sample_type == 3u {
+    } else if rect_info.sample_type == SAMPLE_TYPE_SINT {
         sampled_value = Vec4(textureLoad(texture_sint, icoords, 0));
-    } else if rect_info.sample_type == 4u {
-        // uint
+    } else if rect_info.sample_type == SAMPLE_TYPE_UINT {
         sampled_value = Vec4(textureLoad(texture_uint, icoords, 0));
     } else {
         return ERROR_RGBA; // unknown sample type

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -84,15 +84,15 @@ fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {
 
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) Vec4 {
-    let icoords = IVec2(in.texcoord * Vec2(textureDimensions(texture_uint).xy));
-
     // Sample the main texture:
     var sampled_value: Vec4;
     if rect_info.sample_type == SAMPLE_TYPE_FLOAT {
         sampled_value = textureSample(texture_float, texture_sampler, in.texcoord);
     } else if rect_info.sample_type == SAMPLE_TYPE_SINT {
+        let icoords = IVec2(in.texcoord * Vec2(textureDimensions(texture_sint).xy));
         sampled_value = Vec4(textureLoad(texture_sint, icoords, 0));
     } else if rect_info.sample_type == SAMPLE_TYPE_UINT {
+        let icoords = IVec2(in.texcoord * Vec2(textureDimensions(texture_uint).xy));
         sampled_value = Vec4(textureLoad(texture_uint, icoords, 0));
     } else {
         return ERROR_RGBA; // unknown sample type

--- a/crates/re_renderer/shader/types.wgsl
+++ b/crates/re_renderer/shader/types.wgsl
@@ -48,3 +48,7 @@ const ONE  = Vec4(1.0, 1.0, 1.0, 1.0);
 // fn inf() -> f32 {
 //     return 1.0 / 0.0;
 // }
+
+
+/// The color to use when we encounter an error.
+const ERROR_RGBA = Vec4(1.0, 0.0, 1.0, 1.0);

--- a/crates/re_renderer/src/colormap.rs
+++ b/crates/re_renderer/src/colormap.rs
@@ -5,10 +5,12 @@ use glam::{Vec2, Vec3A, Vec4, Vec4Swizzles};
 // ---
 
 // NOTE: Keep in sync with `colormap.wgsl`!
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ColorMap {
-    // reserve 0 for "disabled"
+    // Reserve 0 for "disabled"
+    /// Perceptually even
+    #[default]
     Grayscale = 1,
     ColorMapTurbo = 2,
     ColorMapViridis = 3,

--- a/crates/re_renderer/src/colormap.rs
+++ b/crates/re_renderer/src/colormap.rs
@@ -7,26 +7,26 @@ use glam::{Vec2, Vec3A, Vec4, Vec4Swizzles};
 // NOTE: Keep in sync with `colormap.wgsl`!
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
-pub enum ColorMap {
+pub enum Colormap {
     // Reserve 0 for "disabled"
     /// Perceptually even
     #[default]
     Grayscale = 1,
-    ColorMapTurbo = 2,
-    ColorMapViridis = 3,
-    ColorMapPlasma = 4,
-    ColorMapMagma = 5,
-    ColorMapInferno = 6,
+    Turbo = 2,
+    Viridis = 3,
+    Plasma = 4,
+    Magma = 5,
+    Inferno = 6,
 }
 
-pub fn colormap_srgb(which: ColorMap, t: f32) -> [u8; 4] {
+pub fn colormap_srgb(which: Colormap, t: f32) -> [u8; 4] {
     match which {
-        ColorMap::Grayscale => grayscale_srgb(t),
-        ColorMap::ColorMapTurbo => colormap_turbo_srgb(t),
-        ColorMap::ColorMapViridis => colormap_viridis_srgb(t),
-        ColorMap::ColorMapPlasma => colormap_plasma_srgb(t),
-        ColorMap::ColorMapMagma => colormap_magma_srgb(t),
-        ColorMap::ColorMapInferno => colormap_inferno_srgb(t),
+        Colormap::Grayscale => grayscale_srgb(t),
+        Colormap::Turbo => colormap_turbo_srgb(t),
+        Colormap::Viridis => colormap_viridis_srgb(t),
+        Colormap::Plasma => colormap_plasma_srgb(t),
+        Colormap::Magma => colormap_magma_srgb(t),
+        Colormap::Inferno => colormap_inferno_srgb(t),
     }
 }
 

--- a/crates/re_renderer/src/colormap.rs
+++ b/crates/re_renderer/src/colormap.rs
@@ -8,12 +8,13 @@ use glam::{Vec2, Vec3A, Vec4, Vec4Swizzles};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ColorMap {
-    Grayscale = 0,
-    ColorMapTurbo = 1,
-    ColorMapViridis = 2,
-    ColorMapPlasma = 3,
-    ColorMapMagma = 4,
-    ColorMapInferno = 5,
+    // reserve 0 for "disabled"
+    Grayscale = 1,
+    ColorMapTurbo = 2,
+    ColorMapViridis = 3,
+    ColorMapPlasma = 4,
+    ColorMapMagma = 5,
+    ColorMapInferno = 6,
 }
 
 pub fn colormap_srgb(which: ColorMap, t: f32) -> [u8; 4] {

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -62,7 +62,7 @@ pub fn load_gltf_from_buffer(
                 format!("gltf image used by {texture_names} in {mesh_name}")
             }
             .into(),
-            data: &data,
+            data: data.into(),
             format,
             width: image.width,
             height: image.height,

--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -33,7 +33,7 @@ pub use allocator::GpuReadbackIdentifier;
 pub use color::Rgba32Unmul;
 pub use colormap::{
     colormap_inferno_srgb, colormap_magma_srgb, colormap_plasma_srgb, colormap_srgb,
-    colormap_turbo_srgb, colormap_viridis_srgb, grayscale_srgb, ColorMap,
+    colormap_turbo_srgb, colormap_viridis_srgb, grayscale_srgb, Colormap,
 };
 pub use context::RenderContext;
 pub use debug_label::DebugLabel;

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -24,7 +24,7 @@ use crate::{
         GpuRenderPipelineHandle, GpuTexture, PipelineLayoutDesc, RenderPipelineDesc,
         Texture2DBufferInfo, TextureDesc,
     },
-    ColorMap, OutlineMaskPreference, PickingLayerProcessor,
+    Colormap, OutlineMaskPreference, PickingLayerProcessor,
 };
 
 use super::{
@@ -160,7 +160,7 @@ pub struct DepthCloud {
     pub depth_data: DepthCloudDepthData,
 
     /// Configures color mapping mode.
-    pub colormap: ColorMap,
+    pub colormap: Colormap,
 
     /// Option outline mask id preference.
     pub outline_mask_id: OutlineMaskPreference,

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -20,7 +20,8 @@ pub use test_triangle::TestTriangleDrawData;
 
 mod rectangles;
 pub use rectangles::{
-    ColormappedTexture, RectangleDrawData, TextureFilterMag, TextureFilterMin, TexturedRect,
+    ColorMapper, ColormappedTexture, RectangleDrawData, TextureFilterMag, TextureFilterMin,
+    TexturedRect,
 };
 
 mod mesh_renderer;

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -19,7 +19,9 @@ mod test_triangle;
 pub use test_triangle::TestTriangleDrawData;
 
 mod rectangles;
-pub use rectangles::{RectangleDrawData, TextureFilterMag, TextureFilterMin, TexturedRect};
+pub use rectangles::{
+    ColormappedTexture, RectangleDrawData, TextureFilterMag, TextureFilterMin, TexturedRect,
+};
 
 mod mesh_renderer;
 pub(crate) use mesh_renderer::MeshRenderer;

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -56,6 +56,10 @@ pub struct ColormappedTexture {
     /// Used to normalize the input values (squash them to the 0-1 range).
     pub range: [f32; 2],
 
+    /// Raise the normalized values to this power (before any color mapping).
+    /// Acts like an inverse brightness.    /// Default: 1.0
+    pub gamma: f32,
+
     /// For any one-component texture, you need to supply a color mapper,
     /// which maps the normalized `.r` component to a color.
     pub color_mapper: Option<ColorMapper>,
@@ -81,6 +85,7 @@ impl Default for ColormappedTexture {
         Self {
             texture: GpuTexture2DHandle::invalid(),
             range: [0.0, 1.0],
+            gamma: 1.0,
             color_mapper: None,
         }
     }
@@ -91,6 +96,7 @@ impl ColormappedTexture {
         Self {
             texture,
             range: [0.0, 1.0],
+            gamma: 1.0,
             color_mapper: None,
         }
     }
@@ -200,7 +206,8 @@ mod gpu_data {
         range_min_max: wgpu_buffer_types::Vec2,
 
         color_mapper: u32,
-        _row_padding: [u32; 3],
+        gamma: f32,
+        _row_padding: [u32; 2],
 
         _end_padding: [wgpu_buffer_types::PaddingRow; 16 - 6],
     }
@@ -215,6 +222,7 @@ mod gpu_data {
             let super::ColormappedTexture {
                 texture: _,
                 range,
+                gamma,
                 color_mapper,
             } = &rectangle.colormapped_texture;
 
@@ -266,6 +274,7 @@ mod gpu_data {
                 outline_mask: rectangle.outline_mask.0.unwrap_or_default().into(),
                 range_min_max: (*range).into(),
                 color_mapper: color_mapper_int,
+                gamma: *gamma,
                 _row_padding: Default::default(),
                 _end_padding: Default::default(),
             })

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -24,7 +24,7 @@ use crate::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
         GpuRenderPipelineHandle, PipelineLayoutDesc, RenderPipelineDesc, SamplerDesc,
     },
-    ColorMap, OutlineMaskPreference, PickingLayerProcessor, Rgba,
+    Colormap, OutlineMaskPreference, PickingLayerProcessor, Rgba,
 };
 
 use super::{
@@ -127,7 +127,7 @@ pub struct ColormappedTexture {
     pub range: [f32; 2],
 
     /// The colormap to apply to single-component textures.
-    pub colormap: ColorMap,
+    pub colormap: Colormap,
 }
 
 impl Default for ColormappedTexture {
@@ -135,7 +135,7 @@ impl Default for ColormappedTexture {
         Self {
             texture: GpuTexture2DHandle::invalid(),
             range: [0.0, 1.0],
-            colormap: ColorMap::default(), // Whatever
+            colormap: Colormap::default(), // Whatever
         }
     }
 }
@@ -145,7 +145,7 @@ impl ColormappedTexture {
         Self {
             texture,
             range: [0.0, 1.0],
-            colormap: ColorMap::default(), // Unused
+            colormap: Colormap::default(), // Unused
         }
     }
 }

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -57,11 +57,16 @@ pub struct ColormappedTexture {
     pub range: [f32; 2],
 
     /// Raise the normalized values to this power (before any color mapping).
-    /// Acts like an inverse brightness.    /// Default: 1.0
+    /// Acts like an inverse brightness.
+    ///
+    /// Default: 1.0
     pub gamma: f32,
 
     /// For any one-component texture, you need to supply a color mapper,
     /// which maps the normalized `.r` component to a color.
+    ///
+    /// Setting a color mapper for a four-component texture is an error.
+    /// Failure to set a color mapper for a one-component texture is an error.
     pub color_mapper: Option<ColorMapper>,
 }
 
@@ -92,7 +97,7 @@ impl Default for ColormappedTexture {
 }
 
 impl ColormappedTexture {
-    pub fn from_srgba_unorm(texture: GpuTexture2DHandle) -> Self {
+    pub fn from_unorm_srgba(texture: GpuTexture2DHandle) -> Self {
         Self {
             texture,
             range: [0.0, 1.0],
@@ -160,7 +165,7 @@ pub enum RectangleError {
     ColormappingRgbaTexture,
 
     #[error("Only 1 and 4 component textures are supported, got {0} components")]
-    UnssuportedComponentCount(u8),
+    UnsupportedComponentCount(u8),
 
     #[error("No color mapper was supplied for this 1-component texture")]
     MissingColorMapper,
@@ -259,7 +264,7 @@ mod gpu_data {
                     }
                 }
                 num_components => {
-                    return Err(RectangleError::UnssuportedComponentCount(num_components))
+                    return Err(RectangleError::UnsupportedComponentCount(num_components))
                 }
             }
 

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -165,6 +165,9 @@ mod gpu_data {
 
     use super::{ColorMapper, RectangleError};
 
+    const SAMPLE_TYPE_FLOAT: u32 = 1;
+    const SAMPLE_TYPE_SINT: u32 = 2;
+    const SAMPLE_TYPE_UINT: u32 = 3;
     // Keep in sync with mirror in rectangle.wgsl
     #[repr(C, align(256))]
     #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
@@ -174,7 +177,7 @@ mod gpu_data {
         pub colormap: u32,
 
         pub extent_u: wgpu_buffer_types::Vec3Unpadded,
-        pub sample_type: u32, // 1=float, 2=depth, 3=sint, 4=uint
+        pub sample_type: u32,
 
         pub extent_v: wgpu_buffer_types::Vec3Unpadded,
         pub depth_offset: f32,
@@ -203,11 +206,12 @@ mod gpu_data {
             } = &rectangle.colormapped_texture;
 
             let sample_type = match texture_info.sample_type {
-                // The number here must match the shader!
-                wgpu::TextureSampleType::Float { .. } => 1,
-                wgpu::TextureSampleType::Depth => 2,
-                wgpu::TextureSampleType::Sint => 3,
-                wgpu::TextureSampleType::Uint => 4,
+                wgpu::TextureSampleType::Float { .. } => SAMPLE_TYPE_FLOAT,
+                wgpu::TextureSampleType::Depth => {
+                    return Err(RectangleError::DepthTexturesNotSupported);
+                }
+                wgpu::TextureSampleType::Sint => SAMPLE_TYPE_SINT,
+                wgpu::TextureSampleType::Uint => SAMPLE_TYPE_UINT,
             };
 
             let mut colormap = 0;

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -47,6 +47,20 @@ mod gpu_data {
 
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 5],
     }
+
+    impl UniformBuffer {
+        pub fn from_textured_rect(rectangle: &super::TexturedRect) -> Self {
+            Self {
+                top_left_corner_position: rectangle.top_left_corner_position.into(),
+                extent_u: rectangle.extent_u.into(),
+                extent_v: rectangle.extent_v.into(),
+                depth_offset: rectangle.depth_offset as f32,
+                multiplicative_tint: rectangle.multiplicative_tint,
+                outline_mask: rectangle.outline_mask.0.unwrap_or_default().into(),
+                end_padding: Default::default(),
+            }
+        }
+    }
 }
 
 /// Texture filter setting for magnification (a texel covers several pixels).
@@ -145,15 +159,9 @@ impl RectangleDrawData {
         let uniform_buffer_bindings = create_and_fill_uniform_buffer_batch(
             ctx,
             "rectangle uniform buffers".into(),
-            rectangles.iter().map(|rectangle| gpu_data::UniformBuffer {
-                top_left_corner_position: rectangle.top_left_corner_position.into(),
-                extent_u: rectangle.extent_u.into(),
-                extent_v: rectangle.extent_v.into(),
-                depth_offset: rectangle.depth_offset as f32,
-                multiplicative_tint: rectangle.multiplicative_tint,
-                outline_mask: rectangle.outline_mask.0.unwrap_or_default().into(),
-                end_padding: Default::default(),
-            }),
+            rectangles
+                .iter()
+                .map(gpu_data::UniformBuffer::from_textured_rect),
         );
 
         let mut instances = Vec::with_capacity(rectangles.len());

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -61,6 +61,7 @@ pub struct TextureManager2D {
     //manager: ResourceManager<Texture2DHandleInner, GpuTextureHandleStrong>,
     white_texture_unorm: GpuTexture2DHandle,
     zeroed_texture_depth: GpuTexture2DHandle,
+    zeroed_texture_sint: GpuTexture2DHandle,
     zeroed_texture_uint: GpuTexture2DHandle,
 
     // For convenience to reduce amount of times we need to pass them around
@@ -116,6 +117,22 @@ impl TextureManager2D {
                 usage: wgpu::TextureUsages::TEXTURE_BINDING,
             },
         )));
+        let zeroed_texture_sint = GpuTexture2DHandle(Some(texture_pool.alloc(
+            &device,
+            &TextureDesc {
+                label: "zeroed pixel - sint".into(),
+                format: wgpu::TextureFormat::Rgba8Sint,
+                size: wgpu::Extent3d {
+                    width: 1,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            },
+        )));
         let zeroed_texture_uint = GpuTexture2DHandle(Some(texture_pool.alloc(
             &device,
             &TextureDesc {
@@ -136,6 +153,7 @@ impl TextureManager2D {
         Self {
             white_texture_unorm,
             zeroed_texture_depth,
+            zeroed_texture_sint,
             zeroed_texture_uint,
             device,
             queue,
@@ -230,6 +248,11 @@ impl TextureManager2D {
     /// Returns a single pixel white pixel with format [`wgpu::TextureFormat::Depth16Unorm`].
     pub fn zeroed_texture_depth(&self) -> &GpuTexture {
         self.zeroed_texture_depth.0.as_ref().unwrap()
+    }
+
+    /// Returns a single pixel white pixel with format [`wgpu::TextureFormat::Rgba8Sint`].
+    pub fn zeroed_texture_sint(&self) -> &GpuTexture {
+        self.zeroed_texture_sint.0.as_ref().unwrap()
     }
 
     /// Returns a single pixel white pixel with format [`wgpu::TextureFormat::Rgba8Uint`].

--- a/crates/re_renderer/src/wgpu_buffer_types.rs
+++ b/crates/re_renderer/src/wgpu_buffer_types.rs
@@ -61,6 +61,13 @@ impl From<glam::Vec2> for Vec2 {
     }
 }
 
+impl From<[f32; 2]> for Vec2 {
+    #[inline]
+    fn from([x, y]: [f32; 2]) -> Self {
+        Vec2 { x, y }
+    }
+}
+
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Zeroable, Pod)]
 pub struct Vec2RowPadded {
@@ -98,10 +105,10 @@ impl From<glam::UVec2> for UVec2 {
 
 impl From<[u8; 2]> for UVec2 {
     #[inline]
-    fn from(v: [u8; 2]) -> Self {
+    fn from([x, y]: [u8; 2]) -> Self {
         UVec2 {
-            x: v[0] as u32,
-            y: v[1] as u32,
+            x: x as u32,
+            y: y as u32,
         }
     }
 }
@@ -129,10 +136,10 @@ impl From<glam::UVec2> for UVec2RowPadded {
 
 impl From<[u8; 2]> for UVec2RowPadded {
     #[inline]
-    fn from(v: [u8; 2]) -> Self {
+    fn from([x, y]: [u8; 2]) -> Self {
         UVec2RowPadded {
-            x: v[0] as u32,
-            y: v[1] as u32,
+            x: x as u32,
+            y: y as u32,
             padding0: 0,
             padding1: 0,
         }

--- a/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
+++ b/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
@@ -50,7 +50,7 @@ impl<'store, 'cache> ColoredTensorView<'store, 'cache> {
     /// Will return None if a valid [`ColorImage`] could not be derived from the [`Tensor`].
     pub fn texture_handle(&self, render_ctx: &mut RenderContext) -> Option<GpuTexture2DHandle> {
         crate::profile_function!();
-        self.colored_image.map(|i| {
+        self.colored_image.map(|image| {
             let texture_key = self.key.hash64();
 
             let debug_name = format!("tensor {:?}", self.tensor.shape());
@@ -58,12 +58,12 @@ impl<'store, 'cache> ColoredTensorView<'store, 'cache> {
             render_ctx.texture_manager_2d.get_or_create(
                 texture_key,
                 &mut render_ctx.gpu_resources.textures,
-                &Texture2DCreationDesc {
+                Texture2DCreationDesc {
                     label: debug_name.into(),
-                    data: bytemuck::cast_slice(&i.pixels),
+                    data: bytemuck::cast_slice(&image.pixels).into(),
                     format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                    width: i.width() as u32,
-                    height: i.height() as u32,
+                    width: image.width() as u32,
+                    height: image.height() as u32,
                 },
             )
         })

--- a/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
+++ b/crates/re_viewer/src/misc/caches/tensor_image_cache.rs
@@ -205,7 +205,7 @@ impl CachedImage {
     fn from_tensor(debug_name: &str, tensor: &Tensor, annotations: &Arc<Annotations>) -> Self {
         crate::profile_function!();
 
-        match apply_color_map(tensor, annotations) {
+        match apply_colormap(tensor, annotations) {
             Ok(colored_image) => {
                 let memory_used = colored_image.pixels.len() * std::mem::size_of::<egui::Color32>();
 
@@ -241,7 +241,7 @@ impl CachedImage {
     }
 }
 
-fn apply_color_map(tensor: &Tensor, annotations: &Arc<Annotations>) -> anyhow::Result<ColorImage> {
+fn apply_colormap(tensor: &Tensor, annotations: &Arc<Annotations>) -> anyhow::Result<ColorImage> {
     match tensor.meaning {
         TensorDataMeaning::Unknown => color_tensor_as_color_image(tensor),
         TensorDataMeaning::ClassId => class_id_tensor_as_color_image(tensor, annotations),

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod mesh_loader;
 pub mod queries;
 mod selection_state;
 pub(crate) mod space_info;
+mod tensor_to_gpu;
 pub(crate) mod time_control;
 pub(crate) mod time_control_ui;
 mod transform_cache;

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod mesh_loader;
 pub mod queries;
 mod selection_state;
 pub(crate) mod space_info;
-mod tensor_to_gpu;
+pub mod tensor_to_gpu;
 pub(crate) mod time_control;
 pub(crate) mod time_control_ui;
 mod transform_cache;

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -1,0 +1,154 @@
+use std::borrow::Cow;
+
+use bytemuck::{allocation::pod_collect_to_vec, cast_slice, Pod};
+use wgpu::TextureFormat;
+
+use re_log_types::component_types::{Tensor, TensorData, TensorTrait as _};
+use re_renderer::resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc};
+
+#[allow(dead_code)] // TODO
+pub fn gpu_texture_handle_from_tensor(
+    render_ctx: &mut re_renderer::RenderContext,
+    debug_name: &str,
+    tensor: &Tensor,
+) -> anyhow::Result<GpuTexture2DHandle> {
+    let texture_key = tensor.id().0.as_u128() as u64;
+    render_ctx.texture_manager_2d.get_or_create_with(
+        texture_key,
+        &mut render_ctx.gpu_resources.textures,
+        || texture_creation_desc_from_tensor(tensor, debug_name),
+    )
+}
+
+fn cast_slice_to_cow<From: Pod>(slice: &[From]) -> Cow<'_, [u8]> {
+    cast_slice(slice).into()
+}
+
+// wgpu doesn't support f64 textures, so we need to convert to f32:
+fn cast_f64_to_f32s(slice: &[f64]) -> Cow<'static, [u8]> {
+    crate::profile_function!();
+    let f32s: Vec<f32> = slice.iter().map(|&f| f as f32).collect::<Vec<f32>>();
+    let bytes: Vec<u8> = pod_collect_to_vec(&f32s);
+    bytes.into()
+}
+
+fn pad_to_four_elements<T: Copy + Default>(data: &[T]) -> Vec<T> {
+    crate::profile_function!();
+    let pad = T::default();
+    data.chunks_exact(3)
+        .flat_map(|chunk| [chunk[0], chunk[1], chunk[2], pad])
+        .collect::<Vec<T>>()
+}
+
+fn pad_and_cast<T: Copy + Default + Pod>(data: &[T]) -> Cow<'static, [u8]> {
+    crate::profile_function!();
+    let padded: Vec<T> = pad_to_four_elements(data);
+    let bytes: Vec<u8> = pod_collect_to_vec(&padded);
+    bytes.into()
+}
+
+fn texture_creation_desc_from_tensor<'a>(
+    tensor: &'a Tensor,
+    debug_name: &str,
+) -> Result<Texture2DCreationDesc<'a>, anyhow::Error> {
+    crate::profile_function!(format!(
+        "dtype: {}, shape: {:?}",
+        tensor.dtype(),
+        tensor.shape()
+    ));
+    let [height, width, depth] = height_width_depth(tensor)?;
+    let (data, format) = match (depth, &tensor.data) {
+        (1, TensorData::U8(buf)) => (cast_slice_to_cow(buf.as_slice()), TextureFormat::R8Uint),
+        (1, TensorData::I8(buf)) => (cast_slice_to_cow(buf), TextureFormat::R8Sint),
+        (1, TensorData::U16(buf)) => (cast_slice_to_cow(buf), TextureFormat::R16Uint),
+        (1, TensorData::I16(buf)) => (cast_slice_to_cow(buf), TextureFormat::R16Sint),
+        (1, TensorData::U32(buf)) => (cast_slice_to_cow(buf), TextureFormat::R32Uint),
+        (1, TensorData::I32(buf)) => (cast_slice_to_cow(buf), TextureFormat::R32Sint),
+        // (1, TensorData::F16(buf)) => (cast_slice_to_cow(buf), TextureFormat::R16Float), TODO(#854)
+        (1, TensorData::F32(buf)) => (cast_slice_to_cow(buf), TextureFormat::R32Float),
+        (1, TensorData::F64(buf)) => (cast_f64_to_f32s(buf), TextureFormat::R32Float),
+
+        // NOTE: 2-channel images are not supported by all of Rerun yet, but are included here for completeness:
+        (2, TensorData::U8(buf)) => (cast_slice_to_cow(buf.as_slice()), TextureFormat::Rg8Uint),
+        (2, TensorData::I8(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg8Sint),
+        (2, TensorData::U16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg16Uint),
+        (2, TensorData::I16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg16Sint),
+        (2, TensorData::U32(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg32Uint),
+        (2, TensorData::I32(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg32Sint),
+        // (2, TensorData::F16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg16Float), TODO(#854)
+        (2, TensorData::F32(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rg32Float),
+        (2, TensorData::F64(buf)) => (cast_f64_to_f32s(buf), TextureFormat::Rg32Float),
+
+        // There are no 3-channel textures in wgpu, so we need to pad to 4 channels:
+        (3, TensorData::U8(buf)) => (pad_and_cast(buf.as_slice()), TextureFormat::Rgba8Uint),
+        (3, TensorData::I8(buf)) => (pad_and_cast(buf), TextureFormat::Rgba8Sint),
+        (3, TensorData::U16(buf)) => (pad_and_cast(buf), TextureFormat::Rgba16Uint),
+        (3, TensorData::I16(buf)) => (pad_and_cast(buf), TextureFormat::Rgba16Sint),
+        (3, TensorData::U32(buf)) => (pad_and_cast(buf), TextureFormat::Rgba32Uint),
+        (3, TensorData::I32(buf)) => (pad_and_cast(buf), TextureFormat::Rgba32Sint),
+        // (3, TensorData::F16(buf)) => (pad_and_cast(buf), TextureFormat::Rgba16Float), TODO(#854)
+        (3, TensorData::F32(buf)) => (pad_and_cast(buf), TextureFormat::Rgba32Float),
+        (3, TensorData::F64(buf)) => {
+            let pad = 0.0;
+            let floats: Vec<f32> = buf
+                .chunks_exact(3)
+                .flat_map(|chunk| [chunk[0] as f32, chunk[1] as f32, chunk[2] as f32, pad])
+                .collect();
+            (
+                pod_collect_to_vec(&floats).into(),
+                TextureFormat::Rgba32Float,
+            )
+        }
+
+        (4, TensorData::U8(buf)) => (cast_slice_to_cow(buf.as_slice()), TextureFormat::Rgba8Uint),
+        (4, TensorData::I8(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba8Sint),
+        (4, TensorData::U16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba16Uint),
+        (4, TensorData::I16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba16Sint),
+        (4, TensorData::U32(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba32Uint),
+        (4, TensorData::I32(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba32Sint),
+        // (4, TensorData::F16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba16Float), TODO(#854)
+        (4, TensorData::F32(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba32Float),
+        (4, TensorData::F64(buf)) => (cast_f64_to_f32s(buf), TextureFormat::Rgba32Float),
+
+        (_depth, dtype) => {
+            anyhow::bail!("Don't know how to turn a tensor of shape={:?} and dtype={dtype:?} into a color image", tensor.shape)
+        }
+    };
+
+    let desc = Texture2DCreationDesc {
+        label: debug_name.into(),
+        data,
+        format,
+        width,
+        height,
+    };
+    Ok(desc)
+}
+
+fn height_width_depth(tensor: &Tensor) -> anyhow::Result<[u32; 3]> {
+    use anyhow::Context as _;
+
+    let shape = &tensor.shape();
+
+    anyhow::ensure!(
+        shape.len() == 2 || shape.len() == 3,
+        "Expected a 2D or 3D tensor, got {shape:?}",
+    );
+
+    let [height, width] = [
+        u32::try_from(shape[0].size).context("tensor too large")?,
+        u32::try_from(shape[1].size).context("tensor too large")?,
+    ];
+    let depth = if shape.len() == 2 { 1 } else { shape[2].size };
+
+    anyhow::ensure!(
+        depth == 1 || depth == 3 || depth == 4,
+        "Expected depth of 1,3,4 (gray, RGB, RGBA), found {depth:?}. Tensor shape: {shape:?}"
+    );
+    debug_assert!(
+        tensor.is_shaped_like_an_image(),
+        "We should make the same checks above, but with actual error messages"
+    );
+
+    Ok([height, width, depth as u32])
+}

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -94,7 +94,10 @@ fn textured_rect_from_color_tensor(
     let gpu_texture = render_ctx.texture_manager_2d.get(&texture_handle)?;
     let texture_format = gpu_texture.creation_desc.format;
 
-    let range = if texture_format == TextureFormat::R8Unorm {
+    let range = if matches!(
+        texture_format,
+        TextureFormat::R8Unorm | TextureFormat::Rgba8UnormSrgb
+    ) {
         [0.0, 1.0]
     } else if texture_format == TextureFormat::R8Snorm {
         [-1.0, 1.0]

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -3,12 +3,14 @@ use std::borrow::Cow;
 use bytemuck::{allocation::pod_collect_to_vec, cast_slice, Pod};
 use wgpu::TextureFormat;
 
-use re_log_types::component_types::{Tensor, TensorData};
+use re_log_types::component_types::{Tensor, TensorData, TensorId};
 use re_renderer::{
     renderer::ColormappedTexture,
     resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc},
     RenderContext,
 };
+
+use super::caches::TensorStats;
 
 // ----------------------------------------------------------------------------
 
@@ -16,71 +18,95 @@ pub fn textured_rect_from_tensor(
     render_ctx: &mut RenderContext,
     debug_name: &str,
     tensor: &Tensor,
+    tensor_stats: &TensorStats,
     annotations: &crate::ui::Annotations,
 ) -> anyhow::Result<ColormappedTexture> {
-    crate::profile_function!();
+    crate::profile_function!(format!(
+        "meaning: {:?}, dtype: {}, shape: {:?}",
+        tensor.meaning,
+        tensor.dtype(),
+        tensor.shape()
+    ));
 
     use re_log_types::component_types::TensorDataMeaning;
 
     match tensor.meaning {
         TensorDataMeaning::Unknown => {
-            textured_rect_from_color_tensor(render_ctx, debug_name, tensor)
+            textured_rect_from_color_tensor(render_ctx, debug_name, tensor, tensor_stats)
         }
         TensorDataMeaning::ClassId => {
             textured_rect_from_class_id_tensor(render_ctx, debug_name, tensor, annotations)
         }
-        TensorDataMeaning::Depth => textured_rect_from_depth_tensor(render_ctx, debug_name, tensor),
+        TensorDataMeaning::Depth => {
+            textured_rect_from_depth_tensor(render_ctx, debug_name, tensor, tensor_stats)
+        }
     }
 }
+
+// ----------------------------------------------------------------------------
+// Color textures:
 
 fn textured_rect_from_color_tensor(
     render_ctx: &mut RenderContext,
     debug_name: &str,
     tensor: &Tensor,
+    tensor_stats: &TensorStats,
 ) -> anyhow::Result<ColormappedTexture> {
-    let texture = get_or_create_texture(render_ctx, tensor, || {
-        texture_creation_desc_from_color_tensor(debug_name, tensor)
+    let texture_handle = get_or_create_texture(render_ctx, tensor.id(), || {
+        let [height, width, depth] = height_width_depth(tensor)?;
+        let (data, format) = match (depth, &tensor.data) {
+            // Use R8Unorm and R8Snorm when we can to get filtering on the GPU:
+            (1, TensorData::U8(buf)) => (cast_slice_to_cow(buf.as_slice()), TextureFormat::R8Unorm),
+            (1, TensorData::I8(buf)) => (cast_slice_to_cow(buf), TextureFormat::R8Snorm),
+
+            // Special handling for sRGB(A) textures:
+            (3, TensorData::U8(buf)) => (
+                pad_and_cast(buf.as_slice(), 255),
+                TextureFormat::Rgba8UnormSrgb,
+            ),
+            (4, TensorData::U8(buf)) => (
+                // TODO(emilk): premultiply alpha
+                cast_slice_to_cow(buf.as_slice()),
+                TextureFormat::Rgba8UnormSrgb,
+            ),
+
+            _ => {
+                // Fallback to general case:
+                return general_texture_creation_desc_from_tensor(debug_name, tensor);
+            }
+        };
+
+        Ok(Texture2DCreationDesc {
+            label: debug_name.into(),
+            data,
+            format,
+            width,
+            height,
+        })
     })?;
-    Ok(ColormappedTexture { texture })
-}
 
-fn texture_creation_desc_from_color_tensor<'a>(
-    debug_name: &str,
-    tensor: &'a Tensor,
-) -> anyhow::Result<Texture2DCreationDesc<'a>> {
-    crate::profile_function!(format!(
-        "dtype: {}, shape: {:?}",
-        tensor.dtype(),
-        tensor.shape()
-    ));
-    let [height, width, depth] = height_width_depth(tensor)?;
-    let (data, format) = match (depth, &tensor.data) {
-        // special handling for sRGB(A) textures:
-        (3, TensorData::U8(buf)) => (
-            pad_and_cast(buf.as_slice(), 255),
-            TextureFormat::Rgba8UnormSrgb,
-        ),
+    let gpu_texture = render_ctx.texture_manager_2d.get(&texture_handle)?;
+    let texture_format = gpu_texture.creation_desc.format;
 
-        (4, TensorData::U8(buf)) => (
-            cast_slice_to_cow(buf.as_slice()),
-            TextureFormat::Rgba8UnormSrgb,
-        ),
-
-        _ => {
-            // Fallback to general case:
-            return general_texture_creation_desc_from_tensor(debug_name, tensor);
-        }
+    let range = if is_unorm(texture_format) {
+        [0.0, 1.0]
+    } else if is_snorm(texture_format) {
+        [-1.0, 1.0]
+    } else {
+        let (min, max) = tensor_stats
+            .range
+            .ok_or_else(|| anyhow::anyhow!("missing tensor range. compressed?"))?;
+        [min as f32, max as f32]
     };
 
-    let desc = Texture2DCreationDesc {
-        label: debug_name.into(),
-        data,
-        format,
-        width,
-        height,
-    };
-    Ok(desc)
+    Ok(ColormappedTexture {
+        texture: texture_handle,
+        range,
+    })
 }
+
+// ----------------------------------------------------------------------------
+// Textures with class_id annotations:
 
 fn textured_rect_from_class_id_tensor(
     _render_ctx: &mut RenderContext,
@@ -91,22 +117,93 @@ fn textured_rect_from_class_id_tensor(
     anyhow::bail!("annotations mapping not implemented")
 }
 
+// ----------------------------------------------------------------------------
+// Depth textures:
+
 fn textured_rect_from_depth_tensor(
-    _render_ctx: &mut RenderContext,
-    _debug_name: &str,
-    _tensor: &Tensor,
+    render_ctx: &mut RenderContext,
+    debug_name: &str,
+    tensor: &Tensor,
+    tensor_stats: &TensorStats,
 ) -> anyhow::Result<ColormappedTexture> {
-    anyhow::bail!("depth tensors not implemented")
+    let [height, width, depth] = height_width_depth(tensor)?;
+    anyhow::ensure!(depth == 1, "Depth tensor of shape {:?}", tensor.shape);
+    let (mut min, mut max) = tensor_range(tensor, tensor_stats)?;
+
+    // Some datatypes are using normalized samplers (see next below)
+    match tensor.data {
+        TensorData::U8(_) => {
+            min /= 255.0;
+            max /= 255.0;
+        }
+        TensorData::I8(_) => {
+            min /= 127.0;
+            max /= 127.0;
+        }
+        _ => {
+            // Other types are passed in as they are to the GPU
+        }
+    }
+
+    let texture = get_or_create_texture(render_ctx, tensor.id(), || {
+        let (data, format) = match &tensor.data {
+            // Use R8Unorm and R8Snorm when we can to get filtering on the GPU:
+            TensorData::U8(buf) => (cast_slice_to_cow(buf.as_slice()), TextureFormat::R8Unorm),
+            TensorData::I8(buf) => (cast_slice_to_cow(buf), TextureFormat::R8Snorm),
+            _ => {
+                return general_texture_creation_desc_from_tensor(debug_name, tensor);
+            }
+        };
+
+        Ok(Texture2DCreationDesc {
+            label: debug_name.into(),
+            data,
+            format,
+            width,
+            height,
+        })
+    })?;
+
+    Ok(ColormappedTexture {
+        texture,
+        range: [min as f32, max as f32],
+    })
+}
+
+fn tensor_range(tensor: &Tensor, tensor_stats: &TensorStats) -> anyhow::Result<(f64, f64)> {
+    let range = tensor_stats.range.ok_or(anyhow::anyhow!(
+        "Depth image had no range!? Was this compressed?"
+    ))?;
+    let (mut min, mut max) = range;
+
+    anyhow::ensure!(
+        min.is_finite() && max.is_finite(),
+        "Depth image had non-finite values"
+    );
+
+    min = min.min(0.0); // Depth usually start at zero.
+
+    if min == max {
+        // Uniform image. We can't remap it to a 0-1 range, so do whatever:
+        min = 0.0;
+        max = if tensor.dtype().is_float() {
+            1.0
+        } else {
+            tensor.dtype().max_value()
+        };
+    }
+
+    Ok((min, max))
 }
 
 // ----------------------------------------------------------------------------
 
 fn get_or_create_texture<'a, Err>(
     render_ctx: &mut RenderContext,
-    tensor: &Tensor,
+    tensor_id: TensorId,
     try_create_texture_desc: impl FnOnce() -> Result<Texture2DCreationDesc<'a>, Err>,
 ) -> Result<GpuTexture2DHandle, Err> {
-    let texture_key = tensor.id().0.as_u128() as u64;
+    let texture_key = tensor_id.0.as_u128() as u64;
     render_ctx.texture_manager_2d.get_or_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,
@@ -193,6 +290,7 @@ fn general_texture_creation_desc_from_tensor<'a>(
             )
         }
 
+        // TODO(emilk): premultiply alpha
         (4, TensorData::U8(buf)) => (cast_slice_to_cow(buf.as_slice()), TextureFormat::Rgba8Uint),
         (4, TensorData::I8(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba8Sint),
         (4, TensorData::U16(buf)) => (cast_slice_to_cow(buf), TextureFormat::Rgba16Uint),
@@ -208,14 +306,13 @@ fn general_texture_creation_desc_from_tensor<'a>(
         }
     };
 
-    let desc = Texture2DCreationDesc {
+    Ok(Texture2DCreationDesc {
         label: debug_name.into(),
         data,
         format,
         width,
         height,
-    };
-    Ok(desc)
+    })
 }
 
 // ----------------------------------------------------------------------------;
@@ -249,3 +346,161 @@ fn height_width_depth(tensor: &Tensor) -> anyhow::Result<[u32; 3]> {
 }
 
 // ----------------------------------------------------------------------------
+
+fn is_unorm(texture_format: TextureFormat) -> bool {
+    match texture_format {
+        TextureFormat::R8Unorm
+        | TextureFormat::R16Unorm
+        | TextureFormat::Rg8Unorm
+        | TextureFormat::Rg16Unorm
+        | TextureFormat::Rgba8Unorm
+        | TextureFormat::Bgra8Unorm
+        | TextureFormat::Rgb10a2Unorm
+        | TextureFormat::Rgba16Unorm
+        | TextureFormat::Depth16Unorm
+        | TextureFormat::Bc1RgbaUnorm
+        | TextureFormat::Bc2RgbaUnorm
+        | TextureFormat::Bc3RgbaUnorm
+        | TextureFormat::Bc4RUnorm
+        | TextureFormat::Bc5RgUnorm
+        | TextureFormat::Bc7RgbaUnorm
+        | TextureFormat::Etc2Rgb8Unorm
+        | TextureFormat::Etc2Rgb8A1Unorm
+        | TextureFormat::Etc2Rgba8Unorm
+        | TextureFormat::EacR11Unorm
+        | TextureFormat::Rgba8UnormSrgb
+        | TextureFormat::Bgra8UnormSrgb
+        | TextureFormat::Bc1RgbaUnormSrgb
+        | TextureFormat::Bc2RgbaUnormSrgb
+        | TextureFormat::Bc3RgbaUnormSrgb
+        | TextureFormat::Bc7RgbaUnormSrgb
+        | TextureFormat::Etc2Rgb8UnormSrgb
+        | TextureFormat::Etc2Rgb8A1UnormSrgb
+        | TextureFormat::Etc2Rgba8UnormSrgb
+        | TextureFormat::EacRg11Unorm => true,
+
+        TextureFormat::R8Snorm
+        | TextureFormat::R8Uint
+        | TextureFormat::R8Sint
+        | TextureFormat::R16Uint
+        | TextureFormat::R16Sint
+        | TextureFormat::R16Snorm
+        | TextureFormat::R16Float
+        | TextureFormat::Rg8Snorm
+        | TextureFormat::Rg8Uint
+        | TextureFormat::Rg8Sint
+        | TextureFormat::R32Uint
+        | TextureFormat::R32Sint
+        | TextureFormat::R32Float
+        | TextureFormat::Rg16Uint
+        | TextureFormat::Rg16Sint
+        | TextureFormat::Rg16Snorm
+        | TextureFormat::Rg16Float
+        | TextureFormat::Rgba8Snorm
+        | TextureFormat::Rgba8Uint
+        | TextureFormat::Rgba8Sint
+        | TextureFormat::Rgb9e5Ufloat
+        | TextureFormat::Rg11b10Float
+        | TextureFormat::Rg32Uint
+        | TextureFormat::Rg32Sint
+        | TextureFormat::Rg32Float
+        | TextureFormat::Rgba16Uint
+        | TextureFormat::Rgba16Sint
+        | TextureFormat::Rgba16Snorm
+        | TextureFormat::Rgba16Float
+        | TextureFormat::Rgba32Uint
+        | TextureFormat::Rgba32Sint
+        | TextureFormat::Rgba32Float
+        | TextureFormat::Stencil8
+        | TextureFormat::Depth24Plus
+        | TextureFormat::Depth24PlusStencil8
+        | TextureFormat::Depth32Float
+        | TextureFormat::Depth32FloatStencil8
+        | TextureFormat::Bc4RSnorm
+        | TextureFormat::Bc5RgSnorm
+        | TextureFormat::Bc6hRgbUfloat
+        | TextureFormat::Bc6hRgbSfloat
+        | TextureFormat::EacR11Snorm
+        | TextureFormat::EacRg11Snorm
+        | TextureFormat::Astc { .. } => false,
+    }
+}
+
+fn is_snorm(texture_format: TextureFormat) -> bool {
+    match texture_format {
+        TextureFormat::R8Snorm
+        | TextureFormat::R16Snorm
+        | TextureFormat::Rg8Snorm
+        | TextureFormat::Rg16Snorm
+        | TextureFormat::Rgba8Snorm
+        | TextureFormat::Rgba16Snorm
+        | TextureFormat::Bc4RSnorm
+        | TextureFormat::Bc5RgSnorm
+        | TextureFormat::EacR11Snorm
+        | TextureFormat::EacRg11Snorm => true,
+
+        TextureFormat::R8Unorm
+        | TextureFormat::R8Uint
+        | TextureFormat::R8Sint
+        | TextureFormat::R16Uint
+        | TextureFormat::R16Sint
+        | TextureFormat::R16Unorm
+        | TextureFormat::R16Float
+        | TextureFormat::Rg8Unorm
+        | TextureFormat::Rg8Uint
+        | TextureFormat::Rg8Sint
+        | TextureFormat::R32Uint
+        | TextureFormat::R32Sint
+        | TextureFormat::R32Float
+        | TextureFormat::Rg16Uint
+        | TextureFormat::Rg16Sint
+        | TextureFormat::Rg16Unorm
+        | TextureFormat::Rg16Float
+        | TextureFormat::Rgba8Unorm
+        | TextureFormat::Rgba8UnormSrgb
+        | TextureFormat::Rgba8Uint
+        | TextureFormat::Rgba8Sint
+        | TextureFormat::Bgra8Unorm
+        | TextureFormat::Bgra8UnormSrgb
+        | TextureFormat::Rgb9e5Ufloat
+        | TextureFormat::Rgb10a2Unorm
+        | TextureFormat::Rg11b10Float
+        | TextureFormat::Rg32Uint
+        | TextureFormat::Rg32Sint
+        | TextureFormat::Rg32Float
+        | TextureFormat::Rgba16Uint
+        | TextureFormat::Rgba16Sint
+        | TextureFormat::Rgba16Unorm
+        | TextureFormat::Rgba16Float
+        | TextureFormat::Rgba32Uint
+        | TextureFormat::Rgba32Sint
+        | TextureFormat::Rgba32Float
+        | TextureFormat::Stencil8
+        | TextureFormat::Depth16Unorm
+        | TextureFormat::Depth24Plus
+        | TextureFormat::Depth24PlusStencil8
+        | TextureFormat::Depth32Float
+        | TextureFormat::Depth32FloatStencil8
+        | TextureFormat::Bc1RgbaUnorm
+        | TextureFormat::Bc1RgbaUnormSrgb
+        | TextureFormat::Bc2RgbaUnorm
+        | TextureFormat::Bc2RgbaUnormSrgb
+        | TextureFormat::Bc3RgbaUnorm
+        | TextureFormat::Bc3RgbaUnormSrgb
+        | TextureFormat::Bc4RUnorm
+        | TextureFormat::Bc5RgUnorm
+        | TextureFormat::Bc6hRgbUfloat
+        | TextureFormat::Bc6hRgbSfloat
+        | TextureFormat::Bc7RgbaUnorm
+        | TextureFormat::Bc7RgbaUnormSrgb
+        | TextureFormat::Etc2Rgb8Unorm
+        | TextureFormat::Etc2Rgb8UnormSrgb
+        | TextureFormat::Etc2Rgb8A1Unorm
+        | TextureFormat::Etc2Rgb8A1UnormSrgb
+        | TextureFormat::Etc2Rgba8Unorm
+        | TextureFormat::Etc2Rgba8UnormSrgb
+        | TextureFormat::EacR11Unorm
+        | TextureFormat::EacRg11Unorm
+        | TextureFormat::Astc { .. } => false,
+    }
+}

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -350,8 +350,10 @@ fn cast_slice_to_cow<From: Pod>(slice: &[From]) -> Cow<'_, [u8]> {
 // wgpu doesn't support f64 textures, so we need to narrow to f32:
 fn narrow_f64_to_f32s(slice: &[f64]) -> Cow<'static, [u8]> {
     crate::profile_function!();
-    let f32s: Vec<f32> = slice.iter().map(|&f| f as f32).collect::<Vec<f32>>();
-    let bytes: Vec<u8> = pod_collect_to_vec(&f32s);
+    let bytes: Vec<u8> = slice
+        .iter()
+        .flat_map(|&f| (f as f32).to_le_bytes())
+        .collect();
     bytes.into()
 }
 

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use bytemuck::{allocation::pod_collect_to_vec, cast_slice, Pod};
 use wgpu::TextureFormat;
 
-use re_log_types::component_types::{Tensor, TensorData, TensorTrait as _};
+use re_log_types::component_types::{Tensor, TensorData};
 use re_renderer::{
     renderer::ColormappedTexture,
     resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc},

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -4,19 +4,116 @@ use bytemuck::{allocation::pod_collect_to_vec, cast_slice, Pod};
 use wgpu::TextureFormat;
 
 use re_log_types::component_types::{Tensor, TensorData, TensorTrait as _};
-use re_renderer::resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc};
+use re_renderer::{
+    resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc},
+    RenderContext,
+};
 
-#[allow(dead_code)] // TODO
-pub fn gpu_texture_handle_from_tensor(
-    render_ctx: &mut re_renderer::RenderContext,
+// ----------------------------------------------------------------------------
+
+pub struct ColormappedTextured {
+    pub texture: GpuTexture2DHandle,
+}
+
+pub fn textured_rect_from_tensor(
+    render_ctx: &mut RenderContext,
     debug_name: &str,
     tensor: &Tensor,
-) -> anyhow::Result<GpuTexture2DHandle> {
+    annotations: &crate::ui::Annotations,
+) -> anyhow::Result<ColormappedTextured> {
+    crate::profile_function!();
+
+    use re_log_types::component_types::TensorDataMeaning;
+
+    match tensor.meaning {
+        TensorDataMeaning::Unknown => {
+            textured_rect_from_color_tensor(render_ctx, debug_name, tensor)
+        }
+        TensorDataMeaning::ClassId => {
+            textured_rect_from_class_id_tensor(render_ctx, debug_name, tensor, annotations)
+        }
+        TensorDataMeaning::Depth => textured_rect_from_depth_tensor(render_ctx, debug_name, tensor),
+    }
+}
+
+fn textured_rect_from_color_tensor(
+    render_ctx: &mut RenderContext,
+    debug_name: &str,
+    tensor: &Tensor,
+) -> anyhow::Result<ColormappedTextured> {
+    let texture = get_or_create_texture(render_ctx, tensor, || {
+        texture_creation_desc_from_color_tensor(debug_name, tensor)
+    })?;
+    Ok(ColormappedTextured { texture })
+}
+
+fn texture_creation_desc_from_color_tensor<'a>(
+    debug_name: &str,
+    tensor: &'a Tensor,
+) -> anyhow::Result<Texture2DCreationDesc<'a>> {
+    crate::profile_function!(format!(
+        "dtype: {}, shape: {:?}",
+        tensor.dtype(),
+        tensor.shape()
+    ));
+    let [height, width, depth] = height_width_depth(tensor)?;
+    let (data, format) = match (depth, &tensor.data) {
+        // special handling for sRGB(A) textures:
+        (3, TensorData::U8(buf)) => (
+            pad_and_cast(buf.as_slice(), 255),
+            TextureFormat::Rgba8UnormSrgb,
+        ),
+
+        (4, TensorData::U8(buf)) => (
+            cast_slice_to_cow(buf.as_slice()),
+            TextureFormat::Rgba8UnormSrgb,
+        ),
+
+        _ => {
+            // Fallback to general case:
+            return general_texture_creation_desc_from_tensor(debug_name, tensor);
+        }
+    };
+
+    let desc = Texture2DCreationDesc {
+        label: debug_name.into(),
+        data,
+        format,
+        width,
+        height,
+    };
+    Ok(desc)
+}
+
+fn textured_rect_from_class_id_tensor(
+    _render_ctx: &mut RenderContext,
+    _debug_name: &str,
+    _tensor: &Tensor,
+    _annotations: &crate::ui::Annotations,
+) -> anyhow::Result<ColormappedTextured> {
+    anyhow::bail!("annotations mapping not implemented")
+}
+
+fn textured_rect_from_depth_tensor(
+    _render_ctx: &mut RenderContext,
+    _debug_name: &str,
+    _tensor: &Tensor,
+) -> anyhow::Result<ColormappedTextured> {
+    anyhow::bail!("depth tensors not implemented")
+}
+
+// ----------------------------------------------------------------------------
+
+fn get_or_create_texture<'a, Err>(
+    render_ctx: &mut RenderContext,
+    tensor: &Tensor,
+    try_create_texture_desc: impl FnOnce() -> Result<Texture2DCreationDesc<'a>, Err>,
+) -> Result<GpuTexture2DHandle, Err> {
     let texture_key = tensor.id().0.as_u128() as u64;
     render_ctx.texture_manager_2d.get_or_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,
-        || texture_creation_desc_from_tensor(tensor, debug_name),
+        try_create_texture_desc,
     )
 }
 
@@ -32,25 +129,24 @@ fn cast_f64_to_f32s(slice: &[f64]) -> Cow<'static, [u8]> {
     bytes.into()
 }
 
-fn pad_to_four_elements<T: Copy + Default>(data: &[T]) -> Vec<T> {
+fn pad_to_four_elements<T: Copy>(data: &[T], pad: T) -> Vec<T> {
     crate::profile_function!();
-    let pad = T::default();
     data.chunks_exact(3)
         .flat_map(|chunk| [chunk[0], chunk[1], chunk[2], pad])
         .collect::<Vec<T>>()
 }
 
-fn pad_and_cast<T: Copy + Default + Pod>(data: &[T]) -> Cow<'static, [u8]> {
+fn pad_and_cast<T: Copy + Pod>(data: &[T], pad: T) -> Cow<'static, [u8]> {
     crate::profile_function!();
-    let padded: Vec<T> = pad_to_four_elements(data);
+    let padded: Vec<T> = pad_to_four_elements(data, pad);
     let bytes: Vec<u8> = pod_collect_to_vec(&padded);
     bytes.into()
 }
 
-fn texture_creation_desc_from_tensor<'a>(
-    tensor: &'a Tensor,
+fn general_texture_creation_desc_from_tensor<'a>(
     debug_name: &str,
-) -> Result<Texture2DCreationDesc<'a>, anyhow::Error> {
+    tensor: &'a Tensor,
+) -> anyhow::Result<Texture2DCreationDesc<'a>> {
     crate::profile_function!(format!(
         "dtype: {}, shape: {:?}",
         tensor.dtype(),
@@ -80,14 +176,14 @@ fn texture_creation_desc_from_tensor<'a>(
         (2, TensorData::F64(buf)) => (cast_f64_to_f32s(buf), TextureFormat::Rg32Float),
 
         // There are no 3-channel textures in wgpu, so we need to pad to 4 channels:
-        (3, TensorData::U8(buf)) => (pad_and_cast(buf.as_slice()), TextureFormat::Rgba8Uint),
-        (3, TensorData::I8(buf)) => (pad_and_cast(buf), TextureFormat::Rgba8Sint),
-        (3, TensorData::U16(buf)) => (pad_and_cast(buf), TextureFormat::Rgba16Uint),
-        (3, TensorData::I16(buf)) => (pad_and_cast(buf), TextureFormat::Rgba16Sint),
-        (3, TensorData::U32(buf)) => (pad_and_cast(buf), TextureFormat::Rgba32Uint),
-        (3, TensorData::I32(buf)) => (pad_and_cast(buf), TextureFormat::Rgba32Sint),
-        // (3, TensorData::F16(buf)) => (pad_and_cast(buf), TextureFormat::Rgba16Float), TODO(#854)
-        (3, TensorData::F32(buf)) => (pad_and_cast(buf), TextureFormat::Rgba32Float),
+        (3, TensorData::U8(buf)) => (pad_and_cast(buf.as_slice(), 0), TextureFormat::Rgba8Uint),
+        (3, TensorData::I8(buf)) => (pad_and_cast(buf, 0), TextureFormat::Rgba8Sint),
+        (3, TensorData::U16(buf)) => (pad_and_cast(buf, 0), TextureFormat::Rgba16Uint),
+        (3, TensorData::I16(buf)) => (pad_and_cast(buf, 0), TextureFormat::Rgba16Sint),
+        (3, TensorData::U32(buf)) => (pad_and_cast(buf, 0), TextureFormat::Rgba32Uint),
+        (3, TensorData::I32(buf)) => (pad_and_cast(buf, 0), TextureFormat::Rgba32Sint),
+        // (3, TensorData::F16(buf)) => (pad_and_cast(buf, 0.0), TextureFormat::Rgba16Float), TODO(#854)
+        (3, TensorData::F32(buf)) => (pad_and_cast(buf, 0.0), TextureFormat::Rgba32Float),
         (3, TensorData::F64(buf)) => {
             let pad = 0.0;
             let floats: Vec<f32> = buf
@@ -125,6 +221,8 @@ fn texture_creation_desc_from_tensor<'a>(
     Ok(desc)
 }
 
+// ----------------------------------------------------------------------------;
+
 fn height_width_depth(tensor: &Tensor) -> anyhow::Result<[u32; 3]> {
     use anyhow::Context as _;
 
@@ -152,3 +250,5 @@ fn height_width_depth(tensor: &Tensor) -> anyhow::Result<[u32; 3]> {
 
     Ok([height, width, depth as u32])
 }
+
+// ----------------------------------------------------------------------------

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -102,6 +102,7 @@ fn textured_rect_from_color_tensor(
     Ok(ColormappedTexture {
         texture: texture_handle,
         range,
+        colormap: re_renderer::ColorMap::Grayscale, // Single-channel images = luminance = grayscale
     })
 }
 
@@ -141,6 +142,7 @@ fn textured_rect_from_depth_tensor(
     Ok(ColormappedTexture {
         texture,
         range: [min as f32, max as f32],
+        colormap: re_renderer::ColorMap::ColorMapTurbo, // TODO(emilk): make this configurable in the UI
     })
 }
 

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -5,22 +5,19 @@ use wgpu::TextureFormat;
 
 use re_log_types::component_types::{Tensor, TensorData, TensorTrait as _};
 use re_renderer::{
+    renderer::ColormappedTexture,
     resource_managers::{GpuTexture2DHandle, Texture2DCreationDesc},
     RenderContext,
 };
 
 // ----------------------------------------------------------------------------
 
-pub struct ColormappedTextured {
-    pub texture: GpuTexture2DHandle,
-}
-
 pub fn textured_rect_from_tensor(
     render_ctx: &mut RenderContext,
     debug_name: &str,
     tensor: &Tensor,
     annotations: &crate::ui::Annotations,
-) -> anyhow::Result<ColormappedTextured> {
+) -> anyhow::Result<ColormappedTexture> {
     crate::profile_function!();
 
     use re_log_types::component_types::TensorDataMeaning;
@@ -40,11 +37,11 @@ fn textured_rect_from_color_tensor(
     render_ctx: &mut RenderContext,
     debug_name: &str,
     tensor: &Tensor,
-) -> anyhow::Result<ColormappedTextured> {
+) -> anyhow::Result<ColormappedTexture> {
     let texture = get_or_create_texture(render_ctx, tensor, || {
         texture_creation_desc_from_color_tensor(debug_name, tensor)
     })?;
-    Ok(ColormappedTextured { texture })
+    Ok(ColormappedTexture { texture })
 }
 
 fn texture_creation_desc_from_color_tensor<'a>(
@@ -90,7 +87,7 @@ fn textured_rect_from_class_id_tensor(
     _debug_name: &str,
     _tensor: &Tensor,
     _annotations: &crate::ui::Annotations,
-) -> anyhow::Result<ColormappedTextured> {
+) -> anyhow::Result<ColormappedTexture> {
     anyhow::bail!("annotations mapping not implemented")
 }
 
@@ -98,7 +95,7 @@ fn textured_rect_from_depth_tensor(
     _render_ctx: &mut RenderContext,
     _debug_name: &str,
     _tensor: &Tensor,
-) -> anyhow::Result<ColormappedTextured> {
+) -> anyhow::Result<ColormappedTexture> {
     anyhow::bail!("depth tensors not implemented")
 }
 

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -157,6 +157,8 @@ fn class_id_tensor_to_gpu(
     // and as many rows as needed to fit all the classes.
     anyhow::ensure!(max <= 65535.0, "Too many class ids");
 
+    // We pack the colormap into a 2D texture so we don't go over the max texture size.
+    // We only support u8 and u16 class ids, so 256^2 is the biggest texture we need.
     let colormap_width = 256;
     let colormap_height = (max as usize + colormap_width - 1) / colormap_width;
 

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -122,6 +122,7 @@ fn color_tensor_to_gpu(
     Ok(ColormappedTexture {
         texture: texture_handle,
         range,
+        gamma: 1.0,
         color_mapper,
     })
 }
@@ -190,6 +191,7 @@ fn class_id_tensor_to_gpu(
     Ok(ColormappedTexture {
         texture: main_texture_handle,
         range: [0.0, (colormap_width * colormap_height) as f32],
+        gamma: 1.0,
         color_mapper: Some(ColorMapper::Texture(colormap_texture_handle)),
     })
 }
@@ -218,7 +220,7 @@ fn depth_tensor_to_gpu(
     Ok(ColormappedTexture {
         texture,
         range: [min as f32, max as f32],
-        // TODO(emilk): make this configurable in the UI
+        gamma: 1.0,
         color_mapper: Some(ColorMapper::Function(re_renderer::Colormap::Turbo)),
     })
 }

--- a/crates/re_viewer/src/misc/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/misc/tensor_to_gpu.rs
@@ -102,7 +102,7 @@ fn textured_rect_from_color_tensor(
     Ok(ColormappedTexture {
         texture: texture_handle,
         range,
-        colormap: re_renderer::ColorMap::Grayscale, // Single-channel images = luminance = grayscale
+        colormap: re_renderer::Colormap::Grayscale, // Single-channel images = luminance = grayscale
     })
 }
 
@@ -142,7 +142,7 @@ fn textured_rect_from_depth_tensor(
     Ok(ColormappedTexture {
         texture,
         range: [min as f32, max as f32],
-        colormap: re_renderer::ColorMap::ColorMapTurbo, // TODO(emilk): make this configurable in the UI
+        colormap: re_renderer::Colormap::Turbo, // TODO(emilk): make this configurable in the UI
     })
 }
 

--- a/crates/re_viewer/src/ui/annotations.rs
+++ b/crates/re_viewer/src/ui/annotations.rs
@@ -21,6 +21,7 @@ pub struct Annotations {
 }
 
 impl Annotations {
+    #[inline]
     pub fn class_description(&self, class_id: Option<ClassId>) -> ResolvedClassDescription<'_> {
         ResolvedClassDescription {
             class_id,
@@ -35,6 +36,7 @@ pub struct ResolvedClassDescription<'a> {
 }
 
 impl<'a> ResolvedClassDescription<'a> {
+    #[inline]
     pub fn annotation_info(&self) -> ResolvedAnnotationInfo {
         ResolvedAnnotationInfo {
             class_id: self.class_id,

--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -231,17 +231,12 @@ fn show_zoomed_image_region_tooltip(
         .on_hover_ui_at_pointer(|ui| {
             ui.set_max_width(320.0);
             ui.horizontal(|ui| {
-                if tensor_view.tensor.is_shaped_like_an_image() {
-                    let h = tensor_view.tensor.shape()[0].size as _;
-                    let w = tensor_view.tensor.shape()[1].size as _;
-
-                    use egui::NumExt;
+                if let Some([h, w, _depth]) = tensor_view.tensor.image_height_width_depth() {
+                    use egui::remap_clamp;
 
                     let center = [
-                        (egui::remap(pointer_pos.x, image_rect.x_range(), 0.0..=w as f32) as isize)
-                            .at_most(w),
-                        (egui::remap(pointer_pos.y, image_rect.y_range(), 0.0..=h as f32) as isize)
-                            .at_most(h),
+                        (remap_clamp(pointer_pos.x, image_rect.x_range(), 0.0..=w as f32) as isize),
+                        (remap_clamp(pointer_pos.y, image_rect.y_range(), 0.0..=h as f32) as isize),
                     ];
                     show_zoomed_image_region_area_outline(
                         parent_ui,
@@ -264,11 +259,11 @@ pub fn show_zoomed_image_region_area_outline(
     [center_x, center_y]: [isize; 2],
     image_rect: egui::Rect,
 ) {
-    if tensor_view.tensor.is_shaped_like_an_image() {
+    if let Some([height, width, _depth]) = tensor_view.tensor.image_height_width_depth() {
         use egui::{pos2, remap, Color32, Rect};
 
-        let h = tensor_view.tensor.shape()[0].size as _;
-        let w = tensor_view.tensor.shape()[1].size as _;
+        let width = width as f32;
+        let height = height as f32;
 
         // Show where on the original image the zoomed-in region is at:
         let left = (center_x - ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
@@ -276,10 +271,10 @@ pub fn show_zoomed_image_region_area_outline(
         let top = (center_y - ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
         let bottom = (center_y + ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
 
-        let left = remap(left, 0.0..=w, image_rect.x_range());
-        let right = remap(right, 0.0..=w, image_rect.x_range());
-        let top = remap(top, 0.0..=h, image_rect.y_range());
-        let bottom = remap(bottom, 0.0..=h, image_rect.y_range());
+        let left = remap(left, 0.0..=width, image_rect.x_range());
+        let right = remap(right, 0.0..=width, image_rect.x_range());
+        let top = remap(top, 0.0..=height, image_rect.y_range());
+        let bottom = remap(bottom, 0.0..=height, image_rect.y_range());
 
         let rect = Rect::from_min_max(pos2(left, top), pos2(right, bottom));
         // TODO(emilk): use `parent_ui.painter()` and put it in a high Z layer, when https://github.com/emilk/egui/issues/1516 is done

--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -231,7 +231,7 @@ fn show_zoomed_image_region_tooltip(
         .on_hover_ui_at_pointer(|ui| {
             ui.set_max_width(320.0);
             ui.horizontal(|ui| {
-                if let Some([h, w, _depth]) = tensor_view.tensor.image_height_width_depth() {
+                if let Some([h, w, _]) = tensor_view.tensor.image_height_width_channels() {
                     use egui::remap_clamp;
 
                     let center = [
@@ -259,7 +259,7 @@ pub fn show_zoomed_image_region_area_outline(
     [center_x, center_y]: [isize; 2],
     image_rect: egui::Rect,
 ) {
-    if let Some([height, width, _depth]) = tensor_view.tensor.image_height_width_depth() {
+    if let Some([height, width, _]) = tensor_view.tensor.image_height_width_channels() {
         use egui::{pos2, remap, Color32, Rect};
 
         let width = width as f32;

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,6 +1,6 @@
 use egui::NumExt as _;
 use re_data_store::{
-    query_latest_single, ColorMap, ColorMapper, EditableAutoValue, EntityPath, EntityProperties,
+    query_latest_single, ColorMapper, Colormap, EditableAutoValue, EntityPath, EntityProperties,
 };
 use re_log_types::{
     component_types::{Tensor, TensorDataMeaning},
@@ -429,12 +429,12 @@ fn colormap_props_ui(ui: &mut egui::Ui, entity_props: &mut EntityProperties) {
                 }
             };
 
-            add_label(ColorMapper::ColorMap(ColorMap::Grayscale));
-            add_label(ColorMapper::ColorMap(ColorMap::Turbo));
-            add_label(ColorMapper::ColorMap(ColorMap::Viridis));
-            add_label(ColorMapper::ColorMap(ColorMap::Plasma));
-            add_label(ColorMapper::ColorMap(ColorMap::Magma));
-            add_label(ColorMapper::ColorMap(ColorMap::Inferno));
+            add_label(ColorMapper::Colormap(Colormap::Grayscale));
+            add_label(ColorMapper::Colormap(Colormap::Turbo));
+            add_label(ColorMapper::Colormap(Colormap::Viridis));
+            add_label(ColorMapper::Colormap(Colormap::Plasma));
+            add_label(ColorMapper::Colormap(Colormap::Magma));
+            add_label(ColorMapper::Colormap(Colormap::Inferno));
         });
 
     ui.end_row();

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -12,7 +12,7 @@ use re_log_types::{
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::{
     renderer::{ColormappedTexture, DepthCloud, DepthCloudDepthData},
-    ColorMap, OutlineMaskPreference,
+    Colormap, OutlineMaskPreference,
 };
 
 use crate::{
@@ -352,13 +352,13 @@ impl ImagesPart {
         let dimensions = glam::UVec2::new(w as _, h as _);
 
         let colormap = match *properties.color_mapper.get() {
-            re_data_store::ColorMapper::ColorMap(colormap) => match colormap {
-                re_data_store::ColorMap::Grayscale => ColorMap::Grayscale,
-                re_data_store::ColorMap::Turbo => ColorMap::ColorMapTurbo,
-                re_data_store::ColorMap::Viridis => ColorMap::ColorMapViridis,
-                re_data_store::ColorMap::Plasma => ColorMap::ColorMapPlasma,
-                re_data_store::ColorMap::Magma => ColorMap::ColorMapMagma,
-                re_data_store::ColorMap::Inferno => ColorMap::ColorMapInferno,
+            re_data_store::ColorMapper::Colormap(colormap) => match colormap {
+                re_data_store::Colormap::Grayscale => Colormap::Grayscale,
+                re_data_store::Colormap::Turbo => Colormap::Turbo,
+                re_data_store::Colormap::Viridis => Colormap::Viridis,
+                re_data_store::Colormap::Plasma => Colormap::Plasma,
+                re_data_store::Colormap::Magma => Colormap::Magma,
+                re_data_store::Colormap::Inferno => Colormap::Inferno,
             },
         };
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -16,7 +16,10 @@ use re_renderer::{
 };
 
 use crate::{
-    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
+    misc::{
+        tensor_to_gpu::ColormappedTextured, SpaceViewHighlights, SpaceViewOutlineMasks,
+        TransformCache, ViewerContext,
+    },
     ui::{
         scene::SceneQuery,
         view_spatial::{scene::scene_part::instance_path_hash_for_picking, Image, SceneSpatial},
@@ -39,9 +42,46 @@ fn push_tensor_texture(
 ) {
     crate::profile_function!();
 
-    let tensor_view = ctx.cache.image.get_colormapped_view(tensor, annotations);
+    let Some([height, width, _depth]) = tensor.image_height_width_depth() else { return; };
 
-    if let Some([height, width, _depth]) = tensor.image_height_width_depth() {
+    let experimental_gpu_colormapping = true;
+    if experimental_gpu_colormapping {
+        let debug_name = "tensor"; // TODO: entity path
+
+        match crate::misc::tensor_to_gpu::textured_rect_from_tensor(
+            ctx.render_ctx,
+            debug_name,
+            tensor,
+            annotations,
+        ) {
+            Ok(colormapped_texture) => {
+                let ColormappedTextured { texture } = colormapped_texture;
+                let textured_rect = re_renderer::renderer::TexturedRect {
+                    top_left_corner_position: world_from_obj.transform_point3(glam::Vec3::ZERO),
+                    extent_u: world_from_obj.transform_vector3(glam::Vec3::X * width as f32),
+                    extent_v: world_from_obj.transform_vector3(glam::Vec3::Y * height as f32),
+                    texture,
+                    texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
+                    texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
+                    multiplicative_tint,
+                    // Push to background. Mostly important for mouse picking order!
+                    depth_offset: -1,
+                    outline_mask,
+                };
+                scene.primitives.textured_rectangles.push(textured_rect);
+                scene
+                    .primitives
+                    .textured_rectangles_ids
+                    .push(instance_path_hash);
+            }
+            Err(err) => {
+                re_log::warn_once!(
+                    "Failed to create texture from tensor for {debug_name:?}: {err}"
+                );
+            }
+        }
+    } else {
+        let tensor_view = ctx.cache.image.get_colormapped_view(tensor, annotations);
         if let Some(texture_handle) = tensor_view.texture_handle(ctx.render_ctx) {
             scene
                 .primitives

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -34,7 +34,7 @@ fn push_tensor_texture(
     world_from_obj: glam::Mat4,
     instance_path_hash: InstancePathHash,
     tensor: &Tensor,
-    tint: egui::Rgba,
+    multiplicative_tint: egui::Rgba,
     outline_mask: OutlineMaskPreference,
 ) {
     crate::profile_function!();
@@ -53,7 +53,7 @@ fn push_tensor_texture(
                     texture: texture_handle,
                     texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                     texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
-                    multiplicative_tint: tint,
+                    multiplicative_tint,
                     // Push to background. Mostly important for mouse picking order!
                     depth_offset: -1,
                     outline_mask,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -41,27 +41,28 @@ fn push_tensor_texture(
 
     let tensor_view = ctx.cache.image.get_colormapped_view(tensor, annotations);
 
-    if let Some(texture_handle) = tensor_view.texture_handle(ctx.render_ctx) {
-        let (h, w) = (tensor.shape()[0].size as f32, tensor.shape()[1].size as f32);
-        scene
-            .primitives
-            .textured_rectangles
-            .push(re_renderer::renderer::TexturedRect {
-                top_left_corner_position: world_from_obj.transform_point3(glam::Vec3::ZERO),
-                extent_u: world_from_obj.transform_vector3(glam::Vec3::X * w),
-                extent_v: world_from_obj.transform_vector3(glam::Vec3::Y * h),
-                texture: texture_handle,
-                texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
-                texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
-                multiplicative_tint: tint,
-                // Push to background. Mostly important for mouse picking order!
-                depth_offset: -1,
-                outline_mask,
-            });
-        scene
-            .primitives
-            .textured_rectangles_ids
-            .push(instance_path_hash);
+    if let Some([height, width, _depth]) = tensor.image_height_width_depth() {
+        if let Some(texture_handle) = tensor_view.texture_handle(ctx.render_ctx) {
+            scene
+                .primitives
+                .textured_rectangles
+                .push(re_renderer::renderer::TexturedRect {
+                    top_left_corner_position: world_from_obj.transform_point3(glam::Vec3::ZERO),
+                    extent_u: world_from_obj.transform_vector3(glam::Vec3::X * width as f32),
+                    extent_v: world_from_obj.transform_vector3(glam::Vec3::Y * height as f32),
+                    texture: texture_handle,
+                    texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
+                    texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
+                    multiplicative_tint: tint,
+                    // Push to background. Mostly important for mouse picking order!
+                    depth_offset: -1,
+                    outline_mask,
+                });
+            scene
+                .primitives
+                .textured_rectangles_ids
+                .push(instance_path_hash);
+        }
     }
 }
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -32,6 +32,7 @@ fn push_tensor_texture(
     ctx: &mut ViewerContext<'_>,
     annotations: &Arc<Annotations>,
     world_from_obj: glam::Mat4,
+    entity_path: &EntityPath,
     instance_path_hash: InstancePathHash,
     tensor: &Tensor,
     multiplicative_tint: egui::Rgba,
@@ -41,15 +42,15 @@ fn push_tensor_texture(
 
     let Some([height, width, _depth]) = tensor.image_height_width_depth() else { return; };
 
-    let experimental_gpu_colormapping = true;
+    let experimental_gpu_colormapping = true; // TODO: remove
     if experimental_gpu_colormapping {
-        let debug_name = "tensor"; // TODO: entity path
+        let debug_name = entity_path.to_string();
 
         let tensor_stats = ctx.cache.tensor_stats(tensor);
 
         match crate::misc::tensor_to_gpu::textured_rect_from_tensor(
             ctx.render_ctx,
-            debug_name,
+            &debug_name,
             tensor,
             tensor_stats,
             annotations,
@@ -277,6 +278,7 @@ impl ImagesPart {
                     ctx,
                     &annotations,
                     world_from_obj,
+                    ent_path,
                     instance_path_hash,
                     &tensor,
                     color.into(),

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -45,10 +45,13 @@ fn push_tensor_texture(
     if experimental_gpu_colormapping {
         let debug_name = "tensor"; // TODO: entity path
 
+        let tensor_stats = ctx.cache.tensor_stats(tensor);
+
         match crate::misc::tensor_to_gpu::textured_rect_from_tensor(
             ctx.render_ctx,
             debug_name,
             tensor,
+            tensor_stats,
             annotations,
         ) {
             Ok(colormapped_texture) => {
@@ -79,7 +82,7 @@ fn push_tensor_texture(
     } else {
         let tensor_view = ctx.cache.image.get_colormapped_view(tensor, annotations);
         if let Some(texture_handle) = tensor_view.texture_handle(ctx.render_ctx) {
-            let colormapped_texture = ColormappedTexture::from_srgba(texture_handle);
+            let colormapped_texture = ColormappedTexture::from_srgba_unorm(texture_handle);
             scene
                 .primitives
                 .textured_rectangles

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -40,7 +40,7 @@ fn push_tensor_texture(
 ) {
     crate::profile_function!();
 
-    let Some([height, width, _depth]) = tensor.image_height_width_depth() else { return; };
+    let Some([height, width, _]) = tensor.image_height_width_channels() else { return; };
 
     let debug_name = entity_path.to_string();
     let tensor_stats = ctx.cache.tensor_stats(tensor);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -71,7 +71,7 @@ fn push_tensor_texture(
                     .push(instance_path_hash);
             }
             Err(err) => {
-                re_log::warn_once!(
+                re_log::error_once!(
                     "Failed to create texture from tensor for {debug_name:?}: {err}"
                 );
             }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -11,15 +11,12 @@ use re_log_types::{
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::{
-    renderer::{DepthCloud, DepthCloudDepthData},
+    renderer::{ColormappedTexture, DepthCloud, DepthCloudDepthData},
     ColorMap, OutlineMaskPreference,
 };
 
 use crate::{
-    misc::{
-        tensor_to_gpu::ColormappedTextured, SpaceViewHighlights, SpaceViewOutlineMasks,
-        TransformCache, ViewerContext,
-    },
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
     ui::{
         scene::SceneQuery,
         view_spatial::{scene::scene_part::instance_path_hash_for_picking, Image, SceneSpatial},
@@ -55,12 +52,11 @@ fn push_tensor_texture(
             annotations,
         ) {
             Ok(colormapped_texture) => {
-                let ColormappedTextured { texture } = colormapped_texture;
                 let textured_rect = re_renderer::renderer::TexturedRect {
                     top_left_corner_position: world_from_obj.transform_point3(glam::Vec3::ZERO),
                     extent_u: world_from_obj.transform_vector3(glam::Vec3::X * width as f32),
                     extent_v: world_from_obj.transform_vector3(glam::Vec3::Y * height as f32),
-                    texture,
+                    colormapped_texture,
                     texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                     texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
                     multiplicative_tint,
@@ -83,6 +79,7 @@ fn push_tensor_texture(
     } else {
         let tensor_view = ctx.cache.image.get_colormapped_view(tensor, annotations);
         if let Some(texture_handle) = tensor_view.texture_handle(ctx.render_ctx) {
+            let colormapped_texture = ColormappedTexture::from_srgba(texture_handle);
             scene
                 .primitives
                 .textured_rectangles
@@ -90,7 +87,7 @@ fn push_tensor_texture(
                     top_left_corner_position: world_from_obj.transform_point3(glam::Vec3::ZERO),
                     extent_u: world_from_obj.transform_vector3(glam::Vec3::X * width as f32),
                     extent_v: world_from_obj.transform_vector3(glam::Vec3::Y * height as f32),
-                    texture: texture_handle,
+                    colormapped_texture,
                     texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                     texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,
                     multiplicative_tint,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -45,7 +45,7 @@ fn push_tensor_texture(
     let debug_name = entity_path.to_string();
     let tensor_stats = ctx.cache.tensor_stats(tensor);
 
-    match crate::misc::tensor_to_gpu::textured_rect_from_tensor(
+    match crate::misc::tensor_to_gpu::tensor_to_gpu(
         ctx.render_ctx,
         &debug_name,
         tensor,

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -348,18 +348,18 @@ fn tensor_ui(
 // ----------------------------------------------------------------------------
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-enum ColorMap {
+enum Colormap {
     Greyscale,
     Turbo,
     Virdis,
 }
 
-impl std::fmt::Display for ColorMap {
+impl std::fmt::Display for Colormap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            ColorMap::Greyscale => "Greyscale",
-            ColorMap::Turbo => "Turbo",
-            ColorMap::Virdis => "Viridis",
+            Colormap::Greyscale => "Greyscale",
+            Colormap::Turbo => "Turbo",
+            Colormap::Virdis => "Viridis",
         })
     }
 }
@@ -367,14 +367,14 @@ impl std::fmt::Display for ColorMap {
 /// How we map values to colors.
 #[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
 struct ColorMapping {
-    map: ColorMap,
+    map: Colormap,
     gamma: f32,
 }
 
 impl Default for ColorMapping {
     fn default() -> Self {
         Self {
-            map: ColorMap::Virdis,
+            map: Colormap::Virdis,
             gamma: 1.0,
         }
     }
@@ -385,15 +385,15 @@ impl ColorMapping {
         let f = f.powf(self.gamma);
 
         match self.map {
-            ColorMap::Greyscale => {
+            Colormap::Greyscale => {
                 let lum = (f * 255.0 + 0.5) as u8;
                 Color32::from_gray(lum)
             }
-            ColorMap::Turbo => {
+            Colormap::Turbo => {
                 let [r, g, b, _] = re_renderer::colormap_turbo_srgb(f);
                 Color32::from_rgb(r, g, b)
             }
-            ColorMap::Virdis => {
+            Colormap::Virdis => {
                 let [r, g, b, _] = re_renderer::colormap_viridis_srgb(f);
                 Color32::from_rgb(r, g, b)
             }
@@ -408,9 +408,9 @@ impl ColorMapping {
             .selected_text(map.to_string())
             .show_ui(ui, |ui| {
                 ui.style_mut().wrap = Some(false);
-                ui.selectable_value(map, ColorMap::Greyscale, ColorMap::Greyscale.to_string());
-                ui.selectable_value(map, ColorMap::Virdis, ColorMap::Virdis.to_string());
-                ui.selectable_value(map, ColorMap::Turbo, ColorMap::Turbo.to_string());
+                ui.selectable_value(map, Colormap::Greyscale, Colormap::Greyscale.to_string());
+                ui.selectable_value(map, Colormap::Virdis, Colormap::Virdis.to_string());
+                ui.selectable_value(map, Colormap::Turbo, Colormap::Turbo.to_string());
             });
         ui.end_row();
 


### PR DESCRIPTION
Part of [#1612](https://github.com/rerun-io/rerun/issues/1612)

This PR augments the `rectangles.wgsl` shader to support multiple texture types (float, sint, uint) and optionally apply a color map (either a function, or a texture).

This is used for color-mapping all images in the Tensor View. Eventually, it will be used for all color mapping and all displaying of images in the viewer.

Supports all tensor datatypes except for U64/I64.

Single-channel color images will be shown in gray-scale. Depth-images will use turbo. This is same as before.

Technically this is a refactor and an optimization, since no functionality changes.

In a future PR we will allow users to select the color map, data range, and gamma curve.

* [x] Tested on web

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
