### PR TITLE
Use an sRGB-correct gray gradient when displaying grayscale images

### DIFF
--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -141,7 +141,7 @@ impl ExtraQueryHistory {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Colormap {
-    /// Perceptually even
+    /// sRGB gray gradient = perceptually even
     Grayscale,
 
     Inferno,

--- a/crates/re_renderer/shader/colormap.wgsl
+++ b/crates/re_renderer/shader/colormap.wgsl
@@ -2,7 +2,7 @@
 #import <./utils/srgb.wgsl>
 
 // NOTE: Keep in sync with `colormap.rs`!
-const COLORMAP_GRAYSCALE: u32 = 1u;
+const COLORMAP_GRAYSCALE: u32 = 1u; // sRGB gradient = perceptually even
 const COLORMAP_INFERNO:   u32 = 2u;
 const COLORMAP_MAGMA:     u32 = 3u;
 const COLORMAP_PLASMA:    u32 = 4u;
@@ -15,7 +15,7 @@ const COLORMAP_VIRIDIS:   u32 = 6u;
 fn colormap_srgb(which: u32, t_unsaturated: f32) -> Vec3 {
     let t = saturate(t_unsaturated);
     if which == COLORMAP_GRAYSCALE {
-        return linear_from_srgb(Vec3(t));
+        return Vec3(t);
     } else if which == COLORMAP_INFERNO {
         return colormap_inferno_srgb(t);
     } else if which == COLORMAP_MAGMA {

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -1,7 +1,4 @@
 #import <./types.wgsl>
-#import <./colormap.wgsl>
-#import <./global_bindings.wgsl>
-#import <./utils/depth_offset.wgsl>
 
 // Keep in sync with mirror in rectangle.rs
 

--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -1,4 +1,6 @@
+#import <./colormap.wgsl>
 #import <./rectangle.wgsl>
+#import <./utils/srgb.wgsl>
 
 fn is_magnifying(pixel_coord: Vec2) -> bool {
     return fwidth(pixel_coord.x) < 1.0;

--- a/crates/re_renderer/shader/rectangle_vs.wgsl
+++ b/crates/re_renderer/shader/rectangle_vs.wgsl
@@ -1,4 +1,5 @@
 #import <./rectangle.wgsl>
+#import <./utils/depth_offset.wgsl>
 
 @vertex
 fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {

--- a/crates/re_renderer/src/colormap.rs
+++ b/crates/re_renderer/src/colormap.rs
@@ -10,7 +10,7 @@ use glam::{Vec2, Vec3A, Vec4, Vec4Swizzles};
 #[repr(u32)]
 pub enum Colormap {
     // Reserve 0 for "disabled"
-    /// Perceptually even
+    /// sRGB gray gradient = perceptually even
     #[default]
     Grayscale = 1,
     Inferno = 2,
@@ -59,7 +59,6 @@ pub fn colormap_srgb(which: Colormap, t: f32) -> [u8; 4] {
 pub fn grayscale_srgb(t: f32) -> [u8; 4] {
     debug_assert!((0.0..=1.0).contains(&t));
 
-    let t = t.powf(2.2);
     let t = ((t * u8::MAX as f32) + 0.5) as u8;
 
     [t, t, t, 255]

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -386,6 +386,8 @@ impl RectangleDrawData {
                         TextureFilterMin::Nearest => wgpu::FilterMode::Nearest,
                     },
                     mipmap_filter: wgpu::FilterMode::Nearest,
+                    address_mode_u: wgpu::AddressMode::ClampToEdge,
+                    address_mode_v: wgpu::AddressMode::ClampToEdge,
                     ..Default::default()
                 },
             );

--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -297,7 +297,7 @@ def run_image_tensors() -> None:
         "uint16",
         "uint32",
         "uint64",
-        "int8", # produces wrap-around when casting, producing ugly images, but clipping which is not useful as a test
+        "int8",  # produces wrap-around when casting, producing ugly images, but clipping which is not useful as a test
         "int16",
         "int32",
         "int64",

--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -297,7 +297,7 @@ def run_image_tensors() -> None:
         "uint16",
         "uint32",
         "uint64",
-        "int8",
+        "int8", # produces wrap-around when casting, producing ugly images, but clipping which is not useful as a test
         "int16",
         "int32",
         "int64",


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1990

This also means using the grayscale colormap for tensors result in a more perceptually even gradient, which is good.

![image](https://user-images.githubusercontent.com/1148717/235528106-7450d1a6-00fb-4300-b115-75b1208642b6.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2014
