### PR TITLE
Depth offset for lines & points

### DIFF
--- a/crates/re_renderer/shader/lines.wgsl
+++ b/crates/re_renderer/shader/lines.wgsl
@@ -5,6 +5,7 @@
 #import <./utils/flags.wgsl>
 #import <./utils/size.wgsl>
 #import <./utils/srgb.wgsl>
+#import <./utils/depth_offset.wgsl>
 
 @group(1) @binding(0)
 var line_strip_texture: texture_2d<f32>;
@@ -28,6 +29,7 @@ struct BatchUniformBuffer {
     world_from_obj: Mat4,
     outline_mask_ids: UVec2,
     picking_layer_object_id: UVec2,
+    depth_offset: f32,
 };
 @group(2) @binding(0)
 var<uniform> batch: BatchUniformBuffer;
@@ -262,7 +264,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 
     // Output, transform to projection space and done.
     var out: VertexOut;
-    out.position = frame.projection_from_world * Vec4(pos, 1.0);
+    out.position = apply_depth_offset(frame.projection_from_world * Vec4(pos, 1.0), batch.depth_offset);
     out.position_world = pos;
     out.center_position = center_position;
     out.round_cap_circle_center = round_cap_circle_center;

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -4,6 +4,7 @@
 #import <./utils/flags.wgsl>
 #import <./utils/size.wgsl>
 #import <./utils/sphere_quad.wgsl>
+#import <./utils/depth_offset.wgsl>
 
 @group(1) @binding(0)
 var position_data_texture: texture_2d<f32>;
@@ -26,7 +27,8 @@ var<uniform> draw_data: DrawDataUniformBuffer;
 struct BatchUniformBuffer {
     world_from_obj: Mat4,
     flags: u32,
-    _padding: UVec2, // UVec3 would take its own 4xf32 row, UVec2 is on the same as flags
+    depth_offset: f32,
+    _padding: UVec2,
     outline_mask: UVec2,
     picking_layer_object_id: UVec2,
 };
@@ -101,7 +103,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 
     // Output, transform to projection space and done.
     var out: VertexOut;
-    out.position = frame.projection_from_world * Vec4(quad.pos_in_world, 1.0);
+    out.position = apply_depth_offset(frame.projection_from_world * Vec4(quad.pos_in_world, 1.0), batch.depth_offset);
     out.color = point_data.color;
     out.radius = quad.point_resolved_radius;
     out.world_position = quad.pos_in_world;

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -5,8 +5,8 @@ use crate::{
     renderer::{
         LineBatchInfo, LineDrawData, LineDrawDataError, LineStripFlags, LineStripInfo, LineVertex,
     },
-    Color32, DebugLabel, OutlineMaskPreference, PickingLayerInstanceId, PickingLayerObjectId,
-    RenderContext, Size,
+    Color32, DebugLabel, DepthOffset, OutlineMaskPreference, PickingLayerInstanceId,
+    PickingLayerObjectId, RenderContext, Size,
 };
 
 /// Builder for a vector of line strips, making it easy to create [`crate::renderer::LineDrawData`].
@@ -70,6 +70,7 @@ impl LineStripSeriesBuilder {
             overall_outline_mask_ids: OutlineMaskPreference::NONE,
             additional_outline_mask_ids_vertex_ranges: Vec::new(),
             picking_object_id: PickingLayerObjectId::default(),
+            depth_offset: 0,
         });
 
         LineBatchBuilder(self)
@@ -160,6 +161,13 @@ impl<'a> LineBatchBuilder<'a> {
     /// Sets the picking object id for every element in the batch.
     pub fn picking_object_id(mut self, picking_object_id: PickingLayerObjectId) -> Self {
         self.batch_mut().picking_object_id = picking_object_id;
+        self
+    }
+
+    /// Sets the depth offset for the entire batch.
+    #[inline]
+    pub fn depth_offset(mut self, depth_offset: DepthOffset) -> Self {
+        self.batch_mut().depth_offset = depth_offset;
         self
     }
 

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -5,7 +5,8 @@ use crate::{
         PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudDrawDataError,
         PointCloudVertex,
     },
-    Color32, DebugLabel, OutlineMaskPreference, PickingLayerInstanceId, RenderContext, Size,
+    Color32, DebugLabel, DepthOffset, OutlineMaskPreference, PickingLayerInstanceId, RenderContext,
+    Size,
 };
 
 /// Builder for point clouds, making it easy to create [`crate::renderer::PointCloudDrawData`].
