### PR TITLE
Fix crash for missing class ids causing zero sized texture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,6 +2856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
+
+[[package]]
 name = "nix"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,6 +4032,7 @@ dependencies = [
  "itertools",
  "log",
  "macaw",
+ "never",
  "notify",
  "ordered-float",
  "parking_lot 0.12.1",

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -55,6 +55,7 @@ glam = { workspace = true, features = ["bytemuck"] }
 half = { workspace = true, features = ["bytemuck"] }
 itertools = { workspace = true }
 macaw.workspace = true
+never = '0.1'
 ordered-float = "3.2"
 parking_lot.workspace = true
 slotmap = "1.0.6"

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -36,16 +36,19 @@ impl framework::Example for Render2D {
             );
         }
 
-        let rerun_logo_texture = re_ctx.texture_manager_2d.create(
-            &mut re_ctx.gpu_resources.textures,
-            &Texture2DCreationDesc {
-                label: "rerun logo".into(),
-                data: image_data.into(),
-                format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                width: rerun_logo.width(),
-                height: rerun_logo.height(),
-            },
-        );
+        let rerun_logo_texture = re_ctx
+            .texture_manager_2d
+            .create(
+                &mut re_ctx.gpu_resources.textures,
+                &Texture2DCreationDesc {
+                    label: "rerun logo".into(),
+                    data: image_data.into(),
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                    width: rerun_logo.width(),
+                    height: rerun_logo.height(),
+                },
+            )
+            .expect("Failed to create texture for rerun logo");
         Render2D {
             rerun_logo_texture,
 

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -408,17 +408,20 @@ impl DepthTexture {
         });
 
         let label = format!("depth texture spiral {dimensions}");
-        let texture = re_ctx.texture_manager_2d.get_or_create(
-            hash(&label),
-            &mut re_ctx.gpu_resources.textures,
-            Texture2DCreationDesc {
-                label: label.into(),
-                data: bytemuck::cast_slice(&data).into(),
-                format: wgpu::TextureFormat::R32Float,
-                width: dimensions.x,
-                height: dimensions.y,
-            },
-        );
+        let texture = re_ctx
+            .texture_manager_2d
+            .get_or_create(
+                hash(&label),
+                &mut re_ctx.gpu_resources.textures,
+                Texture2DCreationDesc {
+                    label: label.into(),
+                    data: bytemuck::cast_slice(&data).into(),
+                    format: wgpu::TextureFormat::R32Float,
+                    width: dimensions.x,
+                    height: dimensions.y,
+                },
+            )
+            .expect("Failed to create depth texture.");
 
         Self {
             dimensions,
@@ -448,17 +451,20 @@ impl AlbedoTexture {
         });
 
         let label = format!("albedo texture spiral {dimensions}");
