### PR TITLE
[pure refactor] move selection state into an independent crate, re_viewer_context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4191,6 +4191,7 @@ dependencies = [
  "re_smart_channel",
  "re_tensor_ops",
  "re_ui",
+ "re_viewer_context",
  "re_ws_comms",
  "rfd",
  "serde",
@@ -4204,6 +4205,23 @@ dependencies = [
  "web-sys",
  "wgpu",
  "winapi",
+]
+
+[[package]]
+name = "re_viewer_context"
+version = "0.6.0-alpha.0"
+dependencies = [
+ "ahash 0.8.2",
+ "glam",
+ "itertools",
+ "nohash-hasher",
+ "puffin",
+ "re_data_store",
+ "re_log_types",
+ "re_renderer",
+ "serde",
+ "slotmap",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ ahash = "0.8"
 anyhow = "1.0"
 arrow2 = "0.16"
 arrow2_convert = "0.4.2"
-nohash-hasher = "0.2"
 bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
 cfg-if = "1.0"
 clap = "4.0"
@@ -64,9 +63,9 @@ ctrlc = { version = "3.0", features = ["termination"] }
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = { version = "0.21.0", features = ["extra_debug_asserts", "log"] }
-egui-wgpu = "0.21.0"
 egui_dock = "0.4"
 egui_extras = { version = "0.21.0", features = ["log"] }
+egui-wgpu = "0.21.0"
 emath = "0.21.0"
 enumset = "1.0.12"
 epaint = "0.21.0"
@@ -79,6 +78,7 @@ lazy_static = "1.4"
 macaw = "0.18"
 mimalloc = "0.1.29"
 ndarray = "0.15"
+nohash-hasher = "0.2"
 parking_lot = "0.12"
 polars-core = "0.27.1"
 polars-lazy = "0.27.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ polars-core = "0.27.1"
 polars-lazy = "0.27.1"
 polars-ops = "0.27.1"
 puffin = "0.14"
+slotmap = { version = "1.0.6", features = ["serde"] }
 smallvec = { version = "1.0", features = ["const_generics", "union"] }
 thiserror = "1.0"
 time = { version = "0.3", default-features = false, features = [
@@ -93,7 +94,6 @@ tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tokio = { version = "1.24", default-features = false }
 wgpu = { version = "0.16" }
 wgpu-core = { version = "0.16" }
-slotmap = { version = "1.0.6", features = ["serde"] }
 
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ version = "0.6.0-alpha.0"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
 # In particular: if we compile rerun 0.3.0-alpha.0 we only want it to use
 # re_log_types 0.3.0-alpha.0, NOT 0.3.0-alpha.4 even though it is newer and semver-compatible.
-re_sdk_comms = { path = "crates/re_sdk_comms", version = "=0.6.0-alpha.0" }
 re_analytics = { path = "crates/re_analytics", version = "=0.6.0-alpha.0" }
 re_arrow_store = { path = "crates/re_arrow_store", version = "=0.6.0-alpha.0" }
 re_build_build_info = { path = "crates/re_build_build_info", version = "=0.6.0-alpha.0" }
@@ -40,12 +39,14 @@ re_memory = { path = "crates/re_memory", version = "=0.6.0-alpha.0" }
 re_query = { path = "crates/re_query", version = "=0.6.0-alpha.0" }
 re_renderer = { path = "crates/re_renderer", version = "=0.6.0-alpha.0", default-features = false }
 re_sdk = { path = "crates/re_sdk", version = "=0.6.0-alpha.0" }
+re_sdk_comms = { path = "crates/re_sdk_comms", version = "=0.6.0-alpha.0" }
 re_smart_channel = { path = "crates/re_smart_channel", version = "=0.6.0-alpha.0" }
 re_string_interner = { path = "crates/re_string_interner", version = "=0.6.0-alpha.0" }
 re_tensor_ops = { path = "crates/re_tensor_ops", version = "=0.6.0-alpha.0" }
 re_tuid = { path = "crates/re_tuid", version = "=0.6.0-alpha.0" }
 re_ui = { path = "crates/re_ui", version = "=0.6.0-alpha.0" }
 re_viewer = { path = "crates/re_viewer", version = "=0.6.0-alpha.0", default-features = false }
+re_viewer_context = { path = "crates/re_viewer_context", version = "=0.6.0-alpha.0" }
 re_web_viewer_server = { path = "crates/re_web_viewer_server", version = "=0.6.0-alpha.0" }
 re_ws_comms = { path = "crates/re_ws_comms", version = "=0.6.0-alpha.0" }
 rerun = { path = "crates/rerun", version = "=0.6.0-alpha.0" }
@@ -54,6 +55,8 @@ ahash = "0.8"
 anyhow = "1.0"
 arrow2 = "0.16"
 arrow2_convert = "0.4.2"
+nohash-hasher = "0.2"
+bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
 cfg-if = "1.0"
 clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }
@@ -90,6 +93,7 @@ tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tokio = { version = "1.24", default-features = false }
 wgpu = { version = "0.16" }
 wgpu-core = { version = "0.16" }
+slotmap = { version = "1.0.6", features = ["serde"] }
 
 
 [profile.dev]

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -48,7 +48,7 @@ re_log.workspace = true
 ahash.workspace = true
 anyhow.workspace = true
 bitflags = "1.3"
-bytemuck = { version = "1.12", features = ["derive"] }
+bytemuck.workspace = true
 clean-path = "0.2"
 document-features = "0.2"
 ecolor = { workspace = true, features = ["bytemuck"] }
@@ -60,7 +60,7 @@ macaw.workspace = true
 never = '0.1'
 ordered-float = "3.2"
 parking_lot.workspace = true
-slotmap = "1.0.6"
+slotmap.workspace = true
 smallvec.workspace = true
 static_assertions = "1.1"
 thiserror.workspace = true

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -57,6 +57,7 @@ re_renderer = { workspace = true, default-features = false, features = [
 re_smart_channel.workspace = true
 re_tensor_ops.workspace = true
 re_ui.workspace = true
+re_viewer_context.workspace = true
 re_ws_comms = { workspace = true, features = ["client"] }
 
 # Internal (optional):
@@ -98,7 +99,7 @@ rfd = { version = "0.11.3", default_features = false, features = [
   "xdg-portal",
 ] }
 serde = { version = "1", features = ["derive"] }
-slotmap = { version = "1.0.6", features = ["serde"] }
+slotmap.workspace = true
 smallvec = { workspace = true, features = ["serde"] }
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting"] }

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -12,7 +12,7 @@ mod remote_viewer_app;
 mod ui;
 mod viewer_analytics;
 
-pub(crate) use misc::{mesh_loader, Item, TimeControl, TimeView, ViewerContext};
+pub(crate) use misc::{mesh_loader, TimeControl, TimeView, ViewerContext};
 use re_log_types::PythonVersion;
 pub(crate) use ui::{memory_panel, selection_panel, time_panel, UiVerbosity};
 

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -1,10 +1,8 @@
 mod app_options;
 pub mod caches;
 pub mod format_time;
-mod item;
 pub(crate) mod mesh_loader;
 pub mod queries;
-mod selection_state;
 pub(crate) mod space_info;
 mod space_view_highlights;
 pub(crate) mod time_control;
@@ -28,14 +26,8 @@ pub(crate) mod profiler;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod clipboard;
 
+pub use app_options::AppOptions;
 pub use transform_cache::{TransformCache, UnreachableTransform};
-pub use {
-    app_options::*,
-    item::{Item, ItemCollection},
-    selection_state::{
-        HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
-    },
-};
 
 pub use space_view_highlights::{
     highlights_for_space_view, OptionalSpaceViewEntityHighlight, SpaceViewHighlights,

--- a/crates/re_viewer/src/misc/space_view_highlights.rs
+++ b/crates/re_viewer/src/misc/space_view_highlights.rs
@@ -5,12 +5,11 @@ use nohash_hasher::IntMap;
 
 use re_log_types::{component_types::InstanceKey, EntityPath, EntityPathHash};
 use re_renderer::OutlineMaskPreference;
-
-use super::{InteractionHighlight, SelectionState};
-use crate::{
-    misc::{HoverHighlight, Item, SelectionHighlight},
-    ui::{SpaceView, SpaceViewId},
+use re_viewer_context::{
+    HoverHighlight, InteractionHighlight, Item, SelectionHighlight, SelectionState, SpaceViewId,
 };
+
+use crate::ui::SpaceView;
 
 /// Highlights of a specific entity path in a specific space view.
 ///

--- a/crates/re_viewer/src/misc/viewer_context.rs
+++ b/crates/re_viewer/src/misc/viewer_context.rs
@@ -1,14 +1,12 @@
 use re_data_store::{log_db::LogDb, InstancePath};
 use re_log_types::{ComponentPath, EntityPath, TimeInt, Timeline};
+use re_viewer_context::{
+    DataBlueprintGroupHandle, HoverHighlight, Item, ItemCollection, SelectionState, SpaceViewId,
+};
 
 use crate::ui::{
     data_ui::{ComponentUiRegistry, DataUi},
-    DataBlueprintGroupHandle, SpaceViewId, UiVerbosity,
-};
-
-use super::{
-    item::{Item, ItemCollection},
-    HoverHighlight,
+    UiVerbosity,
 };
 
 /// Common things needed by many parts of the viewer.
@@ -299,11 +297,11 @@ impl<'a> ViewerContext<'a> {
         self.rec_cfg.selection_state.set_hovered(hovered);
     }
 
-    pub fn selection_state(&self) -> &super::SelectionState {
+    pub fn selection_state(&self) -> &SelectionState {
         &self.rec_cfg.selection_state
     }
 
-    pub fn selection_state_mut(&mut self) -> &mut super::SelectionState {
+    pub fn selection_state_mut(&mut self) -> &mut SelectionState {
         &mut self.rec_cfg.selection_state
     }
 
@@ -323,5 +321,5 @@ pub struct RecordingConfig {
     pub time_ctrl: crate::TimeControl,
 
     /// Selection & hovering state.
-    pub selection_state: super::SelectionState,
+    pub selection_state: SelectionState,
 }

--- a/crates/re_viewer/src/ui/auto_layout.rs
+++ b/crates/re_viewer/src/ui/auto_layout.rs
@@ -16,8 +16,9 @@ use egui::Vec2;
 use itertools::Itertools as _;
 
 use re_data_store::{EntityPath, EntityPathPart};
+use re_viewer_context::SpaceViewId;
 
-use super::{space_view::SpaceView, view_category::ViewCategory, SpaceViewId};
+use super::{space_view::SpaceView, view_category::ViewCategory};
 
 #[derive(Clone, Debug)]
 pub struct SpaceMakeInfo {

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -1,4 +1,6 @@
-use crate::misc::{space_info::SpaceInfoCollection, Item, ViewerContext};
+use re_viewer_context::Item;
+
+use crate::misc::{space_info::SpaceInfoCollection, ViewerContext};
 
 use super::viewport::Viewport;
 

--- a/crates/re_viewer/src/ui/data_blueprint.rs
+++ b/crates/re_viewer/src/ui/data_blueprint.rs
@@ -2,10 +2,9 @@ use std::collections::BTreeSet;
 
 use nohash_hasher::{IntMap, IntSet};
 use re_data_store::{EntityPath, EntityProperties, EntityPropertyMap};
+use re_viewer_context::DataBlueprintGroupHandle;
 use slotmap::SlotMap;
 use smallvec::{smallvec, SmallVec};
-
-slotmap::new_key_type! { pub struct DataBlueprintGroupHandle; }
 
 /// A grouping of several data-blueprints.
 #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -3,7 +3,6 @@ mod auto_layout;
 mod blueprint;
 mod data_blueprint;
 mod scene;
-mod selection_history;
 mod selection_history_ui;
 mod space_view;
 mod space_view_entity_picker;
@@ -27,11 +26,9 @@ pub mod view_spatial;
 use self::scene::SceneQuery;
 
 pub(crate) use self::blueprint::Blueprint;
-pub(crate) use self::space_view::{SpaceView, SpaceViewId};
+pub(crate) use self::space_view::SpaceView;
 
 pub use self::annotations::{Annotations, DefaultColor, MISSING_ANNOTATIONS};
-pub use self::data_blueprint::DataBlueprintGroupHandle;
-pub use self::selection_history::{HistoricalSelection, SelectionHistory};
 pub use self::view_category::ViewCategory;
 pub use self::viewport::Viewport;
 

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -1,9 +1,8 @@
 use egui::RichText;
 use re_ui::Command;
+use re_viewer_context::{Item, ItemCollection, SelectionHistory};
 
-use crate::{misc::ItemCollection, ui::Blueprint, Item};
-
-use super::SelectionHistory;
+use crate::ui::Blueprint;
 
 // ---
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -6,8 +6,9 @@ use re_log_types::{
     component_types::{Tensor, TensorDataMeaning},
     TimeType, Transform,
 };
+use re_viewer_context::{Item, SpaceViewId};
 
-use crate::{ui::Blueprint, Item, UiVerbosity, ViewerContext};
+use crate::{ui::Blueprint, UiVerbosity, ViewerContext};
 
 use super::{
     data_ui::DataUi, selection_history_ui::SelectionHistoryUi, space_view::ViewState,
@@ -267,7 +268,7 @@ fn blueprint_ui(
                 {
                     if let Some(space_view) = blueprint.viewport.space_view(space_view_id) {
                         let mut new_space_view = space_view.clone();
-                        new_space_view.id = super::SpaceViewId::random();
+                        new_space_view.id = SpaceViewId::random();
                         blueprint.viewport.add_space_view(new_space_view);
                         blueprint.viewport.mark_user_interaction();
                     }

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -1,6 +1,7 @@
 use re_arrow_store::Timeline;
 use re_data_store::{EntityPath, EntityPropertyMap, EntityTree, InstancePath, TimeInt};
-use re_renderer::{GpuReadbackIdentifier, ScreenshotProcessor};
+use re_renderer::ScreenshotProcessor;
+use re_viewer_context::SpaceViewId;
 
 use crate::{
     misc::{space_info::SpaceInfoCollection, SpaceViewHighlights, TransformCache, ViewerContext},
@@ -12,24 +13,6 @@ use super::{
     view_bar_chart, view_category::ViewCategory, view_spatial, view_tensor, view_text,
     view_time_series,
 };
-
-// ----------------------------------------------------------------------------
-
-/// A unique id for each space view.
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
-)]
-pub struct SpaceViewId(uuid::Uuid);
-
-impl SpaceViewId {
-    pub fn random() -> Self {
-        Self(uuid::Uuid::new_v4())
-    }
-
-    pub fn gpu_readback_id(self) -> GpuReadbackIdentifier {
-        re_log_types::hash::Hash64::hash(self).hash64()
-    }
-}
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_viewer/src/ui/space_view_entity_picker.rs
+++ b/crates/re_viewer/src/ui/space_view_entity_picker.rs
@@ -2,12 +2,13 @@ use itertools::Itertools;
 use nohash_hasher::IntMap;
 use re_arrow_store::Timeline;
 use re_data_store::{EntityPath, EntityTree, InstancePath};
+use re_viewer_context::SpaceViewId;
 
 use crate::misc::{space_info::SpaceInfoCollection, ViewerContext};
 
 use super::{
     view_category::{categorize_entity_path, ViewCategory},
-    SpaceView, SpaceViewId,
+    SpaceView,
 };
 
 /// Window for adding/removing entities from a space view.

--- a/crates/re_viewer/src/ui/time_panel/data_density_graph.rs
+++ b/crates/re_viewer/src/ui/time_panel/data_density_graph.rs
@@ -9,11 +9,9 @@ use egui::{epaint::Vertex, lerp, pos2, remap, Color32, NumExt as _, Rect, Shape}
 
 use re_data_store::TimeHistogram;
 use re_log_types::{TimeInt, TimeRange, TimeReal};
+use re_viewer_context::Item;
 
-use crate::{
-    misc::{Item, ViewerContext},
-    ui::Blueprint,
-};
+use crate::{misc::ViewerContext, ui::Blueprint};
 
 use super::time_ranges_ui::TimeRangesUi;
 

--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -10,8 +10,9 @@ use egui::{pos2, Color32, CursorIcon, NumExt, PointerButton, Rect, Shape, Vec2};
 
 use re_data_store::{EntityTree, InstancePath, TimeHistogram};
 use re_log_types::{ComponentPath, EntityPathPart, TimeInt, TimeRange, TimeReal};
+use re_viewer_context::Item;
 
-use crate::{Item, TimeControl, TimeView, ViewerContext};
+use crate::{TimeControl, TimeView, ViewerContext};
 
 use super::{data_ui::DataUi, selection_panel::what_is_selected_ui, Blueprint};
 

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -1,23 +1,20 @@
 use eframe::epaint::text::TextWrapping;
-use re_data_store::{query_latest_single, EditableAutoValue, EntityPath, EntityPropertyMap};
-use re_format::format_f32;
-
 use egui::{NumExt, WidgetText};
 use macaw::BoundingBox;
+
+use re_data_store::{query_latest_single, EditableAutoValue, EntityPath, EntityPropertyMap};
+use re_format::format_f32;
 use re_log_types::component_types::{Tensor, TensorDataMeaning};
 use re_renderer::OutlineConfig;
+use re_viewer_context::{HoverHighlight, HoveredSpace, Item, SelectionHighlight, SpaceViewId};
 
 use crate::{
-    misc::{
-        space_info::query_view_coordinates, HoveredSpace, SelectionHighlight, SpaceViewHighlights,
-        ViewerContext,
-    },
+    misc::{space_info::query_view_coordinates, SpaceViewHighlights, ViewerContext},
     ui::{
         data_blueprint::DataBlueprintTree,
         data_ui::{self, DataUi},
         space_view::ScreenshotMode,
         view_spatial::UiLabelTarget,
-        SpaceViewId,
     },
 };
 
@@ -606,16 +603,14 @@ pub fn create_labels(
             .entity_highlight(label.labeled_instance.entity_path_hash)
             .index_highlight(label.labeled_instance.instance_key);
         let fill_color = match highlight.hover {
-            crate::misc::HoverHighlight::None => match highlight.selection {
+            HoverHighlight::None => match highlight.selection {
                 SelectionHighlight::None => parent_ui.style().visuals.widgets.inactive.bg_fill,
                 SelectionHighlight::SiblingSelection => {
                     parent_ui.style().visuals.widgets.active.bg_fill
                 }
                 SelectionHighlight::Selection => parent_ui.style().visuals.widgets.active.bg_fill,
             },
-            crate::misc::HoverHighlight::Hovered => {
-                parent_ui.style().visuals.widgets.hovered.bg_fill
-            }
+            HoverHighlight::Hovered => parent_ui.style().visuals.widgets.hovered.bg_fill,
         };
 
         label_shapes.push(egui::Shape::rect_filled(bg_rect, 3.0, fill_color));
@@ -780,7 +775,7 @@ pub fn picking(
             instance_path.instance_key = re_log_types::component_types::InstanceKey::SPLAT;
         }
 
-        hovered_items.push(crate::misc::Item::InstancePath(
+        hovered_items.push(Item::InstancePath(
             Some(space_view_id),
             instance_path.clone(),
         ));

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -4,6 +4,7 @@ use macaw::IsoTransform;
 use re_data_store::{query_latest_single, EntityPath, EntityPropertyMap};
 use re_log_types::Pinhole;
 use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
+use re_viewer_context::{HoveredSpace, SpaceViewId};
 
 use super::{
     eye::Eye,
@@ -12,14 +13,11 @@ use super::{
 };
 use crate::{
     gpu_bridge,
-    misc::{HoveredSpace, SpaceViewHighlights},
-    ui::{
-        view_spatial::{
-            ui::outline_config,
-            ui_renderer_bridge::{fill_view_builder, ScreenBackground},
-            SceneSpatial,
-        },
-        SpaceViewId,
+    misc::SpaceViewHighlights,
+    ui::view_spatial::{
+        ui::outline_config,
+        ui_renderer_bridge::{fill_view_builder, ScreenBackground},
+        SceneSpatial,
     },
     ViewerContext,
 };

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -9,17 +9,15 @@ use re_renderer::{
     view_builder::{Projection, TargetConfiguration, ViewBuilder},
     Size,
 };
+use re_viewer_context::{HoveredSpace, Item, SpaceViewId};
 
 use crate::{
     gpu_bridge,
-    misc::{HoveredSpace, Item, SpaceViewHighlights},
-    ui::{
-        view_spatial::{
-            ui::{create_labels, outline_config, picking, screenshot_context_menu},
-            ui_renderer_bridge::{fill_view_builder, ScreenBackground},
-            SceneSpatial, SpaceCamera3D, SpatialNavigationMode,
-        },
-        SpaceViewId,
+    misc::SpaceViewHighlights,
+    ui::view_spatial::{
+        ui::{create_labels, outline_config, picking, screenshot_context_menu},
+        ui_renderer_bridge::{fill_view_builder, ScreenBackground},
+        SceneSpatial, SpaceCamera3D, SpatialNavigationMode,
     },
     ViewerContext,
 };

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -6,21 +6,19 @@ use ahash::HashMap;
 use itertools::Itertools as _;
 
 use re_data_store::EntityPath;
+use re_viewer_context::{DataBlueprintGroupHandle, Item, SpaceViewId};
 
 use crate::{
     misc::{
-        highlights_for_space_view, space_info::SpaceInfoCollection, Item, SpaceViewHighlights,
+        highlights_for_space_view, space_info::SpaceInfoCollection, SpaceViewHighlights,
         ViewerContext,
     },
     ui::space_view_heuristics::default_created_space_views,
 };
 
 use super::{
-    data_blueprint::{DataBlueprintGroup, DataBlueprintGroupHandle},
-    space_view_entity_picker::SpaceViewEntityPicker,
-    space_view_heuristics::all_possible_space_views,
-    view_category::ViewCategory,
-    SpaceView, SpaceViewId,
+    data_blueprint::DataBlueprintGroup, space_view_entity_picker::SpaceViewEntityPicker,
+    space_view_heuristics::all_possible_space_views, view_category::ViewCategory, SpaceView,
 };
 
 // ----------------------------------------------------------------------------

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -16,16 +16,16 @@ include = ["../../LICENSE-APACHE", "../../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 all-features = true
 
 [dependencies]
-re_renderer.workspace = true
-re_log_types = { workspace = true, features = ["ecolor", "glam", "image"] }
 re_data_store = { workspace = true, features = ["serde"] }
+re_log_types = { workspace = true, features = ["ecolor", "glam", "image"] }
+re_renderer.workspace = true
 
 ahash.workspace = true
 glam.workspace = true
-slotmap.workspace = true
+itertools.workspace = true
 nohash-hasher.workspace = true
 serde = "1"
-itertools.workspace = true
+slotmap.workspace = true
 uuid = { version = "1.1", features = ["serde", "v4", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+authors.workspace = true
+description = "Rerun viewer state that is shared with the viewer's code components."
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "re_viewer_context"
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+include = ["../../LICENSE-APACHE", "../../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+re_renderer.workspace = true
+re_log_types = { workspace = true, features = ["ecolor", "glam", "image"] }
+re_data_store = { workspace = true, features = ["serde"] }
+
+ahash.workspace = true
+glam.workspace = true
+slotmap.workspace = true
+nohash-hasher.workspace = true
+serde = "1"
+itertools.workspace = true
+uuid = { version = "1.1", features = ["serde", "v4", "js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+puffin.workspace = true

--- a/crates/re_viewer_context/README.md
+++ b/crates/re_viewer_context/README.md
@@ -1,0 +1,12 @@
+# re_viewer_context
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_ui.svg)](https://crates.io/crates/re_ui)
+[![Documentation](https://docs.rs/re_ui/badge.svg)](https://docs.rs/re_ui)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+Basic building blocks for the different modules of the Rerun viewer.
+
+Most prominently, contains a context object that the viewer uses to share global data with each module.

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use re_data_store::InstancePath;
 use re_log_types::ComponentPath;
 
-use crate::ui::SpaceViewId;
+use super::{DataBlueprintGroupHandle, SpaceViewId};
 
 /// One "thing" in the UI.
 ///
@@ -14,7 +14,7 @@ pub enum Item {
     ComponentPath(ComponentPath),
     SpaceView(SpaceViewId),
     InstancePath(Option<SpaceViewId>, InstancePath),
-    DataBlueprintGroup(SpaceViewId, crate::ui::DataBlueprintGroupHandle),
+    DataBlueprintGroup(SpaceViewId, DataBlueprintGroupHandle),
 }
 
 impl std::fmt::Debug for Item {
@@ -83,10 +83,6 @@ impl ItemCollection {
         self.items.iter()
     }
 
-    pub fn into_iter(self) -> impl Iterator<Item = Item> {
-        self.items.into_iter()
-    }
-
     pub fn to_vec(&self) -> Vec<Item> {
         self.items.clone()
     }
@@ -113,5 +109,14 @@ impl ItemCollection {
     /// Retains elements that fulfil a certain condition.
     pub fn retain(&mut self, f: impl Fn(&Item) -> bool) {
         self.items.retain(|item| f(item));
+    }
+}
+
+impl std::iter::IntoIterator for ItemCollection {
+    type Item = Item;
+    type IntoIter = std::vec::IntoIter<Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
     }
 }

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -1,0 +1,55 @@
+mod item;
+mod selection_history;
+mod selection_state;
+
+pub use item::{Item, ItemCollection};
+pub use selection_history::SelectionHistory;
+pub use selection_state::{
+    HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
+};
+
+// ---------------------------------------------------------------------------
+
+/// A unique id for each space view.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
+
+pub struct SpaceViewId(uuid::Uuid);
+
+impl SpaceViewId {
+    pub fn random() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    pub fn gpu_readback_id(self) -> re_renderer::GpuReadbackIdentifier {
+        re_log_types::hash::Hash64::hash(self).hash64()
+    }
+}
+
+slotmap::new_key_type! {
+    /// Identifier for a blueprint group.
+    pub struct DataBlueprintGroupHandle;
+}
+
+// ---------------------------------------------------------------------------
+
+/// Profiling macro for feature "puffin"
+#[doc(hidden)]
+#[macro_export]
+macro_rules! profile_function {
+    ($($arg: tt)*) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        puffin::profile_function!($($arg)*);
+    };
+}
+
+/// Profiling macro for feature "puffin"
+#[doc(hidden)]
+#[macro_export]
+macro_rules! profile_scope {
+    ($($arg: tt)*) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        puffin::profile_scope!($($arg)*);
+    };
+}

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -1,3 +1,7 @@
+//! Rerun Viewer context
+//!
+//! This crate contains data structures that are shared with most modules of the viewer.
+
 mod item;
 mod selection_history;
 mod selection_state;

--- a/crates/re_viewer_context/src/selection_history.rs
+++ b/crates/re_viewer_context/src/selection_history.rs
@@ -1,4 +1,4 @@
-use crate::misc::{Item, ItemCollection};
+use super::{Item, ItemCollection};
 
 /// A `Selection` and its index into the historical stack.
 #[derive(Debug, Clone)]

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -82,7 +82,7 @@ impl InteractionHighlight {
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct SelectionState {
-    /// Currently selected things; shown in the [`crate::selection_panel::SelectionPanel`].
+    /// Currently selected things.
     ///
     /// Do not access this field directly! Use the helper methods instead, which will make sure
     /// to properly maintain the undo/redo history.

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -2,8 +2,7 @@ use ahash::HashSet;
 
 use re_data_store::EntityPath;
 
-use super::{Item, ItemCollection};
-use crate::ui::SelectionHistory;
+use super::{Item, ItemCollection, SelectionHistory};
 
 #[derive(Clone, Default, Debug, PartialEq)]
 pub enum HoveredSpace {

--- a/scripts/publish_crates.sh
+++ b/scripts/publish_crates.sh
@@ -113,6 +113,7 @@ cargo publish $FLAGS -p re_ws_comms
 cargo publish $FLAGS -p re_renderer
 cargo publish $FLAGS -p re_build_web_viewer
 cargo publish $FLAGS -p re_web_viewer_server
+cargo publish $FLAGS -p re_viewer_context
 cargo publish $FLAGS -p re_viewer
 cargo publish $FLAGS -p re_sdk
 cargo publish $FLAGS -p rerun


### PR DESCRIPTION
Another step towards splitting up the viewer. This creates a "base" crate to which the viewer context will move.
So far the only thing moved is the selection state and the associated "universal `Item` enum" that is used to refer to "things" in the viewer.

Part of
* #1873 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
