### PR TITLE
Fix hovering depth clouds

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -63,9 +63,6 @@ pub struct Image {
 
     pub tensor: DecodedTensor,
 
-    /// A thing that provides additional semantic context for your dtype.
-    pub annotations: Arc<Annotations>,
-
     /// Textured rectangle for the renderer.
     pub textured_rect: TexturedRect,
 }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -243,7 +243,6 @@ impl ImagesPart {
                 scene.primitives.images.push(Image {
                     ent_path: ent_path.clone(),
                     tensor,
-                    annotations,
                     textured_rect,
                 });
             }


### PR DESCRIPTION
We didn't add to `scene.primitives.image`. Instead of adding to this list, it is instead now no longer needed for picking since we can very easily query for tensor again.

Fixes #1940

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
