### PR TITLE
Bugfix: allow hovered items to be clicked to set selection

### DIFF
--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -236,7 +236,9 @@ pub fn select_hovered_on_click(
 ) {
     if response.hovered() {
         selection_state.set_hovered(items.iter().cloned());
-    } else if response.clicked() {
+    }
+
+    if response.clicked() {
         if response.ctx.input(|i| i.modifiers.command) {
             selection_state.toggle_selection(selection_state.hovered().to_vec());
         } else {


### PR DESCRIPTION
Fixes a regression from: https://github.com/rerun-io/rerun/pull/2048

The new logic meant click was ignored since we would always hit the hover path of the if/else and never evaluate clicked.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2057
