### PR TITLE
Fix: use the mac icon on mac

### DIFF
--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -45,9 +45,9 @@ pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
 #[allow(clippy::unnecessary_wraps)]
 fn icon_data() -> Option<eframe::IconData> {
     cfg_if::cfg_if! {
-        if #[cfg(macos)] {
+        if #[cfg(target_os = "macos")] {
             let app_icon_png_bytes = include_bytes!("../../re_ui/data/icons/app_icon_mac.png");
-        } else if #[cfg(windows)] {
+        } else if #[cfg(target_os = "windows")] {
             let app_icon_png_bytes = include_bytes!("../../re_ui/data/icons/app_icon_windows.png");
         } else {
             // Use the same icon for X11 as for Windows, at least for now.


### PR DESCRIPTION
### What
I don't know where I got `#[cfg(macos)]` from, but of course it compiled and of course it didn't work.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

PR Build Summary: https://build.rerun.io/pr/2023
