### PR TITLE
[log] Feat/Improve log_view_coordinates API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,6 +3937,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "puffin",
+ "pyo3",
+ "pyo3-build-config",
  "rand",
  "re_format",
  "re_log",

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -89,11 +89,14 @@ macaw = { workspace = true, optional = true }
 rand = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 serde_bytes = { version = "0.11", optional = true }
+pyo3 = { version = "0.18.0", features = ["abi3-py38"] }
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 puffin.workspace = true
 
+[build-dependencies]
+pyo3-build-config = "0.18.0"
 
 [dev-dependencies]
 rmp-serde = "1.1"

--- a/crates/re_log_types/src/component_types/coordinates.rs
+++ b/crates/re_log_types/src/component_types/coordinates.rs
@@ -4,10 +4,12 @@ use arrow2_convert::{
     field::{ArrowField, FixedSizeBinary},
     serialize::ArrowSerialize,
 };
+use pyo3::prelude::*;
 
 use crate::Component;
 
 /// The six cardinal directions for 3D view-space and image-space.
+#[pyclass]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ViewDir {
@@ -311,7 +313,7 @@ impl ArrowDeserialize for ViewCoordinates {
 
 // ----------------------------------------------------------------------------
 
-/// One of `X`, `Y`, `Z`.
+#[pyclass]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Axis3 {
@@ -345,7 +347,7 @@ impl std::fmt::Display for Axis3 {
 
 // ----------------------------------------------------------------------------
 
-/// Positive (`+`) or Negative (`-`).
+#[pyclass]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Sign {
@@ -355,7 +357,6 @@ pub enum Sign {
 
 // ----------------------------------------------------------------------------
 
-/// One of: `+X`, `-X`, `+Y`, `-Y`, `+Z`, `-Z`,
 /// i.e. one of the six cardinal direction in 3D space.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -14,6 +14,7 @@ import logging
 import math
 
 import numpy as np
+from rerun import bindings
 import rerun as rr
 from scipy.spatial.transform import Rotation
 
@@ -168,10 +169,10 @@ def transforms_rigid_3d() -> None:
     rotation_speed_moon = 5.0
 
     # Planetary motion is typically in the XY plane.
-    rr.log_view_coordinates("transforms3d", up="+Z", timeless=True)
-    rr.log_view_coordinates("transforms3d/sun", up="+Z", timeless=True)
-    rr.log_view_coordinates("transforms3d/sun/planet", up="+Z", timeless=True)
-    rr.log_view_coordinates("transforms3d/sun/planet/moon", up="+Z", timeless=True)
+    rr.log_view_coordinates("transforms3d", up=(bindings.Sign.Positive, bindings.Axis3.Z), timeless=True)
+    rr.log_view_coordinates("transforms3d/sun", up=(bindings.Sign.Positive, bindings.Axis3.Z), timeless=True)
+    rr.log_view_coordinates("transforms3d/sun/planet", up=(bindings.Sign.Positive, bindings.Axis3.Z), timeless=True)
+    rr.log_view_coordinates("transforms3d/sun/planet/moon", up=(bindings.Sign.Positive, bindings.Axis3.Z), timeless=True)
 
     # All are in the center of their own space:
     rr.log_point("transforms3d/sun", [0.0, 0.0, 0.0], radius=1.0, color=[255, 200, 10])

--- a/examples/python/arkitscenes/main.py
+++ b/examples/python/arkitscenes/main.py
@@ -9,6 +9,7 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
+from rerun import bindings
 import rerun as rr
 import trimesh
 from download_dataset import AVAILABLE_RECORDINGS, ensure_recording_available
@@ -253,7 +254,7 @@ def log_camera(
         # pathlib makes it easy to get the parent, but log_rigid requires a string
         str(Path(entity_id).parent),
         child_from_parent=camera_from_world,
-        xyz="RDF",  # X=Right, Y=Down, Z=Forward
+        xyz=(bindings.ViewDir.Right, bindings.ViewDir.Down, bindings.ViewDir.Forward),  # X=Right, Y=Down, Z=Forward
     )
     rr.log_pinhole(f"{entity_id}", child_from_parent=intrinsic, width=w, height=h)
 
@@ -342,7 +343,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
         timestamp = f"{round(float(timestamp), 3):.3f}"
         camera_from_world_dict[timestamp] = camera_from_world
 
-    rr.log_view_coordinates("world", up="+Z", right_handed=True, timeless=True)
+    rr.log_view_coordinates("world", up=(bindings.Sign.Positive, bindings.Axis3.Z), right_handed=True, timeless=True)
     ply_path = recording_path / f"{recording_path.stem}_3dod_mesh.ply"
     print(f"Loading {ply_path}…")
     assert os.path.isfile(ply_path), f"Failed to find {ply_path}"

--- a/examples/python/car/main.py
+++ b/examples/python/car/main.py
@@ -8,6 +8,7 @@ from typing import Iterator, Tuple
 import cv2
 import numpy as np
 import numpy.typing as npt
+from rerun import bindings
 import rerun as rr
 
 
@@ -16,7 +17,7 @@ def log_car_data() -> None:
     NUM_FRAMES = 40
 
     # Set our preferred up-axis on the space that we will log the points to:
-    rr.log_view_coordinates("world", up="-Y", timeless=True)
+    rr.log_view_coordinates("world", up=(bindings.Sign.Negative, bindings.Axis3.Y), timeless=True)
 
     for sample in generate_car_data(num_frames=NUM_FRAMES):
         # This will assign logged entities a timeline called `frame_nr`.
@@ -30,7 +31,7 @@ def log_car_data() -> None:
         rr.log_rigid3(
             "world/camera",
             parent_from_child=(sample.camera.position, sample.camera.rotation_q),
-            xyz="RDF",  # X=Right, Y=Down, Z=Forward
+            xyz=(bindings.ViewDir.Right, bindings.ViewDir.Down, bindings.ViewDir.Forward),  # X=Right, Y=Down, Z=Forward
         )
 
         # Log the camera projection matrix:

--- a/examples/python/clock/main.py
+++ b/examples/python/clock/main.py
@@ -11,6 +11,7 @@ import math
 from typing import Final, Tuple
 
 import numpy as np
+from rerun import bindings
 import rerun as rr
 
 LENGTH_S: Final = 20.0
@@ -30,7 +31,7 @@ def log_clock(steps: int) -> None:
             0.0,
         )
 
-    rr.log_view_coordinates("world", up="+Y", timeless=True)
+    rr.log_view_coordinates("world", up=(bindings.Sign.Positive, bindings.Axis3.Y), timeless=True)
 
     rr.log_obb(
         "world/frame",

--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -12,6 +12,7 @@ import cv2
 import numpy as np
 import numpy.typing as npt
 import requests
+from rerun import bindings
 import rerun as rr
 from read_write_model import Camera, read_model
 from tqdm import tqdm
@@ -99,7 +100,7 @@ def read_and_log_sparse_reconstruction(
         # Filter out noisy points
         points3D = {id: point for id, point in points3D.items() if point.rgb.any() and len(point.image_ids) > 4}
 
-    rr.log_view_coordinates("/", up="-Y", timeless=True)
+    rr.log_view_coordinates("/", up=(bindings.Sign.Negative, bindings.Axis3.Y), timeless=True)
 
     # Iterate through images (video frames) logging data related to each frame.
     for image in sorted(images.values(), key=lambda im: im.name):  # type: ignore[no-any-return]
@@ -147,7 +148,7 @@ def read_and_log_sparse_reconstruction(
         rr.log_rigid3(
             "camera",
             child_from_parent=camera_from_world,
-            xyz="RDF",  # X=Right, Y=Down, Z=Forward
+            xyz=(bindings.ViewDir.Right, bindings.ViewDir.Down, bindings.ViewDir.Forward),  # X=Right, Y=Down, Z=Forward
         )
 
         # Log camera intrinsics

--- a/examples/python/mp_pose/main.py
+++ b/examples/python/mp_pose/main.py
@@ -13,6 +13,7 @@ import mediapipe as mp
 import numpy as np
 import numpy.typing as npt
 import requests
+from rerun import bindings
 import rerun as rr
 
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
@@ -36,7 +37,7 @@ def track_pose(video_path: str, segment: bool) -> None:
         "video/mask",
         [rr.AnnotationInfo(id=0, label="Background"), rr.AnnotationInfo(id=1, label="Person", color=(0, 0, 0))],
     )
-    rr.log_view_coordinates("person", up="-Y", timeless=True)
+    rr.log_view_coordinates("person", up=(bindings.Sign.Negative, bindings.Axis3.Y), timeless=True)
 
     with closing(VideoSource(video_path)) as video_source, mp_pose.Pose(enable_segmentation=segment) as pose:
         for bgr_frame in video_source.stream_bgr():

--- a/examples/python/nyud/main.py
+++ b/examples/python/nyud/main.py
@@ -16,6 +16,7 @@ import cv2
 import numpy as np
 import numpy.typing as npt
 import requests
+from rerun import bindings
 import rerun as rr
 from tqdm import tqdm
 
@@ -80,7 +81,7 @@ def read_image(buf: bytes) -> npt.NDArray[np.uint8]:
 def log_nyud_data(recording_path: Path, subset_idx: int = 0, depth_image_interval: int = 1) -> None:
     depth_images_counter = 0
 
-    rr.log_view_coordinates("world", up="-Y", timeless=True)
+    rr.log_view_coordinates("world", up=(bindings.Sign.Negative, bindings.Axis3.Y), timeless=True)
 
     with zipfile.ZipFile(recording_path, "r") as archive:
         archive_dirs = [f.filename for f in archive.filelist if f.is_dir()]
@@ -118,7 +119,7 @@ def log_nyud_data(recording_path: Path, subset_idx: int = 0, depth_image_interva
                     rr.log_rigid3(
                         "world/camera",
                         parent_from_child=(translation, rotation_q),
-                        xyz="RDF",  # X=Right, Y=Down, Z=Forward
+                        xyz=(bindings.ViewDir.Right, bindings.ViewDir.Down, bindings.ViewDir.Forward),  # X=Right, Y=Down, Z=Forward
                     )
                     rr.log_pinhole(
                         "world/camera/image",

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -18,6 +18,7 @@ from typing import Iterable, Iterator, List
 
 import numpy as np
 import numpy.typing as npt
+from rerun import bindings
 import rerun as rr
 from download_dataset import (
     ANNOTATIONS_FILENAME,
@@ -114,7 +115,7 @@ def read_annotations(dirpath: Path) -> Sequence:
 def log_ar_frames(samples: Iterable[SampleARFrame], seq: Sequence) -> None:
     """Logs a stream of `ARFrame` samples and their annotations with the Rerun SDK."""
 
-    rr.log_view_coordinates("world", up="+Y", timeless=True)
+    rr.log_view_coordinates("world", up=(bindings.Sign.Positive, bindings.Axis3.Y), timeless=True)
 
     log_annotated_bboxes(seq.objects)
 
@@ -152,7 +153,7 @@ def log_camera(cam: ARCamera) -> None:
     rot = rot * R.from_rotvec((math.tau / 2.0) * X)  # TODO(emilk): figure out why this is needed
 
     rr.log_rigid3(
-        "world/camera", parent_from_child=(translation, rot.as_quat()), xyz="RDF"  # X=Right, Y=Down, Z=Forward
+        "world/camera", parent_from_child=(translation, rot.as_quat()), xyz=(bindings.ViewDir.Right, bindings.ViewDir.Down, bindings.ViewDir.Forward)  # X=Right, Y=Down, Z=Forward
     )
     rr.log_pinhole(
         "world/camera/video",

--- a/examples/python/raw_mesh/main.py
+++ b/examples/python/raw_mesh/main.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Optional, cast
 
 import numpy as np
+from rerun import bindings
 import rerun as rr
 import trimesh
 from download_dataset import AVAILABLE_MESHES, ensure_mesh_downloaded
@@ -96,7 +97,7 @@ def main() -> None:
     root = next(iter(scene.graph.nodes))
 
     # glTF always uses a right-handed coordinate system when +Y is up and meshes face +Z.
-    rr.log_view_coordinates(root, xyz="RUB", timeless=True)
+    rr.log_view_coordinates(root, xyz=(bindings.ViewDir.Right, bindings.ViewDir.Up, bindings.ViewDir.Back), timeless=True)
     log_scene(scene, root)
 
     rr.script_teardown(args)

--- a/rerun_py/rerun_sdk/rerun/log/transform.py
+++ b/rerun_py/rerun_sdk/rerun/log/transform.py
@@ -23,8 +23,8 @@ __all__ = [
 def log_view_coordinates(
     entity_path: str,
     *,
-    xyz: str = "",
-    up: str = "",
+    xyz: Optional[Tuple[bindings.ViewDir, bindings.ViewDir, bindings.ViewDir]] = None,
+    up: Optional[Tuple[bindings.Sign, bindings.Axis3]] = None,
     right_handed: Optional[bool] = None,
     timeless: bool = False,
 ) -> None:
@@ -35,34 +35,28 @@ def log_view_coordinates(
     By logging view coordinates you can give semantic meaning to the XYZ axes of the space.
     This is for example useful for camera entities ("what axis is forward?").
 
-    For full control, set the `xyz` parameter to a three-letter acronym (`xyz="RDF"`). Each letter represents:
-
-    * R: Right
-    * L: Left
-    * U: Up
-    * D: Down
-    * F: Forward
-    * B: Back
+    For full control, set the `xyz` parameter to a three-component tuple (X, Y, Z).
+    Each component can be of the following variant: Right | Left | Up | Down | Forward | Back.
 
     Some of the most common are:
 
-    * "RDF": X=Right Y=Down Z=Forward  (right-handed)
-    * "RUB"  X=Right Y=Up   Z=Back     (right-handed)
-    * "RDB": X=Right Y=Down Z=Back     (left-handed)
-    * "RUF": X=Right Y=Up   Z=Forward  (left-handed)
+    * (Right, Down, Forward): X=Right Y=Down Z=Forward  (right-handed)
+    * (Right, Up, Back)  X=Right Y=Up   Z=Back     (right-handed)
+    * (Right, Down, Back): X=Right Y=Down Z=Back     (left-handed)
+    * (Right, Up, Forward): X=Right Y=Up   Z=Forward  (left-handed)
 
     Example
     -------
     ```
-    rerun.log_view_coordinates("world/camera", xyz="RUB")
+    rerun.log_view_coordinates("world/camera", xyz=(rerun.bindings.ViewDir.Right, rerun.bindings.ViewDir.Up, rerun.bindings.ViewDir.Back))
     ```
 
     For world-coordinates it's often convenient to just specify an up-axis.
-    You can do so by using the `up`-parameter (where `up` is one of "+X", "-X", "+Y", "-Y", "+Z", "-Z"):
+    You can do so by using the `up`-parameter:
 
     ```
-    rerun.log_view_coordinates("world", up="+Z", right_handed=True, timeless=True)
-    rerun.log_view_coordinates("world", up="-Y", right_handed=False, timeless=True)
+    rerun.log_view_coordinates("world", up=(rerun.bindings.Sign.Positive, rerun.bindings.Axis3.Z), right_handed=True, timeless=True)
+    rerun.log_view_coordinates("world", up=(rerun.bindings.Sign.Negative, rerun.bindings.Axis3.Y), right_handed=False, timeless=True)
     ```
 
     Parameters
@@ -70,22 +64,22 @@ def log_view_coordinates(
     entity_path:
         Path in the space hierarchy where the view coordinate will be set.
     xyz:
-        Three-letter acronym for the view coordinate axes.
+        Three-component tuple for the view coordinate axes (X,Y,Z).
     up:
-        Which axis is up? One of "+X", "-X", "+Y", "-Y", "+Z", "-Z".
+        Which axis is up? Defined by a tuple with (Axis: X|Y|Z, Sign:Positive|Negative).
     right_handed:
         If True, the coordinate system is right-handed. If False, it is left-handed.
     timeless:
         If true, the view coordinates will be timeless (default: False).
 
     """
-    if xyz == "" and up == "":
+    if xyz is None and up is None:
         _send_warning("You must set either 'xyz' or 'up'. Ignoring log.", 1)
         return
-    if xyz != "" and up != "":
+    if xyz is not None and up is not None:
         _send_warning("You must set either 'xyz' or 'up', but not both. Dropping up.", 1)
-        up = ""
-    if xyz != "":
+        up = None
+    if xyz is not None:
         bindings.log_view_coordinates_xyz(entity_path, xyz, right_handed, timeless)
     else:
         if right_handed is None:
@@ -106,7 +100,7 @@ def log_rigid3(
     *,
     parent_from_child: Optional[Tuple[npt.ArrayLike, npt.ArrayLike]] = None,
     child_from_parent: Optional[Tuple[npt.ArrayLike, npt.ArrayLike]] = None,
-    xyz: str = "",
+    xyz: Optional[Tuple[bindings.ViewDir, bindings.ViewDir, bindings.ViewDir]] = None,
     timeless: bool = False,
 ) -> None:
     """
@@ -173,5 +167,5 @@ def log_rigid3(
     else:
         raise TypeError("Set either parent_from_child or child_from_parent.")
 
-    if xyz != "":
+    if xyz is not None:
         log_view_coordinates(entity_path, xyz=xyz, timeless=timeless)


### PR DESCRIPTION
### WHAT
Closes #1295 

Update the `str` and `up` `log_view_coordinates` API parameter types.

#### xyz
```py
str -> Optional[Tuple[bindings.ViewDir, bindings.ViewDir, bindings.ViewDir]]
```

#### up
```py
str -> Optional[Tuple[bindings.Sign, bindings.Axis3]]
```
​
### WHY

Make the `log_view_coordinates` API more consistent.

### HOW

Exposed some Rust types to Python. (`Sign `, `Axis3` and `ViewDir`) thanks to the`#[pyclass]` pyo3 attribute.

Note that we could also expose methods to python so that the correct type is passed directly to rust :

```rust
#[pyclass]
pub struct SignedAxis3 {
    pub sign: Sign,
    pub axis: Axis3,
}

#[pymethods]
impl SignedAxis3 {
    #[new]
    fn new(axis: Axis3, sign: Sign) -> Self {
        Self { axis, sign }
    }
}
```

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
