### PR TITLE
Install the rerun-sdk in CI using --no-index and split out linux wheel build to run first.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -225,10 +225,12 @@ jobs:
 
       - name: Install built wheel
         # Now install the wheel using a specific version and --no-index to guarantee we get the version from
-        # the pre-dist folder.
+        # the pre-dist folder. Note we don't use --force-reinstall here because --no-index means it wouldn't
+        # find the dependencies to reinstall them.
         shell: bash
         run: |
-          pip install rerun-sdk==${{ env.expected_version }} --no-index --find-links pre-dist --force-reinstall
+          pip uninstall rerun-sdk
+          pip install rerun-sdk==${{ env.expected_version }} --no-index --find-links pre-dist
 
       - name: Verify built wheel version
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,50 +63,14 @@ jobs:
           just py-requirements
 
   # ---------------------------------------------------------------------------
-
-  matrix-setup:
-    # Building all the wheels is expensive, so we only run this job when we push (to main or release tags),
-    # or if the job was manually triggered with `force_build_wheel` set to true.
+  # We need one wheel-build to be special so the other builds (namely mac arm) can use its rrd
+  # This copy-paste is awful, but we'll refactor the build soon.
+  wheels-linux:
     if: github.event_name == 'push' || github.event.inputs.force_build_wheel
+    name: Build Python Wheels (Linux)
     runs-on: ubuntu-latest
-
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-
-    steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
-
-      - id: set-matrix
-        shell: bash
-        run: |
-          matrix=()
-          matrix+=('{"platform": "macos",   "target": "x86_64-apple-darwin",      "wheel_suffix": "x86_64", "runs_on": "macos-latest"          },')
-          matrix+=('{"platform": "macos",   "target": "aarch64-apple-darwin",     "wheel_suffix": "x86_64", "runs_on": "macos-latest"          },') # NOTE: we test the x86_64 wheel AGAIN, because the runner is x86_64
-          matrix+=('{"platform": "windows", "target": "x86_64-pc-windows-msvc",   "wheel_suffix": "",       "runs_on": "windows-latest-8-cores"},')
-          matrix+=('{"platform": "linux",   "target": "x86_64-unknown-linux-gnu", "wheel_suffix": "",       "runs_on": "ubuntu-latest-16-cores", container: {"image": "rerunio/ci_docker:0.6"}}')
-
-          echo "Matrix values: ${matrix[@]}"
-
-          echo "matrix={\"include\":[${matrix[@]}]}" >> $GITHUB_OUTPUT
-
-  wheels:
-    name: Build Python Wheels
-    needs: [lint, matrix-setup]
-
-    strategy:
-      matrix: ${{fromJson(needs.matrix-setup.outputs.matrix)}}
-
-    runs-on: ${{ matrix.runs_on }}
-
-    container: ${{ matrix.container }}
-
+    container:
+      image: rerunio/ci_docker:0.6
     steps:
       - uses: actions/checkout@v3
 
@@ -114,7 +78,6 @@ jobs:
       # should be fast, and this way things don't break if we add new packages without rebuilding
       # docker
       - name: Cache APT Packages
-        if: matrix.platform == 'linux'
         uses: awalsh128/cache-apt-pkgs-action@v1.2.2
         with:
           packages: ${{ env.UBUNTU_REQUIRED_PKGS }}
@@ -130,53 +93,10 @@ jobs:
           # the cache. Better cross-job sequencing would be nice here
           save-if: False
 
-      # The pip-cache setup logic doesn't work in the ubuntu docker container
-      # That's probably fine since we bake these deps into the container already
-      - name: Setup python
-        if: matrix.platform != 'linux'
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: "pip"
-          cache-dependency-path: "rerun_py/requirements-build.txt"
-
       # These should already be in the docker container, but run for good measure. A no-op install
       # should be fast, and this way things don't break if we add new packages without rebuilding
       # docker
       - run: pip install -r rerun_py/requirements-build.txt
