### PR TITLE
Detect, warn and gracefully handle corrupt cells in `lookup_arrow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,6 +4039,7 @@ dependencies = [
  "re_arrow_store",
  "re_data_store",
  "re_format",
+ "re_log",
  "re_log_types",
  "thiserror",
 ]

--- a/crates/re_query/Cargo.toml
+++ b/crates/re_query/Cargo.toml
@@ -28,6 +28,7 @@ polars = ["dep:polars-core", "re_arrow_store/polars"]
 re_arrow_store.workspace = true
 re_data_store.workspace = true
 re_format.workspace = true
+re_log.workspace = true
 re_log_types = { workspace = true, features = ["arrow_datagen"] }
 
 # External dependencies:

--- a/crates/re_query/src/entity_view.rs
+++ b/crates/re_query/src/entity_view.rs
@@ -111,7 +111,12 @@ impl ComponentWithInstances {
         };
 
         let arrow_ref = self.values.as_arrow_ref();
-        (arrow_ref.len() > offset).then(|| arrow_ref.slice(offset, 1))
+        (arrow_ref.len() > offset)
+            .then(|| arrow_ref.slice(offset, 1))
+            .or_else(|| {
+                re_log::error_once!("found corrupt cell -- mismatched number of instances");
+                None
+            })
     }
 
     /// Produce a `ComponentWithInstances` from native component types

--- a/crates/re_query/src/entity_view.rs
+++ b/crates/re_query/src/entity_view.rs
@@ -108,9 +108,10 @@ impl ComponentWithInstances {
         } else {
             // Otherwise binary search to find the offset of the instance
             keys.binary_search(&instance_key.0).ok()? as u32
-        };
+        } as usize;
 
-        Some(self.values.as_arrow_ref().slice(offset as _, 1))
+        let arrow_ref = self.values.as_arrow_ref();
+        (arrow_ref.len() > offset).then(|| arrow_ref.slice(offset, 1))
     }
 
     /// Produce a `ComponentWithInstances` from native component types

--- a/crates/re_query/src/entity_view.rs
+++ b/crates/re_query/src/entity_view.rs
@@ -107,8 +107,8 @@ impl ComponentWithInstances {
             0
         } else {
             // Otherwise binary search to find the offset of the instance
-            keys.binary_search(&instance_key.0).ok()? as u32
-        } as usize;
+            keys.binary_search(&instance_key.0).ok()?
+        };
 
         let arrow_ref = self.values.as_arrow_ref();
         (arrow_ref.len() > offset).then(|| arrow_ref.slice(offset, 1))


### PR DESCRIPTION
`lookup_arrow` called arrow's `slice` which is defined to panic on out of bounds slices.

example code that would create such an entity

```rust
    // And some points in front of the rectangle.
    MsgSender::new("2d_layering/points_between_top_and_middle")
        .with_timepoint(sim_time(1 as _))
        .with_component(
            &(0..256).map(|i| Point2D::new(...).collect::<Vec<_>>(),
        )?
        .with_component(&[DrawOrder(1.51)])?
        .send(rec_stream)?;
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2055