-        let texture = re_ctx.texture_manager_2d.get_or_create(
-            hash(&label),
-            &mut re_ctx.gpu_resources.textures,
-            Texture2DCreationDesc {
-                label: label.into(),
-                data: bytemuck::cast_slice(&rgba8).into(),
-                format: wgpu::TextureFormat::Rgba8UnormSrgb,
-                width: dimensions.x,
-                height: dimensions.y,
-            },
-        );
+        let texture = re_ctx
+            .texture_manager_2d
+            .get_or_create(
+                hash(&label),
+                &mut re_ctx.gpu_resources.textures,
+                Texture2DCreationDesc {
+                    label: label.into(),
+                    data: bytemuck::cast_slice(&rgba8).into(),
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                    width: dimensions.x,
+                    height: dimensions.y,
+                },
+            )
+            .expect("Failed to create albedo texture.");
 
         Self {
             dimensions,

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -74,7 +74,7 @@ pub fn load_gltf_from_buffer(
             {
                 Ok(texture) => texture,
                 Err(err) => {
-                    re_log::error!("Failed to create texture: {err:?}");
+                    re_log::error!("Failed to create texture: {err}");
                     ctx.texture_manager_2d.white_texture_unorm_handle().clone()
                 }
             },

--- a/crates/re_renderer/src/importer/gltf.rs
+++ b/crates/re_renderer/src/importer/gltf.rs
@@ -68,8 +68,16 @@ pub fn load_gltf_from_buffer(
         };
 
         images_as_textures.push(
-            ctx.texture_manager_2d
-                .create(&mut ctx.gpu_resources.textures, &texture),
+            match ctx
+                .texture_manager_2d
+                .create(&mut ctx.gpu_resources.textures, &texture)
+            {
+                Ok(texture) => texture,
+                Err(err) => {
+                    re_log::error!("Failed to create texture: {err:?}");
+                    ctx.texture_manager_2d.white_texture_unorm_handle().clone()
+                }
+            },
         );
     }
 

--- a/crates/re_renderer/src/resource_managers/mod.rs
+++ b/crates/re_renderer/src/resource_managers/mod.rs
@@ -10,7 +10,9 @@ mod mesh_manager;
 pub use mesh_manager::{GpuMeshHandle, MeshManager};
 
 mod texture_manager;
-pub use texture_manager::{GpuTexture2D, Texture2DCreationDesc, TextureManager2D};
+pub use texture_manager::{
+    GpuTexture2D, Texture2DCreationDesc, TextureManager2D, TextureManager2DError,
+};
 
 mod resource_manager;
 pub use resource_manager::{ResourceHandle, ResourceLifeTime, ResourceManagerError};

--- a/crates/re_renderer/src/resource_managers/mod.rs
+++ b/crates/re_renderer/src/resource_managers/mod.rs
@@ -12,6 +12,7 @@ pub use mesh_manager::{GpuMeshHandle, MeshManager};
 mod texture_manager;
 pub use texture_manager::{
     GpuTexture2D, Texture2DCreationDesc, TextureManager2D, TextureManager2DError,
+    ZeroSizeTextureError,
 };
 
 mod resource_manager;

--- a/crates/re_renderer/src/resource_managers/mod.rs
+++ b/crates/re_renderer/src/resource_managers/mod.rs
@@ -11,8 +11,8 @@ pub use mesh_manager::{GpuMeshHandle, MeshManager};
 
 mod texture_manager;
 pub use texture_manager::{
-    GpuTexture2D, Texture2DCreationDesc, TextureManager2D, TextureManager2DError,
-    ZeroSizeTextureError,
+    GpuTexture2D, Texture2DCreationDesc, TextureCreationError, TextureManager2D,
+    TextureManager2DError,
 };
 
 mod resource_manager;

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -103,18 +103,20 @@ pub enum TextureCreationError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum TextureManager2DError<DataCreationError> {
+    /// Something went wrong when creating the GPU texture.
     #[error(transparent)]
-    ZeroSize(TextureCreationError),
+    TextureCreation(TextureCreationError),
 
+    /// Something went wrong in a user-callback.
     #[error(transparent)]
-    DataCreationError(#[from] DataCreationError),
+    DataCreation(#[from] DataCreationError),
 }
 
 impl From<TextureManager2DError<never::Never>> for TextureCreationError {
     fn from(err: TextureManager2DError<never::Never>) -> Self {
         match err {
-            TextureManager2DError::ZeroSize(zero_size) => zero_size,
-            TextureManager2DError::DataCreationError(never) => match never {},
+            TextureManager2DError::TextureCreation(texture_creation) => texture_creation,
+            TextureManager2DError::DataCreation(never) => match never {},
         }
     }
 }
@@ -267,7 +269,7 @@ impl TextureManager2D {
                     texture_pool,
                     &tex_creation_desc,
                 )
-                .map_err(TextureManager2DError::ZeroSize)?;
+                .map_err(TextureManager2DError::TextureCreation)?;
                 entry.insert(texture).clone()
             }
         };

--- a/crates/re_viewer/src/gpu_bridge/mod.rs
+++ b/crates/re_viewer/src/gpu_bridge/mod.rs
@@ -10,7 +10,7 @@ use egui::mutex::Mutex;
 use re_renderer::{
     renderer::{ColormappedTexture, RectangleOptions},
     resource_managers::{
-        GpuTexture2D, Texture2DCreationDesc, TextureManager2DError, ZeroSizeTextureError,
+        GpuTexture2D, Texture2DCreationDesc, TextureCreationError, TextureManager2DError,
     },
     RenderContext, ViewBuilder,
 };
@@ -70,7 +70,7 @@ pub fn get_or_create_texture<'a>(
     render_ctx: &mut RenderContext,
     texture_key: u64,
     create_texture_desc: impl FnOnce() -> Texture2DCreationDesc<'a>,
-) -> Result<GpuTexture2D, ZeroSizeTextureError> {
+) -> Result<GpuTexture2D, TextureCreationError> {
     render_ctx.texture_manager_2d.get_or_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,

--- a/crates/re_viewer/src/gpu_bridge/mod.rs
+++ b/crates/re_viewer/src/gpu_bridge/mod.rs
@@ -9,7 +9,9 @@ use egui::mutex::Mutex;
 
 use re_renderer::{
     renderer::{ColormappedTexture, RectangleOptions},
-    resource_managers::{GpuTexture2D, Texture2DCreationDesc, TextureManager2DError},
+    resource_managers::{
+        GpuTexture2D, Texture2DCreationDesc, TextureManager2DError, ZeroSizeTextureError,
+    },
     RenderContext, ViewBuilder,
 };
 
@@ -52,12 +54,12 @@ pub fn viewport_resolution_in_pixels(clip_rect: egui::Rect, pixels_from_point: f
     [resolution.x as u32, resolution.y as u32]
 }
 
-pub fn try_get_or_create_texture<'a, Err>(
+pub fn try_get_or_create_texture<'a, Err: std::fmt::Display>(
     render_ctx: &mut RenderContext,
     texture_key: u64,
     try_create_texture_desc: impl FnOnce() -> Result<Texture2DCreationDesc<'a>, Err>,
 ) -> Result<GpuTexture2D, TextureManager2DError<Err>> {
-    render_ctx.texture_manager_2d.get_or_create_with(
+    render_ctx.texture_manager_2d.get_or_try_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,
         try_create_texture_desc,
@@ -68,11 +70,11 @@ pub fn get_or_create_texture<'a>(
     render_ctx: &mut RenderContext,
     texture_key: u64,
     create_texture_desc: impl FnOnce() -> Texture2DCreationDesc<'a>,
-) -> Result<GpuTexture2D, TextureManager2DError<()>> {
+) -> Result<GpuTexture2D, ZeroSizeTextureError> {
     render_ctx.texture_manager_2d.get_or_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,
-        || Ok(create_texture_desc()),
+        create_texture_desc,
     )
 }
 

