### PR TITLE
Fix incorrect 2D camera for scenes with negative 2D coordinates

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/ui_2d.rs
@@ -413,7 +413,8 @@ fn setup_target_config(
     // For simplicity (and to reduce surprises!) we always render with a pinhole camera.
     // Make up a default pinhole camera if we don't have one placing it in a way to look at the entire space.
     let canvas_size = glam::vec2(canvas_from_ui.to().width(), canvas_from_ui.to().height());
-    let default_principal_point = canvas_size * 0.5;
+    let default_principal_point = canvas_from_ui.to().center();
+    let default_principal_point = glam::vec2(default_principal_point.x, default_principal_point.y);
     let pinhole = pinhole.unwrap_or_else(|| {
         let focal_length_in_pixels = canvas_size.x;
 


### PR DESCRIPTION
Caused this bug
![image](https://user-images.githubusercontent.com/1220815/236405360-b7568093-f5a6-431d-ba06-2c06c0bab633.png)

when it should be

![image](https://user-images.githubusercontent.com/1220815/236405343-72781a47-5e40-4b6c-91c0-fceb61b410f7.png)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2051
