### PR TITLE
If there's a `{{ pr-build-summary }}` in the PR description, update it.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,5 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 * [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
 * [ ] I've included a screenshot or gif (if applicable)
 
+<!-- This line will get updated when the PR build summary job finishes. -->
 PR Build Summary: {{ pr-build-summary }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,5 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 ### Checklist
 * [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
 * [ ] I've included a screenshot or gif (if applicable)
+
+PR Build Summary: {{ pr-build-summary }}

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      pull-requests: "write"
 
     runs-on: ubuntu-latest
 

--- a/scripts/generate_pr_summary.py
+++ b/scripts/generate_pr_summary.py
@@ -79,6 +79,11 @@ def generate_pr_summary(github_token: str, github_repository: str, pr_number: in
         print("Uploading results to {}".format(upload_blob.name))
         upload_blob.upload_from_file(buffer, content_type="text/html")
 
+        # If there's a {{ pr-build-summary }} string in the PR description, replace it with a link to the summary page.
+        pr_description = pull.body
+        new_description = pr_description.replace("{{ pr-build-summary }}", f"https://build.rerun.io/pr/{pr_number}")
+        pull.edit(body=new_description)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a PR summary page")


### PR DESCRIPTION
### What
We are now generating these PR build summaries on every PR, but we want the link to be more easily discoverable. 
It turns out the PR template isn't a template in the template-engine sense and doesn't natively support variable substitution.

However, since we're running a job authenticated with GitHubPy anyways, we go ahead and use that script to patch a place-holder in the PR description if we find one.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

PR Build Summary: https://build.rerun.io/pr/1971