--- a/crates/re_viewer/src/gpu_bridge/mod.rs
+++ b/crates/re_viewer/src/gpu_bridge/mod.rs
@@ -9,7 +9,7 @@ use egui::mutex::Mutex;
 
 use re_renderer::{
     renderer::{ColormappedTexture, RectangleOptions},
-    resource_managers::{GpuTexture2D, Texture2DCreationDesc},
+    resource_managers::{GpuTexture2D, Texture2DCreationDesc, TextureManager2DError},
     RenderContext, ViewBuilder,
 };
 
@@ -56,7 +56,7 @@ pub fn try_get_or_create_texture<'a, Err>(
     render_ctx: &mut RenderContext,
     texture_key: u64,
     try_create_texture_desc: impl FnOnce() -> Result<Texture2DCreationDesc<'a>, Err>,
-) -> Result<GpuTexture2D, Err> {
+) -> Result<GpuTexture2D, TextureManager2DError<Err>> {
     render_ctx.texture_manager_2d.get_or_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,
@@ -68,17 +68,12 @@ pub fn get_or_create_texture<'a>(
     render_ctx: &mut RenderContext,
     texture_key: u64,
     create_texture_desc: impl FnOnce() -> Texture2DCreationDesc<'a>,
-) -> GpuTexture2D {
-    enum Never {}
-    let result: Result<GpuTexture2D, Never> = render_ctx.texture_manager_2d.get_or_create_with(
+) -> Result<GpuTexture2D, TextureManager2DError<()>> {
+    render_ctx.texture_manager_2d.get_or_create_with(
         texture_key,
         &mut render_ctx.gpu_resources.textures,
         || Ok(create_texture_desc()),
-    );
-    match result {
-        Ok(handle) => handle,
-        Err(never) => match never {},
-    }
+    )
 }
 
 /// Render a `re_render` view using the given clip rectangle.

--- a/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
@@ -158,7 +158,7 @@ fn class_id_tensor_to_gpu(
 
     // We pack the colormap into a 2D texture so we don't go over the max texture size.
     // We only support u8 and u16 class ids, so 256^2 is the biggest texture we need.
-    // Note that if max is 0, we still need to generate a row to accomodate the 0 class id
+    // Note that if max is 0, we still need to generate a row to accommodate the 0 class id
     // (also zero sized textures are not allowed)
     let colormap_width = 256;
     let colormap_height = (max.at_least(1.0) as usize + colormap_width - 1) / colormap_width;

--- a/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
@@ -1,5 +1,6 @@
 //! Upload [`Tensor`] to [`re_renderer`].
 
+use anyhow::Context;
 use std::borrow::Cow;
 
 use bytemuck::{allocation::pod_collect_to_vec, cast_slice, Pod};
@@ -180,7 +181,7 @@ fn class_id_tensor_to_gpu(
                 height: colormap_height as u32,
             }
         })
