### PR TITLE
Fix double clicking camera no longer focusing on said camera

### DIFF
--- a/crates/re_viewer/src/misc/selection_state.rs
+++ b/crates/re_viewer/src/misc/selection_state.rs
@@ -3,7 +3,7 @@ use egui::NumExt;
 use lazy_static::lazy_static;
 use nohash_hasher::IntMap;
 
-use re_data_store::{EntityPath, InstancePath, InstancePathHash};
+use re_data_store::EntityPath;
 use re_log_types::{component_types::InstanceKey, EntityPathHash};
 use re_renderer::OutlineMaskPreference;
 
@@ -34,10 +34,10 @@ pub enum HoveredSpace {
 
         /// Path of a space camera, this 3D space is viewed through.
         /// (None for a free floating Eye)
-        tracked_space_camera: Option<InstancePath>,
+        tracked_space_camera: Option<EntityPath>,
 
         /// Corresponding 2D spaces and pixel coordinates (with Z=depth)
-        point_in_space_cameras: Vec<(InstancePathHash, Option<glam::Vec3>)>,
+        point_in_space_cameras: Vec<(EntityPath, Option<glam::Vec3>)>,
     },
 }
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -226,7 +226,7 @@ impl SceneSpatial {
         if self
             .space_cameras
             .iter()
-            .any(|camera| camera.instance_path_hash.entity_path_hash != space_info_path.hash())
+            .any(|camera| &camera.ent_path != space_info_path)
         {
             return SpatialNavigationMode::ThreeD;
         }

--- a/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/primitives.rs
@@ -1,6 +1,6 @@
 use egui::Color32;
-use re_data_store::InstancePathHash;
-use re_log_types::EntityPathHash;
+use re_data_store::EntityPath;
+use re_log_types::{component_types::InstanceKey, EntityPathHash};
 use re_renderer::{
     renderer::{DepthClouds, MeshInstance},
     LineStripSeriesBuilder, PointCloudBuilder,
@@ -169,7 +169,7 @@ impl SceneSpatialPrimitives {
     pub fn add_axis_lines(
         &mut self,
         transform: macaw::IsoTransform,
-        instance_path_hash: InstancePathHash,
+        ent_path: Option<&EntityPath>,
         axis_length: f32,
     ) {
         use re_renderer::renderer::LineStripFlags;
@@ -178,12 +178,10 @@ impl SceneSpatialPrimitives {
         let line_radius = re_renderer::Size::new_scene(axis_length * 0.05);
         let origin = transform.translation();
 
-        let picking_layer_id = picking_layer_id_from_instance_path_hash(instance_path_hash);
-
-        let mut line_batch = self
-            .line_strips
-            .batch("origin axis")
-            .picking_object_id(picking_layer_id.object);
+        let mut line_batch = self.line_strips.batch("origin axis").picking_object_id(
+            re_renderer::PickingLayerObjectId(ent_path.map_or(0, |p| p.hash64())),
+        );
+        let picking_instance_id = re_renderer::PickingLayerInstanceId(InstanceKey::SPLAT.0);
 
         line_batch
             .add_segment(
@@ -193,7 +191,7 @@ impl SceneSpatialPrimitives {
             .radius(line_radius)
             .color(AXIS_COLOR_X)
             .flags(LineStripFlags::CAP_END_TRIANGLE | LineStripFlags::CAP_START_ROUND)
-            .picking_instance_id(picking_layer_id.instance);
+            .picking_instance_id(picking_instance_id);
         line_batch
             .add_segment(
                 origin,
@@ -202,7 +200,7 @@ impl SceneSpatialPrimitives {
             .radius(line_radius)
             .color(AXIS_COLOR_Y)
             .flags(LineStripFlags::CAP_END_TRIANGLE | LineStripFlags::CAP_START_ROUND)
-            .picking_instance_id(picking_layer_id.instance);
+            .picking_instance_id(picking_instance_id);
         line_batch
             .add_segment(
                 origin,
@@ -211,6 +209,6 @@ impl SceneSpatialPrimitives {
             .radius(line_radius)
             .color(AXIS_COLOR_Z)
             .flags(LineStripFlags::CAP_END_TRIANGLE | LineStripFlags::CAP_START_ROUND)
-            .picking_instance_id(picking_layer_id.instance);
+            .picking_instance_id(picking_instance_id);
     }
 }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -1,4 +1,4 @@
-use re_data_store::{EntityPath, EntityProperties, InstancePathHash};
+use re_data_store::{EntityPath, EntityProperties};
 use re_log_types::{
     component_types::InstanceKey,
     coordinates::{Handedness, SignedAxis3},
@@ -60,7 +60,7 @@ impl CamerasPart {
     fn visit_instance(
         scene: &mut SceneSpatial,
         entity_view: &EntityView<Transform>,
-        entity_path: &EntityPath,
+        ent_path: &EntityPath,
         instance_key: InstanceKey,
         props: &EntityProperties,
         transforms: &TransformCache,
@@ -74,7 +74,7 @@ impl CamerasPart {
         //
         // Note that currently a transform on an object can't have both a pinhole AND a rigid transform,
         // which makes this rather well defined here.
-        let parent_path = entity_path
+        let parent_path = ent_path
             .parent()
             .expect("root path can't be part of scene query");
         let Some(world_from_parent) = transforms.reference_from_entity(&parent_path) else {
@@ -90,7 +90,7 @@ impl CamerasPart {
         let frustum_length = *props.pinhole_image_plane_distance.get();
 
         scene.space_cameras.push(SpaceCamera3D {
-            instance_path_hash: InstancePathHash::instance(entity_path, instance_key),
+            ent_path: ent_path.clone(),
             view_coordinates,
             world_from_camera,
             pinhole: Some(pinhole),
@@ -144,7 +144,7 @@ impl CamerasPart {
         let radius = re_renderer::Size::new_points(1.0);
         let color = SceneSpatial::CAMERA_COLOR;
         let instance_path_for_picking = instance_path_hash_for_picking(
-            entity_path,
+            ent_path,
             instance_key,
             entity_view,
             entity_highlight.any_selection_highlight,

--- a/crates/re_viewer/src/ui/view_spatial/space_camera_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/space_camera_3d.rs
@@ -1,16 +1,15 @@
 use glam::{vec3, Affine3A, Mat3, Quat, Vec2, Vec3};
 use macaw::{IsoTransform, Ray3};
 
-use re_data_store::InstancePathHash;
-use re_log_types::ViewCoordinates;
+use re_log_types::{EntityPath, ViewCoordinates};
 
 /// A logged camera that connects spaces.
 #[derive(Clone)]
 pub struct SpaceCamera3D {
-    /// Path to the instance which has the projection (pinhole, ortho or otherwise) transforms.
+    /// Path to the entity which has the projection (pinhole, ortho or otherwise) transforms.
     ///
     /// We expect the camera transform to apply to this instance and every path below it.
-    pub instance_path_hash: InstancePathHash,
+    pub ent_path: EntityPath,
 
     /// The coordinate system of the camera ("view-space").
     pub view_coordinates: ViewCoordinates,
@@ -46,7 +45,7 @@ impl SpaceCamera3D {
         match from_rub_quat(self.view_coordinates) {
             Ok(from_rub) => Some(self.world_from_camera * IsoTransform::from_quat(from_rub)),
             Err(err) => {
-                re_log::warn_once!("Camera {:?}: {err}", self.instance_path_hash);
+                re_log::warn_once!("Camera {:?}: {err}", self.ent_path);
                 None
             }
         }

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -876,7 +876,7 @@ pub fn picking(
                     .iter()
                     .map(|cam| {
                         (
-                            cam.instance_path_hash,
+                            cam.ent_path.clone(),
                             hovered_point.and_then(|pos| cam.project_onto_2d(pos)),
                         )
                     })

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -447,7 +447,7 @@ fn show_projections_from_3d_space(
     } = ctx.selection_state().hovered_space()
     {
         for (space_2d, pos_2d) in target_spaces {
-            if space_2d.entity_path_hash == space.hash() {
+            if space_2d == space {
                 if let Some(pos_2d) = pos_2d {
                     // User is hovering a 2D point inside a 3D view.
                     let pos_in_ui = ui_from_space.transform_pos(pos2(pos_2d.x, pos_2d.y));


### PR DESCRIPTION
Also cleans up how a camera/pinhole transform is referenced in scene/ui code: Only by its path now since several pinholes on the same path don't make sense (in fact we warn when you try to log this)

Fixes #1883 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
