### PR TITLE
Gpu picking for depth clouds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
         "andreas",
         "bbox",
         "bindgroup",
+        "colormap",
         "emath",
         "framebuffer",
         "hoverable",

--- a/crates/re_log_types/src/component_types/instance_key.rs
+++ b/crates/re_log_types/src/component_types/instance_key.rs
@@ -63,6 +63,16 @@ impl InstanceKey {
     pub fn specific_index(self) -> Option<InstanceKey> {
         self.is_specific().then_some(self)
     }
+
+    /// Creates a new [`InstanceKey`] that identifies a 2d coordinate.
+    pub fn from_2d_image_coordinate(x: u32, y: u32, image_width: u64) -> Self {
+        Self((x as u64) + (y as u64) * image_width)
+    }
+
+    /// Retrieves 2d image coordinates (x, y) encoded in an instance key
+    pub fn to_2d_image_coordinate(self, image_width: u64) -> [u32; 2] {
+        [(self.0 % image_width) as u32, (self.0 / image_width) as u32]
+    }
 }
 
 impl std::fmt::Display for InstanceKey {

--- a/crates/re_log_types/src/component_types/instance_key.rs
+++ b/crates/re_log_types/src/component_types/instance_key.rs
@@ -65,7 +65,7 @@ impl InstanceKey {
     }
 
     /// Creates a new [`InstanceKey`] that identifies a 2d coordinate.
-    pub fn from_2d_image_coordinate(x: u32, y: u32, image_width: u64) -> Self {
+    pub fn from_2d_image_coordinate([x, y]: [u32; 2], image_width: u64) -> Self {
         Self((x as u64) + (y as u64) * image_width)
     }
 

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -185,6 +185,7 @@ impl RenderDepthClouds {
                     depth_data: depth.data.clone(),
                     colormap: re_renderer::Colormap::Turbo,
                     outline_mask_id: Default::default(),
+                    picking_object_id: Default::default(),
                 }],
                 radius_boost_in_ui_points_for_outlines: 2.5,
             },

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -28,6 +28,9 @@ struct DepthCloudInfo {
     /// Outline mask id for the outline mask pass.
     outline_mask_id: UVec2,
 
+    /// Picking object id that applies for the entire depth cloud.
+    picking_layer_object_id: UVec2,
+
     /// Multiplier to get world-space depth from whatever is in the texture.
     world_depth_from_texture_value: f32,
 
@@ -51,11 +54,23 @@ var<uniform> depth_cloud_info: DepthCloudInfo;
 var depth_texture: texture_2d<f32>;
 
 struct VertexOut {
-    @builtin(position) pos_in_clip: Vec4,
-    @location(0) pos_in_world: Vec3,
-    @location(1) point_pos_in_world: Vec3,
-    @location(2) point_color: Vec4,
-    @location(3) point_radius: f32,
+    @builtin(position)
+    pos_in_clip: Vec4,
+
+    @location(0) @interpolate(perspective)
+    pos_in_world: Vec3,
+
+    @location(1) @interpolate(flat)
+    point_pos_in_world: Vec3,
+
+    @location(2) @interpolate(flat)
+    point_color: Vec4,
+
+    @location(3) @interpolate(flat)
+    point_radius: f32,
+
+    @location(4) @interpolate(flat)
+    picking_instance_id: UVec2,
 };
 
 // ---
@@ -63,7 +78,8 @@ struct VertexOut {
 struct PointData {
     pos_in_world: Vec3,
     unresolved_radius: f32,
-    color: Vec4
+    color: Vec4,
+    picking_instance_id: UVec2,
 }
 
 // Backprojects the depth texture using the intrinsics passed in the uniform buffer.
@@ -75,6 +91,8 @@ fn compute_point_data(quad_idx: i32) -> PointData {
     let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;
 
     var data: PointData;
+    data.picking_instance_id = UVec2(texcoords);
+
     if 0.0 < world_space_depth && world_space_depth < f32max {
         // TODO(cmc): albedo textures
         let color = Vec4(colormap_linear(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth_in_world), 1.0);
@@ -113,6 +131,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
     var out: VertexOut;
     out.point_pos_in_world = point_data.pos_in_world;
     out.point_color = point_data.color;
+    out.picking_instance_id = point_data.picking_instance_id;
 
     if 0.0 < point_data.unresolved_radius {
         // Span quad
@@ -145,7 +164,7 @@ fn fs_main_picking_layer(in: VertexOut) -> @location(0) UVec4 {
     if coverage <= 0.5 {
         discard;
     }
-    return UVec4(0u, 0u, 0u, 0u); // TODO(andreas): Implement picking layer id pass-through.
+    return UVec4(depth_cloud_info.picking_layer_object_id, in.picking_instance_id);
 }
 
 @fragment

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -21,6 +21,16 @@ impl GpuTexture2DHandle {
     pub fn invalid() -> Self {
         Self(None)
     }
+
+    /// Width of the texture, defaults to 1 if invalid since fallback textures are typically one pixel.
+    pub fn width(&self) -> u32 {
+        self.0.as_ref().map_or(1, |t| t.texture.width())
+    }
+
+    /// Height of the texture, defaults to 1 if invalid since fallback textures are typically one pixel.
+    pub fn height(&self) -> u32 {
+        self.0.as_ref().map_or(1, |t| t.texture.height())
+    }
 }
 
 /// Data required to create a texture 2d resource.

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -56,7 +56,8 @@ pub struct MeshSource {
 }
 
 pub struct Image {
-    pub instance_path_hash: InstancePathHash,
+    /// Path to the image (note image instance ids would refer to pixels!)
+    pub ent_path: EntityPath,
 
     pub tensor: Tensor,
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
@@ -253,8 +253,10 @@ fn picking_textured_rects(
                 instance_path_hash: InstancePathHash {
                     entity_path_hash: *id,
                     instance_key: InstanceKey::from_2d_image_coordinate(
-                        (u * rect.colormapped_texture.texture.width() as f32) as u32,
-                        (v * rect.colormapped_texture.texture.height() as f32) as u32,
+                        [
+                            (u * rect.colormapped_texture.texture.width() as f32) as u32,
+                            (v * rect.colormapped_texture.texture.height() as f32) as u32,
+                        ],
                         rect.colormapped_texture.texture.width() as u64,
                     ),
                 },

--- a/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
@@ -1,5 +1,6 @@
 use egui::Color32;
 use re_data_store::InstancePathHash;
+use re_log_types::EntityPathHash;
 use re_renderer::{
     renderer::{DepthClouds, MeshInstance},
     LineStripSeriesBuilder, PointCloudBuilder,
@@ -21,7 +22,7 @@ pub struct SceneSpatialPrimitives {
 
     // TODO(andreas): Storing extra data like so is unsafe and not future proof either
     //                (see also above comment on the need to separate cpu-readable data)
-    pub textured_rectangles_ids: Vec<InstancePathHash>,
+    pub textured_rectangles_ids: Vec<EntityPathHash>,
     pub textured_rectangles: Vec<re_renderer::renderer::TexturedRect>,
 
     pub line_strips: LineStripSeriesBuilder,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -179,6 +179,7 @@ impl ImagesPart {
                             transforms,
                             properties,
                             &tensor,
+                            ent_path,
                             &pinhole_ent_path,
                             entity_highlight,
                         ) {
@@ -279,6 +280,7 @@ impl ImagesPart {
         transforms: &TransformCache,
         properties: &EntityProperties,
         tensor: &Tensor,
+        ent_path: &EntityPath,
         pinhole_ent_path: &EntityPath,
         entity_highlight: &SpaceViewOutlineMasks,
     ) -> Result<(), String> {
@@ -360,6 +362,7 @@ impl ImagesPart {
             depth_data: data,
             colormap,
             outline_mask_id: entity_highlight.overall,
+            picking_object_id: re_renderer::PickingLayerObjectId(ent_path.hash64()),
         });
 
         Ok(())


### PR DESCRIPTION
The last piece that didn't have gpu picking 🎉🎉
Indeed it didn't have picking at all! Making it the first piece to profit more than just on the accuracy & performance side.

This PR also takes the first step towards using instance ids for indexing pixels in accordance with the discussion results documented in #1756 
In fact, the hover effect for all images now uses instance ids to encode the hovered pixel, making the hover handling of depth clouds a very natural extension of the existing feature!

https://user-images.githubusercontent.com/1220815/232068529-d34d4c85-9cb1-4705-b528-352d4c4ae4d5.mov


Small caveat: The depth values we get via the blueprint meter settings are correctly processed in some places and not in others. Decided to leave it be for now as this is something we need to solve with proper blueprint overwrites.


Fixes #1584 and fixes #1615

* #1615
* #1584


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)