-        .map_err(|err| anyhow::anyhow!("Failed to create class_id_colormap: {err}"))?;
+        .context("Failed to create class_id_colormap.")?;
 
     let main_texture_handle = try_get_or_create_texture(render_ctx, hash(tensor.id()), || {
         general_texture_creation_desc_from_tensor(debug_name, tensor)

--- a/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
@@ -95,7 +95,7 @@ fn color_tensor_to_gpu(
             height,
         })
     })
-    .map_err(|e| anyhow::anyhow!("Failed to create texture for color tensor: {e:?}"))?;
+    .map_err(|err| anyhow::anyhow!("Failed to create texture for color tensor: {err}"))?;
 
     let texture_format = texture_handle.format();
 
@@ -183,12 +183,12 @@ fn class_id_tensor_to_gpu(
                 height: colormap_height as u32,
             }
         })
-        .map_err(|e| anyhow::anyhow!("Failed to create class_id_colormap: {e:?}"))?;
+        .map_err(|err| anyhow::anyhow!("Failed to create class_id_colormap: {err}"))?;
 
     let main_texture_handle = try_get_or_create_texture(render_ctx, hash(tensor.id()), || {
         general_texture_creation_desc_from_tensor(debug_name, tensor)
     })
-    .map_err(|e| anyhow::anyhow!("Failed to create texture for class id tensor: {e:?}"))?;
+    .map_err(|err| anyhow::anyhow!("Failed to create texture for class id tensor: {err}"))?;
 
     Ok(ColormappedTexture {
         texture: main_texture_handle,
@@ -218,7 +218,7 @@ fn depth_tensor_to_gpu(
     let texture = try_get_or_create_texture(render_ctx, hash(tensor.id()), || {
         general_texture_creation_desc_from_tensor(debug_name, tensor)
     })
-    .map_err(|e| anyhow::anyhow!("Failed to create depth tensor texture: {e:?}"))?;
+    .map_err(|err| anyhow::anyhow!("Failed to create depth tensor texture: {err}"))?;
 
     Ok(ColormappedTexture {
         texture,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -292,7 +292,7 @@ impl ImagesPart {
             let mut data_f32 = Vec::new();
             ctx.render_ctx
                 .texture_manager_2d
-                .get_or_create_with(
+                .get_or_try_create_with(
                     texture_key,
                     &mut ctx.render_ctx.gpu_resources.textures,
                     || {
@@ -321,7 +321,7 @@ impl ImagesPart {
                         })
                     },
                 )
-                .map_err(|e| format!("Failed to create depth cloud texture: {e:?}"))?
+                .map_err(|err| format!("Failed to create depth cloud texture: {err}"))?
         };
 
         let depth_from_world_scale = *properties.depth_from_world_scale.get();

--- a/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
+++ b/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
@@ -35,7 +35,7 @@ pub fn colormapped_texture(
     crate::profile_function!();
 
     let range =
-        range(tensor_stats).map_err(|e| TextureManager2DError::DataCreationError(e.into()))?;
+        range(tensor_stats).map_err(|err| TextureManager2DError::DataCreationError(err.into()))?;
     let texture = upload_texture_slice_to_gpu(render_ctx, tensor, state.slice())?;
 
     let color_mapping = state.color_mapping();

--- a/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
+++ b/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
@@ -35,7 +35,7 @@ pub fn colormapped_texture(
     crate::profile_function!();
 
     let range =
-        range(tensor_stats).map_err(|err| TextureManager2DError::DataCreationError(err.into()))?;
+        range(tensor_stats).map_err(|err| TextureManager2DError::DataCreation(err.into()))?;
     let texture = upload_texture_slice_to_gpu(render_ctx, tensor, state.slice())?;
 
     let color_mapping = state.color_mapping();

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -322,7 +322,7 @@ fn paint_colormap_gradient(
                 height,
             }
         })
-        .map_err(|e| anyhow::anyhow!("Failed to create horizontal gradient texture: {e:?}"))?;
+        .map_err(|err| anyhow::anyhow!("Failed to create horizontal gradient texture: {err}"))?;
 
     let colormapped_texture = re_renderer::renderer::ColormappedTexture {
         texture: horizontal_gradient,

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -321,7 +321,8 @@ fn paint_colormap_gradient(
                 width,
                 height,
             }
-        });
+        })
+        .map_err(|e| anyhow::anyhow!("Failed to create horizontal gradient texture: {e:?}"))?;
 
     let colormapped_texture = re_renderer::renderer::ColormappedTexture {
         texture: horizontal_gradient,


### PR DESCRIPTION
Two things fixed actually:
* texture manager now checks for zero sized texture, this ripples out in a lot more error handling
* class id texture texture handles not having any classes gracefully


Fixes #1946

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
