### PR TITLE
Fix backslashes in arkitscene rigid transformation path

### DIFF
--- a/examples/python/arkitscenes/main.py
+++ b/examples/python/arkitscenes/main.py
@@ -251,7 +251,7 @@ def log_camera(
 
     rr.log_rigid3(
         # pathlib makes it easy to get the parent, but log_rigid requires a string
-        str(Path(entity_id).parent),
+        str(Path(entity_id).parent).replace("\\", "/"),
         child_from_parent=camera_from_world,
         xyz="RDF",  # X=Right, Y=Down, Z=Forward
     )

--- a/examples/python/arkitscenes/main.py
+++ b/examples/python/arkitscenes/main.py
@@ -2,7 +2,7 @@
 import argparse
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PosixPath
 from typing import Any, Dict, List, Tuple
 
 import cv2
@@ -251,7 +251,7 @@ def log_camera(
 
     rr.log_rigid3(
         # pathlib makes it easy to get the parent, but log_rigid requires a string
-        str(Path(entity_id).parent).replace("\\", "/"),
+        str(PosixPath(entity_id).parent),
         child_from_parent=camera_from_world,
         xyz="RDF",  # X=Right, Y=Down, Z=Forward
     )


### PR DESCRIPTION
Should be fixed properly by https://github.com/rerun-io/rerun/issues/1937

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
