### PR TITLE
Another attempt to make jobs non-concurrent on a per-PR basis

### DIFF
--- a/.github/workflows/manual_build_wheels_for_pr.yml
+++ b/.github/workflows/manual_build_wheels_for_pr.yml
@@ -32,6 +32,7 @@ jobs:
     name: 'Linux: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       PLATFORM: linux
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
@@ -42,6 +43,7 @@ jobs:
     name: 'Windows: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       PLATFORM: windows
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: ''
@@ -52,6 +54,7 @@ jobs:
     name: 'Macos-Arm: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       PLATFORM: macos-arm
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: ''
@@ -62,6 +65,7 @@ jobs:
     name: 'Macos-Intel: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       PLATFORM: macos-intel
       WHEEL_ARTIFACT_NAME: 'macos-intel-wheel'
       RRD_ARTIFACT_NAME: ''
@@ -72,6 +76,7 @@ jobs:
     needs: [build-linux]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -81,6 +86,7 @@ jobs:
     needs: [build-linux, build-windows]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -90,6 +96,7 @@ jobs:
     needs: [build-linux, build-macos-arm]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -99,6 +106,7 @@ jobs:
     needs: [build-linux, build-macos-intel]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       WHEEL_ARTIFACT_NAME: macos-intel-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -107,6 +115,8 @@ jobs:
     name: 'Generate Pip Index'
     needs: [check-for-pr, upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
     uses: ./.github/workflows/reusable_pip_index.yml
+    with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
     secrets: inherit
 
   update-pr-summary:
@@ -114,5 +124,6 @@ jobs:
     needs: [check-for-pr, upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
     uses: ./.github/workflows/reusable_pr_summary.yml
     with:
+      CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       PR_NUMBER: ${{ needs.check-for-pr.outputs.PR_NUMBER}}
     secrets: inherit

--- a/.github/workflows/manual_dispatch.yml
+++ b/.github/workflows/manual_dispatch.yml
@@ -72,6 +72,7 @@ jobs:
     if: ${{ github.event.inputs.CHECKS == 'true' }}
     uses: ./.github/workflows/reusable_checks.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       SAVE_CACHE: ${{ github.event.inputs.SAVE_CACHE == 'true' }}
     secrets: inherit
 
@@ -82,6 +83,7 @@ jobs:
     if: ${{ github.event.inputs.DEPLOY_DOCS == 'true' }}
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       PY_DOCS_VERSION_NAME: "test"
       UPDATE_LATEST: false
     secrets: inherit
@@ -90,6 +92,8 @@ jobs:
     name: Benchmarks
     if: ${{ github.event.inputs.BENCHES == 'true' }}
     uses: ./.github/workflows/reusable_bench.yml
+    with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
     secrets: inherit
 
   min-test-wheel:
@@ -98,6 +102,7 @@ jobs:
     if: ${{ (github.event.inputs.MIN_TEST_WHEEL == 'true') || ((github.event.inputs.UPLOAD_GCLOUD == 'true') && ( github.event.inputs.BUILD_WEB == 'true') ) }}
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       SAVE_CACHE: ${{ github.event.inputs.SAVE_CACHE == 'true' }}
       PLATFORM: linux
       MATURIN_FEATURE_FLAGS: '--no-default-features --features extension-module'
@@ -113,6 +118,7 @@ jobs:
 
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       SAVE_CACHE: ${{ github.event.inputs.SAVE_CACHE == 'true' }}
       PLATFORM: linux
       WHEEL_ARTIFACT_NAME: linux-wheel
@@ -125,6 +131,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'windows') }}
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       SAVE_CACHE: ${{ github.event.inputs.SAVE_CACHE == 'true' }}
       PLATFORM: windows
       WHEEL_ARTIFACT_NAME: windows-wheel
@@ -137,6 +144,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'macos-arm') }}
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       SAVE_CACHE: ${{ github.event.inputs.SAVE_CACHE == 'true' }}
       PLATFORM: macos-arm
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
@@ -149,6 +157,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'macos-intel') }}
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       SAVE_CACHE: ${{ github.event.inputs.SAVE_CACHE == 'true' }}
       PLATFORM: macos-intel
       WHEEL_ARTIFACT_NAME: 'macos-intel-wheel'