@@ -69,6 +70,7 @@ impl PointCloudBuilder {
             overall_outline_mask_ids: OutlineMaskPreference::NONE,
             additional_outline_mask_ids_vertex_ranges: Vec::new(),
             picking_object_id: Default::default(),
+            depth_offset: 0,
         });
 
         PointCloudBatchBuilder(self)
@@ -137,6 +139,13 @@ impl<'a> PointCloudBatchBuilder<'a> {
     #[inline]
     pub fn outline_mask_ids(mut self, outline_mask_ids: OutlineMaskPreference) -> Self {
         self.batch_mut().overall_outline_mask_ids = outline_mask_ids;
+        self
+    }
+
+    /// Sets the depth offset for the entire batch.
+    #[inline]
+    pub fn depth_offset(mut self, depth_offset: DepthOffset) -> Self {
+        self.batch_mut().depth_offset = depth_offset;
         self
     }
 

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -121,8 +121,8 @@ use crate::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
         GpuRenderPipelineHandle, PipelineLayoutDesc, PoolError, RenderPipelineDesc, TextureDesc,
     },
-    Color32, DebugLabel, LineStripSeriesBuilder, OutlineMaskPreference, PickingLayerObjectId,
-    PickingLayerProcessor,
+    Color32, DebugLabel, DepthOffset, LineStripSeriesBuilder, OutlineMaskPreference,
+    PickingLayerObjectId, PickingLayerProcessor,
 };
 
 use super::{
@@ -174,7 +174,9 @@ pub mod gpu_data {
         pub outline_mask_ids: wgpu_buffer_types::UVec2,
         pub picking_object_id: PickingLayerObjectId,
 
-        pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 5],
+        pub depth_offset: wgpu_buffer_types::F32RowPadded,
+
+        pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 6],
     }
 }
 
@@ -272,6 +274,9 @@ pub struct LineBatchInfo {
 
     /// Picking object id that applies for the entire batch.
     pub picking_object_id: PickingLayerObjectId,
+
+    /// Depth offset applied after projection.
+    pub depth_offset: DepthOffset,
 }
 
 /// Style information for a line strip.
@@ -368,6 +373,7 @@ impl LineDrawData {
                 overall_outline_mask_ids: OutlineMaskPreference::NONE,
                 picking_object_id: PickingLayerObjectId::default(),
                 additional_outline_mask_ids_vertex_ranges: Vec::new(),
+                depth_offset: 0,
             }]
         } else {
             batches
@@ -620,6 +626,7 @@ impl LineDrawData {
                             .unwrap_or_default()
                             .into(),
                         picking_object_id: batch_info.picking_object_id,
+                        depth_offset: (batch_info.depth_offset as f32).into(),
                         end_padding: Default::default(),
                     }),
             );
@@ -640,6 +647,7 @@ impl LineDrawData {
                                     world_from_obj: batch_info.world_from_obj.into(),
                                     outline_mask_ids: mask.0.unwrap_or_default().into(),
                                     picking_object_id: batch_info.picking_object_id,
+                                    depth_offset: (batch_info.depth_offset as f32).into(),
                                     end_padding: Default::default(),
                                 })
                         })

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -75,7 +75,7 @@ mod gpu_data {
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 1],
     }
 
-    /// Uniform buffer that changes for every 1 of points.
+    /// Uniform buffer that changes for every batch of points.
     #[repr(C, align(256))]
     #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct BatchUniformBuffer {
@@ -83,7 +83,7 @@ mod gpu_data {
 
         pub flags: u32, // PointCloudBatchFlags
         pub depth_offset: f32,
-        pub padding: [f32; 2],
+        pub _row_padding: [f32; 2],
 
         pub outline_mask_ids: wgpu_buffer_types::UVec2,
         pub picking_object_id: PickingLayerObjectId,
@@ -417,7 +417,7 @@ impl PointCloudDrawData {
                         picking_object_id: batch_info.picking_object_id,
                         depth_offset: batch_info.depth_offset as f32,
 
-                        padding: [0.0, 0.0],
+                        _row_padding: [0.0, 0.0],
                         end_padding: Default::default(),
                     }),
             );
