### PR TITLE
New helper for sticking Serde-encodable data into arrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +3956,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_bytes",
+ "similar-asserts",
  "smallvec",
  "thiserror",
  "time 0.3.20",
@@ -4277,6 +4289,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -4722,6 +4740,20 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
+dependencies = [
+ "console",
+ "similar",
+]
 
 [[package]]
 name = "slab"

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -34,6 +34,7 @@ image = ["dep:ecolor", "dep:image"]
 
 ## Enable (de)serialization using serde.
 serde = [
+  "dep:rmp-serde",
   "dep:serde",
   "dep:serde_bytes",
   "half/serde",
@@ -89,6 +90,7 @@ image = { workspace = true, optional = true, default-features = false, features 
 ] }
 macaw = { workspace = true, optional = true }
 rand = { version = "0.8", optional = true }
+rmp-serde = {version = "1.1", optional= true}
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 serde_bytes = { version = "0.11", optional = true }
 
@@ -98,4 +100,4 @@ puffin.workspace = true
 
 
 [dev-dependencies]
-rmp-serde = "1.1"
+similar-asserts = "1.4.2"

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -23,6 +23,9 @@ pub mod time_point;
 mod time_range;
 mod time_real;
 
+#[cfg(feature = "serde")]
+pub mod serde_field;
+
 pub mod external {
     pub use arrow2;
     pub use arrow2_convert;

--- a/crates/re_log_types/src/serde_field.rs
+++ b/crates/re_log_types/src/serde_field.rs
@@ -1,0 +1,126 @@
+use arrow2::{
+    array::{BinaryArray, MutableBinaryArray, TryPush},
+    datatypes::DataType,
+};
+use arrow2_convert::{deserialize::ArrowDeserialize, field::ArrowField, serialize::ArrowSerialize};
+
+/// Helper for storing arbitrary serde-compatible types in an arrow2 Binary field
+///
+/// Use as:
+/// ```
+/// use re_log_types::serde_field::SerdeField;
+/// use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize, field::ArrowField};
+/// use arrow2::datatypes::{DataType, Field};
+///
+/// #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+/// struct SomeStruct {
+///     foo: String,
+///     bar: u32,
+/// }
+///
+/// #[derive(Clone, Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
+/// struct SomeArrowStruct {
+///     #[arrow_field(type = "SerdeField<SomeStruct>")]
+///     field: SomeStruct,
+/// }
+///
+/// assert_eq!(
+///     SomeArrowStruct::data_type(),
+///     DataType::Struct(vec![
+///         Field::new("field", DataType::Binary, false),
+///     ])
+/// );
+/// ```
+pub struct SerdeField<T>(std::marker::PhantomData<T>);
+
+impl<T> ArrowField for SerdeField<T>
+where
+    T: serde::ser::Serialize + serde::de::DeserializeOwned,
+{
+    type Type = T;
+
+    #[inline]
+    fn data_type() -> DataType {
+        arrow2::datatypes::DataType::Binary
+    }
+}
+
+impl<T> ArrowSerialize for SerdeField<T>
+where
+    T: serde::ser::Serialize + serde::de::DeserializeOwned,
+{
+    type MutableArrayType = MutableBinaryArray<i32>;
+    #[inline]
+    fn new_array() -> Self::MutableArrayType {
+        MutableBinaryArray::new()
+    }
+
+    fn arrow_serialize(
+        v: &<Self as ArrowField>::Type,
+        array: &mut Self::MutableArrayType,
+    ) -> arrow2::error::Result<()> {
+        let mut buf = Vec::new();
+        rmp_serde::encode::write_named(&mut buf, v).map_err(|_err| {
+            // TODO(jleibs): Could not get re_error::format() to work here
+            arrow2::error::Error::ExternalFormat("Could not encode as rmp".to_owned())
+        })?;
+        array.try_push(Some(buf))
+    }
+}
+
+impl<T> ArrowDeserialize for SerdeField<T>
+where
+    T: serde::ser::Serialize + serde::de::DeserializeOwned,
+{
+    type ArrayType = BinaryArray<i32>;
+
+    #[inline]
+    fn arrow_deserialize(v: <&Self::ArrayType as IntoIterator>::Item) -> Option<T> {
+        v.and_then(|v| rmp_serde::from_slice::<T>(v).ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SerdeField;
+    use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+    struct SomeStruct {
+        foo: String,
+        bar: u32,
+    }
+
+    #[derive(Clone, Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
+    struct SomeArrowStruct {
+        #[arrow_field(type = "SerdeField<SomeStruct>")]
+        field: SomeStruct,
+    }
+
+    impl From<SomeStruct> for SomeArrowStruct {
+        fn from(s: SomeStruct) -> Self {
+            Self { field: s }
+        }
+    }
+
+    #[test]
+    fn round_trip_serdefield() {
+        use arrow2_convert::{deserialize::TryIntoCollection, serialize::TryIntoArrow};
+
+        let data: [SomeArrowStruct; 2] = [
+            SomeStruct {
+                foo: "hello".into(),
+                bar: 42,
+            }
+            .into(),
+            SomeStruct {
+                foo: "world".into(),
+                bar: 1983,
+            }
+            .into(),
+        ];
+        let array: Box<dyn arrow2::array::Array> = data.try_into_arrow().unwrap();
+        let ret: Vec<SomeArrowStruct> = array.try_into_collection().unwrap();
+        assert_eq!(&data, ret.as_slice());
+    }
+}


### PR DESCRIPTION
### What
We're about to add a bunch more arrow components for managing blueprints.

Long term it would be nice for this to all be arrow schemas, but all of our state can already be represented with Serde, and we can move faster by just shimming that data through the store.

This gives us a nice escape hatch by adding an `arrow_field` helper that lets us add any serde-compatible data as a field of a component.

Exa:
```
use re_log_types::serde_field::SerdeField;
use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize, field::ArrowField};
use arrow2::datatypes::{DataType, Field};

#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
struct SomeStruct {
    foo: String,
    bar: u32,
}

#[derive(Clone, Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
struct SomeArrowStruct {
    #[arrow_field(type = "SerdeField<SomeStruct>")]
    field: SomeStruct,
}
```

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
