### PR TITLE
Fix: don't starve web-socket decoding task

### DIFF
--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -48,7 +48,10 @@ impl RemoteViewerApp {
             match re_ws_comms::decode_log_msg(&binary) {
                 Ok(log_msg) => {
                     if tx.send(log_msg).is_ok() {
-                        egui_ctx.request_repaint(); // Wake up UI thread
+                        // Spend a few more milliseconds decoding incoming messages,
+                        // then trigger a repaint (#963):
+                        egui_ctx.request_repaint_after(std::time::Duration::from_millis(10));
+
                         std::ops::ControlFlow::Continue(())
                     } else {
                         re_log::info!("Failed to send log message to viewer - closing");


### PR DESCRIPTION
Give the task that decodes incoming log messages a bit of time before calling `requestAnimationFrame`.

Closes https://github.com/rerun-io/rerun/issues/963

Should improve web performance on Chrome and Edge

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
