### PR TITLE
Don't use console.error

### DIFF
--- a/crates/re_log/src/web_logger.rs
+++ b/crates/re_log/src/web_logger.rs
@@ -31,7 +31,11 @@ impl log::Log for WebLogger {
             log::Level::Debug => console::debug(&msg),
             log::Level::Info => console::info(&msg),
             log::Level::Warn => console::warn(&msg),
-            log::Level::Error => console::error(&msg),
+
+            // Using console.error causes crashes for unknown reason
+            // https://github.com/emilk/egui/pull/2961
+            // log::Level::Error => console::error(&msg),
+            log::Level::Error => console::warn(&format!("ERROR: {msg}")),
         }
     }
 
@@ -60,8 +64,10 @@ mod console {
         #[wasm_bindgen(js_namespace = console)]
         pub fn warn(s: &str);
 
-        /// `console.error`
-        #[wasm_bindgen(js_namespace = console)]
-        pub fn error(s: &str);
+        // Using console.error causes crashes for unknown reason
+        // https://github.com/emilk/egui/pull/2961
+        // /// `console.error`
+        // #[wasm_bindgen(js_namespace = console)]
+        // pub fn error(s: &str);
     }
 }


### PR DESCRIPTION
Because it can apparaently cause crashes:
https://github.com/emilk/egui/pull/2961

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/1984
