### PR TITLE
Remove manual depth projection from car and nyud examples

### DIFF
--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-     "\n",
+    "\n",
     "STEPS = 100\n",
     "twists = math.pi * np.sin(np.linspace(0, math.tau, STEPS)) / 4\n",
     "for t in range(STEPS):\n",

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -177,7 +177,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "STEPS = 100\n",
     "twists = math.pi * np.sin(np.linspace(0, math.tau, STEPS)) / 4\n",
     "for t in range(STEPS):\n",

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -177,6 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+       "\n",
     "STEPS = 100\n",
     "twists = math.pi * np.sin(np.linspace(0, math.tau, STEPS)) / 4\n",
     "for t in range(STEPS):\n",

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-       "\n",
+     "\n",
     "STEPS = 100\n",
     "twists = math.pi * np.sin(np.linspace(0, math.tau, STEPS)) / 4\n",
     "for t in range(STEPS):\n",


### PR DESCRIPTION
The depth point clouds are now much better in every way, and _much_ faster.

Let's simplify and speed up the examples!

In fact, we can now log all depth images in `nyud`, because the costly depth projection is gone.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
