### PR TITLE
Refactor the relationship between the assorted web / websocket servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,6 +4226,7 @@ dependencies = [
  "re_analytics",
  "re_build_web_viewer",
  "re_log",
+ "thiserror",
  "tokio",
 ]
 
@@ -4243,6 +4244,7 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_smart_channel",
+ "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
@@ -4356,6 +4358,7 @@ dependencies = [
  "re_log_encoding",
  "re_log_types",
  "re_memory",
+ "re_web_viewer_server",
  "rerun",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,7 +4216,6 @@ dependencies = [
 name = "re_web_viewer_server"
 version = "0.4.0"
 dependencies = [
- "anyhow",
  "cargo_metadata",
  "ctrlc",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
  "re_log_types",
  "re_memory",
  "re_web_viewer_server",
+ "re_ws_comms",
  "rerun",
  "thiserror",
  "tokio",

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -56,7 +56,7 @@ impl RemoteViewerApp {
                     }
                 }
                 Err(err) => {
-                    re_log::error!("Failed to parse message: {:?}", err);
+                    re_log::error!("Failed to parse message: {err}");
                     std::ops::ControlFlow::Break(())
                 }
             }

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -56,7 +56,7 @@ impl RemoteViewerApp {
                     }
                 }
                 Err(err) => {
-                    re_log::error!("Failed to parse message: {}", re_error::format(&err));
+                    re_log::error!("Failed to parse message: {:?}", err);
                     std::ops::ControlFlow::Break(())
                 }
             }

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -148,7 +148,10 @@ fn get_url(info: &eframe::IntegrationInfo) -> String {
         url = param.clone();
     }
     if url.is_empty() {
-        re_ws_comms::default_server_url(&info.web_info.location.hostname)
+        re_ws_comms::server_url(
+            &info.web_info.location.hostname,
+            re_ws_comms::DEFAULT_WS_SERVER_PORT,
+        )
     } else {
         url
     }

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -148,10 +148,7 @@ fn get_url(info: &eframe::IntegrationInfo) -> String {
         url = param.clone();
     }
     if url.is_empty() {
-        re_ws_comms::server_url(
-            &info.web_info.location.hostname,
-            re_ws_comms::DEFAULT_WS_SERVER_PORT,
-        )
+        re_ws_comms::server_url(&info.web_info.location.hostname, Default::default())
     } else {
         url
     }

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -51,6 +51,7 @@ ctrlc.workspace = true
 document-features = "0.2"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }
+thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = [
   "macros",
   "rt-multi-thread",

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -46,7 +46,6 @@ analytics = ["dep:re_analytics"]
 [dependencies]
 re_log.workspace = true
 
-anyhow.workspace = true
 ctrlc.workspace = true
 document-features = "0.2"
 futures-util = "0.3"

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -205,6 +205,9 @@ pub struct WebViewerServer {
 }
 
 impl WebViewerServer {
+    /// Create new [`WebViewerServer`] to host the Rerun Web Viewer on a specified port.
+    ///
+    /// A port of 0 will let the OS choose a free port.
     pub fn new(port: WebViewerServerPort) -> Result<Self, WebViewerServerError> {
         let bind_addr = format!("0.0.0.0:{port}").parse()?;
         let server = hyper::Server::try_bind(&bind_addr)
@@ -248,6 +251,7 @@ impl Drop for WebViewerServerHandle {
 
 impl WebViewerServerHandle {
     /// Create new [`WebViewerServer`] to host the Rerun Web Viewer on a specified port.
+    /// Returns a [`WebViewerServerHandle`] that will shutdown the server when dropped.
     ///
     /// A port of 0 will let the OS choose a free port.
     ///

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -193,7 +193,7 @@ impl FromStr for WebViewerServerPort {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.parse::<u16>() {
             Ok(port) => Ok(WebViewerServerPort(port)),
-            Err(e) => Err(format!("Failed to parse port: {e}")),
+            Err(err) => Err(format!("Failed to parse port: {err}")),
         }
     }
 }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -190,6 +190,10 @@ impl WebViewerServer {
             .map_err(WebViewerServerError::ServeFailed)?;
         Ok(())
     }
+
+    pub fn port(&self) -> u16 {
+        self.server.local_addr().port()
+    }
 }
 
 /// Sync handle for the [`WebViewerServer`]

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -38,10 +38,13 @@ mod data {
 pub enum WebViewerServerError {
     #[error("Could not parse address: {0}")]
     AddrParseFailed(#[from] std::net::AddrParseError),
+
     #[error("failed to bind to port {0}: {1}")]
     BindFailed(u16, hyper::Error),
+
     #[error("failed to join web viewer server task: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+
     #[error("failed to serve web viewer: {0}")]
     ServeFailed(hyper::Error),
 }
@@ -164,7 +167,7 @@ impl<T> Service<T> for MakeSvc {
 // ----------------------------------------------------------------------------
 
 /// HTTP host for the Rerun Web Viewer application
-/// This serves the HTTP+WASM+JS files that make up the web-viewer.
+/// This serves the HTTP+Wasm+JS files that make up the web-viewer.
 pub struct WebViewerServer {
     server: hyper::Server<AddrIncoming, MakeSvc>,
 }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -234,7 +234,7 @@ impl WebViewerServerHandle {
         Ok(Self { port, shutdown_tx })
     }
 
-    /// Get the port where the web assets are hosted
+    /// Get the port where the HTTP server is listening
     pub fn port(&self) -> u16 {
         self.port
     }

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -4,7 +4,7 @@
 #[tokio::main]
 async fn main() {
     re_log::setup_native_logging();
-    let port = 9090;
+    let port = Default::default();
     eprintln!("Hosting web-viewer on http://127.0.0.1:{port}");
 
     // Shutdown server via Ctrl+C

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -16,6 +16,7 @@ async fn main() {
     .expect("Error setting Ctrl-C handler");
 
     re_web_viewer_server::WebViewerServer::new(port)
+        .expect("Could not create web server")
         .serve(shutdown_rx)
         .await
         .unwrap();

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -45,6 +45,7 @@ re_log_types = { workspace = true, features = ["serde"] }
 anyhow.workspace = true
 bincode = "1.3"
 document-features = "0.2"
+thiserror.workspace = true
 
 # Client:
 ewebsock = { version = "0.2", optional = true }
@@ -59,7 +60,6 @@ futures-util = { version = "0.3", optional = true, default-features = false, fea
   "std",
 ] }
 parking_lot = { workspace = true, optional = true }
-thiserror.workspace = true
 tokio-tungstenite = { version = "0.17.1", optional = true }
 tokio = { workspace = true, optional = true, default-features = false, features = [
   "io-std",

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -59,6 +59,7 @@ futures-util = { version = "0.3", optional = true, default-features = false, fea
   "std",
 ] }
 parking_lot = { workspace = true, optional = true }
+thiserror.workspace = true
 tokio-tungstenite = { version = "0.17.1", optional = true }
 tokio = { workspace = true, optional = true, default-features = false, features = [
   "io-std",

--- a/crates/re_ws_comms/src/client.rs
+++ b/crates/re_ws_comms/src/client.rs
@@ -2,7 +2,8 @@ use std::ops::ControlFlow;
 
 use ewebsock::{WsEvent, WsMessage, WsSender};
 
-use crate::Result;
+// TODO(jleibs): use thiserror
+pub type Result<T> = anyhow::Result<T>;
 
 /// Represents a connection to the server.
 /// Disconnects on drop.

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -6,17 +6,17 @@
 
 #[cfg(feature = "client")]
 mod client;
+use std::{fmt::Display, str::FromStr};
+
 #[cfg(feature = "client")]
 pub use client::Connection;
 
 #[cfg(feature = "server")]
 mod server;
 #[cfg(feature = "server")]
-pub use server::{RerunServer, RerunServerHandle, RerunServerPort};
+pub use server::{RerunServer, RerunServerHandle};
 
 use re_log_types::LogMsg;
-
-pub type Result<T> = anyhow::Result<T>;
 
 pub const DEFAULT_WS_SERVER_PORT: u16 = 9877;
 
@@ -25,6 +25,56 @@ pub const PROTOCOL: &str = "wss";
 
 #[cfg(not(feature = "tls"))]
 pub const PROTOCOL: &str = "ws";
+
+// ----------------------------------------------------------------------------
+
+#[derive(thiserror::Error, Debug)]
+pub enum RerunServerError {
+    #[error("failed to bind to port {0}: {1}")]
+    BindFailed(RerunServerPort, std::io::Error),
+
+    #[error("received an invalid message")]
+    InvalidMessagePrefix,
+
+    #[error("received an invalid message")]
+    InvalidMessage(#[from] bincode::Error),
+
+    #[cfg(feature = "server")]
+    #[error("failed to join web viewer server task: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
+
+    #[cfg(feature = "server")]
+    #[error("tokio error: {0}")]
+    TokioIoError(#[from] tokio::io::Error),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Typed port for use with [`RerunServer`]
+pub struct RerunServerPort(pub u16);
+
+impl Default for RerunServerPort {
+    fn default() -> Self {
+        Self(DEFAULT_WS_SERVER_PORT)
+    }
+}
+
+impl Display for RerunServerPort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Needed for clap
+impl FromStr for RerunServerPort {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<u16>() {
+            Ok(port) => Ok(RerunServerPort(port)),
+            Err(e) => Err(format!("Failed to parse port: {e}")),
+        }
+    }
+}
 
 pub fn server_url(hostname: &str, port: RerunServerPort) -> String {
     format!("{PROTOCOL}://{hostname}:{port}")
@@ -41,14 +91,11 @@ pub fn encode_log_msg(log_msg: &LogMsg) -> Vec<u8> {
     bytes
 }
 
-pub fn decode_log_msg(data: &[u8]) -> Result<LogMsg> {
+pub fn decode_log_msg(data: &[u8]) -> Result<LogMsg, RerunServerError> {
     let payload = data
         .strip_prefix(&PREFIX)
-        .ok_or_else(|| anyhow::format_err!("Message didn't start with the correct prefix"))?;
+        .ok_or(RerunServerError::InvalidMessagePrefix)?;
 
-    use anyhow::Context as _;
     use bincode::Options as _;
-    bincode::DefaultOptions::new()
-        .deserialize(payload)
-        .context("bincode")
+    Ok(bincode::DefaultOptions::new().deserialize(payload)?)
 }

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -12,7 +12,7 @@ pub use client::Connection;
 #[cfg(feature = "server")]
 mod server;
 #[cfg(feature = "server")]
-pub use server::{RerunServer, RerunServerHandle};
+pub use server::{RerunServer, RerunServerHandle, RerunServerPort};
 
 use re_log_types::LogMsg;
 
@@ -26,7 +26,7 @@ pub const PROTOCOL: &str = "wss";
 #[cfg(not(feature = "tls"))]
 pub const PROTOCOL: &str = "ws";
 
-pub fn server_url(hostname: &str, port: u16) -> String {
+pub fn server_url(hostname: &str, port: RerunServerPort) -> String {
     format!("{PROTOCOL}://{hostname}:{port}")
 }
 

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -12,7 +12,7 @@ pub use client::Connection;
 #[cfg(feature = "server")]
 mod server;
 #[cfg(feature = "server")]
-pub use server::Server;
+pub use server::{RerunServer, RerunServerHandle};
 
 use re_log_types::LogMsg;
 
@@ -26,8 +26,8 @@ pub const PROTOCOL: &str = "wss";
 #[cfg(not(feature = "tls"))]
 pub const PROTOCOL: &str = "ws";
 
-pub fn default_server_url(hostname: &str) -> String {
-    format!("{PROTOCOL}://{hostname}:{DEFAULT_WS_SERVER_PORT}")
+pub fn server_url(hostname: &str, port: u16) -> String {
+    format!("{PROTOCOL}://{hostname}:{port}")
 }
 
 const PREFIX: [u8; 4] = *b"RR00";

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -71,7 +71,7 @@ impl FromStr for RerunServerPort {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.parse::<u16>() {
             Ok(port) => Ok(RerunServerPort(port)),
-            Err(e) => Err(format!("Failed to parse port: {e}")),
+            Err(err) => Err(format!("Failed to parse port: {err}")),
         }
     }
 }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -24,8 +24,10 @@ use crate::server_url;
 pub enum RerunServerError {
     #[error("failed to bind to port {0}: {1}")]
     BindFailed(u16, std::io::Error),
+
     #[error("failed to join web viewer server task: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+
     #[error("tokio error: {0}")]
     TokioIoError(#[from] tokio::io::Error),
 }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -77,6 +77,10 @@ impl RerunServer {
             ));
         }
     }
+
+    pub fn server_url(&self) -> Result<String, RerunServerError> {
+        Ok(server_url("localhost", self.listener.local_addr()?.port()))
+    }
 }
 
 pub struct RerunServerHandle {

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -25,7 +25,10 @@ pub struct RerunServer {
 }
 
 impl RerunServer {
-    /// Start a pub-sub server listening on the given port
+    /// Create new [`RerunServer`] to relay [`LogMsg`]s to a websocket.
+    /// The websocket will be available at `port`.
+    ///
+    /// A port of 0 will let the OS choose a free port.
     pub async fn new(port: RerunServerPort) -> Result<Self, RerunServerError> {
         let bind_addr = format!("0.0.0.0:{port}");
 
@@ -92,7 +95,8 @@ impl Drop for RerunServerHandle {
 }
 
 impl RerunServerHandle {
-    /// Create new [`RerunServer`] to relay [`LogMsg`]s to a web viewer.
+    /// Create new [`RerunServer`] to relay [`LogMsg`]s to a websocket.
+    /// Returns a [`RerunServerHandle`] that will shutdown the server when dropped.
     ///
     /// A port of 0 will let the OS choose a free port.
     ///

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -32,6 +32,7 @@ pub enum RerunServerError {
     TokioIoError(#[from] tokio::io::Error),
 }
 
+/// Websocket host for relaying [`LogMsg`]s to a web viewer.
 pub struct RerunServer {
     listener: TcpListener,
     port: u16,
@@ -89,6 +90,9 @@ impl RerunServer {
     }
 }
 
+/// Sync handle for the [`RerunServer`]
+///
+/// When dropped, the server will be shut down.
 pub struct RerunServerHandle {
     port: u16,
     shutdown_tx: tokio::sync::broadcast::Sender<()>,
@@ -124,7 +128,7 @@ impl RerunServerHandle {
         Ok(Self { port, shutdown_tx })
     }
 
-    /// Get the port where the web assets are hosted
+    /// Get the port where the websocket server is listening
     pub fn port(&self) -> u16 {
         self.port
     }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -6,7 +6,7 @@
 //! In the future thing will be changed to a protocol where the clients can query
 //! for specific data based on e.g. time.
 
-use std::{fmt::Display, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
@@ -16,49 +16,7 @@ use tokio_tungstenite::{accept_async, tungstenite::Error};
 use re_log_types::LogMsg;
 use re_smart_channel::Receiver;
 
-use crate::{server_url, DEFAULT_WS_SERVER_PORT};
-
-// ----------------------------------------------------------------------------
-
-#[derive(thiserror::Error, Debug)]
-pub enum RerunServerError {
-    #[error("failed to bind to port {0}: {1}")]
-    BindFailed(RerunServerPort, std::io::Error),
-
-    #[error("failed to join web viewer server task: {0}")]
-    JoinError(#[from] tokio::task::JoinError),
-
-    #[error("tokio error: {0}")]
-    TokioIoError(#[from] tokio::io::Error),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-/// Typed port for use with [`RerunServer`]
-pub struct RerunServerPort(pub u16);
-
-impl Default for RerunServerPort {
-    fn default() -> Self {
-        Self(DEFAULT_WS_SERVER_PORT)
-    }
-}
-
-impl Display for RerunServerPort {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-// Needed for clap
-impl FromStr for RerunServerPort {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.parse::<u16>() {
-            Ok(port) => Ok(RerunServerPort(port)),
-            Err(e) => Err(format!("Failed to parse port: {e}")),
-        }
-    }
-}
+use crate::{server_url, RerunServerError, RerunServerPort};
 
 /// Websocket host for relaying [`LogMsg`]s to a web viewer.
 pub struct RerunServer {

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -41,7 +41,7 @@ impl RerunServer {
 
         let listener = TcpListener::bind(&bind_addr)
             .await
-            .map_err(|e| RerunServerError::BindError(port, e))?;
+            .map_err(|e| RerunServerError::BindFailed(port, e))?;
 
         re_log::info!(
             "Listening for websocket traffic on {bind_addr}. Connect with a web Rerun Viewer."

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -103,7 +103,11 @@ impl RerunArgs {
             #[cfg(feature = "web_viewer")]
             RerunBehavior::Serve => {
                 let open_browser = true;
-                crate::web_viewer::new_sink(open_browser)?
+                crate::web_viewer::new_sink(
+                    open_browser,
+                    re_web_viewer_server::DEFAULT_WEB_VIEWER_PORT,
+                    re_ws_comms::DEFAULT_WS_SERVER_PORT,
+                )?
             }
 
             #[cfg(feature = "native_viewer")]

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -2,7 +2,9 @@
 
 use std::{net::SocketAddr, path::PathBuf};
 
+#[cfg(feature = "web_viewer")]
 use re_web_viewer_server::WebViewerServerPort;
+#[cfg(feature = "web_viewer")]
 use re_ws_comms::RerunServerPort;
 
 use crate::Session;

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -2,6 +2,9 @@
 
 use std::{net::SocketAddr, path::PathBuf};
 
+use re_web_viewer_server::WebViewerServerPort;
+use re_ws_comms::RerunServerPort;
+
 use crate::Session;
 
 // ---
@@ -105,8 +108,8 @@ impl RerunArgs {
                 let open_browser = true;
                 crate::web_viewer::new_sink(
                     open_browser,
-                    re_web_viewer_server::DEFAULT_WEB_VIEWER_PORT,
-                    re_ws_comms::DEFAULT_WS_SERVER_PORT,
+                    WebViewerServerPort::default(),
+                    RerunServerPort::default(),
                 )?
             }
 

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -103,7 +103,7 @@ impl RerunArgs {
             #[cfg(feature = "web_viewer")]
             RerunBehavior::Serve => {
                 let open_browser = true;
-                crate::web_viewer::new_sink(open_browser)
+                crate::web_viewer::new_sink(open_browser)?
             }
 
             #[cfg(feature = "native_viewer")]

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -388,7 +388,7 @@ async fn run_impl(
 
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::RerunServer::new(args.ws_server_port).await?;
-            let ws_server_url = ws_server.server_url()?;
+            let ws_server_url = ws_server.server_url();
             let ws_server_handle = tokio::spawn(ws_server.listen(rx, shutdown_ws_server));
 
             // This is the server that serves the Wasm+HTML:

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -7,6 +7,7 @@ use anyhow::Context as _;
 use clap::Subcommand;
 #[cfg(feature = "web_viewer")]
 use re_web_viewer_server::WebViewerServerPort;
+#[cfg(feature = "web_viewer")]
 use re_ws_comms::RerunServerPort;
 
 #[cfg(feature = "web_viewer")]

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -111,12 +111,12 @@ struct Args {
 
     /// What port do we listen to for hosting the web viewer
     #[cfg(feature = "web_viewer")]
-    #[clap(long)]
+    #[clap(long, default_value_t = Default::default())]
     web_viewer_port: WebViewerServerPort,
 
     /// What port do we listen to for incoming websocket connections from the viewer
     #[cfg(feature = "web_viewer")]
-    #[clap(long)]
+    #[clap(long, default_value_t = Default::default())]
     ws_server_port: RerunServerPort,
 }
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -5,6 +5,8 @@ use re_smart_channel::Receiver;
 
 use anyhow::Context as _;
 use clap::Subcommand;
+use re_web_viewer_server::WebViewerServerPort;
+use re_ws_comms::RerunServerPort;
 
 #[cfg(feature = "web_viewer")]
 use crate::web_viewer::host_web_viewer;
@@ -109,13 +111,13 @@ struct Args {
 
     /// What port do we listen to for hosting the web viewer
     #[cfg(feature = "web_viewer")]
-    #[clap(long, default_value_t = re_web_viewer_server::DEFAULT_WEB_VIEWER_PORT)]
-    web_viewer_port: u16,
+    #[clap(long)]
+    web_viewer_port: WebViewerServerPort,
 
     /// What port do we listen to for incoming websocket connections from the viewer
     #[cfg(feature = "web_viewer")]
-    #[clap(long, default_value_t = re_ws_comms::DEFAULT_WS_SERVER_PORT)]
-    ws_server_port: u16,
+    #[clap(long)]
+    ws_server_port: RerunServerPort,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -373,7 +375,7 @@ async fn run_impl(
         {
             #[cfg(feature = "server")]
             if args.url_or_path.is_none()
-                && (args.port == args.web_viewer_port || args.port == args.ws_server_port)
+                && (args.port == args.web_viewer_port.0 || args.port == args.ws_server_port.0)
             {
                 anyhow::bail!(
                     "Trying to spawn a websocket server on {}, but this port is \

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -5,6 +5,7 @@ use re_smart_channel::Receiver;
 
 use anyhow::Context as _;
 use clap::Subcommand;
+#[cfg(feature = "web_viewer")]
 use re_web_viewer_server::WebViewerServerPort;
 use re_ws_comms::RerunServerPort;
 
@@ -109,12 +110,14 @@ struct Args {
     #[clap(long)]
     web_viewer: bool,
 
-    /// What port do we listen to for hosting the web viewer
+    /// What port do we listen to for hosting the web viewer over HTTP.
+    /// A port of 0 will pick a random port.
     #[cfg(feature = "web_viewer")]
     #[clap(long, default_value_t = Default::default())]
     web_viewer_port: WebViewerServerPort,
 
     /// What port do we listen to for incoming websocket connections from the viewer
+    /// A port of 0 will pick a random port.
     #[cfg(feature = "web_viewer")]
     #[clap(long, default_value_t = Default::default())]
     ws_server_port: RerunServerPort,

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -4,7 +4,7 @@ use re_ws_comms::RerunServerHandle;
 
 /// A [`LogSink`] tied to a hosted Rerun web viewer. This internally stores two servers:
 /// * A [`RerunServer`] to relay messages from the sink to a websocket connection
-/// * A [`WebViewerServer`] to serve the WASM+HTML
+/// * A [`WebViewerServer`] to serve the Wasm+HTML
 struct WebViewerSink {
     /// Sender to send messages to the [`RerunServer`]
     sender: re_smart_channel::Sender<LogMsg>,
@@ -41,7 +41,7 @@ impl WebViewerSink {
 }
 
 /// Async helper to spawn an instance of the [`re_web_viewer_server::WebViewerServer`].
-/// This serves the HTTP+WASM+JS files that make up the web-viewer.
+/// This serves the HTTP+Wasm+JS files that make up the web-viewer.
 ///
 /// Optionally opens a browser with the web-viewer and connects to the provided `target_url`.
 /// This url could be a hosted RRD file or a `ws://` url to a running [`re_ws_comms::RerunServer`].

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -3,8 +3,8 @@ use re_web_viewer_server::WebViewerServerHandle;
 use re_ws_comms::RerunServerHandle;
 
 /// A [`crate::sink::LogSink`] tied to a hosted Rerun web viewer. This internally stores two servers:
-/// * A [`RerunServer`] to relay messages from the sink to a websocket connection
-/// * A [`WebViewerServer`] to serve the Wasm+HTML
+/// * A [`re_ws_comms::RerunServer`] to relay messages from the sink to a websocket connection
+/// * A [`re_web_viewer_server::WebViewerServer`] to serve the Wasm+HTML
 struct WebViewerSink {
     /// Sender to send messages to the [`re_ws_comms::RerunServer`]
     sender: re_smart_channel::Sender<LogMsg>,

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -2,17 +2,17 @@ use re_log_types::LogMsg;
 use re_web_viewer_server::WebViewerServerHandle;
 use re_ws_comms::RerunServerHandle;
 
-/// A [`LogSink`] tied to a hosted Rerun web viewer. This internally stores two servers:
+/// A [`crate::sink::LogSink`] tied to a hosted Rerun web viewer. This internally stores two servers:
 /// * A [`RerunServer`] to relay messages from the sink to a websocket connection
 /// * A [`WebViewerServer`] to serve the Wasm+HTML
 struct WebViewerSink {
-    /// Sender to send messages to the [`RerunServer`]
+    /// Sender to send messages to the [`re_ws_comms::RerunServer`]
     sender: re_smart_channel::Sender<LogMsg>,
 
-    /// Handle to keep the [`RerunServer`] alive
+    /// Handle to keep the [`re_ws_comms::RerunServer`] alive
     _rerun_server: RerunServerHandle,
 
-    /// Handle to keep the [`WebViewerServer`] alive
+    /// Handle to keep the [`re_web_viewer_server::WebViewerServer`] alive
     _webviewer_server: WebViewerServerHandle,
 }
 

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -20,7 +20,7 @@
     "# Uncomment to use locally-hosted assets. Necessary for local-builds or offline setups.\n",
     "# Won't work for remotely hosted notebook environments.\n",
     "\n",
-    "# rr.self_host_assets()"
+    "# rr.start_web_viewer_server()"
    ]
   },
   {

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -35,7 +35,7 @@ native_viewer = ["rerun/native_viewer"]
 ##
 ## You also need to install some additional tools, which you can do by running
 ## [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
-web_viewer = ["rerun/web_viewer", "dep:re_web_viewer_server"]
+web_viewer = ["rerun/web_viewer", "dep:re_web_viewer_server", "dep:re_ws_comms"]
 
 
 [dependencies]
@@ -51,6 +51,7 @@ rerun = { workspace = true, default-features = false, features = [
   "sdk",
 ] }
 re_web_viewer_server = { workspace = true, optional = true }
+re_ws_comms = { workspace = true, optional = true }
 
 arrow2 = { workspace = true, features = ["io_ipc", "io_print"] }
 document-features = "0.2"

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -35,7 +35,7 @@ native_viewer = ["rerun/native_viewer"]
 ##
 ## You also need to install some additional tools, which you can do by running
 ## [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
-web_viewer = ["rerun/web_viewer"]
+web_viewer = ["rerun/web_viewer", "dep:re_web_viewer_server"]
 
 
 [dependencies]
@@ -50,6 +50,7 @@ rerun = { workspace = true, default-features = false, features = [
   "server",
   "sdk",
 ] }
+re_web_viewer_server = { workspace = true, optional = true }
 
 arrow2 = { workspace = true, features = ["io_ipc", "io_print"] }
 document-features = "0.2"

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -338,7 +338,7 @@ def spawn(port: int = 9876, connect: bool = True) -> None:
 _spawn = spawn  # we need this because Python scoping is horrible
 
 
-def serve(open_browser: bool = True) -> None:
+def serve(open_browser: bool = True, web_port: Optional[int] = None, ws_port: Optional[int] = None) -> None:
     """
     Serve log-data over WebSockets and serve a Rerun web viewer over HTTP.
 
@@ -352,14 +352,17 @@ def serve(open_browser: bool = True) -> None:
     ----------
     open_browser
         Open the default browser to the viewer.
-
+    web_port:
+        The port to serve the web viewer on (defaults to 9090).
+    ws_port:
+        The port to serve the WebSocket server on (defaults to 9877)
     """
 
     if not bindings.is_enabled():
         print("Rerun is disabled - serve() call ignored")
         return
 
-    bindings.serve(open_browser)
+    bindings.serve(open_browser, web_port, ws_port)
 
 
 def start_web_viewer_server(port: int = 0) -> None:

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -362,21 +362,21 @@ def serve(open_browser: bool = True) -> None:
     bindings.serve(open_browser)
 
 
-def self_host_assets(port: int = 9090) -> None:
+def start_web_viewer_server(port: int = 0) -> None:
     """
     Self-host the rerun web-viewer assets on a specified port.
 
     Parameters
     ----------
     port
-        Port to serve assets on. Pass None to disable. (Defaults to 9090)
+        Port to serve assets on. Defaults to 0 (random port).
     """
 
     if not bindings.is_enabled():
         print("Rerun is disabled - self_host_assets() call ignored")
         return
 
-    bindings.self_host_assets(port)
+    bindings.start_web_viewer_server(port)
 
 
 def disconnect() -> None:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -142,7 +142,7 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(is_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(memory_recording, m)?)?;
     m.add_function(wrap_pyfunction!(save, m)?)?;
-    m.add_function(wrap_pyfunction!(self_host_assets, m)?)?;
+    m.add_function(wrap_pyfunction!(start_web_viewer_server, m)?)?;
     m.add_function(wrap_pyfunction!(serve, m)?)?;
     m.add_function(wrap_pyfunction!(set_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(shutdown, m)?)?;
@@ -324,7 +324,10 @@ fn serve(open_browser: bool) -> PyResult<()> {
 
         let _guard = enter_tokio_runtime();
 
-        session.set_sink(rerun::web_viewer::new_sink(open_browser));
+        session.set_sink(
+            rerun::web_viewer::new_sink(open_browser)
+                .map_err(|err| PyRuntimeError::new_err(err.to_string()))?,
+        );
 
         Ok(())
     }
@@ -339,11 +342,11 @@ fn serve(open_browser: bool) -> PyResult<()> {
 }
 
 #[pyfunction]
-fn self_host_assets(port: Option<u16>) -> PyResult<()> {
+fn start_web_viewer_server(port: u16) -> PyResult<()> {
     let mut session = python_session();
     let _guard = enter_tokio_runtime();
     session
-        .self_host_assets(port)
+        .start_web_viewer_server(port)
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))
 }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -312,7 +312,7 @@ fn enter_tokio_runtime() -> tokio::runtime::EnterGuard<'static> {
 /// Serve a web-viewer.
 #[allow(clippy::unnecessary_wraps)] // False positive
 #[pyfunction]
-fn serve(open_browser: bool) -> PyResult<()> {
+fn serve(open_browser: bool, web_port: Option<u16>, ws_port: Option<u16>) -> PyResult<()> {
     #[cfg(feature = "web_viewer")]
     {
         let mut session = python_session();
@@ -325,8 +325,12 @@ fn serve(open_browser: bool) -> PyResult<()> {
         let _guard = enter_tokio_runtime();
 
         session.set_sink(
-            rerun::web_viewer::new_sink(open_browser)
-                .map_err(|err| PyRuntimeError::new_err(err.to_string()))?,
+            rerun::web_viewer::new_sink(
+                open_browser,
+                web_port.unwrap_or(re_web_viewer_server::DEFAULT_WEB_VIEWER_PORT),
+                ws_port.unwrap_or(re_ws_comms::DEFAULT_WS_SERVER_PORT),
+            )
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?,
         );
 
         Ok(())

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -15,6 +15,7 @@ pub enum PythonSessionError {
     #[allow(dead_code)]
     #[error("The Rerun SDK was not compiled with the '{0}' feature")]
     FeatureNotEnabled(&'static str),
+
     #[error("Could not start the WebViewerServer: '{0}'")]
     WebViewerServerError(#[from] re_web_viewer_server::WebViewerServerError),
 }

--- a/rerun_py/src/python_session.rs
+++ b/rerun_py/src/python_session.rs
@@ -6,8 +6,8 @@ use re_log_types::{
     RecordingId, RecordingInfo, RecordingSource, RowId, Time, TimePoint,
 };
 
+use re_web_viewer_server::WebViewerServerPort;
 use rerun::sink::LogSink;
-
 // ----------------------------------------------------------------------------
 
 #[derive(thiserror::Error, Debug)]
@@ -327,18 +327,13 @@ impl PythonSession {
     ///
     /// The caller needs to ensure that there is a `tokio` runtime running.
     #[allow(clippy::unnecessary_wraps)]
-    pub fn start_web_viewer_server(&mut self, _web_port: u16) -> Result<(), PythonSessionError> {
-        #[cfg(feature = "web_viewer")]
-        {
-            self.web_viewer_server =
-                Some(re_web_viewer_server::WebViewerServerHandle::new(_web_port)?);
+    #[cfg(feature = "web_viewer")]
+    pub fn start_web_viewer_server(
+        &mut self,
+        _web_port: WebViewerServerPort,
+    ) -> Result<(), PythonSessionError> {
+        self.web_viewer_server = Some(re_web_viewer_server::WebViewerServerHandle::new(_web_port)?);
 
-            Ok(())
-        }
-
-        #[cfg(not(feature = "web_viewer"))]
-        {
-            Err(PythonSessionError::FeatureNotEnabled("web_viewer"))
-        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Builds on top of:
 - https://github.com/rerun-io/rerun/pull/1798

### WHAT
This pull request refactors the web viewer server and rerun/websocket server components.  In particular:
 - `WebViewerServer` is solely responsible for hosting the web viewer application over HTTP
 - `RerunServer` is solely responsible for serving data over the websocket

Both are structured as an async Struct, and a matching Handle-variant for the convenience of shutting down when dropped.

`RemoteViewerServer` is now `WebViewerSink` -- it just uses the two servers above.

Along the way I added additional plumbing for controlling which ports are being used and use the acquired port when building urls so we get the correct strings. This means using 0 for OS-provided random ports works as expected:
```
$ rerun --web-viewer --web-viewer-port 0 --ws-server-port 0
DEV ENVIRONMENT DETECTED! Re-importing rerun from: /home/jleibs/rerun/rerun_py/rerun_sdk
[2023-04-14T01:24:52Z INFO  re_ws_comms::server] Listening for websocket traffic on 0.0.0.0:36595. Connect with a Rerun Web Viewer.
[2023-04-14T01:24:52Z INFO  rerun::web_viewer] Web server is running - view it at http://127.0.0.1:46525?url=ws://localhost:36595
```

Also got rid of a bunch of `unwrap` calls and plumbed errors through appropriately.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
