### PR TITLE
Fix broken instance picking in presence of images

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -754,8 +754,6 @@ pub fn picking(
         let picked_image_with_coords = if hit.hit_type == PickingHitType::TexturedRect
             || *ent_properties.backproject_depth.get()
         {
-            // We don't support selecting pixels yet.
-            instance_path.instance_key = re_log_types::component_types::InstanceKey::SPLAT;
             scene
                 .ui
                 .images
@@ -774,6 +772,10 @@ pub fn picking(
         } else {
             None
         };
+        if picked_image_with_coords.is_some() {
+            // We don't support selecting pixels yet.
+            instance_path.instance_key = re_log_types::component_types::InstanceKey::SPLAT;
+        }
 
         hovered_items.push(crate::misc::Item::InstancePath(
             Some(space_view_id),


### PR DESCRIPTION
Recently broke by accident all instance picking for any scene that also has an image.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!--
Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.
-->
