### PR TITLE
Join threads at end of multi-threading example

### DIFF
--- a/examples/python/multithreading/main.py
+++ b/examples/python/multithreading/main.py
@@ -26,11 +26,16 @@ def main() -> None:
 
     rr.script_setup(args, "multithreading")
 
+    threads = []
     for i in range(10):
         t = threading.Thread(
             target=rect_logger, args=("thread/{}".format(i), [random.randrange(255) for _ in range(3)])
         )
         t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join()
 
     rr.script_teardown(args)
 


### PR DESCRIPTION
This is a generally reasonable thing to do and prevents the error from:
 - https://github.com/rerun-io/rerun/issues/1932

Fixes #1932 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