@@ -163,6 +172,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'linux') && (github.event.inputs.UPLOAD_GCLOUD == 'true') }}
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -173,6 +183,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'windows') && (github.event.inputs.UPLOAD_GCLOUD == 'true') }}
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -183,6 +194,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'macos-arm') && (github.event.inputs.UPLOAD_GCLOUD == 'true') }}
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -193,6 +205,7 @@ jobs:
     if: ${{ contains(github.event.inputs.WHEEL_PLATFORMS, 'macos-intel') && (github.event.inputs.UPLOAD_GCLOUD == 'true') }}
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       WHEEL_ARTIFACT_NAME: macos-intel-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
@@ -202,6 +215,7 @@ jobs:
     if: ${{ github.event.inputs.BUILD_WEB == 'true'}}
     uses: ./.github/workflows/reusable_build_web.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
     secrets: inherit
 
@@ -211,6 +225,7 @@ jobs:
     if: ${{ (github.event.inputs.BUILD_WEB == 'true') && (github.event.inputs.UPLOAD_GCLOUD == 'true') }}
     uses: ./.github/workflows/reusable_upload_web.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       MARK_PRERELEASE_FOR_MAINLINE: false
       MARK_TAGGED_VERSION: false
       RRD_ARTIFACT_NAME: linux-rrd-fast
@@ -250,5 +265,6 @@ jobs:
     if: ${{ github.event.inputs.UPDATE_PR_SUMMARY == 'true' }}
     uses: ./.github/workflows/reusable_pr_summary.yml
     with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
       PR_NUMBER: ${{ needs.check-for-pr.outputs.PR_NUMBER }}
     secrets: inherit

--- a/.github/workflows/manual_run_bench.yml
+++ b/.github/workflows/manual_run_bench.yml
@@ -16,14 +16,6 @@ on:
 
 jobs:
 
-  run-benches:
-    name: Benchmarks
-    uses: ./.github/workflows/reusable_bench.yml
-    with:
-      BENCH_NAME: ${{ github.event.inputs.BENCH_NAME }}
-      COMPARE_TO: ${{ github.event.inputs.COMPARE_TO }}
-    secrets: inherit
-
   check-for-pr:
     runs-on: ubuntu-latest
     outputs:
@@ -46,10 +38,22 @@ jobs:
             echo "PR_NUMBER=$pr_number" >> "$GITHUB_OUTPUT"
           fi
 
+  run-benches:
+    name: Benchmarks
+    needs: [check-for-pr]
+    uses: ./.github/workflows/reusable_bench.yml
+    with:
+      CONCURRENCY: manual-bench-${{ needs.check-for-pr.outputs.PR_NUMBER }}
+      BENCH_NAME: ${{ github.event.inputs.BENCH_NAME }}
+      COMPARE_TO: ${{ github.event.inputs.COMPARE_TO }}
+    secrets: inherit
+
+
   update-pr-summary:
     name: 'Update PR Summary'
     needs: [check-for-pr, run-benches]
     uses: ./.github/workflows/reusable_pr_summary.yml
     with:
+      CONCURRENCY: manual-bench-${{ needs.check-for-pr.outputs.PR_NUMBER }}
       PR_NUMBER: ${{ needs.check-for-pr.outputs.PR_NUMBER}}
     secrets: inherit

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -12,11 +12,8 @@ jobs:
     name: Checks
     uses: ./.github/workflows/reusable_checks.yml
     with:
-      CONCURRENCY: ${{ github.event.pull_request.number }}
+      CONCURRENCY: pr-checks-${{ github.event.pull_request.number }}
     secrets: inherit
-    concurrency:
-      group: pr-checks-${{ inputs.CONCURRENCY }}
-      cancel-in-progress: true
 
   min-test-wheel:
     name: 'Minimum Wheel'

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -11,9 +11,11 @@ jobs:
   checks:
     name: Checks
     uses: ./.github/workflows/reusable_checks.yml
+    with:
+      CONCURRENCY: ${{ github.event.pull_request.number }}
     secrets: inherit
     concurrency:
-      group: pr-checks-${{ github.event.pull_request.number }}
+      group: pr-checks-${{ inputs.CONCURRENCY }}
       cancel-in-progress: true
 
   min-test-wheel:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -12,50 +12,43 @@ jobs:
     name: Checks
     uses: ./.github/workflows/reusable_checks.yml
     with:
