### PR TITLE
Fix annotation images sometimes drawn in the background.

### DIFF
--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -33,7 +33,7 @@ use super::{
 };
 
 /// Texture filter setting for magnification (a texel covers several pixels).
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum TextureFilterMag {
     Linear,
     Nearest,
@@ -41,7 +41,7 @@ pub enum TextureFilterMag {
 }
 
 /// Texture filter setting for minification (several texels fall to one pixel).
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum TextureFilterMin {
     Linear,
     Nearest,
@@ -98,6 +98,7 @@ impl ColormappedTexture {
     }
 }
 
+#[derive(Clone)]
 pub struct TexturedRect {
     /// Top left corner position in world space.
     pub top_left_corner_position: glam::Vec3,
@@ -114,6 +115,7 @@ pub struct TexturedRect {
     pub options: RectangleOptions,
 }
 
+#[derive(Clone)]
 pub struct RectangleOptions {
     pub texture_filter_magnification: TextureFilterMag,
     pub texture_filter_minification: TextureFilterMin,

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -755,7 +755,7 @@ pub fn picking(
             || *ent_properties.backproject_depth.get()
         {
             scene
-                .ui
+                .primitives
                 .images
                 .iter()
                 .find(|image| image.ent_path == instance_path.entity_path)
@@ -790,7 +790,7 @@ pub fn picking(
         ));
 
         response = if let Some((image, coords)) = picked_image_with_coords {
-            if let Some(meter) = image.meter {
+            if let Some(meter) = image.tensor.meter {
                 if let Some(raw_value) = image.tensor.get(&[
                     picking_context.pointer_in_space2d.y.round() as _,
                     picking_context.pointer_in_space2d.x.round() as _,
@@ -840,7 +840,7 @@ pub fn picking(
                                     &image.tensor,
                                     &tensor_stats,
                                     &image.annotations,
-                                    image.meter,
+                                    image.tensor.meter,
                                     &debug_name,
                                     [coords[0] as _, coords[1] as _],
                                 );

--- a/crates/re_viewer/src/ui/view_spatial/ui_renderer_bridge.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_renderer_bridge.rs
@@ -32,7 +32,11 @@ pub fn fill_view_builder(
         .queue_draw(&primitives.points.to_draw_data(render_ctx)?)
         .queue_draw(&RectangleDrawData::new(
             render_ctx,
-            &primitives.textured_rectangles,
+            &primitives
+                .images
+                .iter()
+                .map(|image| image.textured_rect.clone())
+                .collect::<Vec<_>>(),
         )?);
 
     if matches!(background, ScreenBackground::GenericSkybox) {


### PR DESCRIPTION
Took the opportunity to cleanup some weird redundancy in textured_rect/image buildup in SpatialScene

This makes any scene with class id masks look a lot better in some cases as whenever the class id came last for some reason, the actual image got darker. Also behavior on hiding any of the mask layers was naturally quite weird (lighting up the image at random)

Before:
<img width="1642" alt="image" src="https://user-images.githubusercontent.com/1220815/233122411-28b073da-ae4a-4513-b436-1202c7dc5f54.png">


After:
<img width="1630" alt="image" src="https://user-images.githubusercontent.com/1220815/233121821-26e162ce-0df4-4276-9e57-b643389eb8f8.png">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
