### PR TITLE
Handle leaking of prerelease into alpha version

### DIFF
--- a/crates/re_build_info/src/crate_version.rs
+++ b/crates/re_build_info/src/crate_version.rs
@@ -55,7 +55,7 @@ impl CrateVersion {
     pub fn from_bytes([major, minor, patch, suffix_byte]: [u8; 4]) -> Self {
         let is_alpha = (suffix_byte & IS_ALPHA_BIT) != 0;
         let is_prerelease = (suffix_byte & IS_PRERELEASE_BIT) != 0;
-        let alpha_version = suffix_byte & 0b0111_1111;
+        let alpha_version = suffix_byte & !(IS_ALPHA_BIT | IS_PRERELEASE_BIT);
 
         Self {
             major,
@@ -270,6 +270,22 @@ fn test_format_parse_roundtrip() {
         // "12.23.24-alpha.31+foobar",
     ] {
         assert_eq!(parse(version).to_string(), version);
+    }
+}
+
+#[test]
+fn test_format_parse_roundtrip_bytes() {
+    let parse = CrateVersion::parse;
+    for version in [
+        "0.2.0",
+        "1.2.3",
+        "12.23.24",
+        "12.23.24-alpha.31",
+        "12.23.24-alpha.31+foo",
+    ] {
+        let version = parse(version);
+        let bytes = version.to_bytes();
+        assert_eq!(CrateVersion::from_bytes(bytes), version);
     }
 }
 


### PR DESCRIPTION
After setting up new web builds to mark pre-releases as appropriate I noticed:
```
_log_encoding/src/decoder.rs:20: Found log stream with Rerun version 0.6.0-alpha.64+, which is incompatible with the local Rerun version 0.6.0-alpha.0+. Loading will try to continue, but might fail in subtle ways.
```

Turns out our CrateVersion decode was broken a while ago and the tests hadn't caught it.

Adds a new test and the correct fix.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
