### PR TITLE
Fix error on file save

### DIFF
--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -782,9 +782,15 @@ impl DataTable {
         let mut columns = Vec::new();
 
         for (component, rows) in table {
-            let (field, column) = Self::serialize_data_column(component.as_str(), rows)?;
-            schema.fields.push(field);
-            columns.push(column);
+            // If none of the rows have any data, there's nothing to do here
+            // TODO(jleibs): would be nice to make serialize_data_column robust to this case
+            // but I'm not sure if returning an empty column is the right thing to do there.
+            // See: https://github.com/rerun-io/rerun/issues/2005
+            if rows.iter().any(|c| c.is_some()) {
+                let (field, column) = Self::serialize_data_column(component.as_str(), rows)?;
+                schema.fields.push(field);
+                columns.push(column);
+            }
         }
 
         Ok((schema, columns))


### PR DESCRIPTION
Fixes: 
- https://github.com/rerun-io/rerun/issues/2005

### What
The root cause of the problem was arrow failing to concatenate if there was no data in the table. This checks for that condition and bypasses the `serialize_data_column` call all together.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
