### PR TITLE
Fix run-wasm crash on trying to wait for server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,12 +572,13 @@ dependencies = [
 
 [[package]]
 name = "cargo-run-wasm"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611b811fad83eebfcdcf47ae1e425c82d1249608bc571d537448d706be08cf27"
+checksum = "cc1e37cf14ef470ed74ec2a8b95e51b8623bcf6f76d24f233ebaeb209f766230"
 dependencies = [
  "devserver_lib",
  "pico-args",
+ "serde_json",
  "wasm-bindgen-cli-support",
 ]
 

--- a/run_wasm/Cargo.toml
+++ b/run_wasm/Cargo.toml
@@ -7,6 +7,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cargo-run-wasm = "0.2.0"
+cargo-run-wasm = "0.3.2"
 pico-args = "0.5"
 webbrowser = "0.8"

--- a/run_wasm/src/main.rs
+++ b/run_wasm/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! This is a temporary solution while we're in the process of building our own xtask tools.
 
-use std::{net::ToSocketAddrs, time::Duration};
+use std::time::Duration;
 
 fn main() {
     // TODO(cmc): Why is this not taking the full screen?
@@ -106,20 +106,9 @@ fn main() {
         })
         .expect("Failed to spawn thread");
 
-    // Wait for the server to be up before opening a browser tab.
-    let addr = format!("{host}:{port}")
-        .to_socket_addrs()
-        .unwrap()
-        .next()
-        .unwrap();
-    loop {
-        // TODO(cmc): this will make the webserver embedded within cargo-run-wasm complain
-        // a bit but eh... that's only temporary.
-        if std::net::TcpStream::connect(addr).is_ok() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(200));
-    }
+    // It would be nice to start a webbrowser, but we can't really know when the server is ready.
+    // So we just sleep for a while and hope it works.
+    std::thread::sleep(Duration::from_millis(500));
 
     // Open browser tab.
     let viewer_url = format!("http://{host}:{port}",);


### PR DESCRIPTION
This ruined my dev experience for re_renderer examples a bit. Not sure what made the previous hack stop working, might be a timing issue. It ended up crashing the `cargo_run_wasm` web server

Updating run-wasm is not actually relevant to this, did so in passing, trying to see if that would fix it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
