### PR TITLE
Update egui to latest and wgpu to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ version = "0.37.2+1.3.238"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -1157,11 +1157,10 @@ dependencies = [
 [[package]]
 name = "d3d12"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
+source = "git+https://github.com/gfx-rs/d3d12-rs?rev=b940b1d71#b940b1d71ab7083ae80eec697872672dc1f2bd32"
 dependencies = [
  "bitflags 1.3.2",
- "libloading 0.7.4",
+ "libloading",
  "winapi",
 ]
 
@@ -1279,7 +1278,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -2064,7 +2063,7 @@ dependencies = [
  "bitflags 1.3.2",
  "com-rs",
  "libc",
- "libloading 0.7.4",
+ "libloading",
  "thiserror",
  "widestring",
  "winapi",
@@ -2402,7 +2401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
- "libloading 0.7.4",
+ "libloading",
  "pkg-config",
 ]
 
@@ -2516,16 +2515,6 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2788,8 +2777,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00ce114f2867153c079d4489629dbd27aa4b5387a8ba5341bd3f6dfe870688f"
+source = "git+https://github.com/gfx-rs/naga?rev=b99d58ea435090e561377949f428bce2c18451bb#b99d58ea435090e561377949f428bce2c18451bb"
 dependencies = [
  "bit-set",
  "bitflags 1.3.2",
@@ -4058,7 +4046,6 @@ dependencies = [
  "web-sys",
  "wgpu",
  "wgpu-core",
- "wgpu-hal",
  "winit",
  "zip",
 ]
@@ -5853,15 +5840,14 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13edd72c7b08615b7179dd7e778ee3f0bdc870ef2de9019844ff2cceeee80b11"
+source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5877,8 +5863,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625bea30a0ba50d88025f95c80211d1a85c86901423647fb74f397f614abbd9a"
+source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5886,7 +5871,7 @@ dependencies = [
  "codespan-reporting",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
@@ -5900,8 +5885,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41af2ea7d87bd41ad0a37146252d5f7c26490209f47f544b2ee3b3ff34c7732e"
+source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5920,12 +5904,12 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.0",
+ "libloading",
  "log",
  "metal",
  "naga",
  "objc",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -5942,8 +5926,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd33a976130f03dcdcd39b3810c0c3fc05daf86f0aaf867db14bfb7c4a9a32b"
+source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
 dependencies = [
  "bitflags 2.1.0",
  "js-sys",
@@ -6013,7 +5996,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
- "windows-targets 0.42.1",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6022,13 +6005,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -6037,16 +6020,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets 0.42.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6055,28 +6029,13 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -6086,22 +6045,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6110,22 +6057,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6134,34 +6069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "330223a1aecc308757b9926e9391c9b47f8ef2dbd8aea9df88312aea18c5e8d6"
 
 [[package]]
 name = "accesskit"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4803cf8c252f374ae6bfbb341e49e5a37f7601f2ce74a105927a663eba952c67"
+checksum = "704d532b1cd3d912bb37499c55a81ac748cc1afa737eedd100ba441acdd47d38"
 dependencies = [
  "enumn",
  "serde",
@@ -84,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4165a1aef703232031b40a6e8908c2f9e314d495f11aa7f98db75d39a497cc6a"
 dependencies = [
  "android-properties",
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "jni-sys",
  "libc",
@@ -245,7 +245,7 @@ version = "0.37.2+1.3.238"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
 dependencies = [
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -468,6 +468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,7 +682,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
@@ -688,7 +694,7 @@ version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex 0.3.0",
  "is-terminal",
@@ -751,7 +757,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
  "core-foundation",
@@ -767,7 +773,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
@@ -907,7 +913,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -920,7 +926,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "foreign-types",
  "libc",
@@ -1053,7 +1059,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1154,8 +1160,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
 dependencies = [
- "bitflags",
- "libloading",
+ "bitflags 1.3.2",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -1273,7 +1279,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
 dependencies = [
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -1309,8 +1315,7 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 [[package]]
 name = "ecolor"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f99fe3cac305af9d6d92971af60d0f7ea4d783201ef1673571567b6699964d9"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1319,16 +1324,19 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df3ce60931e5f2d83bab4484d1a283908534d5308cc6b0c5c22c59cd15ee7cc"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "bytemuck",
+ "cocoa",
  "directories-next",
  "egui",
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
+ "image",
  "js-sys",
+ "log",
+ "objc",
  "percent-encoding",
  "pollster",
  "puffin",
@@ -1336,39 +1344,37 @@ dependencies = [
  "ron",
  "serde",
  "thiserror",
- "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
+ "winapi",
  "winit",
 ]
 
 [[package]]
 name = "egui"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6412a21e0bde7c0918f7fb44bbbb86b5e1f88e63c026a4e747cc7af02f76dfbe"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "accesskit",
  "ahash 0.8.2",
  "epaint",
+ "log",
  "nohash-hasher",
  "ron",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "egui-wgpu"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1678d8f30181193e78c15dddae16e6027c6058fdda9631950ade511b8a4b26f5"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "bytemuck",
  "epaint",
+ "log",
  "puffin",
- "tracing",
  "type-map",
  "wgpu",
  "winit",
@@ -1377,17 +1383,16 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab43597ba41f0ce39a364ad83185594578bfd8b3409b99dbcbb01df23afc3dbb"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
- "android-activity",
  "arboard",
  "egui",
  "instant",
+ "log",
  "puffin",
+ "raw-window-handle",
  "serde",
  "smithay-clipboard",
- "tracing",
  "webbrowser",
  "winit",
 ]
@@ -1405,27 +1410,25 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f051342e97dfa2445107cb7d2e720617f5c840199b5cb4fe0ffcf481fcf5cce"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "egui",
+ "log",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "egui_glow"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8257332fb168a965b3dca81d6a344e053153773c889cabdba0b3b76f1629ae81"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "bytemuck",
  "egui",
  "egui-winit",
  "glow",
+ "log",
  "memoffset 0.6.5",
  "puffin",
- "tracing",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1452,8 +1455,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "emath"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ecd80612937e0267909d5351770fe150004e24dab93954f69ca62eecd3f77e"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1534,8 +1536,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e78b5c58a1f7f621f9d546add2adce20636422c9b251e29f749e8a2f713c95"
+source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.2",
@@ -1543,6 +1544,7 @@ dependencies = [
  "bytemuck",
  "ecolor",
  "emath",
+ "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "serde",
@@ -1835,15 +1837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,9 +1894,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edf6019dff2d92ad27c1e3ff82ad50a0aea5b01370353cc928bfdc33e95925c"
+checksum = "4e007a07a24de5ecae94160f141029e9a347282cfe25d1d58d85d845cf3130f1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1955,7 +1948,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-alloc-types",
 ]
 
@@ -1965,7 +1958,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1987,7 +1980,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-descriptor-types",
  "hashbrown 0.12.3",
 ]
@@ -1998,7 +1991,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2064,14 +2057,14 @@ dependencies = [
 
 [[package]]
 name = "hassle-rs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90601c6189668c7345fc53842cb3f3a3d872203d523be1b3cb44a36a3e62fb85"
+checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "com-rs",
  "libc",
- "libloading",
+ "libloading 0.7.4",
  "thiserror",
  "widestring",
  "winapi",
@@ -2282,7 +2275,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -2409,7 +2402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
- "libloading",
+ "libloading 0.7.4",
  "pkg-config",
 ]
 
@@ -2429,7 +2422,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -2523,6 +2516,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2689,7 +2692,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -2784,12 +2787,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eafe22a23b797c9bc227c6c896419b26b5bb88fa903417a3adaed08778850d5"
+checksum = "f00ce114f2867153c079d4489629dbd27aa4b5387a8ba5341bd3f6dfe870688f"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -2832,7 +2835,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -2867,7 +2870,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -2880,7 +2883,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -2908,7 +2911,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -3360,7 +3363,7 @@ version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0e7f4c94ec26ff209cee506314212639d6c91b80afb82984819fafce9df01c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
  "miniz_oxide",
@@ -3387,7 +3390,7 @@ dependencies = [
  "ahash 0.8.2",
  "anyhow",
  "arrow2",
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
  "comfy-table 6.1.4",
  "hashbrown 0.13.1",
@@ -4014,7 +4017,7 @@ dependencies = [
  "anyhow",
  "arrow2",
  "async-executor",
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "clean-path",
  "console_error_panic_hook",
@@ -4260,7 +4263,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4269,7 +4272,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb02a9aee8e8c7ad8d86890f1e16b49e0bbbffc9961ff3788c31d57c98bcbf03"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4302,9 +4305,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "renderdoc-sys"
-version = "0.7.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
+checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
 
 [[package]]
 name = "rerun"
@@ -4438,7 +4441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -4478,7 +4481,7 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes",
  "libc",
@@ -4492,7 +4495,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.3.0",
  "io-lifetimes",
  "libc",
@@ -4784,7 +4787,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "calloop",
  "dlib",
  "lazy_static",
@@ -4829,7 +4832,7 @@ version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "num-traits",
 ]
 
@@ -5719,7 +5722,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "libc",
  "nix 0.24.2",
@@ -5758,7 +5761,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "wayland-client",
  "wayland-commons",
  "wayland-scanner",
@@ -5849,9 +5852,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d745a1b6d91d85c33defbb29f0eee0450e1d2614d987e14bf6baf26009d132d7"
+checksum = "13edd72c7b08615b7179dd7e778ee3f0bdc870ef2de9019844ff2cceeee80b11"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5873,20 +5876,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7131408d940e335792645a98f03639573b0480e9e2e7cddbbab74f7c6d9f3fff"
+checksum = "625bea30a0ba50d88025f95c80211d1a85c86901423647fb74f397f614abbd9a"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags",
+ "bitflags 2.1.0",
  "codespan-reporting",
- "fxhash",
  "log",
  "naga",
  "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle",
+ "rustc-hash",
  "smallvec",
  "thiserror",
  "web-sys",
@@ -5896,20 +5899,19 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcf61a283adc744bb5453dd88ea91f3f86d5ca6b027661c6c73c7734ae0288b"
+checksum = "41af2ea7d87bd41ad0a37146252d5f7c26490209f47f544b2ee3b3ff34c7732e"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags",
+ "bitflags 2.1.0",
  "block",
  "core-graphics-types",
  "d3d12",
  "foreign-types",
- "fxhash",
  "glow",
  "gpu-alloc",
  "gpu-allocator",
@@ -5918,7 +5920,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading",
+ "libloading 0.8.0",
  "log",
  "metal",
  "naga",
@@ -5928,6 +5930,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
+ "rustc-hash",
  "smallvec",
  "thiserror",
  "wasm-bindgen",
@@ -5938,11 +5941,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32444e121b0bd00cb02c0de32fde457a9491bd44e03e7a5db6df9b1da2f6f110"
+checksum = "5bd33a976130f03dcdcd39b3810c0c3fc05daf86f0aaf867db14bfb7c4a9a32b"
 dependencies = [
- "bitflags",
+ "bitflags 2.1.0",
  "js-sys",
  "web-sys",
 ]
@@ -5960,9 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -6010,7 +6013,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
 ]
 
 [[package]]
@@ -6019,13 +6022,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -6034,7 +6037,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -6043,13 +6055,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -6059,10 +6086,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6071,10 +6110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6083,10 +6134,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6095,13 +6158,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
 name = "winit"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4755d4ba0e3d30fc7beef2095e246b1e6a6fad0717608bcb87a2df4b003bcf"
 dependencies = [
  "android-activity",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg_aliases",
  "core-foundation",
  "core-graphics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,12 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
 name = "cxx"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,7 +1308,7 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 [[package]]
 name = "ecolor"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1323,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.21.3"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1354,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "accesskit",
  "ahash 0.8.2",
@@ -1368,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "bytemuck",
  "epaint",
@@ -1382,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.21.1"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "arboard",
  "egui",
@@ -1409,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "egui",
  "log",
@@ -1419,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1454,7 +1448,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "emath"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1535,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui#f96237824328e30e25e1322ce722d7e1b42fe68a"
+source = "git+https://github.com/emilk/egui?rev=0e6d69d#0e6d69d4c460c288a257f47cd007c5131a1d61de"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.2",
@@ -3718,12 +3712,9 @@ checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
-dependencies = [
- "cty",
-]
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw_mesh"
@@ -5840,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
+source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5863,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
+source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5885,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
+source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5926,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu#3432aabab158b2183d4eb2b6f58b74639acad2f3"
+source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
 dependencies = [
  "bitflags 2.1.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,14 +114,14 @@ debug = true
 
 # TODO(andreas/emilk): Update to a stable egui version
 # wgpu 0.16 support.
-ecolor = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
-eframe = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
-egui = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
-egui-wgpu = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
-egui_extras = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
-emath = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+ecolor = { git = "https://github.com/emilk/egui", rev = "0e6d69d" }
+eframe = { git = "https://github.com/emilk/egui", rev = "0e6d69d" }
+egui = { git = "https://github.com/emilk/egui", rev = "0e6d69d" }
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "0e6d69d" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "0e6d69d" }
+emath = { git = "https://github.com/emilk/egui", rev = "0e6d69d" }
 
 # TODO(andreas): Either work around this issue in wgpu-egui (never discard command buffers) or wait for wgpu patch release.
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726
-wgpu = { git = "https://github.com/rerun-io/wgpu", commit = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
-wgpu-core = { git = "https://github.com/rerun-io/wgpu", commit = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
+wgpu = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
+wgpu-core = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tokio = "1.24"
 wgpu = { version = "0.16", default-features = false }
 wgpu-core = { version = "0.16", default-features = false }
-wgpu-hal = { version = "0.16", default-features = false }
 
 
 [profile.dev]
@@ -115,9 +114,14 @@ debug = true
 
 # TODO(andreas/emilk): Update to a stable egui version
 # wgpu 0.16 support.
-ecolor = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
-eframe = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
-egui = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
-egui-wgpu = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
-egui_extras = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
-emath = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
+ecolor = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+eframe = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+egui = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+egui-wgpu = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+egui_extras = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+emath = { git = "https://github.com/emilk/egui", commit = "0e6d69d" }
+
+# TODO(andreas): Either work around this issue in wgpu-egui (never discard command buffers) or wait for wgpu patch release.
+# Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726
+wgpu = { git = "https://github.com/rerun-io/wgpu", commit = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
+wgpu-core = { git = "https://github.com/rerun-io/wgpu", commit = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,10 @@ comfy-table = { version = "6.1", default-features = false }
 ctrlc = { version = "3.0", features = ["termination"] }
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
-egui = { version = "0.21.0", features = ["extra_debug_asserts", "tracing"] }
+egui = { version = "0.21.0", features = ["extra_debug_asserts", "log"] }
 egui-wgpu = "0.21.0"
 egui_dock = "0.4"
-egui_extras = { version = "0.21.0", features = ["tracing"] }
+egui_extras = { version = "0.21.0", features = ["log"] }
 emath = "0.21.0"
 enumset = "1.0.12"
 epaint = "0.21.0"
@@ -85,9 +85,9 @@ thiserror = "1.0"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tokio = "1.24"
-wgpu = { version = "0.15.1", default-features = false }
-wgpu-core = { version = "0.15.1", default-features = false }
-wgpu-hal = { version = "0.15.4", default-features = false }
+wgpu = { version = "0.16", default-features = false }
+wgpu-core = { version = "0.16", default-features = false }
+wgpu-hal = { version = "0.16", default-features = false }
 
 
 [profile.dev]
@@ -113,9 +113,11 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-# ecolor = { path = "../../egui/crates/ecolor" }
-# eframe = { path = "../../egui/crates/eframe" }
-# egui = { path = "../../egui/crates/egui" }
-# egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
-# egui_extras = { path = "../../egui/crates/egui_extras" }
-# emath = { path = "../../egui/crates/emath" }
+# TODO(andreas/emilk): Update to a stable egui version
+# wgpu 0.16 support.
+ecolor = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
+eframe = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
+egui = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
+egui-wgpu = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
+egui_extras = { git = "https://github.com/emilk/egui", commit = "2001b6d" }
+emath = { git = "https://github.com/emilk/egui", commit = "2001b6d" }

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -77,7 +77,6 @@ notify = "5.0"
 puffin.workspace = true
 wgpu = { workspace = true, default-features = false, features = ["wgsl"] }
 wgpu-core.workspace = true
-wgpu-hal.workspace = true
 
 # wasm
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -82,9 +82,9 @@ struct PointData {
 }
 
 // Backprojects the depth texture using the intrinsics passed in the uniform buffer.
-fn compute_point_data(quad_idx: i32) -> PointData {
+fn compute_point_data(quad_idx: u32) -> PointData {
     let wh = textureDimensions(depth_texture);
-    let texcoords = IVec2(quad_idx % wh.x, quad_idx / wh.x);
+    let texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
 
     // TODO(cmc): expose knobs to linearize/normalize/flip/cam-to-plane depth.
     let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;

--- a/crates/re_renderer/shader/lines.wgsl
+++ b/crates/re_renderer/shader/lines.wgsl
@@ -32,11 +32,8 @@ struct BatchUniformBuffer {
 @group(2) @binding(0)
 var<uniform> batch: BatchUniformBuffer;
 
-
-// textureLoad needs i32 right now, so we use that with all sizes & indices to avoid casts
-// https://github.com/gfx-rs/naga/issues/1997
-const POSITION_TEXTURE_SIZE: i32 = 512;
-const LINE_STRIP_TEXTURE_SIZE: i32 = 256;
+const POSITION_TEXTURE_SIZE: u32 = 512u;
+const LINE_STRIP_TEXTURE_SIZE: u32 = 256u;
 
 // Flags
 // See lines.rs#LineStripFlags
@@ -87,9 +84,7 @@ struct LineStripData {
 
 // Read and unpack line strip data at a given location
 fn read_strip_data(idx: u32) -> LineStripData {
-    // can be u32 once https://github.com/gfx-rs/naga/issues/1997 is solved
-    let idx = i32(idx);
-    let coord = IVec2(idx % LINE_STRIP_TEXTURE_SIZE, idx / LINE_STRIP_TEXTURE_SIZE);
+    let coord = UVec2(idx % LINE_STRIP_TEXTURE_SIZE, idx / LINE_STRIP_TEXTURE_SIZE);
     var raw_data = textureLoad(position_data_texture, coord, 0).xy;
 
     var data: LineStripData;
@@ -110,9 +105,7 @@ struct PositionData {
 
 // Read and unpack position data at a given location
 fn read_position_data(idx: u32) -> PositionData {
-    // can be u32 once https://github.com/gfx-rs/naga/issues/1997 is solved
-    let idx = i32(idx);
-    var raw_data = textureLoad(line_strip_texture, IVec2(idx % POSITION_TEXTURE_SIZE, idx / POSITION_TEXTURE_SIZE), 0);
+    var raw_data = textureLoad(line_strip_texture, UVec2(idx % POSITION_TEXTURE_SIZE, idx / POSITION_TEXTURE_SIZE), 0);
 
     var data: PositionData;
     let pos_4d = batch.world_from_obj * Vec4(raw_data.xyz, 1.0);

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -36,10 +36,7 @@ var<uniform> batch: BatchUniformBuffer;
 // Flags
 // See point_cloud.rs#PointCloudBatchFlags
 const ENABLE_SHADING: u32 = 1u;
-
-// textureLoad needs i32 right now, so we use that with all sizes & indices to avoid casts
-// https://github.com/gfx-rs/naga/issues/1997
-var<private> TEXTURE_SIZE: i32 = 2048;
+var<private> TEXTURE_SIZE: u32 = 2048;
 
 struct VertexOut {
     @builtin(position)
@@ -75,8 +72,8 @@ struct PointData {
 }
 
 // Read and unpack data at a given location
-fn read_data(idx: i32) -> PointData {
-    let coord = IVec2(i32(idx % TEXTURE_SIZE), idx / TEXTURE_SIZE);
+fn read_data(idx: u32) -> PointData {
+    let coord = UVec2(idx % TEXTURE_SIZE, idx / TEXTURE_SIZE);
     let position_data = textureLoad(position_data_texture, coord, 0);
     let color = textureLoad(color_texture, coord, 0);
 

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -36,7 +36,7 @@ var<uniform> batch: BatchUniformBuffer;
 // Flags
 // See point_cloud.rs#PointCloudBatchFlags
 const ENABLE_SHADING: u32 = 1u;
-var<private> TEXTURE_SIZE: u32 = 2048;
+const TEXTURE_SIZE: u32 = 2048u;
 
 struct VertexOut {
     @builtin(position)

--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -86,10 +86,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
         let colormap_size = textureDimensions(colormap_texture).xy;
         let color_index = normalized_value.r * f32(colormap_size.x * colormap_size.y);
         // TODO(emilk): interpolate between neighboring colors for non-integral color indices
-        let color_index_i32 = i32(color_index);
-        let x = color_index_i32 % colormap_size.x;
-        let y = color_index_i32 / colormap_size.x;
-        texture_color = textureLoad(colormap_texture, IVec2(x, y), 0);
+        let color_index_u32 = u32(color_index);
+        let x = color_index_u32 % colormap_size.x;
+        let y = color_index_u32 / colormap_size.x;
+        texture_color = textureLoad(colormap_texture, UVec2(x, y), 0);
     } else {
         return ERROR_RGBA; // unknown color mapper
     }

--- a/crates/re_renderer/shader/types.wgsl
+++ b/crates/re_renderer/shader/types.wgsl
@@ -1,16 +1,16 @@
 // Names chosen to match [`glam`](https://docs.rs/glam/latest/glam/)
-type Vec2 = vec2<f32>;
-type Vec3 = vec3<f32>;
-type Vec4 = vec4<f32>;
-type UVec2 = vec2<u32>;
-type UVec3 = vec3<u32>;
-type UVec4 = vec4<u32>;
-type IVec2 = vec2<i32>;
-type IVec3 = vec3<i32>;
-type IVec4 = vec4<i32>;
-type Mat3 = mat3x3<f32>;
-type Mat4x3 = mat4x3<f32>;
-type Mat4 = mat4x4<f32>;
+alias Vec2 = vec2<f32>;
+alias Vec3 = vec3<f32>;
+alias Vec4 = vec4<f32>;
+alias UVec2 = vec2<u32>;
+alias UVec3 = vec3<u32>;
+alias UVec4 = vec4<u32>;
+alias IVec2 = vec2<i32>;
+alias IVec3 = vec3<i32>;
+alias IVec4 = vec4<i32>;
+alias Mat3 = mat3x3<f32>;
+alias Mat4x3 = mat4x3<f32>;
+alias Mat4 = mat4x4<f32>;
 
 // Extreme values as documented by the spec:
 // https://www.w3.org/TR/WGSL/#floating-point-types

--- a/crates/re_renderer/shader/utils/sphere_quad.wgsl
+++ b/crates/re_renderer/shader/utils/sphere_quad.wgsl
@@ -56,8 +56,8 @@ fn sphere_quad_span_orthographic(point_pos: Vec3, point_radius: f32, top_bottom:
 }
 
 /// Returns the index of the current quad.
-fn sphere_quad_index(vertex_idx: u32) -> i32 {
-    return i32(vertex_idx) / 6;
+fn sphere_quad_index(vertex_idx: u32) -> u32 {
+    return vertex_idx / 6u;
 }
 
 struct SphereQuadData {

--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -1,6 +1,9 @@
-use std::{num::NonZeroU32, sync::mpsc};
+use std::sync::mpsc;
 
-use crate::wgpu_resources::{BufferDesc, GpuBuffer, GpuBufferPool, Texture2DBufferInfo};
+use crate::{
+    texture_info::Texture2DBufferInfo,
+    wgpu_resources::{BufferDesc, GpuBuffer, GpuBufferPool},
+};
 
 /// A sub-allocated staging buffer that can be written to.
 ///
@@ -119,7 +122,7 @@ where
                 buffer: &self.chunk_buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: self.byte_offset_in_chunk_buffer,
-                    bytes_per_row: NonZeroU32::new(buffer_info.bytes_per_row_padded),
+                    bytes_per_row: Some(buffer_info.bytes_per_row_padded),
                     rows_per_image: None,
                 },
             },
@@ -290,7 +293,7 @@ impl CpuWriteGpuReadBelt {
         );
         // Largest uncompressed texture format (btw. many compressed texture format have the same block size!)
         debug_assert!(
-            wgpu::TextureFormat::Rgba32Uint.describe().block_size as u64
+            wgpu::TextureFormat::Rgba32Uint.block_size(None).unwrap() as u64
                 <= CpuWriteGpuReadBelt::MIN_OFFSET_ALIGNMENT
         );
 

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -9,7 +9,8 @@ mod uniform_buffer_fill;
 
 pub use cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};
 pub use gpu_readback_belt::{
-    GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackIdentifier, GpuReadbackUserDataStorage,
+    GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackError, GpuReadbackIdentifier,
+    GpuReadbackUserDataStorage,
 };
 pub use uniform_buffer_fill::{
     create_and_fill_uniform_buffer, create_and_fill_uniform_buffer_batch,

--- a/crates/re_renderer/src/draw_phases/mod.rs
+++ b/crates/re_renderer/src/draw_phases/mod.rs
@@ -6,7 +6,8 @@ pub use outlines::{OutlineConfig, OutlineMaskPreference, OutlineMaskProcessor};
 
 mod picking_layer;
 pub use picking_layer::{
-    PickingLayerId, PickingLayerInstanceId, PickingLayerObjectId, PickingLayerProcessor,
+    PickingLayerError, PickingLayerId, PickingLayerInstanceId, PickingLayerObjectId,
+    PickingLayerProcessor,
 };
 
 mod screenshot;

--- a/crates/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/re_renderer/src/draw_phases/picking_layer.rs
@@ -13,11 +13,12 @@ use crate::{
     allocator::create_and_fill_uniform_buffer,
     global_bindings::FrameUniformBuffer,
     include_shader_module,
+    texture_info::Texture2DBufferInfo,
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuRenderPipelineHandle,
         GpuTexture, GpuTextureHandle, PipelineLayoutDesc, PoolError, RenderPipelineDesc,
-        Texture2DBufferInfo, TextureDesc, WgpuResourcePools,
+        TextureDesc, WgpuResourcePools,
     },
     DebugLabel, GpuReadbackBuffer, GpuReadbackIdentifier, IntRect, RenderContext,
 };
@@ -130,6 +131,15 @@ pub fn pixel_coord_to_ndc(coord: glam::Vec2, target_resolution: glam::Vec2) -> g
         coord.x / target_resolution.x * 2.0 - 1.0,
         1.0 - coord.y / target_resolution.y * 2.0,
     )
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PickingLayerError {
+    #[error(transparent)]
+    ReadbackError(#[from] crate::allocator::GpuReadbackError),
+
+    #[error(transparent)]
+    ResourcePoolError(#[from] PoolError),
 }
 
 /// Manages the rendering of the picking layer pass, its render targets & readback buffer.
@@ -278,8 +288,10 @@ impl PickingLayerProcessor {
         // Offset of the depth buffer in the readback buffer needs to be aligned to size of a depth pixel.
         // This is "trivially true" if the size of the depth format is a multiple of the size of the id format.
         debug_assert!(
-            Self::PICKING_LAYER_FORMAT.describe().block_size
-                % Self::PICKING_LAYER_DEPTH_FORMAT.describe().block_size
+            Self::PICKING_LAYER_FORMAT.block_size(None).unwrap()
+                % Self::PICKING_LAYER_DEPTH_FORMAT
+                    .block_size(Some(wgpu::TextureAspect::DepthOnly))
+                    .unwrap()
                 == 0
         );
         let buffer_size = row_info_id.buffer_size_padded + row_info_depth.buffer_size_padded;
@@ -342,7 +354,7 @@ impl PickingLayerProcessor {
         self,
         encoder: &mut wgpu::CommandEncoder,
         pools: &WgpuResourcePools,
-    ) -> Result<(), PoolError> {
+    ) -> Result<(), PickingLayerError> {
         let extent = glam::uvec2(
             self.picking_target.texture.width(),
             self.picking_target.texture.height(),
@@ -373,12 +385,12 @@ impl PickingLayerProcessor {
                         texture: &readable_depth_texture.texture,
                         mip_level: 0,
                         origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
+                        aspect: wgpu::TextureAspect::DepthOnly,
                     },
                     extent,
                 ),
             ],
-        );
+        )?;
 
         Ok(())
     }
@@ -401,11 +413,13 @@ impl PickingLayerProcessor {
             .readback_data::<ReadbackBeltMetadata<T>>(identifier, |data, metadata| {
                 // Assert that our texture data reinterpretation works out from a pixel size point of view.
                 debug_assert_eq!(
-                    Self::PICKING_LAYER_DEPTH_FORMAT.describe().block_size as usize,
-                    std::mem::size_of::<f32>()
+                    Self::PICKING_LAYER_DEPTH_FORMAT
+                        .block_size(Some(wgpu::TextureAspect::DepthOnly))
+                        .unwrap(),
+                    std::mem::size_of::<f32>() as u32
                 );
                 debug_assert_eq!(
-                    Self::PICKING_LAYER_FORMAT.describe().block_size as usize,
+                    Self::PICKING_LAYER_FORMAT.block_size(None).unwrap() as usize,
                     std::mem::size_of::<PickingLayerId>()
                 );
 
@@ -432,8 +446,8 @@ impl PickingLayerProcessor {
                     // See https://github.com/gfx-rs/wgpu/issues/3644
                     debug_assert_eq!(
                         DepthReadbackWorkaround::READBACK_FORMAT
-                            .describe()
-                            .block_size as usize,
+                            .block_size(None)
+                            .unwrap() as usize,
                         std::mem::size_of::<f32>() * 4
                     );
                     picking_depth_data = picking_depth_data.into_iter().step_by(4).collect();

--- a/crates/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/re_renderer/src/draw_phases/picking_layer.rs
@@ -385,7 +385,11 @@ impl PickingLayerProcessor {
                         texture: &readable_depth_texture.texture,
                         mip_level: 0,
                         origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::DepthOnly,
+                        aspect: if self.depth_readback_workaround.is_some() {
+                            wgpu::TextureAspect::All
+                        } else {
+                            wgpu::TextureAspect::DepthOnly
+                        },
                     },
                     extent,
                 ),

--- a/crates/re_renderer/src/draw_phases/screenshot.rs
+++ b/crates/re_renderer/src/draw_phases/screenshot.rs
@@ -11,7 +11,9 @@
 //! Or alternatively try to render the images in several tiles 🤔. In any case this would greatly improve quality!
 
 use crate::{
-    wgpu_resources::{GpuTexture, Texture2DBufferInfo, TextureDesc},
+    allocator::GpuReadbackError,
+    texture_info::Texture2DBufferInfo,
+    wgpu_resources::{GpuTexture, TextureDesc},
     DebugLabel, GpuReadbackBuffer, GpuReadbackIdentifier, RenderContext,
 };
 
@@ -95,7 +97,10 @@ impl ScreenshotProcessor {
         pass
     }
 
-    pub fn end_render_pass(self, encoder: &mut wgpu::CommandEncoder) {
+    pub fn end_render_pass(
+        self,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> Result<(), GpuReadbackError> {
         self.screenshot_readback_buffer.read_texture2d(
             encoder,
             wgpu::ImageCopyTexture {
@@ -108,7 +113,7 @@ impl ScreenshotProcessor {
                 self.screenshot_texture.texture.width(),
                 self.screenshot_texture.texture.height(),
             ),
-        );
+        )
     }
 
     /// Returns the oldest received screenshot results for a given identifier and user data type.

--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -12,6 +12,7 @@ pub mod importer;
 pub mod mesh;
 pub mod renderer;
 pub mod resource_managers;
+pub mod texture_info;
 pub mod view_builder;
 
 mod allocator;

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -252,8 +252,8 @@ impl DepthCloudDrawData {
             depth_cloud_ubo_binding_opaque
         ) {
             if !matches!(
-                depth_cloud.depth_texture.format().describe().sample_type,
-                wgpu::TextureSampleType::Float { filterable: _ }
+                depth_cloud.depth_texture.format().sample_type(None),
+                Some(wgpu::TextureSampleType::Float { filterable: _ })
             ) {
                 return Err(DepthCloudDrawDataError::InvalidDepthTextureFormat(
                     depth_cloud.depth_texture.format(),

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -104,10 +104,7 @@
 //!    * note that this would let us remove the degenerated quads between lines, making the approach cleaner and removing the "restart bit"
 //!
 
-use std::{
-    num::{NonZeroU32, NonZeroU64},
-    ops::Range,
-};
+use std::{num::NonZeroU64, ops::Range};
 
 use bitflags::bitflags;
 use bytemuck::Zeroable;
@@ -479,7 +476,7 @@ impl LineDrawData {
                 bytemuck::cast_slice(&position_data_staging),
                 wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(
+                    bytes_per_row: Some(
                         POSITION_TEXTURE_SIZE * std::mem::size_of::<gpu_data::LineVertex>() as u32,
                     ),
                     rows_per_image: None,
@@ -529,7 +526,7 @@ impl LineDrawData {
                 bytemuck::cast_slice(&line_strip_info_staging),
                 wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: NonZeroU32::new(
+                    bytes_per_row: Some(
                         LINE_STRIP_TEXTURE_SIZE
                             * std::mem::size_of::<gpu_data::LineStripInfo>() as u32,
                     ),

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -33,7 +33,7 @@ mod compositor;
 pub(crate) use compositor::CompositorDrawData;
 
 mod debug_overlay;
-pub use debug_overlay::{DebugOverlayDrawData, DebugOverlayRenderer};
+pub use debug_overlay::{DebugOverlayDrawData, DebugOverlayError, DebugOverlayRenderer};
 
 use crate::{
     context::{RenderContext, SharedRendererData},

--- a/crates/re_renderer/src/texture_info.rs
+++ b/crates/re_renderer/src/texture_info.rs
@@ -132,20 +132,23 @@ pub fn num_texture_components(format: wgpu::TextureFormat) -> u8 {
         | wgpu::TextureFormat::R16Sint
         | wgpu::TextureFormat::R16Unorm
         | wgpu::TextureFormat::R16Snorm
-        | wgpu::TextureFormat::R16Float => 1,
+        | wgpu::TextureFormat::R16Float
+        | wgpu::TextureFormat::R32Uint
+        | wgpu::TextureFormat::R32Sint
+        | wgpu::TextureFormat::R32Float => 1,
 
         wgpu::TextureFormat::Rg8Unorm
         | wgpu::TextureFormat::Rg8Snorm
         | wgpu::TextureFormat::Rg8Uint
         | wgpu::TextureFormat::Rg8Sint
-        | wgpu::TextureFormat::R32Uint
-        | wgpu::TextureFormat::R32Sint
-        | wgpu::TextureFormat::R32Float
         | wgpu::TextureFormat::Rg16Uint
         | wgpu::TextureFormat::Rg16Sint
         | wgpu::TextureFormat::Rg16Unorm
         | wgpu::TextureFormat::Rg16Snorm
-        | wgpu::TextureFormat::Rg16Float => 2,
+        | wgpu::TextureFormat::Rg16Float
+        | wgpu::TextureFormat::Rg32Uint
+        | wgpu::TextureFormat::Rg32Sint
+        | wgpu::TextureFormat::Rg32Float => 2,
 
         wgpu::TextureFormat::Rgba8Unorm
         | wgpu::TextureFormat::Rgba8UnormSrgb
@@ -153,17 +156,8 @@ pub fn num_texture_components(format: wgpu::TextureFormat) -> u8 {
         | wgpu::TextureFormat::Rgba8Uint
         | wgpu::TextureFormat::Rgba8Sint
         | wgpu::TextureFormat::Bgra8Unorm
-        | wgpu::TextureFormat::Bgra8UnormSrgb => 4,
-
-        wgpu::TextureFormat::Rgb9e5Ufloat => 3,
-        wgpu::TextureFormat::Rgb10a2Unorm => 4,
-        wgpu::TextureFormat::Rg11b10Float => 3,
-
-        wgpu::TextureFormat::Rg32Uint
-        | wgpu::TextureFormat::Rg32Sint
-        | wgpu::TextureFormat::Rg32Float => 2,
-
-        wgpu::TextureFormat::Rgba16Uint
+        | wgpu::TextureFormat::Bgra8UnormSrgb
+        | wgpu::TextureFormat::Rgba16Uint
         | wgpu::TextureFormat::Rgba16Sint
         | wgpu::TextureFormat::Rgba16Unorm
         | wgpu::TextureFormat::Rgba16Snorm
@@ -171,6 +165,9 @@ pub fn num_texture_components(format: wgpu::TextureFormat) -> u8 {
         | wgpu::TextureFormat::Rgba32Uint
         | wgpu::TextureFormat::Rgba32Sint
         | wgpu::TextureFormat::Rgba32Float => 4,
+
+        wgpu::TextureFormat::Rgb9e5Ufloat | wgpu::TextureFormat::Rg11b10Float => 3,
+        wgpu::TextureFormat::Rgb10a2Unorm => 4,
 
         wgpu::TextureFormat::Stencil8
         | wgpu::TextureFormat::Depth16Unorm

--- a/crates/re_renderer/src/texture_info.rs
+++ b/crates/re_renderer/src/texture_info.rs
@@ -1,0 +1,209 @@
+use std::borrow::Cow;
+
+/// Utility for dealing with buffers containing raw 2D texture data.
+#[derive(Clone)]
+pub struct Texture2DBufferInfo {
+    /// How many bytes per row contain actual data.
+    pub bytes_per_row_unpadded: u32,
+
+    /// How many bytes per row are required to be allocated in total.
+    ///
+    /// Padding bytes are always at the end of a row.
+    pub bytes_per_row_padded: u32,
+
+    /// Size required for an unpadded buffer.
+    pub buffer_size_unpadded: wgpu::BufferAddress,
+
+    /// Size required for a padded buffer as it is read/written from/to the GPU.
+    pub buffer_size_padded: wgpu::BufferAddress,
+}
+
+impl Texture2DBufferInfo {
+    /// Retrieves 2D texture buffer info for a given format & texture size.
+    ///
+    /// If a single buffer is not possible for all aspects of the texture format, all sizes will be zero.
+    #[inline]
+    pub fn new(format: wgpu::TextureFormat, extent: glam::UVec2) -> Self {
+        let block_dimensions = format.block_dimensions();
+        let width_blocks = extent.x / block_dimensions.0;
+        let height_blocks = extent.y / block_dimensions.1;
+
+        let block_size = format
+            .block_size(Some(wgpu::TextureAspect::All))
+            .unwrap_or(0); // This happens if we can't have a single buffer.
+        let bytes_per_row_unpadded = width_blocks * block_size;
+        let bytes_per_row_padded =
+            wgpu::util::align_to(bytes_per_row_unpadded, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+
+        Self {
+            bytes_per_row_unpadded,
+            bytes_per_row_padded,
+            buffer_size_unpadded: (bytes_per_row_unpadded * height_blocks) as wgpu::BufferAddress,
+            buffer_size_padded: (bytes_per_row_padded * height_blocks) as wgpu::BufferAddress,
+        }
+    }
+
+    #[inline]
+    pub fn num_rows(&self) -> u32 {
+        self.buffer_size_padded as u32 / self.bytes_per_row_padded
+    }
+
+    /// Removes the padding from a buffer containing gpu texture data.
+    ///
+    /// The passed in buffer is to be expected to be exactly of size [`Texture2DBufferInfo::buffer_size_padded`].
+    ///
+    /// Note that if you're passing in gpu data, there no alignment guarantees on the returned slice,
+    /// do NOT convert it using [`bytemuck`]. Use [`Texture2DBufferInfo::remove_padding_and_convert`] instead.
+    pub fn remove_padding<'a>(&self, buffer: &'a [u8]) -> Cow<'a, [u8]> {
+        crate::profile_function!();
+
+        assert_eq!(buffer.len() as wgpu::BufferAddress, self.buffer_size_padded);
+
+        if self.bytes_per_row_padded == self.bytes_per_row_unpadded {
+            return Cow::Borrowed(buffer);
+        }
+
+        let mut unpadded_buffer = Vec::with_capacity(self.buffer_size_unpadded as _);
+
+        for row in 0..self.num_rows() {
+            let offset = (self.bytes_per_row_padded * row) as usize;
+            unpadded_buffer.extend_from_slice(
+                &buffer[offset..(offset + self.bytes_per_row_unpadded as usize)],
+            );
+        }
+
+        unpadded_buffer.into()
+    }
+
+    /// Removes the padding from a buffer containing gpu texture data and remove convert to a given type.
+    ///
+    /// The passed in buffer is to be expected to be exactly of size [`Texture2DBufferInfo::buffer_size_padded`].
+    ///
+    /// The unpadded row size is expected to be a multiple of the size of the target type.
+    /// (Which means that, while uncommon, it technically doesn't need to be as big as a block in the pixel - this can be useful for e.g. packing wide bitfields)
+    pub fn remove_padding_and_convert<T: bytemuck::Pod>(&self, buffer: &[u8]) -> Vec<T> {
+        crate::profile_function!();
+
+        assert_eq!(buffer.len() as wgpu::BufferAddress, self.buffer_size_padded);
+        assert!(self.bytes_per_row_unpadded % std::mem::size_of::<T>() as u32 == 0);
+
+        // Due to https://github.com/gfx-rs/wgpu/issues/3508 the data might be completely unaligned,
+        // so much, that we can't even interpret it as e.g. a u32 slice.
+        // Therefore, we have to do a copy of the data regardless of whether it's padded or not.
+
+        let mut unpadded_buffer: Vec<T> = vec![
+            T::zeroed();
+            (self.num_rows() * self.bytes_per_row_unpadded / std::mem::size_of::<T>() as u32)
+                as usize
+        ]; // TODO(andreas): Consider using unsafe set_len() instead of vec![] to avoid zeroing the memory.
+
+        // The copy has to happen on a u8 slice, because any other type would assume some alignment that we can't guarantee because of the above.
+        let unpadded_buffer_u8_view = bytemuck::cast_slice_mut(&mut unpadded_buffer);
+
+        for row in 0..self.num_rows() {
+            let offset_padded = (self.bytes_per_row_padded * row) as usize;
+            let offset_unpadded = (self.bytes_per_row_unpadded * row) as usize;
+            unpadded_buffer_u8_view
+                [offset_unpadded..(offset_unpadded + self.bytes_per_row_unpadded as usize)]
+                .copy_from_slice(
+                    &buffer[offset_padded..(offset_padded + self.bytes_per_row_unpadded as usize)],
+                );
+        }
+
+        unpadded_buffer
+    }
+}
+
+pub fn is_float_filterable(format: wgpu::TextureFormat, device_features: wgpu::Features) -> bool {
+    format
+        .guaranteed_format_features(device_features)
+        .flags
+        .contains(wgpu::TextureFormatFeatureFlags::FILTERABLE)
+}
+
+pub fn num_texture_components(format: wgpu::TextureFormat) -> u8 {
+    #[allow(clippy::match_same_arms)]
+    match format {
+        wgpu::TextureFormat::R8Unorm
+        | wgpu::TextureFormat::R8Snorm
+        | wgpu::TextureFormat::R8Uint
+        | wgpu::TextureFormat::R8Sint
+        | wgpu::TextureFormat::R16Uint
+        | wgpu::TextureFormat::R16Sint
+        | wgpu::TextureFormat::R16Unorm
+        | wgpu::TextureFormat::R16Snorm
+        | wgpu::TextureFormat::R16Float => 1,
+
+        wgpu::TextureFormat::Rg8Unorm
+        | wgpu::TextureFormat::Rg8Snorm
+        | wgpu::TextureFormat::Rg8Uint
+        | wgpu::TextureFormat::Rg8Sint
+        | wgpu::TextureFormat::R32Uint
+        | wgpu::TextureFormat::R32Sint
+        | wgpu::TextureFormat::R32Float
+        | wgpu::TextureFormat::Rg16Uint
+        | wgpu::TextureFormat::Rg16Sint
+        | wgpu::TextureFormat::Rg16Unorm
+        | wgpu::TextureFormat::Rg16Snorm
+        | wgpu::TextureFormat::Rg16Float => 2,
+
+        wgpu::TextureFormat::Rgba8Unorm
+        | wgpu::TextureFormat::Rgba8UnormSrgb
+        | wgpu::TextureFormat::Rgba8Snorm
+        | wgpu::TextureFormat::Rgba8Uint
+        | wgpu::TextureFormat::Rgba8Sint
+        | wgpu::TextureFormat::Bgra8Unorm
+        | wgpu::TextureFormat::Bgra8UnormSrgb => 4,
+
+        wgpu::TextureFormat::Rgb9e5Ufloat => 3,
+        wgpu::TextureFormat::Rgb10a2Unorm => 4,
+        wgpu::TextureFormat::Rg11b10Float => 3,
+
+        wgpu::TextureFormat::Rg32Uint
+        | wgpu::TextureFormat::Rg32Sint
+        | wgpu::TextureFormat::Rg32Float => 2,
+
+        wgpu::TextureFormat::Rgba16Uint
+        | wgpu::TextureFormat::Rgba16Sint
+        | wgpu::TextureFormat::Rgba16Unorm
+        | wgpu::TextureFormat::Rgba16Snorm
+        | wgpu::TextureFormat::Rgba16Float
+        | wgpu::TextureFormat::Rgba32Uint
+        | wgpu::TextureFormat::Rgba32Sint
+        | wgpu::TextureFormat::Rgba32Float => 4,
+
+        wgpu::TextureFormat::Stencil8
+        | wgpu::TextureFormat::Depth16Unorm
+        | wgpu::TextureFormat::Depth24Plus
+        | wgpu::TextureFormat::Depth32Float => 1,
+
+        // It's complicated. Each aspect has actually only a single channel.
+        wgpu::TextureFormat::Depth24PlusStencil8 | wgpu::TextureFormat::Depth32FloatStencil8 => 2,
+
+        wgpu::TextureFormat::Bc1RgbaUnorm
+        | wgpu::TextureFormat::Bc1RgbaUnormSrgb
+        | wgpu::TextureFormat::Bc2RgbaUnorm
+        | wgpu::TextureFormat::Bc2RgbaUnormSrgb
+        | wgpu::TextureFormat::Bc3RgbaUnorm
+        | wgpu::TextureFormat::Bc3RgbaUnormSrgb
+        | wgpu::TextureFormat::Bc4RUnorm
+        | wgpu::TextureFormat::Bc4RSnorm
+        | wgpu::TextureFormat::Bc5RgUnorm
+        | wgpu::TextureFormat::Bc5RgSnorm
+        | wgpu::TextureFormat::Bc6hRgbUfloat
+        | wgpu::TextureFormat::Bc6hRgbFloat
+        | wgpu::TextureFormat::Bc7RgbaUnorm
+        | wgpu::TextureFormat::Bc7RgbaUnormSrgb
+        | wgpu::TextureFormat::Etc2Rgb8Unorm
+        | wgpu::TextureFormat::Etc2Rgb8UnormSrgb
+        | wgpu::TextureFormat::Etc2Rgb8A1Unorm
+        | wgpu::TextureFormat::Etc2Rgb8A1UnormSrgb
+        | wgpu::TextureFormat::Etc2Rgba8Unorm
+        | wgpu::TextureFormat::Etc2Rgba8UnormSrgb
+        | wgpu::TextureFormat::EacR11Unorm
+        | wgpu::TextureFormat::EacR11Snorm
+        | wgpu::TextureFormat::EacRg11Unorm
+        | wgpu::TextureFormat::EacRg11Snorm
+        | wgpu::TextureFormat::Astc { .. } => 4,
+    }
+}

--- a/crates/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/re_renderer/src/wgpu_resources/mod.rs
@@ -7,7 +7,6 @@
 //! higher level resources that arise from processing user provided data.
 
 mod bind_group_layout_pool;
-use std::borrow::Cow;
 
 pub use bind_group_layout_pool::{
     BindGroupLayoutDesc, GpuBindGroupLayoutHandle, GpuBindGroupLayoutPool,
@@ -114,114 +113,5 @@ impl WgpuResourcePools {
             total_buffer_size_in_bytes: self.buffers.total_gpu_size_in_bytes(),
             total_texture_size_in_bytes: self.textures.total_gpu_size_in_bytes(),
         }
-    }
-}
-
-/// Utility for dealing with buffers containing raw 2D texture data.
-#[derive(Clone)]
-pub struct Texture2DBufferInfo {
-    /// How many bytes per row contain actual data.
-    pub bytes_per_row_unpadded: u32,
-
-    /// How many bytes per row are required to be allocated in total.
-    ///
-    /// Padding bytes are always at the end of a row.
-    pub bytes_per_row_padded: u32,
-
-    /// Size required for an unpadded buffer.
-    pub buffer_size_unpadded: wgpu::BufferAddress,
-
-    /// Size required for a padded buffer as it is read/written from/to the GPU.
-    pub buffer_size_padded: wgpu::BufferAddress,
-}
-
-impl Texture2DBufferInfo {
-    #[inline]
-    pub fn new(format: wgpu::TextureFormat, extent: glam::UVec2) -> Self {
-        let format_info = format.describe();
-
-        let width_blocks = extent.x / format_info.block_dimensions.0 as u32;
-        let height_blocks = extent.y / format_info.block_dimensions.1 as u32;
-
-        let bytes_per_row_unpadded = width_blocks * format_info.block_size as u32;
-        let bytes_per_row_padded =
-            wgpu::util::align_to(bytes_per_row_unpadded, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
-
-        Self {
-            bytes_per_row_unpadded,
-            bytes_per_row_padded,
-            buffer_size_unpadded: (bytes_per_row_unpadded * height_blocks) as wgpu::BufferAddress,
-            buffer_size_padded: (bytes_per_row_padded * height_blocks) as wgpu::BufferAddress,
-        }
-    }
-
-    #[inline]
-    pub fn num_rows(&self) -> u32 {
-        self.buffer_size_padded as u32 / self.bytes_per_row_padded
-    }
-
-    /// Removes the padding from a buffer containing gpu texture data.
-    ///
-    /// The passed in buffer is to be expected to be exactly of size [`Texture2DBufferInfo::buffer_size_padded`].
-    ///
-    /// Note that if you're passing in gpu data, there no alignment guarantees on the returned slice,
-    /// do NOT convert it using [`bytemuck`]. Use [`Texture2DBufferInfo::remove_padding_and_convert`] instead.
-    pub fn remove_padding<'a>(&self, buffer: &'a [u8]) -> Cow<'a, [u8]> {
-        crate::profile_function!();
-
-        assert_eq!(buffer.len() as wgpu::BufferAddress, self.buffer_size_padded);
-
-        if self.bytes_per_row_padded == self.bytes_per_row_unpadded {
-            return Cow::Borrowed(buffer);
-        }
-
-        let mut unpadded_buffer = Vec::with_capacity(self.buffer_size_unpadded as _);
-
-        for row in 0..self.num_rows() {
-            let offset = (self.bytes_per_row_padded * row) as usize;
-            unpadded_buffer.extend_from_slice(
-                &buffer[offset..(offset + self.bytes_per_row_unpadded as usize)],
-            );
-        }
-
-        unpadded_buffer.into()
-    }
-
-    /// Removes the padding from a buffer containing gpu texture data and remove convert to a given type.
-    ///
-    /// The passed in buffer is to be expected to be exactly of size [`Texture2DBufferInfo::buffer_size_padded`].
-    ///
-    /// The unpadded row size is expected to be a multiple of the size of the target type.
-    /// (Which means that, while uncommon, it technically doesn't need to be as big as a block in the pixel - this can be useful for e.g. packing wide bitfields)
-    pub fn remove_padding_and_convert<T: bytemuck::Pod>(&self, buffer: &[u8]) -> Vec<T> {
-        crate::profile_function!();
-
-        assert_eq!(buffer.len() as wgpu::BufferAddress, self.buffer_size_padded);
-        assert!(self.bytes_per_row_unpadded % std::mem::size_of::<T>() as u32 == 0);
-
-        // Due to https://github.com/gfx-rs/wgpu/issues/3508 the data might be completely unaligned,
-        // so much, that we can't even interpret it as e.g. a u32 slice.
-        // Therefore, we have to do a copy of the data regardless of whether it's padded or not.
-
-        let mut unpadded_buffer: Vec<T> = vec![
-            T::zeroed();
-            (self.num_rows() * self.bytes_per_row_unpadded / std::mem::size_of::<T>() as u32)
-                as usize
-        ]; // TODO(andreas): Consider using unsafe set_len() instead of vec![] to avoid zeroing the memory.
-
-        // The copy has to happen on a u8 slice, because any other type would assume some alignment that we can't guarantee because of the above.
-        let unpadded_buffer_u8_view = bytemuck::cast_slice_mut(&mut unpadded_buffer);
-
-        for row in 0..self.num_rows() {
-            let offset_padded = (self.bytes_per_row_padded * row) as usize;
-            let offset_unpadded = (self.bytes_per_row_unpadded * row) as usize;
-            unpadded_buffer_u8_view
-                [offset_unpadded..(offset_unpadded + self.bytes_per_row_unpadded as usize)]
-                .copy_from_slice(
-                    &buffer[offset_padded..(offset_padded + self.bytes_per_row_unpadded as usize)],
-                );
-        }
-
-        unpadded_buffer
     }
 }

--- a/crates/re_renderer/src/wgpu_resources/sampler_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/sampler_pool.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, num::NonZeroU8};
+use std::hash::Hash;
 
 use super::{resource::PoolError, static_resource_pool::StaticResourcePool};
 use crate::debug_label::DebugLabel;
@@ -33,9 +33,6 @@ pub struct SamplerDesc {
 
     /// Maximum level of detail (i.e. mip level) to use
     pub lod_max_clamp: ordered_float::NotNan<f32>,
-
-    /// Valid values: 1, 2, 4, 8, and 16.
-    pub anisotropy_clamp: Option<NonZeroU8>,
 }
 
 #[derive(Default)]
@@ -56,11 +53,11 @@ impl GpuSamplerPool {
                 mipmap_filter: desc.mipmap_filter,
                 lod_min_clamp: desc.lod_min_clamp.into(),
                 lod_max_clamp: desc.lod_max_clamp.into(),
-                anisotropy_clamp: desc.anisotropy_clamp,
 
                 // Unsupported
                 compare: None,
                 border_color: None,
+                anisotropy_clamp: 1,
             })
         })
     }

--- a/crates/re_renderer/src/wgpu_resources/texture_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/texture_pool.rs
@@ -72,7 +72,15 @@ impl DynamicResourcesDesc for TextureDesc {
         let block_size = self
             .format
             .block_size(Some(wgpu::TextureAspect::All))
-            .unwrap_or(1);
+            .unwrap_or_else(|| {
+                self.format
+                    .block_size(Some(wgpu::TextureAspect::DepthOnly))
+                    .unwrap_or(0)
+                    + self
+                        .format
+                        .block_size(Some(wgpu::TextureAspect::StencilOnly))
+                        .unwrap_or(0)
+            });
         let block_dimension = self.format.block_dimensions();
         let pixels_per_block = block_dimension.0 as u64 * block_dimension.1 as u64;
 

--- a/crates/re_renderer/src/wgpu_resources/texture_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/texture_pool.rs
@@ -69,9 +69,12 @@ impl DynamicResourcesDesc for TextureDesc {
     /// The actual number might be both bigger (padding) and lower (gpu sided compression).
     fn resource_size_in_bytes(&self) -> u64 {
         let mut size_in_bytes = 0;
-        let format_desc = self.format.describe();
-        let pixels_per_block =
-            format_desc.block_dimensions.0 as u64 * format_desc.block_dimensions.1 as u64;
+        let block_size = self
+            .format
+            .block_size(Some(wgpu::TextureAspect::All))
+            .unwrap_or(1);
+        let block_dimension = self.format.block_dimensions();
+        let pixels_per_block = block_dimension.0 as u64 * block_dimension.1 as u64;
 
         for mip in 0..self.size.max_mips(self.dimension) {
             let mip_size = self
@@ -80,7 +83,7 @@ impl DynamicResourcesDesc for TextureDesc {
                 .physical_size(self.format);
             let num_pixels = mip_size.width * mip_size.height * mip_size.depth_or_array_layers;
             let num_blocks = num_pixels as u64 / pixels_per_block;
-            size_in_bytes += num_blocks * format_desc.block_size as u64;
+            size_in_bytes += num_blocks * block_size as u64;
         }
 
         size_in_bytes

--- a/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer/src/gpu_bridge/tensor_to_gpu.rs
@@ -112,7 +112,7 @@ fn color_tensor_to_gpu(
         crate::gpu_bridge::range(tensor_stats)?
     };
 
-    let color_mapper = if texture_format.describe().components == 1 {
+    let color_mapper = if re_renderer::texture_info::num_texture_components(texture_format) == 1 {
         // Single-channel images = luminance = grayscale
         Some(ColorMapper::Function(re_renderer::Colormap::Grayscale))
     } else {

--- a/crates/re_viewer/src/ui/view_time_series/ui.rs
+++ b/crates/re_viewer/src/ui/view_time_series/ui.rs
@@ -82,9 +82,10 @@ pub(crate) fn view_time_series(
         plot = plot.x_grid_spacer(move |spacer| ns_grid_spacer(canvas_size, &spacer));
     }
 
-    let egui::InnerResponse {
+    let egui::plot::PlotResponse {
         inner: time_x,
         response,
+        transform: _,
     } = plot.show(ui, |plot_ui| {
         if plot_ui.plot_secondary_clicked() {
             let timeline = ctx.rec_cfg.time_ctrl.timeline();


### PR DESCRIPTION
Update to wgpu 0.16 and latest egui. This is regular maintenance and part of: #1811 

The egui patch is very intentional and in our control. The wgpu patch on top however is a bit more problematic, we don't know for sure if we're getting a patch release with https://github.com/gfx-rs/wgpu/pull/3726 in time. It is however very likely that we can workaround this issue in wgpu-egui: We'd need to never discard command buffers which right now can happen in rare cases.

Tested all re_renderer samples both on web and native. Ran through (and played around with) both `just py-run-all` and `just-py-run-all-web`, as well as some examples in more depth. Looking all good now as far as I can tell!


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
