### PR TITLE
Try making pull-request workflows non-concurrent

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -12,7 +12,9 @@ jobs:
     name: Checks
     uses: ./.github/workflows/reusable_checks.yml
     secrets: inherit
-
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
   min-test-wheel:
     name: 'Minimum Wheel'

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -6,10 +6,6 @@ on:
       - opened
       - synchronize
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 # These jobs use fairly short names as they are a prefix in the display hierarchy
 jobs:
   checks:
@@ -28,11 +24,17 @@ jobs:
       WHEEL_ARTIFACT_NAME: '' # the min-test wheel isn't used for anything
       RRD_ARTIFACT_NAME: linux-rrd-fast
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
   build-web:
     name: 'Build Web'
     uses: ./.github/workflows/reusable_build_web.yml
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
   upload-web:
     name: 'Upload Web'
@@ -42,6 +44,9 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd-fast
       UPLOAD_COMMIT_OVERRIDE: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
   save-pr-summary:
     name: 'Save PR Summary'
@@ -50,3 +55,6 @@ jobs:
     with:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      group: pr-checks-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
   min-test-wheel:
@@ -27,7 +27,7 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd-fast
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      group: pr-min-test-wheel-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
   build-web:
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/reusable_build_web.yml
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      group: pr-build-web-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
   upload-web:
@@ -47,7 +47,7 @@ jobs:
       UPLOAD_COMMIT_OVERRIDE: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      group: pr-upload-web-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
   save-pr-summary:
@@ -58,5 +58,5 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      group: pr-save-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -5,15 +5,14 @@ on:
     branches:
       - "main"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   checks:
     name: Checks
     uses: ./.github/workflows/reusable_checks.yml
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   benches:
     name: Benchmarks
@@ -23,6 +22,9 @@ jobs:
       BENCH_NAME: main
       COMPARE_TO: main
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   deploy-docs:
     needs: [checks, benches]
@@ -32,11 +34,17 @@ jobs:
       PY_DOCS_VERSION_NAME: "HEAD"
       UPDATE_LATEST: false
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   build-web:
     name: 'Build Web'
     uses: ./.github/workflows/reusable_build_web.yml
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   upload-web:
     name: 'Upload Web'
@@ -46,6 +54,9 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
       MARK_PRERELEASE_FOR_MAINLINE: true
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   build-linux:
     needs: [checks]
@@ -56,6 +67,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   build-windows:
     needs: [checks]
@@ -66,6 +80,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   build-macos-arm:
     needs: [checks]
@@ -76,6 +93,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   build-macos-intel:
     needs: [checks]
@@ -86,6 +106,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: 'macos-intel-wheel'
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   upload-wheels-linux:
     name: 'Linux: Upload Wheels'
@@ -95,6 +118,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   upload-wheels-windows:
     name: 'Windows: Upload Wheels'
@@ -104,6 +130,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   upload-wheels-macos-arm:
     name: 'Macos-Arm: Upload Wheels'
@@ -113,6 +142,9 @@ jobs:
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   upload-wheels-macos-intel:
     name: 'Macos-Intel: Upload Wheels'
@@ -122,15 +154,24 @@ jobs:
       WHEEL_ARTIFACT_NAME: macos-intel-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   generate-pip-index:
     name: 'Generate Pip Index'
     needs: [upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
     uses: ./.github/workflows/reusable_pip_index.yml
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
   pre-release:
     name: Pre Release
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
     needs: [upload-web, generate-pip-index]
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-checks-${{ github.ref_name }}
       cancel-in-progress: true
 
   benches:
@@ -23,7 +23,7 @@ jobs:
       COMPARE_TO: main
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-benches-${{ github.ref_name }}
       cancel-in-progress: true
 
   deploy-docs:
@@ -35,7 +35,7 @@ jobs:
       UPDATE_LATEST: false
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-deploy-docs-${{ github.ref_name }}
       cancel-in-progress: true
 
   build-web:
@@ -43,7 +43,7 @@ jobs:
     uses: ./.github/workflows/reusable_build_web.yml
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-build-web-${{ github.ref_name }}
       cancel-in-progress: true
 
   upload-web:
@@ -55,7 +55,7 @@ jobs:
       MARK_PRERELEASE_FOR_MAINLINE: true
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-upload-web-${{ github.ref_name }}
       cancel-in-progress: true
 
   build-linux:
@@ -68,7 +68,7 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-build-linux-${{ github.ref_name }}
       cancel-in-progress: true
 
   build-windows:
@@ -81,7 +81,7 @@ jobs:
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-build-windows-${{ github.ref_name }}
       cancel-in-progress: true
 
   build-macos-arm:
@@ -94,7 +94,7 @@ jobs:
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-build-macos-arm-${{ github.ref_name }}
       cancel-in-progress: true
 
   build-macos-intel:
@@ -107,7 +107,7 @@ jobs:
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-build-macos-intel-${{ github.ref_name }}
       cancel-in-progress: true
 
   upload-wheels-linux:
@@ -119,7 +119,7 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-upload-wheels-linux-${{ github.ref_name }}
       cancel-in-progress: true
 
   upload-wheels-windows:
@@ -131,7 +131,7 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-upload-wheels-windows-${{ github.ref_name }}
       cancel-in-progress: true
 
   upload-wheels-macos-arm:
@@ -143,7 +143,7 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-upload-wheels-macos-arm-${{ github.ref_name }}
       cancel-in-progress: true
 
   upload-wheels-macos-intel:
@@ -155,7 +155,7 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-upload-wheels-macos-intel-${{ github.ref_name }}
       cancel-in-progress: true
 
   generate-pip-index:
@@ -164,13 +164,13 @@ jobs:
     uses: ./.github/workflows/reusable_pip_index.yml
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-generate-pip-index-${{ github.ref_name }}
       cancel-in-progress: true
 
   pre-release:
     name: Pre Release
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}
+      group: push-prerelease-${{ github.ref_name }}
       cancel-in-progress: true
     needs: [upload-web, generate-pip-index]
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Concurrency groups from top-level of a caller workflow *aren't* inherited by children. This is a lot of duplication, but keeps us from running out unnecessary builds gratuitously.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
