### PR TITLE
Fix mp_pose example 2D points having incorrectly interpreted depth

### DIFF
--- a/examples/python/mp_pose/main.py
+++ b/examples/python/mp_pose/main.py
@@ -67,9 +67,7 @@ def read_landmark_positions_2d(
         return None
     else:
         normalized_landmarks = [results.pose_landmarks.landmark[lm] for lm in mp.solutions.pose.PoseLandmark]
-        return np.array(
-            [(image_width * lm.x, image_height * lm.y) for lm in normalized_landmarks]
-        )
+        return np.array([(image_width * lm.x, image_height * lm.y) for lm in normalized_landmarks])
 
 
 def read_landmark_positions_3d(

--- a/examples/python/mp_pose/main.py
+++ b/examples/python/mp_pose/main.py
@@ -67,10 +67,8 @@ def read_landmark_positions_2d(
         return None
     else:
         normalized_landmarks = [results.pose_landmarks.landmark[lm] for lm in mp.solutions.pose.PoseLandmark]
-        # Log points as 3d points with some scaling so they "pop out" when looked at in a 3d view
-        # Negative depth in order to move them towards the camera.
         return np.array(
-            [(image_width * lm.x, image_height * lm.y, -(lm.z + 1.0) * 300.0) for lm in normalized_landmarks]
+            [(image_width * lm.x, image_height * lm.y) for lm in normalized_landmarks]
         )
 
 


### PR DESCRIPTION
made up depth values are problematic now since there's no camera set since #2008 . Internally we generate an automatic camera causing the skeleton points in the 2D view to be off if they have a real depth

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2034
