### PR TITLE
`run_all.py`: add `--fast`, `--separate`, and `--close`

### DIFF
--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -64,17 +64,17 @@ def collect_examples(fast: bool) -> List[str]:
 
 
 class Viewer:
-    port: int
     should_close: bool
     web: bool
+    sdk_port: int
     web_viewer_port: int
     ws_server_port: int
     process: Optional[Any]
 
     def __init__(self, close: bool = False, web: bool = False):
-        self.port = get_free_port()
         self.should_close = close
         self.web = web
+        self.sdk_port = get_free_port()
         self.web_viewer_port = get_free_port()
         self.ws_server_port = get_free_port()
         self.process = None
@@ -85,7 +85,7 @@ class Viewer:
         self.process = None
 
     def start(self) -> "Viewer":
-        args = ["--port", str(self.port)]
+        args = ["--port", str(self.sdk_port)]
         if self.web:
             args += [
                 "--web-viewer",
@@ -132,7 +132,7 @@ def run_web(examples: List[str], separate: bool) -> None:
     if not separate:
         with Viewer(close=True, web=True) as viewer:
             for path in examples:
-                run_py_example(path, viewer_port=viewer.port)
+                run_py_example(path, viewer_port=viewer.sdk_port)
         return
 
     cleanup: List[Tuple[Any, Any]] = []
@@ -140,7 +140,7 @@ def run_web(examples: List[str], separate: bool) -> None:
     for path in examples:
         # each example gets its own viewer
         viewer = Viewer(web=True).start()
-        example = run_py_example(path, viewer_port=viewer.port, wait=False)
+        example = run_py_example(path, viewer_port=viewer.sdk_port, wait=False)
         cleanup.append((viewer, example))
 
     # wait for all processes to finish, and close the viewers
@@ -153,7 +153,7 @@ def run_web(examples: List[str], separate: bool) -> None:
 def run_save(examples: List[str]) -> None:
     with Viewer(close=True) as viewer:  # ephemeral viewer that exists only while saving
         for example in examples:
-            run_py_example(example, viewer_port=viewer.port, save="out.rrd")
+            run_py_example(example, viewer_port=viewer.sdk_port, save="out.rrd")
 
 
 def run_load(examples: List[str], separate: bool, close: bool) -> None:
@@ -180,7 +180,7 @@ def run_native(examples: List[str], separate: bool, close: bool) -> None:
         # run all examples sequentially in a single viewer
         with Viewer(close) as viewer:
             for path in examples:
-                run_py_example(path, viewer_port=viewer.port, wait=True)
+                run_py_example(path, viewer_port=viewer.sdk_port, wait=True)
         return
 
     cleanup: List[Tuple[Any, Any]] = []
@@ -188,7 +188,7 @@ def run_native(examples: List[str], separate: bool, close: bool) -> None:
     for path in examples:
         # each example gets its own viewer
         viewer = Viewer().start()
-        example = run_py_example(path, viewer.port, False)
+        example = run_py_example(path, viewer.sdk_port, False)
         cleanup.append((viewer, example))
 
     # wait for all processes to finish, and close the viewers if requested

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -93,25 +93,8 @@ class Viewer:
                 f"--ws-server-port={self.ws_server_port}",
             ]
 
-        process = subprocess.Popen(
-            args,
-            bufsize=1,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-        )
-        assert process.stdout is not None
-
-        # wait for process to start
-        # we look for the message "Hosting a SDK server over TCP" in its standard output
-        started = False
-        while not started and process.poll() is None:
-            line = process.stdout.readline()
-            if "Hosting a SDK server over TCP" in line:
-                started = True
-            sys.stdout.write(line)
-
-        self.process = process
+        self.process = subprocess.Popen(args)
+        time.sleep(1)
         return self
 
     def __enter__(self) -> "Viewer":

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -13,10 +13,12 @@ from types import TracebackType
 from typing import Any, List, Optional, Tuple, Type
 
 
