### PR TITLE
Lint error names in `map_err`

### DIFF
--- a/crates/re_log_types/src/arrow_msg.rs
+++ b/crates/re_log_types/src/arrow_msg.rs
@@ -42,13 +42,13 @@ impl serde::Serialize for ArrowMsg {
         let mut writer = StreamWriter::new(&mut buf, Default::default());
         writer
             .start(&self.schema, None)
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+            .map_err(|err| serde::ser::Error::custom(err.to_string()))?;
         writer
             .write(&self.chunk, None)
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+            .map_err(|err| serde::ser::Error::custom(err.to_string()))?;
         writer
             .finish()
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+            .map_err(|err| serde::ser::Error::custom(err.to_string()))?;
 
         let mut inner = serializer.serialize_tuple(3)?;
         inner.serialize_element(&self.table_id)?;

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -211,7 +211,7 @@ impl WebViewerServer {
     pub fn new(port: WebViewerServerPort) -> Result<Self, WebViewerServerError> {
         let bind_addr = format!("0.0.0.0:{port}").parse()?;
         let server = hyper::Server::try_bind(&bind_addr)
-            .map_err(|e| WebViewerServerError::BindFailed(port, e))?
+            .map_err(|err| WebViewerServerError::BindFailed(port, err))?
             .serve(MakeSvc);
         Ok(Self { server })
     }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -34,7 +34,7 @@ impl RerunServer {
 
         let listener = TcpListener::bind(&bind_addr)
             .await
-            .map_err(|e| RerunServerError::BindFailed(port, e))?;
+            .map_err(|err| RerunServerError::BindFailed(port, err))?;
 
         let port = RerunServerPort(listener.local_addr()?.port());
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -441,7 +441,7 @@ async fn run_impl(
             app.set_profiler(profiler);
             Box::new(app)
         }))
-        .map_err(|e| e.into());
+        .map_err(|err| err.into());
 
         #[cfg(not(feature = "native_viewer"))]
         {

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -35,7 +35,7 @@ fn array_to_rust(arrow_array: &PyAny, name: Option<&str>) -> PyResult<(Box<dyn A
     // Following pattern from: https://github.com/pola-rs/polars/blob/master/examples/python_rust_compiled_function/src/ffi.rs
     unsafe {
         let mut field = ffi::import_field_from_c(schema.as_ref())
-            .map_err(|e| PyValueError::new_err(format!("Error importing Field: {e}")))?;
+            .map_err(|err| PyValueError::new_err(format!("Error importing Field: {err}")))?;
 
         // There is a bad incompatibility between pyarrow and arrow2-convert
         // Force the type to be correct.
@@ -49,7 +49,7 @@ fn array_to_rust(arrow_array: &PyAny, name: Option<&str>) -> PyResult<(Box<dyn A
         }
 
         let array = ffi::import_array_from_c(*array, field.data_type.clone())
-            .map_err(|e| PyValueError::new_err(format!("Error importing Array: {e}")))?;
+            .map_err(|err| PyValueError::new_err(format!("Error importing Array: {err}")))?;
 
         if let Some(name) = name {
             field.name = name.to_owned();


### PR DESCRIPTION
### What
It is important that we never use `Debug` when formatting errors, because `Debug`-formatted errors look really bad, while `Display`-formatted errors look nice. Errors are shown to the user, so this is important!

We have a lint that ensures we never do `{err:?}`, but that requires that we name all the errors `err`. We enforce that when destructing using `Err(foo)`, and with this PR we also enforce it for `map_err(|foo| …`.

This was sparked by `Debug`-formatting of errors found in https://github.com/rerun-io/rerun/pull/1947


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
