### PR TITLE
Add argument parsing to the rerun_demo

### DIFF
--- a/rerun_py/rerun_sdk/rerun_demo/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_demo/__main__.py
@@ -5,14 +5,15 @@ import pathlib
 import sys
 
 
-def run_cube():
+def run_cube(args: argparse.Namespace):
     import math
 
     import numpy as np
     import rerun as rr
 
-    rr.init("Cube", spawn=True, default_enabled=True)
     from rerun_demo.data import build_color_grid
+
+    rr.script_setup(args, "Cube")
 
     STEPS = 100
     twists = math.pi * np.sin(np.linspace(0, math.tau, STEPS)) / 4
@@ -21,9 +22,24 @@ def run_cube():
         cube = build_color_grid(10, 10, 10, twist=twists[t])
         rr.log_points("cube", positions=cube.positions, colors=cube.colors, radii=0.5)
 
+    rr.script_teardown(args)
 
-def run_colmap():
+
+def run_colmap(args):
     from rerun import bindings, unregister_shutdown  # type: ignore[attr-defined]
+
+    serve_opts = []
+
+    # TODO(https://github.com/rerun-io/rerun/issues/1924): The need to special-case
+    # this flag conversion is a bit awkward.
+    if args.connect or args.addr:
+        print("Connecting to external viewer is only supported with the --cube demo.", file=sys.stderr)
+        exit(1)
+    if args.save:
+        print("Saving an RRD file is only supported from the --cube demo.", file=sys.stderr)
+        exit(1)
+    if args.serve:
+        serve_opts.append("--web-viewer")
 
     # We don't need to call shutdown in this case. Rust should be handling everything
     unregister_shutdown()
@@ -33,11 +49,13 @@ def run_colmap():
         print("No demo file found at {}. Package was built without demo support".format(rrd_file), file=sys.stderr)
         exit(1)
     else:
-        exit(bindings.main([sys.argv[0], str(rrd_file)]))
+        exit(bindings.main([sys.argv[0], str(rrd_file)] + serve_opts))
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run rerun example programs")
+    import rerun as rr
+
+    parser = argparse.ArgumentParser(description="Run rerun example programs.")
 
     group = parser.add_mutually_exclusive_group()
 
@@ -53,16 +71,18 @@ def main() -> None:
         help="Run the COLMAP data demo",
     )
 
+    rr.script_add_args(parser)
+
     args = parser.parse_args()
 
     if not any([args.cube, args.colmap]):
         args.cube = True
 
     if args.cube:
-        run_cube()
+        run_cube(args)
 
     elif args.colmap:
-        run_colmap()
+        run_colmap(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Uses the rerun script_helpers so that rerun_demo matches our other examples.

This is a little ugly due to the need to handle:
 - https://github.com/rerun-io/rerun/issues/1924

Arguments now work as expected:
```
$ python -m rerun_demo --serve
[2023-04-19T13:16:13Z INFO  re_ws_comms::server] Listening for websocket traffic on 0.0.0.0:9877. Connect with a Rerun Web Viewer.
[2023-04-19T13:16:13Z INFO  re_web_viewer_server] Started web server on port 9090.
[2023-04-19T13:16:13Z INFO  rerun::web_viewer] Web server is running - view it at http://127.0.0.1:9090?url=ws://localhost:9877
Sleeping while serving the web viewer. Abort with Ctrl-C
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