-def run_py_example(path: str, viewer_port: int, wait: bool = True, save: Optional[str] = None) -> Any:
-    args = ["python3", "main.py", "--num-frames=30", "--steps=200", "--connect", f"--addr=127.0.0.1:{viewer_port}"]
+def run_py_example(path: str, viewer_port: Optional[int] = None, wait: bool = True, save: Optional[str] = None) -> Any:
+    args = ["python3", "main.py", "--num-frames=30", "--steps=200", "--connect", f"--addr='127.0.0.1:{viewer_port}'"]
     if save is not None:
-        args.append(f"--save={save}")
+        args += [f"--save={save}"]
+    if viewer_port is not None:
+        args += ["--connect", f"--addr=127.0.0.1:{viewer_port}"]
 
     process = subprocess.Popen(args, cwd=path)
     if wait:
@@ -174,9 +176,8 @@ def run_web(examples: List[str], separate: bool) -> None:
 
 
 def run_save(examples: List[str]) -> None:
-    with Viewer(close=True) as viewer:  # ephemeral viewer that exists only while saving
-        for example in examples:
-            run_py_example(example, viewer_port=viewer.sdk_port, save="out.rrd")
+    for example in examples:
+        run_py_example(example, save="out.rrd")
 
 
 def run_load(examples: List[str], separate: bool, close: bool) -> None:

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -14,7 +14,7 @@ from typing import Any, List, Optional, Tuple, Type
 
 
 def run_py_example(path: str, viewer_port: Optional[int] = None, wait: bool = True, save: Optional[str] = None) -> Any:
-    args = ["python3", "main.py", "--num-frames=30", "--steps=200", "--connect", f"--addr='127.0.0.1:{viewer_port}'"]
+    args = ["python3", "main.py", "--num-frames=30", "--steps=200"]
     if save is not None:
         args += [f"--save={save}"]
     if viewer_port is not None:
@@ -136,13 +136,23 @@ def run_sdk_build() -> None:
             "--manifest-path",
             "rerun_py/Cargo.toml",
             '--extras="tests"',
+            "--quiet",
         ],
     ).wait()
     assert returncode == 0, f"process exited with error code {returncode}"
 
 
 def run_viewer_build() -> None:
-    returncode = subprocess.Popen(["cargo", "build", "-p", "rerun", "--all-features"]).wait()
+    returncode = subprocess.Popen(
+        [
+            "cargo",
+            "build",
+            "-p",
+            "rerun",
+            "--all-features",
+            "--quiet",
+        ]
+    ).wait()
     assert returncode == 0, f"process exited with error code {returncode}"
 
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -23,7 +23,7 @@ def run_py_example(path: str, viewer_port: int, wait: bool = True, save: Optiona
     )
     if wait:
         returncode = process.wait()
-        print(f"process exited with error code {returncode}")
+        assert returncode == 0, f"process exited with error code {returncode}"
     return process
 
 
@@ -34,7 +34,7 @@ def run_saved_example(path: str, wait: bool = True) -> Any:
     )
     if wait:
         returncode = process.wait()
-        print(f"process exited with error code {returncode}")
+        assert returncode == 0, f"process exited with error code {returncode}"
     return process
 
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -66,9 +66,9 @@ def collect_examples(fast: bool) -> List[str]:
 class Viewer:
     should_close: bool
     web: bool
-    sdk_port: int
-    web_viewer_port: int
-    ws_server_port: int
+    sdk_port: int  # where the logging SDK sends the log stream (where the server receives)
+    web_viewer_port: int  # the HTTP port where we serve the web viewer
+    ws_server_port: int  # the WebSocket port where we serve the log stream
     process: Optional[Any]
 
     def __init__(self, close: bool = False, web: bool = False):

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -122,6 +122,7 @@ class Viewer:
 
 
 def run_sdk_build() -> None:
