### PR TITLE
More robust wait for exit condition during .serve()

### DIFF
--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -91,10 +91,9 @@ def script_teardown(args: Namespace) -> None:
 
     """
     if args.serve:
-        import signal
-        from threading import Event
-
-        exit = Event()
-        signal.signal(signal.SIGINT, lambda sig, frame: exit.set())
-        print("Sleeping while serving the web viewer. Abort with Ctrl-C")
-        exit.wait()
+        import time
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("Ctrl-C received. Exiting.")

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -92,6 +92,7 @@ def script_teardown(args: Namespace) -> None:
     """
     if args.serve:
         import time
+
         try:
             while True:
                 time.sleep(1)


### PR DESCRIPTION
The previous implementation of waiting for ctrl-c does not work on windows.
 - https://github.com/python/cpython/issues/80116

Given the expectation of script teardown is that this is run from the main thread, the standard python KeyboardInterrupt seems like the right solution.

This now appears to work as expected on windows including graceful shutdown.
```
(venv) PS C:\Users\jleibs\rerun> python .\examples\python\api_demo\main.py --serve
[2023-04-20T01:17:51Z INFO  re_ws_comms::server] Listening for websocket traffic on 0.0.0.0:9877. Connect with a Rerun Web Viewer.
[2023-04-20T01:17:51Z INFO  re_web_viewer_server] Started web server on port 9090.
[2023-04-20T01:17:51Z INFO  rerun::web_viewer] Web server is running - view it at http://127.0.0.1:9090?url=ws://localhost:9877
Running most demos…
INFO:root:This log got added through a `LoggingHandler`
INFO:root:Starting transforms_3d
[2023-04-20T01:17:51Z INFO  re_web_viewer_server] Serving DEBUG web-viewer
Sleeping while serving the web viewer. Abort with Ctrl-C
Ctrl-C received. Exiting.
[2023-04-20T01:17:53Z INFO  re_ws_comms::server] Shutting down Rerun server on port 9877.
[2023-04-20T01:17:53Z INFO  re_web_viewer_server] Shutting down web server on port 9090.
```

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
