### PR TITLE
[pure refactor] Move `ViewerContext` & `ComponentUiRegistry` to `viewer_context`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,14 +4237,18 @@ name = "re_viewer_context"
 version = "0.6.0-alpha.0"
 dependencies = [
  "ahash 0.8.2",
+ "egui",
  "glam",
  "itertools",
  "nohash-hasher",
  "puffin",
  "re_arrow_store",
  "re_data_store",
+ "re_log",
  "re_log_types",
+ "re_query",
  "re_renderer",
+ "re_ui",
  "serde",
  "slotmap",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,7 +4244,6 @@ dependencies = [
  "puffin",
  "re_arrow_store",
  "re_data_store",
- "re_log",
  "re_log_types",
  "re_query",
  "re_renderer",

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -14,13 +14,11 @@ use re_log_types::{ApplicationId, LogMsg, RecordingId};
 use re_renderer::WgpuResourcePoolStatistics;
 use re_smart_channel::Receiver;
 use re_ui::{toasts, Command};
-use re_viewer_context::{AppOptions, Caches, PlayState};
-
-use crate::{
-    misc::{RecordingConfig, ViewerContext},
-    ui::{data_ui::ComponentUiRegistry, Blueprint},
-    viewer_analytics::ViewerAnalytics,
+use re_viewer_context::{
+    AppOptions, Caches, ComponentUiRegistry, PlayState, RecordingConfig, ViewerContext,
 };
+
+use crate::{ui::Blueprint, viewer_analytics::ViewerAnalytics};
 
 #[cfg(not(target_arch = "wasm32"))]
 use re_log_types::TimeRangeF;
@@ -134,7 +132,7 @@ impl App {
             ram_limit_warner: re_memory::RamLimitWarner::warn_at_fraction_of_max(0.75),
             re_ui,
             text_log_rx,
-            component_ui_registry: Default::default(),
+            component_ui_registry: crate::ui::data_ui::create_component_ui_registry(),
             rx,
             log_dbs: Default::default(),
             state,

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -12,9 +12,9 @@ mod remote_viewer_app;
 mod ui;
 mod viewer_analytics;
 
-pub(crate) use misc::{mesh_loader, ViewerContext};
+pub(crate) use misc::mesh_loader;
 use re_log_types::PythonVersion;
-pub(crate) use ui::{memory_panel, selection_panel, time_panel, UiVerbosity};
+pub(crate) use ui::{memory_panel, selection_panel, time_panel};
 
 pub use app::{App, StartupOptions};
 pub use remote_viewer_app::RemoteViewerApp;

--- a/crates/re_viewer/src/misc/mod.rs
+++ b/crates/re_viewer/src/misc/mod.rs
@@ -6,14 +6,11 @@ pub(crate) mod space_info;
 mod space_view_highlights;
 mod time_control_ui;
 mod transform_cache;
-mod viewer_context;
 
 pub mod instance_hash_conversions;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use clipboard::Clipboard;
-
-pub(crate) use viewer_context::*;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod profiler;

--- a/crates/re_viewer/src/misc/queries.rs
+++ b/crates/re_viewer/src/misc/queries.rs
@@ -1,8 +1,7 @@
 use re_arrow_store::LatestAtQuery;
 use re_data_store::{query_latest_single, EntityPath};
 use re_log_types::Transform;
-
-use super::ViewerContext;
+use re_viewer_context::ViewerContext;
 
 /// Find closest entity with a pinhole transform.
 pub fn closest_pinhole_transform(

--- a/crates/re_viewer/src/ui/annotations.rs
+++ b/crates/re_viewer/src/ui/annotations.rs
@@ -11,8 +11,9 @@ use re_log_types::{
     AnnotationContext, RowId,
 };
 use re_query::query_entity_with_primary;
+use re_viewer_context::ViewerContext;
 
-use crate::{misc::ViewerContext, ui::scene::SceneQuery};
+use crate::ui::scene::SceneQuery;
 
 #[derive(Clone, Debug)]
 pub struct Annotations {

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -1,6 +1,7 @@
 use re_viewer_context::Item;
 
-use crate::misc::{space_info::SpaceInfoCollection, ViewerContext};
+use crate::misc::space_info::SpaceInfoCollection;
+use re_viewer_context::ViewerContext;
 
 use super::viewport::Viewport;
 

--- a/crates/re_viewer/src/ui/data_ui/annotation_context.rs
+++ b/crates/re_viewer/src/ui/data_ui/annotation_context.rs
@@ -1,19 +1,19 @@
 use egui::{color_picker, Vec2};
 use itertools::Itertools;
 use re_log_types::{context::AnnotationInfo, AnnotationContext};
-
-use crate::ui::{annotations::auto_color, UiVerbosity};
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
+use crate::ui::annotations::auto_color;
 
 const TABLE_SCROLL_AREA_HEIGHT: f32 = 500.0; // add scroll-bars when we get to this height
 
 impl DataUi for AnnotationContext {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: crate::ui::UiVerbosity,
+        verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
     ) {
         match verbosity {

--- a/crates/re_viewer/src/ui/data_ui/component.rs
+++ b/crates/re_viewer/src/ui/data_ui/component.rs
@@ -1,9 +1,9 @@
 use re_data_store::{ComponentName, EntityPath, InstancePath};
 use re_query::ComponentWithInstances;
-
-use crate::ui::item_ui;
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
+use crate::ui::item_ui;
 
 // We do NOT implement `DataUi` for just `ComponentWithInstances`
 // because we also want the context of what entity it is part of!
@@ -27,9 +27,9 @@ impl EntityComponentWithInstances {
 impl DataUi for EntityComponentWithInstances {
     fn data_ui(
         &self,
-        ctx: &mut crate::misc::ViewerContext<'_>,
+        ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: super::UiVerbosity,
+        verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
         crate::profile_function!(self.component_name().full_name());
@@ -45,8 +45,8 @@ impl DataUi for EntityComponentWithInstances {
         let num_instances = self.num_instances();
 
         let one_line = match verbosity {
-            crate::ui::UiVerbosity::Small => true,
-            crate::UiVerbosity::Reduced | crate::ui::UiVerbosity::All => false,
+            UiVerbosity::Small => true,
+            UiVerbosity::Reduced | UiVerbosity::All => false,
         };
 
         if num_instances == 0 {
@@ -109,7 +109,7 @@ impl DataUi for EntityComponentWithInstances {
                                 ctx.component_ui_registry.ui(
                                     ctx,
                                     ui,
-                                    crate::ui::UiVerbosity::Small,
+                                    UiVerbosity::Small,
                                     query,
                                     &self.entity_path,
                                     &self.component_data,

--- a/crates/re_viewer/src/ui/data_ui/component_path.rs
+++ b/crates/re_viewer/src/ui/data_ui/component_path.rs
@@ -1,13 +1,14 @@
 use re_log_types::ComponentPath;
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
 
 impl DataUi for ComponentPath {
     fn data_ui(
         &self,
-        ctx: &mut crate::misc::ViewerContext<'_>,
+        ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: crate::ui::UiVerbosity,
+        verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
         let store = &ctx.log_db.entity_db.data_store;

--- a/crates/re_viewer/src/ui/data_ui/component_ui_registry.rs
+++ b/crates/re_viewer/src/ui/data_ui/component_ui_registry.rs
@@ -1,79 +1,15 @@
-use std::collections::BTreeMap;
-
-use re_arrow_store::LatestAtQuery;
-use re_data_store::EntityPath;
-use re_log_types::{
-    component_types::InstanceKey, external::arrow2, Component, ComponentName,
-    DeserializableComponent,
-};
-use re_query::ComponentWithInstances;
-
-use crate::{misc::ViewerContext, ui::UiVerbosity};
+use re_log_types::DeserializableComponent;
+use re_viewer_context::{ComponentUiRegistry, UiVerbosity, ViewerContext};
 
 use super::{DataUi, EntityDataUi};
 
-type ComponentUiCallback = Box<
-    dyn Fn(
-        &mut ViewerContext<'_>,
-        &mut egui::Ui,
-        UiVerbosity,
-        &LatestAtQuery,
-        &EntityPath,
-        &ComponentWithInstances,
-        &InstanceKey,
-    ),
->;
-
-/// How to display components in a Ui
-pub struct ComponentUiRegistry {
-    components: BTreeMap<ComponentName, ComponentUiCallback>,
-}
-
-impl Default for ComponentUiRegistry {
-    fn default() -> Self {
-        let mut registry = Self {
-            components: Default::default(),
-        };
-
-        // The things that are out-commented are components we have, but
-        // where the default arrow-format for them looks good enough (at least for now).
-        // Basically: adding custom UI:s for these out-commented components would be nice, but is not a must.
-        registry.add::<re_log_types::component_types::AnnotationContext>();
-        // registry.add::<re_log_types::component_types::Arrow3D>();
-        // registry.add::<re_log_types::component_types::Box3D>();
-        // registry.add::<re_log_types::component_types::ClassId>();
-        registry.add::<re_log_types::component_types::ColorRGBA>();
-        // registry.add::<re_log_types::component_types::InstanceKey>();
-        // registry.add::<re_log_types::component_types::KeypointId>();
-        // registry.add::<re_log_types::component_types::Label>();
-        registry.add::<re_log_types::component_types::LineStrip2D>();
-        registry.add::<re_log_types::component_types::LineStrip3D>();
-        registry.add::<re_log_types::component_types::Mesh3D>();
-        // registry.add::<re_log_types::component_types::Point2D>();
-        // registry.add::<re_log_types::component_types::Point3D>();
-        // registry.add::<re_log_types::component_types::Quaternion>();
-        // registry.add::<re_log_types::component_types::Radius>();
-        registry.add::<re_log_types::component_types::Rect2D>();
-        // registry.add::<re_log_types::component_types::Scalar>();
-        // registry.add::<re_log_types::component_types::ScalarPlotProps>();
-        // registry.add::<re_log_types::component_types::Size3D>();
-        registry.add::<re_log_types::component_types::Tensor>();
-        registry.add::<re_log_types::component_types::TextEntry>();
-        registry.add::<re_log_types::component_types::Transform>();
-        registry.add::<re_log_types::component_types::Vec2D>();
-        registry.add::<re_log_types::component_types::Vec3D>();
-        registry.add::<re_log_types::ViewCoordinates>();
-
-        registry
-    }
-}
-
-impl ComponentUiRegistry {
-    fn add<C: DeserializableComponent + EntityDataUi>(&mut self)
+pub fn create_component_ui_registry() -> ComponentUiRegistry {
+    /// Registers how to show a given component in the ui.
+    pub fn add<C: DeserializableComponent + EntityDataUi>(registry: &mut ComponentUiRegistry)
     where
         for<'a> &'a C::ArrayType: IntoIterator,
     {
-        self.components.insert(
+        registry.add(
             C::name(),
             Box::new(
                 |ctx, ui, verbosity, query, entity_path, component, instance| match component
@@ -93,54 +29,38 @@ impl ComponentUiRegistry {
         );
     }
 
-    /// Show a ui for this instance of this component.
-    #[allow(clippy::too_many_arguments)]
-    pub fn ui(
-        &self,
-        ctx: &mut crate::misc::ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        verbosity: crate::ui::UiVerbosity,
-        query: &LatestAtQuery,
-        entity_path: &EntityPath,
-        component: &ComponentWithInstances,
-        instance_key: &InstanceKey,
-    ) {
-        crate::profile_function!(component.name().full_name());
+    let mut registry = ComponentUiRegistry::default();
 
-        if component.name() == InstanceKey::name() {
-            // The user wants to show a ui for the `InstanceKey` component - well, that's easy:
-            ui.label(instance_key.to_string());
-            return;
-        }
+    // The things that are out-commented are components we have, but
+    // where the default arrow-format for them looks good enough (at least for now).
+    // Basically: adding custom UI:s for these out-commented components would be nice, but is not a must.
+    add::<re_log_types::component_types::AnnotationContext>(&mut registry);
+    // add::<re_log_types::component_types::Arrow3D>(&mut registry);
+    // add::<re_log_types::component_types::Box3D>(&mut registry);
+    // add::<re_log_types::component_types::ClassId>(&mut registry);
+    add::<re_log_types::component_types::ColorRGBA>(&mut registry);
+    // add::<re_log_types::component_types::InstanceKey>(&mut registry);
+    // add::<re_log_types::component_types::KeypointId>(&mut registry);
+    // add::<re_log_types::component_types::Label>(&mut registry);
+    add::<re_log_types::component_types::LineStrip2D>(&mut registry);
+    add::<re_log_types::component_types::LineStrip3D>(&mut registry);
+    add::<re_log_types::component_types::Mesh3D>(&mut registry);
+    // add::<re_log_types::component_types::Point2D>(&mut registry);
+    // add::<re_log_types::component_types::Point3D>(&mut registry);
+    // add::<re_log_types::component_types::Quaternion>(&mut registry);
+    // add::<re_log_types::component_types::Radius>(&mut registry);
+    add::<re_log_types::component_types::Rect2D>(&mut registry);
+    // add::<re_log_types::component_types::Scalar>(&mut registry);
+    // add::<re_log_types::component_types::ScalarPlotProps>(&mut registry);
+    // add::<re_log_types::component_types::Size3D>(&mut registry);
+    add::<re_log_types::component_types::Tensor>(&mut registry);
+    add::<re_log_types::component_types::TextEntry>(&mut registry);
+    add::<re_log_types::component_types::Transform>(&mut registry);
+    add::<re_log_types::component_types::Vec2D>(&mut registry);
+    add::<re_log_types::component_types::Vec3D>(&mut registry);
+    add::<re_log_types::ViewCoordinates>(&mut registry);
 
-        if let Some(ui_callback) = self.components.get(&component.name()) {
-            (*ui_callback)(
-                ctx,
-                ui,
-                verbosity,
-                query,
-                entity_path,
-                component,
-                instance_key,
-            );
-        } else {
-            // No special ui implementation - use a generic one:
-            if let Some(value) = component.lookup_arrow(instance_key) {
-                let bytes = arrow2::compute::aggregate::estimated_bytes_size(value.as_ref());
-                if bytes < 256 {
-                    // For small items, print them
-                    let mut repr = String::new();
-                    let display = arrow2::array::get_display(value.as_ref(), "null");
-                    display(&mut repr, 0).unwrap();
-                    ui.label(repr);
-                } else {
-                    ui.label(format!("{bytes} bytes"));
-                }
-            } else {
-                ui.weak("(null)");
-            }
-        }
-    }
+    registry
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/re_viewer/src/ui/data_ui/data.rs
+++ b/crates/re_viewer/src/ui/data_ui/data.rs
@@ -6,8 +6,7 @@ use re_log_types::{
     component_types::{LineStrip2D, LineStrip3D, Mat3x3, Rect2D, Vec2D, Vec3D, Vec4D},
     Pinhole, Rigid3, Transform, ViewCoordinates,
 };
-
-use crate::ui::UiVerbosity;
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
 
@@ -17,7 +16,7 @@ const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
 impl DataUi for [u8; 4] {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -37,7 +36,7 @@ impl DataUi for [u8; 4] {
 impl DataUi for ColorRGBA {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -57,7 +56,7 @@ impl DataUi for ColorRGBA {
 impl DataUi for Transform {
     fn data_ui(
         &self,
-        ctx: &mut crate::misc::ViewerContext<'_>,
+        ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -75,7 +74,7 @@ impl DataUi for Transform {
 impl DataUi for ViewCoordinates {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -95,7 +94,7 @@ impl DataUi for Rigid3 {
     #[allow(clippy::only_used_in_recursion)]
     fn data_ui(
         &self,
-        ctx: &mut crate::misc::ViewerContext<'_>,
+        ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -134,7 +133,7 @@ impl DataUi for Rigid3 {
 impl DataUi for Pinhole {
     fn data_ui(
         &self,
-        ctx: &mut crate::misc::ViewerContext<'_>,
+        ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -178,7 +177,7 @@ impl DataUi for Pinhole {
 impl DataUi for Mat3x3 {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -205,7 +204,7 @@ impl DataUi for Mat3x3 {
 impl DataUi for Vec2D {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -217,7 +216,7 @@ impl DataUi for Vec2D {
 impl DataUi for Vec3D {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -229,7 +228,7 @@ impl DataUi for Vec3D {
 impl DataUi for Rect2D {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -263,7 +262,7 @@ impl DataUi for Rect2D {
 impl DataUi for LineStrip2D {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -312,7 +311,7 @@ impl DataUi for LineStrip2D {
 impl DataUi for LineStrip3D {
     fn data_ui(
         &self,
-        _ctx: &mut crate::misc::ViewerContext<'_>,
+        _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_viewer/src/ui/data_ui/entity_path.rs
+++ b/crates/re_viewer/src/ui/data_ui/entity_path.rs
@@ -1,8 +1,7 @@
 use re_data_store::InstancePath;
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
-use crate::misc::ViewerContext;
-
-use super::{DataUi, UiVerbosity};
+use super::DataUi;
 
 impl DataUi for re_data_store::EntityPath {
     fn data_ui(

--- a/crates/re_viewer/src/ui/data_ui/image.rs
+++ b/crates/re_viewer/src/ui/data_ui/image.rs
@@ -7,16 +7,13 @@ use re_log_types::{
 };
 use re_renderer::renderer::ColormappedTexture;
 use re_ui::ReUi;
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
+use super::EntityDataUi;
 use crate::{
-    misc::{
-        caches::{TensorDecodeCache, TensorStats, TensorStatsCache},
-        ViewerContext,
-    },
+    misc::caches::{TensorDecodeCache, TensorStats, TensorStatsCache},
     ui::annotations::AnnotationMap,
 };
-
-use super::{EntityDataUi, UiVerbosity};
 
 pub fn format_tensor_shape_single_line(
     shape: &[re_log_types::component_types::TensorDimension],
@@ -29,7 +26,7 @@ impl EntityDataUi for Tensor {
         &self,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: crate::ui::UiVerbosity,
+        verbosity: UiVerbosity,
         entity_path: &re_log_types::EntityPath,
         query: &re_arrow_store::LatestAtQuery,
     ) {

--- a/crates/re_viewer/src/ui/data_ui/instance_path.rs
+++ b/crates/re_viewer/src/ui/data_ui/instance_path.rs
@@ -1,13 +1,10 @@
 use re_data_store::InstancePath;
 use re_log_types::ComponentPath;
 use re_query::{get_component_with_instances, QueryError};
-
-use crate::{
-    misc::ViewerContext,
-    ui::{item_ui, UiVerbosity},
-};
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
+use crate::ui::item_ui;
 
 const HIDDEN_COMPONENTS_FOR_ALL_VERBOSITY: &[&str] = &["rerun.instance_key"];
 const HIDDEN_COMPONENTS_FOR_LOW_VERBOSITY: &[&str] = &[];

--- a/crates/re_viewer/src/ui/data_ui/log_msg.rs
+++ b/crates/re_viewer/src/ui/data_ui/log_msg.rs
@@ -1,13 +1,10 @@
 use re_log_types::{
     ArrowMsg, BeginRecordingMsg, DataTable, EntityPathOpMsg, LogMsg, RecordingInfo,
 };
-
-use crate::{
-    misc::ViewerContext,
-    ui::{item_ui, UiVerbosity},
-};
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
+use crate::ui::item_ui;
 
 impl DataUi for LogMsg {
     fn data_ui(

--- a/crates/re_viewer/src/ui/data_ui/mod.rs
+++ b/crates/re_viewer/src/ui/data_ui/mod.rs
@@ -1,10 +1,8 @@
 //! The `DataUi` trait and implementations provide methods for representing data using [`egui`].
 
 use itertools::Itertools;
-use re_data_store::EntityPath;
-use re_log_types::{DataCell, PathOp, TimePoint};
-
-use crate::misc::ViewerContext;
+use re_log_types::{DataCell, EntityPath, PathOp, TimePoint};
+use re_viewer_context::{UiVerbosity, ViewerContext};
 
 mod annotation_context;
 mod component;
@@ -16,25 +14,12 @@ pub(crate) mod image;
 mod instance_path;
 mod log_msg;
 
-pub(crate) use component_ui_registry::ComponentUiRegistry;
+pub use component_ui_registry::create_component_ui_registry;
 
 use super::item_ui;
 
-/// Controls how mich space we use to show the data in [`DataUi`].
-#[derive(Clone, Copy, Debug)]
-pub enum UiVerbosity {
-    /// Keep it small enough to fit on one row.
-    Small,
-
-    /// Display a reduced set, used for hovering.
-    Reduced,
-
-    /// Display everything, as large as you want. Used for selection panel.
-    All,
-}
-
 /// Types implementing [`DataUi`] can display themselves in an [`egui::Ui`].
-pub(crate) trait DataUi {
+pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.
     fn data_ui(
         &self,
@@ -48,7 +33,7 @@ pub(crate) trait DataUi {
 /// Similar to [`DataUi`], but for data that is related to an entity (e.g. a component).
 ///
 /// This is given the context of the entity it is part of so it can do queries.
-pub(crate) trait EntityDataUi {
+pub trait EntityDataUi {
     /// If you need to lookup something in the data store, use the given query to do so.
     fn entity_data_ui(
         &self,

--- a/crates/re_viewer/src/ui/item_ui.rs
+++ b/crates/re_viewer/src/ui/item_ui.rs
@@ -3,15 +3,11 @@
 use re_data_store::InstancePath;
 use re_log_types::{ComponentPath, EntityPath, TimeInt, Timeline};
 use re_viewer_context::{
-    DataBlueprintGroupHandle, HoverHighlight, Item, SelectionState, SpaceViewId,
+    DataBlueprintGroupHandle, HoverHighlight, Item, SelectionState, SpaceViewId, UiVerbosity,
+    ViewerContext,
 };
 
-use crate::{
-    misc::ViewerContext,
-    ui::{data_ui::DataUi, UiVerbosity},
-};
-
-use super::selection_panel::select_hovered_on_click;
+use super::{data_ui::DataUi, selection_panel::select_hovered_on_click};
 
 // TODO(andreas): This is where we want to go, but we need to figure out how get the `SpaceViewCategory` from the `SpaceViewId`.
 // Simply pass in optional icons?
@@ -108,12 +104,7 @@ pub fn instance_path_button_to(
         .on_hover_ui(|ui| {
             ui.strong(subtype_string);
             ui.label(format!("Path: {instance_path}"));
-            instance_path.data_ui(
-                ctx,
-                ui,
-                crate::ui::UiVerbosity::Reduced,
-                &ctx.current_query(),
-            );
+            instance_path.data_ui(ctx, ui, UiVerbosity::Reduced, &ctx.current_query());
         });
 
     cursor_interact_with_selectable(ctx.selection_state_mut(), response, item)

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -32,5 +32,3 @@ pub(crate) use self::space_view::SpaceView;
 pub use self::annotations::{Annotations, DefaultColor, MISSING_ANNOTATIONS};
 pub use self::view_category::ViewCategory;
 pub use self::viewport::Viewport;
-
-pub(crate) use data_ui::UiVerbosity;

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,4 +1,5 @@
 use egui::NumExt as _;
+
 use re_data_store::{
     query_latest_single, ColorMapper, Colormap, EditableAutoValue, EntityPath, EntityProperties,
 };
@@ -6,9 +7,9 @@ use re_log_types::{
     component_types::{Tensor, TensorDataMeaning},
     TimeType, Transform,
 };
-use re_viewer_context::{Item, SelectionState, SpaceViewId};
+use re_viewer_context::{Item, SelectionState, SpaceViewId, UiVerbosity, ViewerContext};
 
-use crate::{ui::Blueprint, UiVerbosity, ViewerContext};
+use crate::ui::Blueprint;
 
 use super::{
     data_ui::DataUi, item_ui, selection_history_ui::SelectionHistoryUi, space_view::ViewState,

--- a/crates/re_viewer/src/ui/space_view.rs
+++ b/crates/re_viewer/src/ui/space_view.rs
@@ -1,10 +1,10 @@
 use re_arrow_store::Timeline;
 use re_data_store::{EntityPath, EntityPropertyMap, EntityTree, InstancePath, TimeInt};
 use re_renderer::ScreenshotProcessor;
-use re_viewer_context::SpaceViewId;
+use re_viewer_context::{SpaceViewId, ViewerContext};
 
 use crate::{
-    misc::{space_info::SpaceInfoCollection, SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{space_info::SpaceInfoCollection, SpaceViewHighlights, TransformCache},
     ui::view_category::categorize_entity_path,
 };
 

--- a/crates/re_viewer/src/ui/space_view_entity_picker.rs
+++ b/crates/re_viewer/src/ui/space_view_entity_picker.rs
@@ -2,9 +2,9 @@ use itertools::Itertools;
 use nohash_hasher::IntMap;
 use re_arrow_store::Timeline;
 use re_data_store::{EntityPath, EntityTree, InstancePath};
-use re_viewer_context::SpaceViewId;
+use re_viewer_context::{SpaceViewId, ViewerContext};
 
-use crate::misc::{space_info::SpaceInfoCollection, ViewerContext};
+use crate::misc::space_info::SpaceInfoCollection;
 
 use super::{
     item_ui,

--- a/crates/re_viewer/src/ui/space_view_heuristics.rs
+++ b/crates/re_viewer/src/ui/space_view_heuristics.rs
@@ -6,9 +6,10 @@ use nohash_hasher::IntSet;
 use re_arrow_store::{DataStore, LatestAtQuery, Timeline};
 use re_data_store::{log_db::EntityDb, query_latest_single, ComponentName, EntityPath};
 use re_log_types::{component_types::Tensor, Component};
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{space_info::SpaceInfoCollection, ViewerContext},
+    misc::space_info::SpaceInfoCollection,
     ui::{view_category::categorize_entity_path, ViewCategory},
 };
 

--- a/crates/re_viewer/src/ui/time_panel/data_density_graph.rs
+++ b/crates/re_viewer/src/ui/time_panel/data_density_graph.rs
@@ -9,9 +9,9 @@ use egui::{epaint::Vertex, lerp, pos2, remap, Color32, NumExt as _, Rect, Shape}
 
 use re_data_store::TimeHistogram;
 use re_log_types::{TimeInt, TimeRange, TimeReal};
-use re_viewer_context::Item;
+use re_viewer_context::{Item, UiVerbosity, ViewerContext};
 
-use crate::{misc::ViewerContext, ui::Blueprint};
+use crate::ui::{data_ui::DataUi, Blueprint};
 
 use super::time_ranges_ui::TimeRangesUi;
 
@@ -528,8 +528,6 @@ fn show_row_ids_tooltip(
         return;
     }
 
-    use crate::ui::data_ui::DataUi as _;
-
     egui::show_tooltip_at_pointer(egui_ctx, egui::Id::new("data_tooltip"), |ui| {
         if num_messages == 1 {
             ui.label(format!("{num_messages} message"));
@@ -543,6 +541,6 @@ fn show_row_ids_tooltip(
 
         let timeline = *ctx.rec_cfg.time_ctrl.timeline();
         let query = re_arrow_store::LatestAtQuery::new(timeline, time_range.max);
-        item.data_ui(ctx, ui, crate::ui::UiVerbosity::Reduced, &query);
+        item.data_ui(ctx, ui, UiVerbosity::Reduced, &query);
     });
 }

--- a/crates/re_viewer/src/ui/time_panel/mod.rs
+++ b/crates/re_viewer/src/ui/time_panel/mod.rs
@@ -10,9 +10,9 @@ use egui::{pos2, Color32, CursorIcon, NumExt, PointerButton, Rect, Shape, Vec2};
 
 use re_data_store::{EntityTree, InstancePath, TimeHistogram};
 use re_log_types::{ComponentPath, EntityPathPart, TimeInt, TimeRange, TimeReal};
-use re_viewer_context::{Item, TimeControl, TimeView};
+use re_viewer_context::{Item, TimeControl, TimeView, UiVerbosity, ViewerContext};
 
-use crate::{misc::TimeControlUi, ViewerContext};
+use crate::misc::TimeControlUi;
 
 use super::{data_ui::DataUi, item_ui, selection_panel::what_is_selected_ui, Blueprint};
 
@@ -541,7 +541,7 @@ impl TimePanel {
                         what_is_selected_ui(ui, ctx, blueprint, &item);
                         ui.add_space(8.0);
                         let query = ctx.current_query();
-                        component_path.data_ui(ctx, ui, super::UiVerbosity::Small, &query);
+                        component_path.data_ui(ctx, ui, UiVerbosity::Small, &query);
                     });
 
                     // show the data in the time area:

--- a/crates/re_viewer/src/ui/time_panel/time_ranges_ui.rs
+++ b/crates/re_viewer/src/ui/time_panel/time_ranges_ui.rs
@@ -10,9 +10,7 @@ use egui::{lerp, remap, NumExt};
 use itertools::Itertools as _;
 
 use re_log_types::{TimeInt, TimeRange, TimeRangeF, TimeReal};
-use re_viewer_context::{PlayState, TimeView};
-
-use crate::ViewerContext;
+use re_viewer_context::{PlayState, TimeView, ViewerContext};
 
 /// The ideal gap between time segments.
 ///

--- a/crates/re_viewer/src/ui/view_bar_chart/scene.rs
+++ b/crates/re_viewer/src/ui/view_bar_chart/scene.rs
@@ -5,8 +5,9 @@ use re_data_store::EntityPath;
 use re_log::warn_once;
 use re_log_types::component_types::{self, InstanceKey, Tensor};
 use re_query::query_entity_with_primary;
+use re_viewer_context::ViewerContext;
 
-use crate::{misc::ViewerContext, ui::scene::SceneQuery};
+use crate::ui::scene::SceneQuery;
 
 /// A bar chart scene, with everything needed to render it.
 #[derive(Default)]

--- a/crates/re_viewer/src/ui/view_bar_chart/ui.rs
+++ b/crates/re_viewer/src/ui/view_bar_chart/ui.rs
@@ -5,8 +5,9 @@ use egui::util::hash;
 use re_data_store::EntityPath;
 use re_log::warn_once;
 use re_log_types::component_types::{self, InstanceKey};
+use re_viewer_context::ViewerContext;
 
-use crate::{misc::ViewerContext, ui::annotations::auto_color};
+use crate::ui::annotations::auto_color;
 
 use super::SceneBarChart;
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/mod.rs
@@ -8,9 +8,10 @@ use re_log_types::{
     DecodedTensor,
 };
 use re_renderer::{renderer::TexturedRect, Color32, OutlineMaskPreference, Size};
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{mesh_loader::LoadedMesh, SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{mesh_loader::LoadedMesh, SpaceViewHighlights, TransformCache},
     ui::{
         annotations::{auto_color, AnnotationMap},
         Annotations, SceneQuery,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
@@ -5,9 +5,10 @@ use re_log_types::{
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::{renderer::LineStripFlags, Size};
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, TransformCache},
     ui::{scene::SceneQuery, view_spatial::SceneSpatial, DefaultColor},
 };
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
@@ -5,9 +5,10 @@ use re_log_types::{
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::Size;
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, TransformCache},
     ui::{
         scene::SceneQuery,
         view_spatial::{

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
@@ -5,9 +5,10 @@ use re_log_types::{
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::Size;
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache},
     ui::{
         scene::SceneQuery,
         view_spatial::{SceneSpatial, UiLabel, UiLabelTarget},

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -7,12 +7,13 @@ use re_log_types::{
 use re_query::{query_entity_with_primary, EntityView, QueryError};
 use re_renderer::renderer::LineStripFlags;
 use re_viewer_context::TimeControl;
+use re_viewer_context::ViewerContext;
 
 use crate::{
     misc::{
         instance_hash_conversions::picking_layer_id_from_instance_path_hash,
         space_info::query_view_coordinates, SpaceViewHighlights, SpaceViewOutlineMasks,
-        TransformCache, ViewerContext,
+        TransformCache,
     },
     ui::{
         scene::SceneQuery,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/images.rs
@@ -13,11 +13,12 @@ use re_renderer::{
     resource_managers::Texture2DCreationDesc,
     Colormap, OutlineMaskPreference,
 };
+use re_viewer_context::ViewerContext;
 
 use crate::{
     misc::{
         caches::{TensorDecodeCache, TensorStatsCache},
-        SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext,
+        SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache,
     },
     ui::{
         scene::SceneQuery,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
@@ -5,9 +5,10 @@ use re_log_types::{
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::Size;
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache},
     ui::{scene::SceneQuery, view_spatial::SceneSpatial, DefaultColor},
 };
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
@@ -5,9 +5,10 @@ use re_log_types::{
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
 use re_renderer::Size;
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache},
     ui::{scene::SceneQuery, view_spatial::SceneSpatial, DefaultColor},
 };
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -4,9 +4,10 @@ use re_log_types::{
     Component, Mesh3D,
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{caches::MeshCache, SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{caches::MeshCache, SpaceViewHighlights, TransformCache},
     ui::{
         scene::SceneQuery,
         view_spatial::{MeshSource, SceneSpatial},

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
@@ -28,13 +28,14 @@ use re_log_types::component_types::{ClassId, ColorRGBA, KeypointId, Radius};
 
 use super::SceneSpatial;
 use crate::{
-    misc::{SpaceViewHighlights, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, TransformCache},
     ui::{
         annotations::ResolvedAnnotationInfo, scene::SceneQuery, view_spatial::scene::Keypoints,
         Annotations, DefaultColor,
     },
 };
 use re_data_store::{EntityPath, InstancePathHash};
+use re_viewer_context::ViewerContext;
 
 pub trait ScenePart {
     fn load(

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
@@ -4,9 +4,10 @@ use re_log_types::{
     Component,
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache},
     ui::{
         annotations::ResolvedAnnotationInfo,
         scene::SceneQuery,

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
@@ -4,9 +4,10 @@ use re_log_types::{
     Component,
 };
 use re_query::{query_primary_with_history, EntityView, QueryError};
+use re_viewer_context::ViewerContext;
 
 use crate::{
-    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache, ViewerContext},
+    misc::{SpaceViewHighlights, SpaceViewOutlineMasks, TransformCache},
     ui::{
         annotations::ResolvedAnnotationInfo,
         scene::SceneQuery,

--- a/crates/re_viewer/src/ui/view_spatial/ui.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui.rs
@@ -6,13 +6,15 @@ use re_data_store::{query_latest_single, EditableAutoValue, EntityPath, EntityPr
 use re_format::format_f32;
 use re_log_types::component_types::{Tensor, TensorDataMeaning};
 use re_renderer::OutlineConfig;
-use re_viewer_context::{HoverHighlight, HoveredSpace, Item, SelectionHighlight, SpaceViewId};
+use re_viewer_context::{
+    HoverHighlight, HoveredSpace, Item, SelectionHighlight, SpaceViewId, UiVerbosity, ViewerContext,
+};
 
 use crate::{
     misc::{
         caches::{TensorDecodeCache, TensorStatsCache},
         space_info::query_view_coordinates,
-        SpaceViewHighlights, ViewerContext,
+        SpaceViewHighlights,
     },
     ui::{
         data_blueprint::DataBlueprintTree,
@@ -808,7 +810,7 @@ pub fn picking(
                         instance_path.data_ui(
                             ctx,
                             ui,
-                            crate::ui::UiVerbosity::Small,
+                            UiVerbosity::Small,
                             &ctx.current_query(),
                         );
 
@@ -857,12 +859,7 @@ pub fn picking(
             // Hover ui for everything else
             response.on_hover_ui_at_pointer(|ui| {
                 item_ui::instance_path_button(ctx, ui, Some(space_view_id), &instance_path);
-                instance_path.data_ui(
-                    ctx,
-                    ui,
-                    crate::ui::UiVerbosity::Reduced,
-                    &ctx.current_query(),
-                );
+                instance_path.data_ui(ctx, ui, UiVerbosity::Reduced, &ctx.current_query());
             })
         };
     }

--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -4,7 +4,7 @@ use macaw::IsoTransform;
 use re_data_store::{query_latest_single, EntityPath, EntityPropertyMap};
 use re_log_types::Pinhole;
 use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
-use re_viewer_context::{HoveredSpace, SpaceViewId};
+use re_viewer_context::{HoveredSpace, SpaceViewId, ViewerContext};
 
 use super::{
     eye::Eye,
@@ -19,7 +19,6 @@ use crate::{
         ui_renderer_bridge::{fill_view_builder, ScreenBackground},
         SceneSpatial,
     },
-    ViewerContext,
 };
 
 // ---

--- a/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_3d.rs
@@ -9,7 +9,7 @@ use re_renderer::{
     view_builder::{Projection, TargetConfiguration, ViewBuilder},
     Size,
 };
-use re_viewer_context::{HoveredSpace, Item, SpaceViewId};
+use re_viewer_context::{HoveredSpace, Item, SpaceViewId, ViewerContext};
 
 use crate::{
     gpu_bridge,
@@ -19,7 +19,6 @@ use crate::{
         ui_renderer_bridge::{fill_view_builder, ScreenBackground},
         SceneSpatial, SpaceCamera3D, SpatialNavigationMode,
     },
-    ViewerContext,
 };
 
 use super::{

--- a/crates/re_viewer/src/ui/view_tensor/scene.rs
+++ b/crates/re_viewer/src/ui/view_tensor/scene.rs
@@ -5,11 +5,9 @@ use re_log_types::{
     DecodedTensor,
 };
 use re_query::{query_entity_with_primary, EntityView, QueryError};
+use re_viewer_context::ViewerContext;
 
-use crate::{
-    misc::{caches::TensorDecodeCache, ViewerContext},
-    ui::SceneQuery,
-};
+use crate::{misc::caches::TensorDecodeCache, ui::SceneQuery};
 
 // ---
 

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -10,6 +10,7 @@ use re_log_types::{
 };
 use re_renderer::Colormap;
 use re_tensor_ops::dimension_mapping::{DimensionMapping, DimensionSelector};
+use re_viewer_context::ViewerContext;
 
 use crate::{misc::caches::TensorStatsCache, ui::data_ui::image::tensor_summary_ui_grid_contents};
 
@@ -65,7 +66,7 @@ impl ViewTensorState {
         &self.color_mapping
     }
 
-    pub(crate) fn ui(&mut self, ctx: &mut crate::misc::ViewerContext<'_>, ui: &mut egui::Ui) {
+    pub(crate) fn ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         let Some(tensor) = &self.tensor else {
             ui.label("No Tensor shown in this Space View.");
             return;
@@ -103,7 +104,7 @@ impl ViewTensorState {
 }
 
 pub(crate) fn view_tensor(
-    ctx: &mut crate::misc::ViewerContext<'_>,
+    ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut ViewTensorState,
     tensor: &DecodedTensor,
@@ -158,7 +159,7 @@ pub(crate) fn view_tensor(
 }
 
 fn tensor_slice_ui(
-    ctx: &mut crate::misc::ViewerContext<'_>,
+    ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut ViewTensorState,
     tensor: &DecodedTensor,
@@ -175,7 +176,7 @@ fn tensor_slice_ui(
 }
 
 fn paint_tensor_slice(
-    ctx: &mut crate::misc::ViewerContext<'_>,
+    ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut ViewTensorState,
     tensor: &DecodedTensor,

--- a/crates/re_viewer/src/ui/view_text/scene.rs
+++ b/crates/re_viewer/src/ui/view_text/scene.rs
@@ -5,8 +5,9 @@ use re_log_types::{
     Component, RowId,
 };
 use re_query::{range_entity_with_primary, QueryError};
+use re_viewer_context::ViewerContext;
 
-use crate::{ui::SceneQuery, ViewerContext};
+use crate::ui::SceneQuery;
 
 use super::ui::ViewTextFilters;
 

--- a/crates/re_viewer/src/ui/view_text/ui.rs
+++ b/crates/re_viewer/src/ui/view_text/ui.rs
@@ -4,8 +4,9 @@ use egui::{Color32, RichText};
 
 use re_data_store::{EntityPath, Timeline};
 use re_log_types::TimePoint;
+use re_viewer_context::ViewerContext;
 
-use crate::{ui::item_ui, ViewerContext};
+use crate::ui::item_ui;
 
 use super::{SceneText, TextEntry};
 

--- a/crates/re_viewer/src/ui/view_time_series/scene.rs
+++ b/crates/re_viewer/src/ui/view_time_series/scene.rs
@@ -1,13 +1,12 @@
-use crate::{
-    ui::{annotations::AnnotationMap, DefaultColor, SceneQuery},
-    ViewerContext,
-};
 use re_arrow_store::TimeRange;
 use re_log_types::{
     component_types::{self, InstanceKey},
     Component,
 };
 use re_query::{range_entity_with_primary, QueryError};
+use re_viewer_context::ViewerContext;
+
+use crate::ui::{annotations::AnnotationMap, DefaultColor, SceneQuery};
 
 // ---
 

--- a/crates/re_viewer/src/ui/view_time_series/ui.rs
+++ b/crates/re_viewer/src/ui/view_time_series/ui.rs
@@ -4,13 +4,12 @@ use egui::{
 };
 
 use re_arrow_store::TimeType;
-
-use crate::{
-    misc::format_time::next_grid_tick_magnitude_ns, ui::view_time_series::scene::PlotSeriesKind,
-    ViewerContext,
-};
+use re_viewer_context::ViewerContext;
 
 use super::SceneTimeSeries;
+use crate::{
+    misc::format_time::next_grid_tick_magnitude_ns, ui::view_time_series::scene::PlotSeriesKind,
+};
 
 // ---
 

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -6,13 +6,10 @@ use ahash::HashMap;
 use itertools::Itertools as _;
 
 use re_data_store::EntityPath;
-use re_viewer_context::{DataBlueprintGroupHandle, Item, SpaceViewId};
+use re_viewer_context::{DataBlueprintGroupHandle, Item, SpaceViewId, ViewerContext};
 
 use crate::{
-    misc::{
-        highlights_for_space_view, space_info::SpaceInfoCollection, SpaceViewHighlights,
-        ViewerContext,
-    },
+    misc::{highlights_for_space_view, space_info::SpaceInfoCollection, SpaceViewHighlights},
     ui::{item_ui, space_view_heuristics::default_created_space_views},
 };
 

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -19,7 +19,6 @@ all-features = true
 re_arrow_store.workspace = true
 re_data_store = { workspace = true, features = ["serde"] }
 re_log_types = { workspace = true, features = ["ecolor", "glam", "image"] }
-re_log.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_ui.workspace = true

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -19,9 +19,13 @@ all-features = true
 re_arrow_store.workspace = true
 re_data_store = { workspace = true, features = ["serde"] }
 re_log_types = { workspace = true, features = ["ecolor", "glam", "image"] }
+re_log.workspace = true
+re_query.workspace = true
 re_renderer.workspace = true
+re_ui.workspace = true
 
 ahash.workspace = true
+egui.workspace = true
 glam.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+
+use re_arrow_store::LatestAtQuery;
+use re_data_store::EntityPath;
+use re_log_types::{component_types::InstanceKey, external::arrow2, Component, ComponentName};
+use re_query::ComponentWithInstances;
+
+use crate::ViewerContext;
+
+/// Controls how mich space we use to show the data in [`DataUi`].
+#[derive(Clone, Copy, Debug)]
+pub enum UiVerbosity {
+    /// Keep it small enough to fit on one row.
+    Small,
+
+    /// Display a reduced set, used for hovering.
+    Reduced,
+
+    /// Display everything, as large as you want. Used for selection panel.
+    All,
+}
+
+type ComponentUiCallback = Box<
+    dyn Fn(
+        &mut ViewerContext<'_>,
+        &mut egui::Ui,
+        UiVerbosity,
+        &LatestAtQuery,
+        &EntityPath,
+        &ComponentWithInstances,
+        &InstanceKey,
+    ),
+>;
+
+/// How to display components in a Ui.
+#[derive(Default)]
+pub struct ComponentUiRegistry {
+    components: BTreeMap<ComponentName, ComponentUiCallback>,
+}
+
+impl ComponentUiRegistry {
+    /// Registers how to show a given component in the ui.
+    ///
+    /// If the component was already registered, the new callback replaces the old one.
+    pub fn add(&mut self, name: ComponentName, callback: ComponentUiCallback) {
+        self.components.insert(name, callback);
+    }
+
+    /// Show a ui for this instance of this component.
+    #[allow(clippy::too_many_arguments)]
+    pub fn ui(
+        &self,
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        verbosity: UiVerbosity,
+        query: &LatestAtQuery,
+        entity_path: &EntityPath,
+        component: &ComponentWithInstances,
+        instance_key: &InstanceKey,
+    ) {
+        crate::profile_function!(component.name().full_name());
+
+        if component.name() == InstanceKey::name() {
+            // The user wants to show a ui for the `InstanceKey` component - well, that's easy:
+            ui.label(instance_key.to_string());
+            return;
+        }
+
+        if let Some(ui_callback) = self.components.get(&component.name()) {
+            (*ui_callback)(
+                ctx,
+                ui,
+                verbosity,
+                query,
+                entity_path,
+                component,
+                instance_key,
+            );
+        } else {
+            // No special ui implementation - use a generic one:
+            if let Some(value) = component.lookup_arrow(instance_key) {
+                let bytes = arrow2::compute::aggregate::estimated_bytes_size(value.as_ref());
+                if bytes < 256 {
+                    // For small items, print them
+                    let mut repr = String::new();
+                    let display = arrow2::array::get_display(value.as_ref(), "null");
+                    display(&mut repr, 0).unwrap();
+                    ui.label(repr);
+                } else {
+                    ui.label(format!("{bytes} bytes"));
+                }
+            } else {
+                ui.weak("(null)");
+            }
+        }
+    }
+}

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -7,7 +7,7 @@ use re_query::ComponentWithInstances;
 
 use crate::ViewerContext;
 
-/// Controls how mich space we use to show the data in [`DataUi`].
+/// Controls how mich space we use to show the data in a component ui.
 #[derive(Clone, Copy, Debug)]
 pub enum UiVerbosity {
     /// Keep it small enough to fit on one row.

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
-use re_log_types::{component_types::InstanceKey, external::arrow2, Component, ComponentName};
+use re_log_types::{component_types::InstanceKey, Component, ComponentName};
 use re_query::ComponentWithInstances;
 
 use crate::ViewerContext;
@@ -33,12 +33,20 @@ type ComponentUiCallback = Box<
 >;
 
 /// How to display components in a Ui.
-#[derive(Default)]
 pub struct ComponentUiRegistry {
+    /// Ui method to use if there was no specific one registered for a component.
+    fallback_ui: ComponentUiCallback,
     components: BTreeMap<ComponentName, ComponentUiCallback>,
 }
 
 impl ComponentUiRegistry {
+    pub fn new(fallback_ui: ComponentUiCallback) -> Self {
+        Self {
+            fallback_ui,
+            components: Default::default(),
+        }
+    }
+
     /// Registers how to show a given component in the ui.
     ///
     /// If the component was already registered, the new callback replaces the old one.
@@ -66,32 +74,18 @@ impl ComponentUiRegistry {
             return;
         }
 
-        if let Some(ui_callback) = self.components.get(&component.name()) {
-            (*ui_callback)(
-                ctx,
-                ui,
-                verbosity,
-                query,
-                entity_path,
-                component,
-                instance_key,
-            );
-        } else {
-            // No special ui implementation - use a generic one:
-            if let Some(value) = component.lookup_arrow(instance_key) {
-                let bytes = arrow2::compute::aggregate::estimated_bytes_size(value.as_ref());
-                if bytes < 256 {
-                    // For small items, print them
-                    let mut repr = String::new();
-                    let display = arrow2::array::get_display(value.as_ref(), "null");
-                    display(&mut repr, 0).unwrap();
-                    ui.label(repr);
-                } else {
-                    ui.label(format!("{bytes} bytes"));
-                }
-            } else {
-                ui.weak("(null)");
-            }
-        }
+        let ui_callback = self
+            .components
+            .get(&component.name())
+            .unwrap_or(&self.fallback_ui);
+        (*ui_callback)(
+            ctx,
+            ui,
+            verbosity,
+            query,
+            entity_path,
+            component,
+            instance_key,
+        );
     }
 }

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -4,19 +4,23 @@
 
 mod app_options;
 mod caches;
+mod component_ui_registry;
 mod item;
 mod selection_history;
 mod selection_state;
 mod time_control;
+mod viewer_context;
 
 pub use app_options::AppOptions;
 pub use caches::{Cache, Caches};
+pub use component_ui_registry::{ComponentUiRegistry, UiVerbosity};
 pub use item::{Item, ItemCollection};
 pub use selection_history::SelectionHistory;
 pub use selection_state::{
     HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
 };
 pub use time_control::{Looping, PlayState, TimeControl, TimeView};
+pub use viewer_context::{RecordingConfig, ViewerContext};
 
 // ---------------------------------------------------------------------------
 

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -1,8 +1,8 @@
 use re_data_store::log_db::LogDb;
-use re_viewer_context::{AppOptions, Caches, Item, ItemCollection, SelectionState, TimeControl};
 
-// TODO(andreas): Either viewer_context independent of these or move to re_viewer_context crate.
-use crate::ui::data_ui::ComponentUiRegistry;
+use crate::{
+    AppOptions, Caches, ComponentUiRegistry, Item, ItemCollection, SelectionState, TimeControl,
+};
 
 /// Common things needed by many parts of the viewer.
 pub struct ViewerContext<'a> {


### PR DESCRIPTION
Yet another part of:
* #1873 

This is a major milestone: We now can move out more crates out of re_viewer that only depend on the viewer context.

Sadly, this introduces a gui dependency to `re_viewer_context` that I wanted to avoid, but I couldn't figure out how to do that. It gets quite complex. But I opted to at least have _almost_ zero ui setup code in `re_viewer_context`

Next step is now to move the `data_ui` folder to a separate crate. If I'm not mistaken this should be very easy now
Next step after that is to move the timeline to a separate crate which should in turn be then quite easy 🤞 

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2047
