### PR TITLE
Better crash reports on Web + WebGPU support detection

### DIFF
--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -44,7 +44,7 @@ pub use misc::profiler::Profiler;
 #[cfg(target_arch = "wasm32")]
 mod web;
 #[cfg(target_arch = "wasm32")]
-pub use web::start;
+pub use web::WebHandle;
 
 // ---------------------------------------------------------------------------
 

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -43,8 +43,6 @@ pub use misc::profiler::Profiler;
 
 #[cfg(target_arch = "wasm32")]
 mod web;
-#[cfg(target_arch = "wasm32")]
-pub use web::WebHandle;
 
 // ---------------------------------------------------------------------------
 

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -1,4 +1,8 @@
-use eframe::wasm_bindgen::{self, prelude::*};
+use eframe::{
+    wasm_bindgen::{self, prelude::*},
+    web::AppRunnerRef,
+};
+
 use std::sync::Arc;
 
 use re_memory::AccountingAllocator;
@@ -7,111 +11,138 @@ use re_memory::AccountingAllocator;
 static GLOBAL: AccountingAllocator<std::alloc::System> =
     AccountingAllocator::new(std::alloc::System);
 
-/// This is the entry-point for all the Wasm.
-///
-/// This is called once from the HTML.
-/// It loads the app, installs some callbacks, then returns.
-/// The `url` is an optional URL to either an .rrd file over http, or a Rerun WebSocket server.
 #[wasm_bindgen]