-
-      # ----------------------------------------------------------------------------------
-      # Install prerequisites for building the web-viewer Wasm
-
-      # We have a nice script for that: ./scripts/setup_web.sh
-      # Unfortunately, we can't run that on Windows, because Windows doesn't come with
-      # a package manager like grown-up OSes do (at least not the CI version of Windows).
-      # Also we can't run it on linux because the 20.04 Docker container will install
-      # an old version of binaryen/wasm-opt that barfs on the `--fast-math` flag
-      # So we only run the script on macos, and then on Windows we do the parts of the script manually.
-      # On ubuntu, the correct packages are pre-installed in our docker container.
-
-      - name: Install prerequisites for building the web-viewer Wasm (non-Windows)
-        if: matrix.platform == 'macos'
-        shell: bash
-        run: ./scripts/setup_web.sh
-
-      # The first steps of setup_web.sh, for Windows:
-      - name: Install wasm32 and wasm-bindgen-cli for building the web-viewer Wasm on windows
-        if: matrix.platform == 'windows'
-        shell: bash
-        run: rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.84
-
-      # The last step of setup_web.sh, for Windows.
-      # Since 'winget' is not available within the GitHub runner, we download the package directly:
-      # See: https://github.com/marketplace/actions/engineerd-configurator
-      - name: Install binaryen for building the web-viewer Wasm on windows
-        if: matrix.platform == 'windows'
-        uses: engineerd/configurator@v0.0.9
-        with:
-          name: "wasm-opt.exe"
-          url: "https://github.com/WebAssembly/binaryen/releases/download/version_111/binaryen-version_111-x86_64-windows.tar.gz"
-          pathInArchive: "binaryen-version_111/bin/wasm-opt.exe"
 
       # ----------------------------------------------------------------------------------
 
@@ -210,7 +130,7 @@ jobs:
           args: |
             --manifest-path rerun_py/Cargo.toml
             --release
-            --target ${{ matrix.target }}
+            --target x86_64-unknown-linux-gnu
             --no-default-features
             --features pypi
             --out pre-dist
@@ -298,11 +218,222 @@ jobs:
 
       # All platforms are currently creating the same rrd file, upload one of them
       - name: Save RRD artifact
-        if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v3
         with:
           name: rrd
           path: rrd
