### PR TITLE
Fix displaying image plane depth instead of object depth when showing depth from 3D in 2D view

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/picking.rs
@@ -51,7 +51,13 @@ pub struct PickingResult {
 
 impl PickingResult {
     pub fn space_position(&self) -> Option<glam::Vec3> {
-        self.hits.last().map(|hit| hit.space_position)
+        // Use gpu hit if available as they are usually the position one expects.
+        // (other picking sources might be in here even if hidden!)
+        self.hits
+            .iter()
+            .find(|h| h.hit_type == PickingHitType::GpuPickingResult)
+            .or_else(|| self.hits.first())
+            .map(|hit| hit.space_position)
     }
 }
 


### PR DESCRIPTION
Small but annoying issue I noticed while working on #2008, somewhat related to #1818

Before:
![image](https://user-images.githubusercontent.com/1220815/235349279-88df49fe-42b2-4b66-ad2c-a8f861b50ea4.png)


After:
![image](https://user-images.githubusercontent.com/1220815/235349247-a9086103-733b-4a29-b4b8-a26278efe463.png)


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
