### PR TITLE
Show previews of colormaps when selecting them

### DIFF
--- a/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
+++ b/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
@@ -56,7 +56,7 @@ fn upload_texture_slice_to_gpu(
 ) -> Result<re_renderer::resource_managers::GpuTexture2DHandle, TensorUploadError> {
     let id = egui::util::hash((tensor.id(), slice_selection));
 
-    crate::gpu_bridge::get_or_create_texture(render_ctx, id, || {
+    crate::gpu_bridge::try_get_or_create_texture(render_ctx, id, || {
         texture_desc_from_tensor(tensor, slice_selection)
     })
 }

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -291,7 +291,7 @@ fn colormap_preview_ui(
     let (rect, response) = ui.allocate_exact_size(desired_size, egui::Sense::hover());
 
     if ui.is_rect_visible(rect) {
-        if let Err(err) = paint_colormap_graident(render_ctx, colormap, ui, rect) {
+        if let Err(err) = paint_colormap_gradient(render_ctx, colormap, ui, rect) {
             re_log::error_once!("Failed to paint colormap preview: {err}");
         }
     }
@@ -299,7 +299,7 @@ fn colormap_preview_ui(
     response
 }
 
-fn paint_colormap_graident(
+fn paint_colormap_gradient(
     render_ctx: &mut re_renderer::RenderContext,
     colormap: Colormap,
     ui: &mut egui::Ui,


### PR DESCRIPTION
The UX isn't fantastic - you can't click the gradients, only the label - but it is better than before!

And yes, they are rendered on GPU.

![image](https://user-images.githubusercontent.com/1148717/232010923-84f4d342-939f-4fde-a03b-a49848e7bb45.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
