### PR TITLE
Fix twice as wide alpha-to-coverage edge on circles, leading to artifacts

### DIFF
--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -120,8 +120,8 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 /// perspective projection is not taken into account.
 fn circle_quad_coverage(world_position: Vec3, radius: f32, circle_center: Vec3) -> f32 {
     let distance = distance(circle_center, world_position);
-    let distance_pixel_difference = fwidth(distance) * 0.5;
-    return smoothstep(radius + distance_pixel_difference, radius - distance_pixel_difference, distance);
+    let feathering_radius = fwidth(distance) * 0.5;
+    return smoothstep(radius + feathering_radius, radius - feathering_radius, distance);
 }
 
 fn coverage(world_position: Vec3, radius: f32, point_center: Vec3) -> f32 {

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -119,9 +119,8 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 /// 2D primitives are always facing the camera - the difference to sphere_quad_coverage is that
 /// perspective projection is not taken into account.
 fn circle_quad_coverage(world_position: Vec3, radius: f32, circle_center: Vec3) -> f32 {
-    let to_center = circle_center - world_position;
-    let distance = length(to_center);
-    let distance_pixel_difference = fwidth(distance);
+    let distance = distance(circle_center, world_position);
+    let distance_pixel_difference = fwidth(distance) * 0.5;
     return smoothstep(radius + distance_pixel_difference, radius - distance_pixel_difference, distance);
 }
 


### PR DESCRIPTION
Before:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/1220815/236432886-3b20d799-f919-4ff6-86a3-3cb34f61c04f.png">

After:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/1220815/236433260-60943cef-8d6f-4ce4-8244-b92c3d543f1c.png">



Regression since MSAA for circles was handled like for spheres in 0.5

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2053
