### PR TITLE
Revert "Implement billinear filtering of textures (#1850)"

### DIFF
--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -192,9 +192,6 @@ mod gpu_data {
     const COLOR_MAPPER_FUNCTION: u32 = 2;
     const COLOR_MAPPER_TEXTURE: u32 = 3;
 
-    const FILTER_NEAREST: u32 = 1;
-    const FILTER_BILINEAR: u32 = 2;
-
     #[repr(C, align(256))]
     #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct UniformBuffer {
@@ -216,8 +213,7 @@ mod gpu_data {
 
         color_mapper: u32,
         gamma: f32,
-        minification_filter: u32,
-        magnification_filter: u32,
+        _row_padding: [u32; 2],
 
         _end_padding: [wgpu_buffer_types::PaddingRow; 16 - 6],
     }
@@ -279,15 +275,6 @@ mod gpu_data {
                 }
             }
 
-            let minification_filter = match rectangle.texture_filter_minification {
-                super::TextureFilterMin::Linear => FILTER_BILINEAR,
-                super::TextureFilterMin::Nearest => FILTER_NEAREST,
-            };
-            let magnification_filter = match rectangle.texture_filter_magnification {
-                super::TextureFilterMag::Linear => FILTER_BILINEAR,
-                super::TextureFilterMag::Nearest => FILTER_NEAREST,
-            };
-
             Ok(Self {
                 top_left_corner_position: rectangle.top_left_corner_position.into(),
                 colormap_function,
@@ -300,8 +287,7 @@ mod gpu_data {
                 range_min_max: (*range).into(),
                 color_mapper: color_mapper_int,
                 gamma: *gamma,
-                minification_filter,
-                magnification_filter,
+                _row_padding: Default::default(),
                 _end_padding: Default::default(),
             })
         }

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -426,29 +426,32 @@ impl TextureSettings {
         });
         ui.end_row();
 
-        re_ui
-            .grid_left_hand_label(ui, "Filtering")
-            .on_hover_text("Filtering to use when magnifying");
+        // TODO(#1612): support texture filtering again
+        if false {
+            re_ui
+                .grid_left_hand_label(ui, "Filtering")
+                .on_hover_text("Filtering to use when magnifying");
 
-        fn tf_to_string(tf: egui::TextureFilter) -> &'static str {
-            match tf {
-                egui::TextureFilter::Nearest => "Nearest",
-                egui::TextureFilter::Linear => "Linear",
+            fn tf_to_string(tf: egui::TextureFilter) -> &'static str {
+                match tf {
+                    egui::TextureFilter::Nearest => "Nearest",
+                    egui::TextureFilter::Linear => "Linear",
+                }
             }
-        }
-        egui::ComboBox::from_id_source("texture_filter")
-            .selected_text(tf_to_string(options.magnification))
-            .show_ui(ui, |ui| {
-                ui.style_mut().wrap = Some(false);
-                ui.set_min_width(64.0);
+            egui::ComboBox::from_id_source("texture_filter")
+                .selected_text(tf_to_string(options.magnification))
+                .show_ui(ui, |ui| {
+                    ui.style_mut().wrap = Some(false);
+                    ui.set_min_width(64.0);
 
-                let mut selectable_value = |ui: &mut egui::Ui, e| {
-                    ui.selectable_value(&mut options.magnification, e, tf_to_string(e))
-                };
-                selectable_value(ui, egui::TextureFilter::Nearest);
-                selectable_value(ui, egui::TextureFilter::Linear);
-            });
-        ui.end_row();
+                    let mut selectable_value = |ui: &mut egui::Ui, e| {
+                        ui.selectable_value(&mut options.magnification, e, tf_to_string(e))
+                    };
+                    selectable_value(ui, egui::TextureFilter::Linear);
+                    selectable_value(ui, egui::TextureFilter::Nearest);
+                });
+            ui.end_row();
+        }
     }
 }
 


### PR DESCRIPTION
This reverts commit d33dab6e7a33f82ab2513058d0f85744e3ce6ef4.

See: https://github.com/rerun-io/rerun/issues/1858

Demonstration of issue: https://app.rerun.io/commit/8d25b9e/index.html