### PR TITLE
Round to nearest color_index when doing color mapping

### DIFF
--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -86,7 +86,9 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
         let colormap_size = textureDimensions(colormap_texture).xy;
         let color_index = normalized_value.r * f32(colormap_size.x * colormap_size.y);
         // TODO(emilk): interpolate between neighboring colors for non-integral color indices
-        let color_index_u32 = u32(color_index);
+        // It's important to round here since otherwise numerical instability can push us to the adjacent class-id
+        // See: https://github.com/rerun-io/rerun/issues/1968
+        let color_index_u32 = u32(round(color_index));
         let x = color_index_u32 % colormap_size.x;
         let y = color_index_u32 / colormap_size.x;
         texture_color = textureLoad(colormap_texture, UVec2(x, y), 0);


### PR DESCRIPTION
Fixes:
 - https://github.com/rerun-io/rerun/issues/1968

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