-pub async fn start(
-    canvas_id: &str,
-    url: Option<String>,
-) -> std::result::Result<(), eframe::wasm_bindgen::JsValue> {
-    // Make sure panics are logged using `console.error`.
-    console_error_panic_hook::set_once();
+pub struct WebHandle {
+    runner: AppRunnerRef,
+}
 
-    re_log::setup_web_logging();
+#[wasm_bindgen]
+impl WebHandle {
+    /// This is the entry-point for all the Wasm.
+    ///
+    /// This is called once from the HTML.
+    /// It loads the app, installs some callbacks, then returns.
+    /// The `url` is an optional URL to either an .rrd file over http, or a Rerun WebSocket server.
+    #[wasm_bindgen(constructor)]
+    pub async fn new(
+        canvas_id: &str,
+        url: Option<String>,
+    ) -> Result<WebHandle, wasm_bindgen::JsValue> {
+        // Make sure panics are logged using `console.error`.
+        console_error_panic_hook::set_once();
 
-    let web_options = eframe::WebOptions {
-        follow_system_theme: false,
-        default_theme: eframe::Theme::Dark,
-        wgpu_options: crate::wgpu_options(),
-        depth_buffer: 0,
-    };
+        re_log::setup_web_logging();
 
-    eframe::start_web(
-        canvas_id,
-        web_options,
-        Box::new(move |cc| {
-            let build_info = re_build_info::build_info!();
-            let app_env = crate::AppEnvironment::Web;
-            let persist_state = get_persist_state(&cc.integration_info);
-            let startup_options = crate::StartupOptions {
-                memory_limit: re_memory::MemoryLimit {
-                    // On wasm32 we only have 4GB of memory to play around with.
-                    limit: Some(2_500_000_000),
-                },
-                persist_state,
-            };
-            let re_ui = crate::customize_eframe(cc);
-            let url = url.unwrap_or_else(|| get_url(&cc.integration_info));
+        let web_options = eframe::WebOptions {
+            follow_system_theme: false,
+            default_theme: eframe::Theme::Dark,
+            wgpu_options: crate::wgpu_options(),
+            depth_buffer: 0,
+        };
 
-            match categorize_uri(url) {
-                EndpointCategory::HttpRrd(url) => {
-                    // Download an .rrd file over http:
-                    let (tx, rx) =
-                        re_smart_channel::smart_channel(re_smart_channel::Source::RrdHttpStream {
-                            url: url.clone(),
-                        });
-                    let egui_ctx = cc.egui_ctx.clone();
-                    re_log_encoding::stream_rrd_from_http::stream_rrd_from_http(
-                        url,
-                        Arc::new(move |msg| {
-                            egui_ctx.request_repaint(); // wake up ui thread
-                            tx.send(msg).ok();
-                        }),
-                    );
+        let runner = eframe::start_web(
+            canvas_id,
+            web_options,
+            Box::new(move |cc| {
+                let build_info = re_build_info::build_info!();
+                let app_env = crate::AppEnvironment::Web;
+                let persist_state = get_persist_state(&cc.integration_info);
+                let startup_options = crate::StartupOptions {
+                    memory_limit: re_memory::MemoryLimit {
+                        // On wasm32 we only have 4GB of memory to play around with.
+                        limit: Some(2_500_000_000),
+                    },
+                    persist_state,
+                };
+                let re_ui = crate::customize_eframe(cc);
+                let url = url.unwrap_or_else(|| get_url(&cc.integration_info));
 
-                    Box::new(crate::App::from_receiver(
-                        build_info,
-                        &app_env,
-                        startup_options,
-                        re_ui,
-                        cc.storage,
-                        rx,
-                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                    ))
+                match categorize_uri(url) {
+                    EndpointCategory::HttpRrd(url) => {
+                        // Download an .rrd file over http:
+                        let (tx, rx) = re_smart_channel::smart_channel(
+                            re_smart_channel::Source::RrdHttpStream { url: url.clone() },
+                        );
+                        let egui_ctx = cc.egui_ctx.clone();
+                        re_log_encoding::stream_rrd_from_http::stream_rrd_from_http(
+                            url,
+                            Arc::new(move |msg| {
+                                egui_ctx.request_repaint(); // wake up ui thread
+                                tx.send(msg).ok();
+                            }),
+                        );
+
+                        Box::new(crate::App::from_receiver(
+                            build_info,
+                            &app_env,
+                            startup_options,
+                            re_ui,
+                            cc.storage,
+                            rx,
+                            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                        ))
+                    }
+                    EndpointCategory::WebEventListener => {
+                        // Process an rrd when it's posted via `window.postMessage`
+                        let (tx, rx) = re_smart_channel::smart_channel(
+                            re_smart_channel::Source::RrdWebEventListener,
+                        );
+                        let egui_ctx = cc.egui_ctx.clone();
+                        re_log_encoding::stream_rrd_from_http::stream_rrd_from_event_listener(
+                            Arc::new(move |msg| {
+                                egui_ctx.request_repaint(); // wake up ui thread
+                                tx.send(msg).ok();
+                            }),
+                        );
+
+                        Box::new(crate::App::from_receiver(
+                            build_info,
+                            &app_env,
+                            startup_options,
+                            re_ui,
+                            cc.storage,
+                            rx,
+                            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                        ))
+                    }
+                    EndpointCategory::WebSocket(url) => {
+                        // Connect to a Rerun server over WebSockets.
+                        Box::new(crate::RemoteViewerApp::new(
+                            build_info,
+                            app_env,
+                            startup_options,
+                            re_ui,
+                            cc.storage,
+                            url,
+                        ))
+                    }
                 }
-                EndpointCategory::WebEventListener => {
-                    // Process an rrd when it's posted via `window.postMessage`
-                    let (tx, rx) = re_smart_channel::smart_channel(
-                        re_smart_channel::Source::RrdWebEventListener,
-                    );
-                    let egui_ctx = cc.egui_ctx.clone();
-                    re_log_encoding::stream_rrd_from_http::stream_rrd_from_event_listener(
-                        Arc::new(move |msg| {
-                            egui_ctx.request_repaint(); // wake up ui thread
-                            tx.send(msg).ok();
-                        }),
-                    );
+            }),
+        )
+        .await?;
 
-                    Box::new(crate::App::from_receiver(
-                        build_info,
-                        &app_env,
-                        startup_options,
-                        re_ui,
-                        cc.storage,
-                        rx,
-                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                    ))
-                }
-                EndpointCategory::WebSocket(url) => {
-                    // Connect to a Rerun server over WebSockets.
-                    Box::new(crate::RemoteViewerApp::new(
-                        build_info,
-                        app_env,
-                        startup_options,
-                        re_ui,
-                        cc.storage,
-                        url,
-                    ))
-                }
-            }
-        }),
-    )
-    .await?;
+        Ok(WebHandle { runner })
+    }
 
-    Ok(())
+    #[wasm_bindgen]
+    pub fn destroy(&self) {
+        self.runner.destroy();
+    }
+
+    #[wasm_bindgen]
+    pub fn has_panicked(&self) -> bool {
+        self.runner.panic_summary().is_some()
+    }
+
+    #[wasm_bindgen]
+    pub fn panic_message(&self) -> Option<String> {
+        self.runner.panic_summary().map(|s| s.message())
+    }
+
+    #[wasm_bindgen]
+    pub fn panic_callstack(&self) -> Option<String> {
+        self.runner.panic_summary().map(|s| s.callstack())
+    }
 }
 
 enum EndpointCategory {

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -145,6 +145,11 @@ impl WebHandle {
     }
 }
 
+#[wasm_bindgen]
+pub fn is_webgpu_build() -> bool {
+    !cfg!(feature = "webgl")
+}
+
 enum EndpointCategory {
     /// Could be a local path (`/foo.rrd`) or a remote url (`http://foo.com/bar.rrd`).
     HttpRrd(String),

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -264,7 +264,13 @@
         function on_wasm_error(error) {
             console.error("Failed to start: " + error);
 
-            let render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
+            let render_backend_name = "WebGPU/WebGL";
+            try {
+                render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
+            } catch (e) {
+                // loading the wasm probably failed.
+            }
+
             document.getElementById("center_text").innerHTML = `
                 <p>
                     An error occurred during loading:

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -171,17 +171,51 @@
 
 
         function on_wasm_loaded() {
-            console.debug("wasm loaded. starting app…");
+            console.debug("Wasm loaded. Starting app…");
 
             // This call installs a bunch of callbacks and then returns:
-            wasm_bindgen.start("the_canvas_id", determine_url());
+            let handle = new wasm_bindgen.WebHandle("the_canvas_id", determine_url());
+            handle.then(on_app_started).catch(on_wasm_error);
+        }
 
-            console.debug("app started.");
-            document.getElementById("center_text").remove();
+        function on_app_started(handle) {
+            // Call `handle.destroy()` to stop. Uncomment to quick result:
+            // setTimeout(() => { handle.destroy(); handle.free()) }, 2000)
+
+            console.debug("App started.");
+            document.getElementById("center_text").innerHTML = '';
 
             if (window.location !== window.parent.location) {
                 window.parent.postMessage("READY", "*");
             }
+
+            function check_for_panic() {
+                if (handle.has_panicked()) {
+                    console.error("Rerun has crashed");
+
+                    // Rerun already logs the panic message and callstack, but you
+                    // can access them like this if you want to show them in the html:
+                    // console.error(`${handle.panic_message()}`);
+                    // console.error(`${handle.panic_callstack()}`);
+
+                    document.getElementById("the_canvas_id").remove();
+                    document.getElementById("center_text").innerHTML = `
+                        <p>
+                            Rerun has crashed.
+                        </p>
+                        <p style="font-size:14px">
+                            See the console for details.
+                        </p>
+                        <p style="font-size:14px">
+                            Reload the page to try again.
+                        </p>`;
+                } else {
+                    let delay_ms = 1000;
+                    setTimeout(check_for_panic, delay_ms);
+                }
+            }
+
+            check_for_panic();
         }
 
         function determine_url() {

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -171,6 +171,20 @@
 
 
         function on_wasm_loaded() {
+            // WebGPU version is currently only supported on browsers with WebGPU support, there is no dynamic fallback to WebGL.
+            if (wasm_bindgen.is_webgpu_build() && typeof navigator.gpu === 'undefined') {
+                console.debug("`navigator.gpu` is undefined. This indicates lack of WebGPU support.");
+                document.getElementById("center_text").innerHTML = `
+                <p>
+                    Missing WebGPU support.
+                </p>
+                <p style="font-size:18px">
+                    This version of Rerun requires WebGPU support which is not available in your browser.
+                    Either try a different browser or use the WebGL version of Rerun.
+                </p>`;
+                return;
+            }
+
             console.debug("Wasm loaded. Starting app…");
 
             // This call installs a bunch of callbacks and then returns:
@@ -249,16 +263,18 @@
 
         function on_wasm_error(error) {
             console.error("Failed to start: " + error);
+
+            let render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
             document.getElementById("center_text").innerHTML = `
-                <p>
-                    An error occurred during loading:
-                </p>
-                <p style="font-family:Courier New">
-                    ${error}
-                </p>
-                <p style="font-size:14px">
-                    Make sure you use a modern browser with WebGL and Wasm enabled.
-                </p>`;
+            <p>
+                An error occurred during loading:
+            </p>
+            <p style="font-family:Courier New">
+                ${error}
+            </p>
+            <p style="font-size:14px">
+                    Make sure you use a modern browser with ${render_backend_name} and Wasm enabled.
+            </p>`;
         }
     </script>
 </body>

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -266,15 +266,15 @@
 
             let render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
             document.getElementById("center_text").innerHTML = `
-            <p>
-                An error occurred during loading:
-            </p>
-            <p style="font-family:Courier New">
-                ${error}
-            </p>
-            <p style="font-size:14px">
-                    Make sure you use a modern browser with ${render_backend_name} and Wasm enabled.
-            </p>`;
+                <p>
+                    An error occurred during loading:
+                </p>
+                <p style="font-family:Courier New">
+                    ${error}
+                </p>
+                <p style="font-size:14px">
+                        Make sure you use a modern browser with ${render_backend_name} and Wasm enabled.
+                </p>`;
         }
     </script>
 </body>

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -233,7 +233,13 @@
         function on_wasm_error(error) {
             console.error("Failed to start: " + error);
 
-            let render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
+            let render_backend_name = "WebGPU/WebGL";
+            try {
+                render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
+            } catch (e) {
+                // loading the wasm probably failed.
+            }
+
             document.getElementById("center_text").innerHTML = `
                 <p>
                     An error occurred during loading:

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -168,18 +168,81 @@
         }
 
         function on_wasm_loaded() {
-            console.debug("wasm loaded. starting app…");
+            console.debug("Wasm loaded. Starting app…");
 
             // This call installs a bunch of callbacks and then returns:
             let url = null; // you can use this to point to an .rrd file over http, or a WebSocket Rerun server.
-            wasm_bindgen.start("the_canvas_id", url);
+            let handle = new wasm_bindgen.WebHandle("the_canvas_id", url);
+            handle.then(on_app_started).catch(on_wasm_error);
+        }
 
-            console.debug("app started.");
-            document.getElementById("center_text").remove();
+        function on_app_started(handle) {
+            // Call `handle.destroy()` to stop. Uncomment to quick result:
+            // setTimeout(() => { handle.destroy(); handle.free()) }, 2000)
+
+            console.debug("App started.");
+            document.getElementById("center_text").innerHTML = '';
 
             if (window.location !== window.parent.location) {
                 window.parent.postMessage("READY", "*");
             }
+
+            function check_for_panic() {
+                if (handle.has_panicked()) {
+                    console.error("Rerun has crashed");
+
+                    // Rerun already logs the panic message and callstack, but you
+                    // can access them like this if you want to show them in the html:
+                    // console.error(`${handle.panic_message()}`);
+                    // console.error(`${handle.panic_callstack()}`);
+
+                    document.getElementById("the_canvas_id").remove();
+                    document.getElementById("center_text").innerHTML = `
+                        <p>
+                            Rerun has crashed.
+                        </p>
+                        <p style="font-size:14px">
+                            See the console for details.
+                        </p>
+                        <p style="font-size:14px">
+                            Reload the page to try again.
+                        </p>`;
+                } else {
+                    let delay_ms = 1000;
+                    setTimeout(check_for_panic, delay_ms);
+                }
+            }
+
+            check_for_panic();
+        }
+
+        function determine_url() {
+            // If a 'url' is provided as a url-param, use it.
+            // Although `web.rs` can also parse the url-param itself,
+            // it won't do so if we pass in a non-null url. We could
+            // arguably return null here instead and achieve the same
+            // behavior, but as long as we've queried it anyways, we
+            // may as well just pass it in for consistency.
+
+            const url_params = new URLSearchParams(window.location.search);
+
+            let url = url_params.get('url');
+
+            if (url) {
+                return url;
+            }
+
+            // Otherwise, look up an rrd in the data path.
+
+            // The expected data path is the current pathname relocated to inside of "/data" with the
+            // index.html stripped off if it's present.
+            // exa: 'https://app.rerun.io/version/v4.0.0/index.html' -> '/data/version/v4.0.0/'
+            let data_path = '/data/' + window.location.pathname.replace(/index\.html$/, '') + '/';
+
+            const rrd_file = url_params.get('file') || 'colmap_fiat.rrd';
+
+            // Normalize the extra slashes from the url
+            return (data_path + rrd_file).replace(/\/{2,}/g, '/');
         }
 
         function on_wasm_error(error) {

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -264,15 +264,15 @@
 
             let render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
             document.getElementById("center_text").innerHTML = `
-            <p>
-                An error occurred during loading:
-            </p>
-            <p style="font-family:Courier New">
-                ${error}
-            </p>
-            <p style="font-size:14px">
-                    Make sure you use a modern browser with ${render_backend_name} and Wasm enabled.
-            </p>`;
+                <p>
+                    An error occurred during loading:
+                </p>
+                <p style="font-family:Courier New">
+                    ${error}
+                </p>
+                <p style="font-size:14px">
+                        Make sure you use a modern browser with ${render_backend_name} and Wasm enabled.
+                </p>`;
         }
     </script>
 </body>

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- The version of index.html bundled with the Rerun SDK. -->
+<!-- The version of index.html that will be served by app.rerun.io -->
 <html>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
@@ -168,6 +168,20 @@
         }
 
         function on_wasm_loaded() {
+            // WebGPU version is currently only supported on browsers with WebGPU support, there is no dynamic fallback to WebGL.
+            if (wasm_bindgen.is_webgpu_build() && typeof navigator.gpu === 'undefined') {
+                console.debug("`navigator.gpu` is undefined. This indicates lack of WebGPU support.");
+                document.getElementById("center_text").innerHTML = `
+                <p>
+                    Missing WebGPU support.
+                </p>
+                <p style="font-size:18px">
+                    This version of Rerun requires WebGPU support which is not available in your browser.
+                    Either try a different browser or use the WebGL version of Rerun.
+                </p>`;
+                return;
+            }
+
             console.debug("Wasm loaded. Starting app…");
 
             // This call installs a bunch of callbacks and then returns:
@@ -247,16 +261,18 @@
 
         function on_wasm_error(error) {
             console.error("Failed to start: " + error);
+
+            let render_backend_name = wasm_bindgen.is_webgpu_build() ? "WebGPU" : "WebGL";
             document.getElementById("center_text").innerHTML = `
-                <p>
-                    An error occurred during loading:
-                </p>
-                <p style="font-family:Courier New">
-                    ${error}
-                </p>
-                <p style="font-size:14px">
-                    Make sure you use a modern browser with WebGL and Wasm enabled.
-                </p>`;
+            <p>
+                An error occurred during loading:
+            </p>
+            <p style="font-family:Courier New">
+                ${error}
+            </p>
+            <p style="font-size:14px">
+                    Make sure you use a modern browser with ${render_backend_name} and Wasm enabled.
+            </p>`;
         }
     </script>
 </body>

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- The version of index.html that will be served by app.rerun.io -->
+<!-- The version of index.html bundled with the Rerun SDK. -->
 <html>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -230,35 +230,6 @@
             check_for_panic();
         }
 
-        function determine_url() {
-            // If a 'url' is provided as a url-param, use it.
-            // Although `web.rs` can also parse the url-param itself,
-            // it won't do so if we pass in a non-null url. We could
-            // arguably return null here instead and achieve the same
-            // behavior, but as long as we've queried it anyways, we
-            // may as well just pass it in for consistency.
-
-            const url_params = new URLSearchParams(window.location.search);
-
-            let url = url_params.get('url');
-
-            if (url) {
-                return url;
-            }
-
-            // Otherwise, look up an rrd in the data path.
-
-            // The expected data path is the current pathname relocated to inside of "/data" with the
-            // index.html stripped off if it's present.
-            // exa: 'https://app.rerun.io/version/v4.0.0/index.html' -> '/data/version/v4.0.0/'
-            let data_path = '/data/' + window.location.pathname.replace(/index\.html$/, '') + '/';
-
-            const rrd_file = url_params.get('file') || 'colmap_fiat.rrd';
-
-            // Normalize the extra slashes from the url
-            return (data_path + rrd_file).replace(/\/{2,}/g, '/');
-        }
-
         function on_wasm_error(error) {
             console.error("Failed to start: " + error);
 


### PR DESCRIPTION
Using egui's new ability to pass through errors on panic and otherwise for better crashes on the web:

https://user-images.githubusercontent.com/1220815/234574967-8594f89b-4a6d-49b7-9881-ef73e00419a8.mov

Additionally, added detection for running webgpu version on a non-webgpu browser:
<img width="1645" alt="image" src="https://user-images.githubusercontent.com/1220815/234574123-c5516bab-6999-4562-826a-7ad704d093f1.png">


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/1975