-      CONCURRENCY: pr-checks-${{ github.event.pull_request.number }}
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
     secrets: inherit
 
   min-test-wheel:
     name: 'Minimum Wheel'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
       SAVE_CACHE: false
       PLATFORM: linux
       MATURIN_FEATURE_FLAGS: '--no-default-features --features extension-module'
       WHEEL_ARTIFACT_NAME: '' # the min-test wheel isn't used for anything
       RRD_ARTIFACT_NAME: linux-rrd-fast
     secrets: inherit
-    concurrency:
-      group: pr-min-test-wheel-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
 
   build-web:
     name: 'Build Web'
     uses: ./.github/workflows/reusable_build_web.yml
+    with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
     secrets: inherit
-    concurrency:
-      group: pr-build-web-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
 
   upload-web:
     name: 'Upload Web'
     needs: [min-test-wheel, build-web]
     uses: ./.github/workflows/reusable_upload_web.yml
     with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
       RRD_ARTIFACT_NAME: linux-rrd-fast
       UPLOAD_COMMIT_OVERRIDE: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
-    concurrency:
-      group: pr-upload-web-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
 
   save-pr-summary:
     name: 'Save PR Summary'
     needs: [upload-web]
     uses: ./.github/workflows/reusable_pr_summary.yml
     with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
-    concurrency:
-      group: pr-save-pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: true

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -9,168 +9,143 @@ jobs:
   checks:
     name: Checks
     uses: ./.github/workflows/reusable_checks.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
     secrets: inherit
-    concurrency:
-      group: push-checks-${{ github.ref_name }}
-      cancel-in-progress: true
 
   benches:
     name: Benchmarks
     uses: ./.github/workflows/reusable_bench.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       SAVE_BENCHES: true
       BENCH_NAME: main
       COMPARE_TO: main
     secrets: inherit
-    concurrency:
-      group: push-benches-${{ github.ref_name }}
-      cancel-in-progress: true
 
   deploy-docs:
     needs: [checks, benches]
     name: Deploy Docs
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       PY_DOCS_VERSION_NAME: "HEAD"
       UPDATE_LATEST: false
     secrets: inherit
-    concurrency:
-      group: push-deploy-docs-${{ github.ref_name }}
-      cancel-in-progress: true
 
   build-web:
     name: 'Build Web'
     uses: ./.github/workflows/reusable_build_web.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
     secrets: inherit
-    concurrency:
-      group: push-build-web-${{ github.ref_name }}
-      cancel-in-progress: true
 
   upload-web:
     name: 'Upload Web'
     needs: [build-linux, build-web]
     uses: ./.github/workflows/reusable_upload_web.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       RRD_ARTIFACT_NAME: linux-rrd
       MARK_PRERELEASE_FOR_MAINLINE: true
     secrets: inherit
-    concurrency:
-      group: push-upload-web-${{ github.ref_name }}
-      cancel-in-progress: true
 
   build-linux:
     needs: [checks]
     name: 'Linux: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       PLATFORM: linux
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
-    concurrency:
-      group: push-build-linux-${{ github.ref_name }}
-      cancel-in-progress: true
 
   build-windows:
     needs: [checks]
     name: 'Windows: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       PLATFORM: windows
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
-    concurrency:
-      group: push-build-windows-${{ github.ref_name }}
-      cancel-in-progress: true
 
   build-macos-arm:
     needs: [checks]
     name: 'Macos-Arm: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       PLATFORM: macos-arm
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
-    concurrency:
-      group: push-build-macos-arm-${{ github.ref_name }}
-      cancel-in-progress: true
 
   build-macos-intel:
     needs: [checks]
     name: 'Macos-Intel: Build/Test Wheels'
     uses: ./.github/workflows/reusable_build_and_test_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       PLATFORM: macos-intel
       WHEEL_ARTIFACT_NAME: 'macos-intel-wheel'
       RRD_ARTIFACT_NAME: ''
     secrets: inherit
-    concurrency:
-      group: push-build-macos-intel-${{ github.ref_name }}
-      cancel-in-progress: true
 
   upload-wheels-linux:
     name: 'Linux: Upload Wheels'
     needs: [build-linux]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       WHEEL_ARTIFACT_NAME: linux-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
-    concurrency:
-      group: push-upload-wheels-linux-${{ github.ref_name }}
-      cancel-in-progress: true
 
   upload-wheels-windows:
     name: 'Windows: Upload Wheels'
     needs: [build-linux, build-windows]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       WHEEL_ARTIFACT_NAME: windows-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
