### PR TITLE
New manual job to publish a release based on pre-built wheels

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -46,8 +46,7 @@ jobs:
 
       - name: Install packaging
         run: |
-          python -m pip install --upgrade pip
-          pip install packaging
+          python3 -m pip install packaging
 
       - name: Download wheels from Google Cloud Storage
         env:
@@ -58,7 +57,7 @@ jobs:
 
       - name: Verify wheels match the expected release
         run: |
-          python scripts/verify-wheels.py --folder wheels --version ${{ inputs.RELEASE_VERSION }}
+          python3 scripts/verify-wheels.py --folder wheels --version ${{ inputs.RELEASE_VERSION }}
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -17,7 +17,7 @@ jobs:
     name: 'Publish Wheels'
 
     permissions:
-      contents: "read"
+      contents: write
       id-token: "write"
 
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
         uses: ncipollo/release-action@v1.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: "Release - ${{ inputs.RELEASE_VERSION }}}"
+          name: "Release - ${{ inputs.RELEASE_VERSION }}"
           commit: ${{ env.SHORT_SHA }}
           tag: ${{ inputs.RELEASE_VERSION }}
           artifacts: "wheels/*.whl"

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -58,7 +58,7 @@ jobs:
           BUCKET_PATH:
         run: |
           mkdir wheels
-          gsutil cp "gs://rerun-builds/commit/${{ env.SHORT_SHA }}/*.whl" wheels/
+          gsutil cp "gs://rerun-builds/commit/${{ env.SHORT_SHA }}/wheels/*.whl" wheels/
 
       - name: Verify wheels match the expected release
         run: |

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -7,13 +7,79 @@ on:
         description: 'Release Version Number (Must match Cargo.toml)'
         type: string
         required: true
+      OVERRIDE_COMMIT:
+        description: 'Commit to release'
+        type: string
+        required: false
 
 jobs:
-
   publish-wheels:
     name: 'Publish Wheels'
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
     runs-on: ubuntu-latest
+
+    container:
+      image: rerunio/ci_docker:0.6
+
     steps:
-      - name: publish
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Add SHORT_SHA env property with commit short sha
         run: |
-          echo "TODO: jleibs"
+          if [ -z "${{ inputs.OVERRIDE_COMMIT }}" ]; then
+            USED_SHA=${{ github.sha }}
+          else
+            USED_SHA=${{ inputs.OVERRIDE_COMMIT }}
+          fi
+          echo "SHORT_SHA=$(echo $USED_SHA | cut -c1-7)" >> $GITHUB_ENV
+
+      - id: "auth"
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Install packaging
+        run: |
+          python -m pip install --upgrade pip
+          pip install packaging
+
+      - name: Download wheels from Google Cloud Storage
+        env:
+          BUCKET_PATH:
+        run: |
+          mkdir wheels
+          gsutil cp "gs://rerun-builds/commit/${{ env.SHORT_SHA }}/*.whl" wheels/
+
+      - name: Verify wheels match the expected release
+        run: |
+          python scripts/verify-wheels.py --folder wheels --version ${{ inputs.RELEASE_VERSION }}
+
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          # These are both set in the GitHub project configuration
+          MATURIN_REPOSITORY: ${{ vars.PYPI_REPOSITORY }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.MATURIN_PYPI_TOKEN }}
+        with:
+          command: upload
+          args: --skip-existing wheels/*
+
+      # Create the actual prerelease
+      # https://github.com/ncipollo/release-action
+      - name: GitHub Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          draft: true
+          name: "Release - ${{ inputs.RELEASE_VERSION }}}"
+          tag: ${{ inputs.RELEASE_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generateReleaseNotes: true
+          allowUpdates: true
+          artifacts: "wheels/*.whl"
+

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -22,9 +22,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image: rerunio/ci_docker:0.6
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -44,9 +44,14 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          version: '>= 363.0.0'
+
       - name: Install packaging
         run: |
-          python3 -m pip install packaging
+          python3 -m pip install packaging google-cloud-storage
 
       - name: Download wheels from Google Cloud Storage
         env:

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Don't do a shallow clone since we need it for finding the full commit hash
 
       - name: Add SHORT_SHA env property with commit short sha
         run: |
@@ -34,6 +36,11 @@ jobs:
             USED_SHA=${{ inputs.OVERRIDE_COMMIT }}
           fi
           echo "SHORT_SHA=$(echo $USED_SHA | cut -c1-7)" >> $GITHUB_ENV
+
+      - name: Expand short hash to FULL_SHA hash
+        run: |
+          FULL_SHA=$(git rev-parse ${{ env.SHORT_SHA }})
+          echo "FULL_SHA=$FULL_SHA" >> $GITHUB_ENV
 
       - id: "auth"
         uses: google-github-actions/auth@v1
@@ -78,7 +85,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: "Release - ${{ inputs.RELEASE_VERSION }}"
-          commit: ${{ env.SHORT_SHA }}
+          commit: ${{ env.FULL_SHA }}
           tag: ${{ inputs.RELEASE_VERSION }}
           artifacts: "wheels/*.whl"
           generateReleaseNotes: true

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Verify wheels match the expected release
         run: |
-          python3 scripts/verify-wheels.py --folder wheels --version ${{ inputs.RELEASE_VERSION }}
+          python3 scripts/verify_wheels.py --folder wheels --version ${{ inputs.RELEASE_VERSION }}
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -79,11 +79,12 @@ jobs:
       - name: GitHub Release
         uses: ncipollo/release-action@v1.12.0
         with:
-          draft: true
-          name: "Release - ${{ inputs.RELEASE_VERSION }}}"
-          tag: ${{ inputs.RELEASE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Release - ${{ inputs.RELEASE_VERSION }}}"
+          commit: ${{ env.SHORT_SHA }}
+          tag: ${{ inputs.RELEASE_VERSION }}
+          artifacts: "wheels/*.whl"
           generateReleaseNotes: true
           allowUpdates: true
-          artifacts: "wheels/*.whl"
+          draft: true
 

--- a/scripts/verify_wheels.py
+++ b/scripts/verify_wheels.py
@@ -1,0 +1,31 @@
+"""Script to confirm wheels have the expected version number."""
+import argparse
+import sys
+from pathlib import Path
+
+from packaging.utils import canonicalize_version
+
+
+def check_version(folder: str, expected_version: str) -> None:
+    wheels = list(Path("wheels").glob("*.whl"))
+
+    for wheel in wheels:
+        wheel_version = wheel.stem.split("-")[1]
+        if canonicalize_version(wheel_version) != expected_version:
+            print(f"Unexpected version: {wheel_version} (expected: {expected_version}) in {wheel.name}")
+            sys.exit(1)
+
+    print(f"All wheel versions match the expected version: {expected_version}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate wheels have the specified version")
+    parser.add_argument("--version", required=True, help="Version to expect")
+    parser.add_argument("--folder", required=True, help="Version to expect")
+    args = parser.parse_args()
+
+    check_version(args.folder, canonicalize_version(args.version))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What
Provide an implementation for a new job which uploads python wheels and creates a new draft release.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2025