@@ -441,7 +441,7 @@ impl PointCloudDrawData {
                                     picking_object_id: batch_info.picking_object_id,
                                     depth_offset: batch_info.depth_offset as f32,
 
-                                    padding: [0.0, 0.0],
+                                    _row_padding: [0.0, 0.0],
                                     end_padding: Default::default(),
                                 })
                         })

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -18,7 +18,7 @@ use std::{num::NonZeroU64, ops::Range};
 use crate::{
     allocator::create_and_fill_uniform_buffer_batch,
     draw_phases::{DrawPhase, OutlineMaskProcessor, PickingLayerObjectId, PickingLayerProcessor},
-    include_shader_module, DebugLabel, OutlineMaskPreference, PointCloudBuilder,
+    include_shader_module, DebugLabel, DepthOffset, OutlineMaskPreference, PointCloudBuilder,
 };
 use bitflags::bitflags;
 use bytemuck::Zeroable as _;
@@ -75,12 +75,16 @@ mod gpu_data {
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 1],
     }
 
-    /// Uniform buffer that changes for every batch of points.
+    /// Uniform buffer that changes for every 1 of points.
     #[repr(C, align(256))]
     #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct BatchUniformBuffer {
         pub world_from_obj: wgpu_buffer_types::Mat4,
-        pub flags: wgpu_buffer_types::U32RowPadded, // PointCloudBatchFlags
+
+        pub flags: u32, // PointCloudBatchFlags
+        pub depth_offset: f32,
+        pub padding: [f32; 2],
+
         pub outline_mask_ids: wgpu_buffer_types::UVec2,
         pub picking_object_id: PickingLayerObjectId,
 
@@ -141,6 +145,9 @@ pub struct PointCloudBatchInfo {
 
     /// Picking object id that applies for the entire batch.
     pub picking_object_id: PickingLayerObjectId,
+
+    /// Depth offset applied after projection.
+    pub depth_offset: DepthOffset,
 }
 
 /// Description of a point cloud.
@@ -209,6 +216,7 @@ impl PointCloudDrawData {
             overall_outline_mask_ids: OutlineMaskPreference::NONE,
             additional_outline_mask_ids_vertex_ranges: Vec::new(),
             picking_object_id: Default::default(),
+            depth_offset: 0,
         }];
         let batches = if batches.is_empty() {
             &fallback_batches
@@ -400,14 +408,17 @@ impl PointCloudDrawData {
                     .iter()
                     .map(|batch_info| gpu_data::BatchUniformBuffer {
                         world_from_obj: batch_info.world_from_obj.into(),
-                        flags: batch_info.flags.bits.into(),
+                        flags: batch_info.flags.bits,
                         outline_mask_ids: batch_info
                             .overall_outline_mask_ids
                             .0
                             .unwrap_or_default()
                             .into(),
-                        end_padding: Default::default(),
                         picking_object_id: batch_info.picking_object_id,
+                        depth_offset: batch_info.depth_offset as f32,
+
+                        padding: [0.0, 0.0],
+                        end_padding: Default::default(),
                     }),
             );
 
@@ -425,10 +436,13 @@ impl PointCloudDrawData {
                                 .iter()
                                 .map(|(_, mask)| gpu_data::BatchUniformBuffer {
                                     world_from_obj: batch_info.world_from_obj.into(),
-                                    flags: batch_info.flags.bits.into(),
+                                    flags: batch_info.flags.bits,
                                     outline_mask_ids: mask.0.unwrap_or_default().into(),
-                                    end_padding: Default::default(),
                                     picking_object_id: batch_info.picking_object_id,
+                                    depth_offset: batch_info.depth_offset as f32,
+
+                                    padding: [0.0, 0.0],
+                                    end_padding: Default::default(),
                                 })
                         })
                         .collect::<Vec<_>>()


### PR DESCRIPTION
Adds depth offset to lines and points on re_renderer

https://user-images.githubusercontent.com/1220815/236430807-03c87988-2ccd-4fdd-988f-411506409cd1.mov


Known issue: Doesn't work well with 2D in 3D, see #1025 


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2052
