### PR TITLE
2.5GB before GC kick in on web

### DIFF
--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -38,7 +38,7 @@ pub async fn start(
             let startup_options = crate::StartupOptions {
                 memory_limit: re_memory::MemoryLimit {
                     // On wasm32 we only have 4GB of memory to play around with.
-                    limit: Some(3_500_000_000),
+                    limit: Some(2_500_000_000),
                 },
                 persist_state,
             };


### PR DESCRIPTION
We're flying too close to the sun on the web: we're always one big allocation away from crashing.

Give us some headroom memory-wise.