### PR TITLE
Limit ipython to 8.12 in the jupyter example

### DIFF
--- a/examples/python/notebook/requirements.txt
+++ b/examples/python/notebook/requirements.txt
@@ -1,2 +1,3 @@
+ipython<=8.12 # ipython 8.13 or greater doesn't work with python 3.8
 jupyter
 rerun-sdk


### PR DESCRIPTION
We started seeing build issues for notebooks as in:
https://github.com/rerun-io/rerun/actions/runs/4831163897/jobs/8609275586

Turns out ipython 8.13...
![image](https://user-images.githubusercontent.com/3312232/235191738-6b751335-4426-4fde-a2c5-63003a134120.png)
drops support for Python 3.8.

The fact that it allows itself to be installed by pip is technically a bug, but has already been reported:
 - https://github.com/ipython/ipython/issues/14053

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2001
