### PR TITLE
Restore: New API to reset_time (#1826)

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -528,3 +528,19 @@ def set_time_nanos(timeline: str, nanos: Optional[int]) -> None:
         return
 
     bindings.set_time_nanos(timeline, nanos)
+
+
+def reset_time() -> None:
+    """
+    Clear all timeline information on this thread.
+
+    This is the same as calling `set_time_*` with `None` for all of the active timelines.
+
+    Used for all subsequent logging on the same thread,
+    until the next call to [`rerun.set_time_nanos`][] or [`rerun.set_time_seconds`][].
+    """
+
+    if not bindings.is_enabled():
+        return
+
+    bindings.reset_time()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -63,6 +63,10 @@ impl ThreadInfo {
         Self::with(|ti| ti.set_time(timeline, time_int));
     }
 
+    pub fn reset_thread_time() {
+        Self::with(|ti| ti.reset_time());
+    }
+
     /// Get access to the thread-local [`ThreadInfo`].
     fn with<R>(f: impl FnOnce(&mut ThreadInfo) -> R) -> R {
         use std::cell::RefCell;
@@ -89,6 +93,10 @@ impl ThreadInfo {
         } else {
             self.time_point.remove(&timeline);
         }
+    }
+
+    fn reset_time(&mut self) {
+        self.time_point = TimePoint::default();
     }
 }
 
@@ -153,6 +161,7 @@ fn rerun_bindings(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_time_sequence, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_seconds, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_nanos, m)?)?;
+    m.add_function(wrap_pyfunction!(reset_time, m)?)?;
 
     m.add_function(wrap_pyfunction!(log_unknown_transform, m)?)?;
     m.add_function(wrap_pyfunction!(log_rigid3, m)?)?;
@@ -479,6 +488,11 @@ fn set_time_nanos(timeline: &str, ns: Option<i64>) {
         Timeline::new(timeline, TimeType::Time),
         ns.map(|ns| Time::from_ns_since_epoch(ns).into()),
     );
+}
+
+#[pyfunction]
+fn reset_time() {
+    ThreadInfo::reset_thread_time();
 }
 
 fn convert_color(color: Vec<u8>) -> PyResult<[u8; 4]> {


### PR DESCRIPTION
Somehow the original PR:
 - https://github.com/rerun-io/rerun/pull/1826

Got reverted here: https://github.com/rerun-io/rerun/pull/1727/files#r1167115556