+
+  # ---------------------------------------------------------------------------
+  matrix-setup:
+    # Building all the wheels is expensive, so we only run this job when we push (to main or release tags),
+    # or if the job was manually triggered with `force_build_wheel` set to true.
+    if: github.event_name == 'push' || github.event.inputs.force_build_wheel
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+
+      - id: set-matrix
+        shell: bash
+        run: |
+          matrix=()
+          matrix+=('{"platform": "macos",   "target": "x86_64-apple-darwin",    "run_tests": true,  "runs_on": "macos-latest"          },')
+          matrix+=('{"platform": "macos",   "target": "aarch64-apple-darwin",   "run_tests": false, "runs_on": "macos-latest"          },') # NOTE: we can't run tests on arm since our macos runner is x86_64
+          matrix+=('{"platform": "windows", "target": "x86_64-pc-windows-msvc", "run_tests": true,  "runs_on": "windows-latest-8-cores"},')
+
+          echo "Matrix values: ${matrix[@]}"
+
+          echo "matrix={\"include\":[${matrix[@]}]}" >> $GITHUB_OUTPUT
+
+  wheels:
+    name: Build Remaining Python Wheels
+    needs: [lint, matrix-setup, wheels-linux]
+
+    strategy:
+      matrix: ${{fromJson(needs.matrix-setup.outputs.matrix)}}
+
+    runs-on: ${{ matrix.runs_on }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST CACHE_KEY
+          # Don't update the cache -- it will be updated by the lint job
+          # TODO(jleibs): this job will likely run before rust.yml updates
+          # the cache. Better cross-job sequencing would be nice here
+          save-if: False
+
+      # The pip-cache setup logic doesn't work in the ubuntu docker container
+      # That's probably fine since we bake these deps into the container already
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: "rerun_py/requirements-build.txt"
+
+      # These should already be in the docker container, but run for good measure. A no-op install
+      # should be fast, and this way things don't break if we add new packages without rebuilding
+      # docker
+      - run: pip install -r rerun_py/requirements-build.txt
+
+      # ----------------------------------------------------------------------------------
+      # Install prerequisites for building the web-viewer Wasm
+
+      # We have a nice script for that: ./scripts/setup_web.sh
+      # Unfortunately, we can't run that on Windows, because Windows doesn't come with
+      # a package manager like grown-up OSes do (at least not the CI version of Windows).
+      # Also we can't run it on linux because the 20.04 Docker container will install
+      # an old version of binaryen/wasm-opt that barfs on the `--fast-math` flag
+      # So we only run the script on macos, and then on Windows we do the parts of the script manually.
+      # On ubuntu, the correct packages are pre-installed in our docker container.
+
+      - name: Install prerequisites for building the web-viewer Wasm (non-Windows)
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: ./scripts/setup_web.sh
+
+      # The first steps of setup_web.sh, for Windows:
+      - name: Install wasm32 and wasm-bindgen-cli for building the web-viewer Wasm on windows
+        if: matrix.platform == 'windows'
+        shell: bash
+        run: rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.84
+
+      # The last step of setup_web.sh, for Windows.
+      # Since 'winget' is not available within the GitHub runner, we download the package directly:
+      # See: https://github.com/marketplace/actions/engineerd-configurator
+      - name: Install binaryen for building the web-viewer Wasm on windows
+        if: matrix.platform == 'windows'
+        uses: engineerd/configurator@v0.0.9
+        with:
+          name: "wasm-opt.exe"
+          url: "https://github.com/WebAssembly/binaryen/releases/download/version_111/binaryen-version_111-x86_64-windows.tar.gz"
+          pathInArchive: "binaryen-version_111/bin/wasm-opt.exe"
+
+      # ----------------------------------------------------------------------------------
+
+      - name: Patch Cargo.toml for pre-release
+        if: github.ref == 'refs/heads/main'
+        # After patching the pre-release version, run cargo update.
+        # This updates the cargo.lock file with the new version numbers and keeps the wheel build from failing
+        run: |
+          python3 scripts/version_util.py --patch_prerelease
+          cargo update -w
+
+      - name: Version check for tagged-release
+        if: startsWith(github.ref, 'refs/tags/v')
+        # This call to version_util.py will assert version from Cargo.toml matches git tagged version vX.Y.Z
+        run: |
+          python3 scripts/version_util.py --check_version
+
+      - name: Store the expected version
+        # Find the current cargo version and store it in the GITHUB_ENV var: `expected_version`
+        shell: bash
+        run: |
+          echo "expected_version=$(python3 scripts/version_util.py --bare_cargo_version)" >> $GITHUB_ENV
+
+      - name: Build Wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: "0.14.10"
+          manylinux: manylinux_2_31
+          container: off
+          command: build
+          args: |
+            --manifest-path rerun_py/Cargo.toml
+            --release
+            --target ${{ matrix.target }}
+            --no-default-features
+            --features pypi
+            --out pre-dist
+
+      - name: Install built wheel
+        if: ${{ matrix.run_tests }}
+        # First we install the dependencies manually so we can use `--no-index` when installing the wheel.
+        # Then install the wheel using a specific version and --no-index to guarantee we get the version from
+        # the pre-dist folder. Note we don't use --force-reinstall here because --no-index means it wouldn't
+        # find the dependencies to reinstall them.
+        # TODO(jleibs): pull these deps from pyproject.toml
+        shell: bash
+        run: |
+          pip uninstall rerun-sdk
+          pip install deprecated numpy>=1.23 pyarrow==10.0.1
+          pip install rerun-sdk==${{ env.expected_version }} --no-index --find-links pre-dist
+
+      - name: Verify built wheel version
+        if: ${{ matrix.run_tests }}
+        shell: bash
+        run: |
+          python3 -m rerun --version
+          which rerun
+          rerun --version
+
+      - name: Run unit tests
+        if: ${{ matrix.run_tests }}
+        shell: bash
+        run: cd rerun_py/tests && pytest
+
+      - name: Install requriements for e2e test
+        if: ${{ matrix.run_tests }}
+        run: |
+          pip install -r examples/python/api_demo/requirements.txt
+          pip install -r examples/python/car/requirements.txt
+          pip install -r examples/python/multithreading/requirements.txt
+          pip install -r examples/python/plots/requirements.txt
+          pip install -r examples/python/text_logging/requirements.txt
+
+      - name: Run e2e test
+        if: ${{ matrix.run_tests }}
+        shell: bash
+        run: scripts/run_python_e2e_test.py --no-build # rerun-sdk is already built and installed
+
+      - name: Unpack the wheel
+        shell: bash
+        run: |
+          mkdir unpack-dist
+          wheel unpack pre-dist/*.whl --dest unpack-dist
+
+      - name: Get the folder name
+        shell: bash
+        run: |
+          echo "pkg_folder=$(ls unpack-dist)" >> $GITHUB_ENV
+
+      - name: Download RRD
+        uses: actions/download-artifact@v3
+        with:
+          name: rrd
+          path: rrd
+
+      - name: Insert the rrd
+        shell: bash
+        # If you change the line below you should almost definitely change the `key:` line above by giving it a new, unique name
+        run: |
+          cp rrd/colmap_fiat.rrd unpack-dist/${{ env.pkg_folder }}/rerun_sdk/rerun_demo/colmap_fiat.rrd
+
+      - name: Repack the wheel
+        shell: bash
+        run: |
+          mkdir dist
+          wheel pack unpack-dist/${{ env.pkg_folder }} --dest dist/
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -195,7 +195,7 @@ jobs:
           python3 scripts/version_util.py --check_version
 
       - name: Store the expected version
-        # This call to version_util.py store the expected version number in the github env `expected_version`
+        # This call to version_util.py store the expected version number in the GitHub env `expected_version`
         run: |
           python3 scripts/version_util.py --expected_version >> $GITHUB_ENV
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -195,7 +195,7 @@ jobs:
           python3 scripts/version_util.py --check_version
 
       - name: Store the expected version
-        # This call to version_util.py will assert version from Cargo.toml matches git tagged version vX.Y.Z
+        # This call to version_util.py store the expected version number in the github env `expected_version`
         run: |
           python3 scripts/version_util.py --expected_version >> $GITHUB_ENV
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -196,6 +196,7 @@ jobs:
 
       - name: Store the expected version
         # Find the current cargo version and store it in the GITHUB_ENV var: `expected_version`
+        shell: bash
         run: |
           echo "expected_version=$(python3 scripts/version_util.py --bare_cargo_version)" >> $GITHUB_ENV
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -214,14 +214,20 @@ jobs:
             --features pypi
             --out pre-dist
 
-      - name: Install built wheel
-        # First we install the dependencies manually so we can use `--no-index` when installing the
-        # main rerun wheel to guarantee we only get it from the pre-dist folder. We additionally
-        # specify the version explicitly to make sure we have built what we expected.
+      - name: Install wheel dependencies
+        # First we install the dependencies manually so we can use `--no-index` when installing the wheel.
+        # This needs to be a separate step for some reason or the following step fails
         # TODO(jleibs): pull these deps from pyproject.toml
+        # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
           pip install deprecated numpy>=1.23 pyarrow==10.0.1
+
+      - name: Install built wheel
+        # Now install the wheel using a specific version and --no-index to guarantee we get the version from
+        # the pre-dist folder.
+        shell: bash
+        run: |
           pip install rerun-sdk==${{ env.expected_version }} --no-index --find-links pre-dist --force-reinstall
 
       - name: Verify built wheel version

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -215,9 +215,14 @@ jobs:
             --out pre-dist
 
       - name: Install built wheel
+        # First we install the dependencies manually so we can use `--no-index` when installing the
+        # main rerun wheel to guarantee we only get it from the pre-dist folder. We additionally
+        # specify the version explicitly to make sure we have built what we expected.
+        # TODO(jleibs): pull these deps from pyproject.toml
         shell: bash
         run: |
-          pip install rerun-sdk==${{ env.expected_version }} --find-links pre-dist --force-reinstall
+          pip install deprecated numpy>=1.23 pyarrow==10.0.1
+          pip install rerun-sdk==${{ env.expected_version }} --no-index --find-links pre-dist --force-reinstall
 
       - name: Verify built wheel version
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -194,6 +194,11 @@ jobs:
         run: |
           python3 scripts/version_util.py --check_version
 
+      - name: Store the expected version
+        # This call to version_util.py will assert version from Cargo.toml matches git tagged version vX.Y.Z
+        run: |
+          python3 scripts/version_util.py --expected_version >> $GITHUB_ENV
+
       - name: Build Wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -212,7 +217,7 @@ jobs:
       - name: Install built wheel
         shell: bash
         run: |
-          pip install pre-dist/*${{ matrix.wheel_suffix }}.whl --force-reinstall
+          pip install rerun-sdk==${{ env.expected_version }} --find-links pre-dist --force-reinstall
 
       - name: Verify built wheel version
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -195,9 +195,9 @@ jobs:
           python3 scripts/version_util.py --check_version
 
       - name: Store the expected version
-        # This call to version_util.py store the expected version number in the GitHub env `expected_version`
+        # Find the current cargo version and store it in the GITHUB_ENV var: `expected_version`
         run: |
-          python3 scripts/version_util.py --expected_version >> $GITHUB_ENV
+          echo "expected_version=$(python3 scripts/version_util.py --bare_cargo_version)" >> $GITHUB_ENV
 
       - name: Build Wheel
         uses: PyO3/maturin-action@v1

--- a/scripts/version_util.py
+++ b/scripts/version_util.py
@@ -89,10 +89,10 @@ def main() -> None:
         cargo_toml = f.read()
 
     cargo_version = get_cargo_version(cargo_toml)
+    date = datetime.now().strftime("%Y-%m-%d")
+    new_version = f"{cargo_version}+{date}-{get_git_sha()}"
 
     if sys.argv[1] == "--patch_prerelease":
-        date = datetime.now().strftime("%Y-%m-%d")
-        new_version = f"{cargo_version}+{date}-{get_git_sha()}"
         new_cargo_toml = patch_cargo_version(cargo_toml, new_version)
 
         # Write the patched Cargo.toml back to disk
@@ -106,6 +106,8 @@ def main() -> None:
                 f"Version number in Cargo.toml ({cargo_version}) does not match tag version ({ref_version})"
             )
         print(f"Version numbers match: {cargo_version} == {ref_version}")
+    elif sys.argv[1] == "--expected_version":
+        print(f"expected_version={new_version}")
 
     else:
         raise Exception("Invalid argument")

--- a/scripts/version_util.py
+++ b/scripts/version_util.py
@@ -89,10 +89,10 @@ def main() -> None:
         cargo_toml = f.read()
 
     cargo_version = get_cargo_version(cargo_toml)
-    date = datetime.now().strftime("%Y-%m-%d")
-    new_version = f"{cargo_version}+{date}-{get_git_sha()}"
 
     if sys.argv[1] == "--patch_prerelease":
+        date = datetime.now().strftime("%Y-%m-%d")
+        new_version = f"{cargo_version}+{date}-{get_git_sha()}"
         new_cargo_toml = patch_cargo_version(cargo_toml, new_version)
 
         # Write the patched Cargo.toml back to disk
@@ -107,7 +107,9 @@ def main() -> None:
             )
         print(f"Version numbers match: {cargo_version} == {ref_version}")
     elif sys.argv[1] == "--expected_version":
-        print(f"expected_version={new_version}")
+        # We always expect the version built to match what is in cargo.toml
+        # NOTE: what is in Cargo.toml may have been modified by an earlier call to `--patch-prerelease`
+        print(f"expected_version={cargo_version}")
 
     else:
         raise Exception("Invalid argument")

--- a/scripts/version_util.py
+++ b/scripts/version_util.py
@@ -106,10 +106,10 @@ def main() -> None:
                 f"Version number in Cargo.toml ({cargo_version}) does not match tag version ({ref_version})"
             )
         print(f"Version numbers match: {cargo_version} == {ref_version}")
-    elif sys.argv[1] == "--expected_version":
-        # We always expect the version built to match what is in cargo.toml
-        # NOTE: what is in Cargo.toml may have been modified by an earlier call to `--patch-prerelease`
-        print(f"expected_version={cargo_version}")
+    elif sys.argv[1] == "--bare_cargo_version":
+        # Print the bare cargo version. NOTE: do not add additional formatting here. This output
+        # is expected to be fed into an environment variable.
+        print(f"{cargo_version}")
 
     else:
         raise Exception("Invalid argument")


### PR DESCRIPTION
Another try at deterministically installing the wheel we just built.  The problem I believe we were hitting before was the version in the index was deemed 'newer' than the version in the find-links. This goes back to using find-links and avoiding wheel-path-globbing complexities, but introduces --no-index and a restricted version.

This turned out to be even more subtle that I realized:
 - The wheels built for mac on arm weren't installable on intel, which meant for that platform we were falling back to the last released version of rerun. This install procedure at least cathes that now, but uncovered a bigger problem. Not only did this mean we weren't testing the right package in that case, it also meant that we were using that incorrect package to generate the rrd file that we bundled into the wheel.

This now pulls the linux wheel build out as an explicit pre-step before the remaining mac/windows builds, and uses that RRD for the other packages.

Note for the future: there is another related problem here that all of our incremental PR build with the same version as our last release. I suspect we should change this behavior and go out of our way to ensure that only true release builds ever get a bare `x.y.z` version.

Wheel-build job results: https://github.com/rerun-io/rerun/actions/runs/4695949855

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