-    concurrency:
-      group: push-upload-wheels-windows-${{ github.ref_name }}
-      cancel-in-progress: true
 
   upload-wheels-macos-arm:
     name: 'Macos-Arm: Upload Wheels'
     needs: [build-linux, build-macos-arm]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       WHEEL_ARTIFACT_NAME: macos-arm-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
-    concurrency:
-      group: push-upload-wheels-macos-arm-${{ github.ref_name }}
-      cancel-in-progress: true
 
   upload-wheels-macos-intel:
     name: 'Macos-Intel: Upload Wheels'
     needs: [build-linux, build-macos-intel]
     uses: ./.github/workflows/reusable_upload_wheels.yml
     with:
+      CONCURRENCY: push-${{ github.ref_name }}
       WHEEL_ARTIFACT_NAME: macos-intel-wheel
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
-    concurrency:
-      group: push-upload-wheels-macos-intel-${{ github.ref_name }}
-      cancel-in-progress: true
 
   generate-pip-index:
     name: 'Generate Pip Index'
     needs: [upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
     uses: ./.github/workflows/reusable_pip_index.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
     secrets: inherit
-    concurrency:
-      group: push-generate-pip-index-${{ github.ref_name }}
-      cancel-in-progress: true
 
   pre-release:
     name: Pre Release
     concurrency:
-      group: push-prerelease-${{ github.ref_name }}
+      group: push-${{ github.ref_name }}-prerelease
       cancel-in-progress: true
     needs: [upload-web, generate-pip-index]
     runs-on: "ubuntu-latest"

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-bench
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -3,6 +3,9 @@ name: Reusable Bench
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       SAVE_BENCHES:
         required: false
         type: boolean
@@ -19,6 +22,10 @@ on:
         required: false
         type: boolean
         default: false
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -31,7 +31,7 @@ on:
         default: ''
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-build-wheels
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -3,6 +3,9 @@ name: Reusable Build and Test Wheels
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       MATURIN_FEATURE_FLAGS:
         required: false
         type: string
@@ -26,6 +29,10 @@ on:
         required: false
         type: string
         default: ''
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -12,7 +12,7 @@ on:
         default: 'prerelease'
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-build-web
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -3,10 +3,17 @@ name: Reusable Build Web
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       RELEASE_VERSION:
         required: false
         type: string
         default: 'prerelease'
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 env:
   # web_sys_unstable_apis is required to enable the web_sys clipboard API which egui_web uses

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -3,6 +3,9 @@ name: 'Checks: Lints, Tests, Docs'
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       SAVE_CACHE:
         required: false
         type: boolean

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -23,6 +23,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: "3.8"
   # web_sys_unstable_apis is required to enable the web_sys clipboard API which egui_web uses

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-checks
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -15,7 +15,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-deploy-docs
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -3,6 +3,9 @@ name: 'Reusable Deploy Docs'
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       PY_DOCS_VERSION_NAME:
         required: true
         type: string
@@ -10,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-pip-index
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -2,6 +2,14 @@ name: Reusable Pip Index
 
 on:
   workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   pr-summary:

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -3,9 +3,16 @@ name: Reusable PR Summary
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       PR_NUMBER:
         required: true
         type: string
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   pr-summary:

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-pr-summary
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -30,7 +30,7 @@ on:
         default: ''
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-upload-web
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -3,6 +3,9 @@ name: Reusable Upload Web
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       MARK_PRERELEASE_FOR_MAINLINE:
         required: false
         type: boolean
@@ -25,6 +28,10 @@ on:
         required: false
         type: string
         default: ''
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/reusable_upload_wheels.yml
+++ b/.github/workflows/reusable_upload_wheels.yml
@@ -16,7 +16,7 @@ on:
         default: ''
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  group: ${{ inputs.CONCURRENCY }}-upload-wheels
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable_upload_wheels.yml
+++ b/.github/workflows/reusable_upload_wheels.yml
@@ -3,6 +3,9 @@ name: Reusable Upload Wheels
 on:
   workflow_call:
     inputs:
+      CONCURRENCY:
+        required: true
+        type: string
       RRD_ARTIFACT_NAME:
         required: false
         type: string
@@ -11,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
Handling concurrency for reusable workflows was a bit awkward. We want the *calling* job to control the concurrency rather than the *called* job. The only way to ultimately get this to work was passing through the concurrency value as a new input and setting it up appropriately from all callers.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