+    print("Building Python SDK…")
     returncode = subprocess.Popen(
         [
             "maturin",
@@ -136,6 +137,7 @@ def run_sdk_build() -> None:
 
 
 def run_viewer_build() -> None:
+    print("Building rerun…")
     returncode = subprocess.Popen(
         [
             "cargo",

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -48,15 +48,15 @@ def collect_examples(fast: bool) -> List[str]:
     if fast:
         # cherry picked
         return [
-            "examples/python/deep_sdf",
-            "examples/python/dicom",
-            "examples/python/raw_mesh",
-            "examples/python/clock",
             "examples/python/api_demo",
             "examples/python/car",
+            "examples/python/clock",
             "examples/python/colmap",
-            "examples/python/plots",
+            "examples/python/deep_sdf",
+            "examples/python/dicom",
             "examples/python/nyud",
+            "examples/python/plots",
+            "examples/python/raw_mesh",
             "examples/python/text_logging",
         ]
     else:

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -13,14 +13,11 @@ from typing import Any, List, Optional, Tuple, Type
 
 
 def run_py_example(path: str, viewer_port: int, wait: bool = True, save: Optional[str] = None) -> Any:
-    args = ["--connect", "--addr", f"127.0.0.1:{viewer_port}"]
+    args = ["python3", "main.py", "--num-frames=30", "--steps=200", "--connect", f"--addr=127.0.0.1:{viewer_port}"]
     if save is not None:
-        args += ["--save", str(save)]
+        args.append(f"--save={save}")
 
-    process = subprocess.Popen(
-        ["python3", "main.py", "--num-frames=30", "--steps=200"] + args,
-        cwd=path,
-    )
+    process = subprocess.Popen(args, cwd=path)
     if wait:
         returncode = process.wait()
         assert returncode == 0, f"process exited with error code {returncode}"
@@ -85,20 +82,15 @@ class Viewer:
         self.process = None
 
     def start(self) -> "Viewer":
-        args = ["--port", str(self.sdk_port)]
+        args = ["./target/debug/rerun", f"--port={self.sdk_port}"]
         if self.web:
             args += [
                 "--web-viewer",
-                "--web-viewer-port",
-                str(self.web_viewer_port),
-                "--ws-server-port",
-                str(self.ws_server_port),
+                f"--web-viewer-port={self.web_viewer_port}",
+                f"--ws-server-port={self.ws_server_port}",
             ]
 
-        self.process = subprocess.Popen(
-            ["cargo", "run", "-p", "rerun", "--all-features", "--"] + args,
-            stdout=subprocess.PIPE,
-        )
+        self.process = subprocess.Popen(args, stdout=subprocess.PIPE)
         time.sleep(1)  # give it a moment to start
         return self
 
@@ -118,7 +110,13 @@ class Viewer:
 
 def run_sdk_build() -> None:
     returncode = subprocess.Popen(
-        ["maturin", "develop", "--manifest-path", "rerun_py/Cargo.toml", '--extras="tests"'],
+        [
+            "maturin",
+            "develop",
+            "--manifest-path",
+            "rerun_py/Cargo.toml",
+            '--extras="tests"',
+        ],
     ).wait()
     assert returncode == 0, f"process exited with error code {returncode}"
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -9,7 +9,7 @@ import subprocess
 import time
 from glob import glob
 from types import TracebackType
-from typing import Any, List, Optional, Tuple, Type, cast
+from typing import Any, List, Optional, Tuple, Type
 
 
 def run_py_example(path: str, viewer_port: int, wait: bool = True, save: Optional[str] = None) -> Any:
@@ -41,7 +41,7 @@ def run_saved_example(path: str, wait: bool = True) -> Any:
 def get_free_port() -> int:
     with socket.socket() as s:
         s.bind(("", 0))
-        return cast(int, s.getsockname()[1])
+        return int(s.getsockname()[1])
 
 
 def collect_examples(fast: bool) -> List[str]:

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -4,41 +4,117 @@
 
 import argparse
 import os
+import socket
 import subprocess
 import time
 from glob import glob
-from typing import Any, List
+from types import TracebackType
+from typing import Any, Callable, List, Optional, Tuple, Type, cast
 
 
-def run_py_example(path: str, args: List[str] = []) -> None:
+def run_py_example(path: str, viewer_port: int, wait: bool = True, save: Optional[str] = None) -> Any:
+    args = ["--connect", "--addr", f"127.0.0.1:{viewer_port}"]
+    if save is not None:
+        args += ["--save", str(save)]
+
     process = subprocess.Popen(
         ["python3", "main.py", "--num-frames=30", "--steps=200"] + args,
         cwd=path,
     )
-    returncode = process.wait()
-    print(f"process exited with error code {returncode}")
+    if wait:
+        returncode = process.wait()
+        print(f"process exited with error code {returncode}")
+    return process
 
 
-def run_saved_example(path: str, args: List[str] = []) -> None:
-    process = subprocess.Popen(
-        ["cargo", "run", "-p", "rerun", "--all-features", "--", "out.rrd"] + args,
-        cwd=path,
-    )
-    returncode = process.wait()
-    print(f"process exited with error code {returncode}")
-
-
-def collect_examples() -> List[str]:
-    return [os.path.dirname(entry) for entry in glob("examples/python/**/main.py")]
-
-
-def start_viewer(args: List[str] = []) -> Any:
+def run_saved_example(path: str, wait: bool = True) -> Any:
+    args = ["out.rrd"]
     process = subprocess.Popen(
         ["cargo", "run", "-p", "rerun", "--all-features", "--"] + args,
-        stdout=subprocess.PIPE,
+        cwd=path,
     )
-    time.sleep(1)  # give it a moment to start
+    if wait:
+        returncode = process.wait()
+        print(f"process exited with error code {returncode}")
     return process
+
+
+def get_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return cast(int, s.getsockname()[1])
+
+
+def collect_examples(fast: bool) -> List[str]:
+    if not fast:
+        return [os.path.dirname(entry) for entry in glob("examples/python/**/main.py")]
+    else:
+        # cherry picked
+        return [
+            "examples/python/deep_sdf",
+            "examples/python/dicom",
+            "examples/python/raw_mesh",
+            "examples/python/clock",
+            "examples/python/api_demo",
+            "examples/python/car",
+            "examples/python/colmap",
+            "examples/python/plots",
+            "examples/python/nyud",
+            "examples/python/text_logging",
+        ]
+
+
+class Viewer:
+    port: int
+    should_close: bool
+    web: bool
+    web_viewer_port: int
+    ws_server_port: int
+    process: Optional[Any]
+
+    def __init__(self, close: bool = False, web: bool = False):
+        self.port = get_free_port()
+        self.should_close = close
+        self.web = web
+        self.web_viewer_port = get_free_port()
+        self.ws_server_port = get_free_port()
+        self.process = None
+
+    def close(self) -> None:
+        if self.process is not None:
+            self.process.kill()
+        self.process = None
+
+    def start(self) -> "Viewer":
+        args = ["--port", str(self.port)]
+        if self.web:
+            args += [
+                "--web-viewer",
+                "--web-viewer-port",
+                str(self.web_viewer_port),
+                "--ws-server-port",
+                str(self.ws_server_port),
+            ]
+
+        self.process = subprocess.Popen(
+            ["cargo", "run", "-p", "rerun", "--all-features", "--"] + args,
+            stdout=subprocess.PIPE,
+        )
+        time.sleep(1)  # give it a moment to start
+        return self
+
+    def __enter__(self) -> "Viewer":
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        if self.process is not None and self.should_close:
+            self.process.kill()
 
 
 def run_build() -> None:
@@ -49,41 +125,91 @@ def run_build() -> None:
     assert returncode == 0, f"process exited with error code {returncode}"
 
 
+def run_web(examples: List[str], separate: bool) -> None:
+    if separate:
+        processes: List[Tuple[Any, Any]] = []
+        # start all examples in parallel
+        for path in examples:
+            # each example gets its own viewer
+            viewer = Viewer(web=True).start()
+            example = run_py_example(path, viewer_port=viewer.port, wait=False)
+            processes.append((viewer, example))
+        # wait for all processes to finish, and close the viewers
+        for process in processes:
+            viewer, example = process
+            example.wait()
+            viewer.close()
+    else:
+        with Viewer(close=True, web=True) as viewer:
+            for example in examples:
+                run_py_example(example, viewer_port=viewer.port)
+
+
+def run_separate_with(examples: List[str], close: bool, start_example: Callable[[str, int, bool], Any]) -> None:
+    processes: List[Tuple[Any, Any]] = []
+    # start all examples in parallel
+    for path in examples:
+        # each example gets its own viewer
+        viewer = Viewer().start()
+        example = start_example(path, viewer.port, False)
+        processes.append((viewer, example))
+    # wait for all examples to finish
+    for process in processes:
+        process[1].wait()
+    # close viewers if requested
+    if close:
+        for process in processes:
+            process[0].close()
+
+
+def run_save(examples: List[str], separate: bool, close: bool) -> None:
+    with Viewer(close=True) as viewer:  # ephemeral viewer that exists only while saving
+        for example in examples:
+            run_py_example(example, viewer_port=viewer.port, save="out.rrd")
+
+    if separate:
+        run_separate_with(examples, close, lambda path, viewer_port, wait: run_saved_example(path, wait))
+    else:
+        with Viewer(close) as viewer:
+            for example in examples:
+                run_saved_example(example)
+
+
+def run_native(examples: List[str], separate: bool, close: bool) -> None:
+    if separate:
+        run_separate_with(examples, close, run_py_example)
+    else:
+        with Viewer(close) as viewer:
+            for example in examples:
+                run_py_example(example, viewer_port=viewer.port)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Runs all examples.")
-    parser.add_argument("--skip-build", action="store_true", help="Skip building the Python SDK")
-    parser.add_argument("--web", action="store_true", help="Run all examples in a web viewer.")
+    parser.add_argument("--skip-build", action="store_true", help="Skip building the Python SDK.")
+    parser.add_argument("--web", action="store_true", help="Run examples in a web viewer.")
     parser.add_argument(
         "--save",
         action="store_true",
-        help="Run all examples, save them to disk as rrd, then view them natively.",
+        help="Run examples, save them to disk as rrd, then view them natively.",
     )
+    parser.add_argument("--fast", action="store_true", help="Run only examples which complete quickly.")
+    parser.add_argument("--separate", action="store_true", help="Run each example in a separate viewer.")
+    parser.add_argument("--close", action="store_true", help="Close the viewer after running all examples.")
 
     args = parser.parse_args()
 
-    examples = collect_examples()
+    examples = collect_examples(args.fast)
 
     if not args.skip_build:
         run_build()
 
     if args.web:
-        viewer = start_viewer(["--web-viewer"])
-        for example in examples:
-            run_py_example(example, ["--connect"])
-        viewer.kill()
+        run_web(examples, separate=args.separate)
     elif args.save:
-        viewer = start_viewer()
-        for example in examples:
-            run_py_example(example, ["--save", "out.rrd"])
-        viewer.kill()
-
-        for example in examples:
-            run_saved_example(example)
+        run_save(examples, separate=args.separate, close=args.close)
     else:
-        viewer = start_viewer()
-        for example in examples:
-            run_py_example(example)
-        viewer.kill()
+        run_native(examples, separate=args.separate, close=args.close)
 
 
 if __name__ == "__main__":

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -45,9 +45,7 @@ def get_free_port() -> int:
 
 
 def collect_examples(fast: bool) -> List[str]:
-    if not fast:
-        return [os.path.dirname(entry) for entry in glob("examples/python/**/main.py")]
-    else:
+    if fast:
         # cherry picked
         return [
             "examples/python/deep_sdf",
@@ -61,6 +59,8 @@ def collect_examples(fast: bool) -> List[str]:
             "examples/python/nyud",
             "examples/python/text_logging",
         ]
+    else:
+        return [os.path.dirname(entry) for entry in glob("examples/python/**/main.py")]
 
 
 class Viewer:


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

Fixes https://github.com/rerun-io/rerun/issues/1945

- Refactored the `run_all.py` script
- Added `--fast` flag which limits examples to just cherry-picked examples
- Added `--separate` flag which runs each example in a separate viewer
  - For `--web`, this opens a new tab for each example
  - For native/`--save`, this opens a new window for each example
- Added `--close` flag which closes all open viewers when the examples finish running

The refactoring mainly consisted of moving the viewer starting logic into a class which can be used as a context manager in a `with` statement. It also finds and uses free ports every time it's started, which makes running it much more consistent (no more `port already in use` warnings).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2054
