### PR TITLE
Lazily send RecordingId

### DIFF
--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1096,6 +1096,21 @@ mod tests {
     }
 
     #[test]
+    fn lazy_recording_info() {
+        let rec_stream = RecordingStreamBuilder::new("lazy_recording_info")
+            .enabled(true)
+            .batcher_config(DataTableBatcherConfig::ALWAYS)
+            .buffered()
+            .unwrap();
+
+        let storage = rec_stream.memory();
+        let msgs = storage.take();
+
+        // Nothing should have been sent if we didn't log anything
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
     fn flush_hierarchy() {
         let (rec_stream, storage) = RecordingStreamBuilder::new("flush_hierarchy")
             .enabled(true)

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1133,17 +1133,7 @@ mod tests {
                 msgs
             };
 
-            // First message should be a set_recording_info resulting from the original sink swap
-            // to in-memory mode.
-            match msgs.pop().unwrap() {
-                LogMsg::BeginRecordingMsg(msg) => {
-                    assert!(msg.row_id != RowId::ZERO);
-                    similar_asserts::assert_eq!(rec_info, msg.info);
-                }
-                _ => panic!("expected BeginRecordingMsg"),
-            }
-
-            // The underlying batcher is never flushing: there's nothing else.
+            // The underlying batcher is never flushing. So there's nothing.
             assert!(msgs.pop().is_none());
         }
 
@@ -1158,6 +1148,16 @@ mod tests {
                 msgs.reverse();
                 msgs
             };
+
+            // First message should be a set_recording_info resulting from the original sink swap
+            // to in-memory mode.
+            match msgs.pop().unwrap() {
+                LogMsg::BeginRecordingMsg(msg) => {
+                    assert!(msg.row_id != RowId::ZERO);
+                    similar_asserts::assert_eq!(rec_info, msg.info);
+                }
+                _ => panic!("expected BeginRecordingMsg"),
+            }
 
             // The batched table itself, which was sent as a result of the explicit flush above.
             match msgs.pop().unwrap() {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -4,8 +4,8 @@ use ahash::HashMap;
 use crossbeam::channel::{Receiver, Sender};
 use re_log_types::{
     ApplicationId, DataRow, DataTable, DataTableBatcher, DataTableBatcherConfig,
-    DataTableBatcherError, LogMsg, RecordingId, RecordingInfo, RecordingSource, RecordingType,
-    Time, TimeInt, TimePoint, TimeType, Timeline, TimelineName,
+    DataTableBatcherError, LogMsg, RecordingId, RecordingInfo, RecordingSource, Time, TimeInt,
+    TimePoint, TimeType, Timeline, TimelineName,
 };
 
 use crate::sink::{LogSink, MemorySinkStorage};
@@ -53,7 +53,6 @@ pub struct RecordingStreamBuilder {
     batcher_config: Option<DataTableBatcherConfig>,
 
     is_official_example: bool,
-    recording_type: RecordingType,
 }
 
 impl RecordingStreamBuilder {
@@ -83,7 +82,6 @@ impl RecordingStreamBuilder {
 
             batcher_config: None,
             is_official_example,
-            recording_type: RecordingType::Data, // Default to data recording
         }
     }
 
@@ -138,12 +136,6 @@ impl RecordingStreamBuilder {
     #[doc(hidden)]
     pub fn is_official_example(mut self, is_official_example: bool) -> Self {
         self.is_official_example = is_official_example;
-        self
-    }
-
-    #[doc(hidden)]
-    pub fn blueprint(mut self) -> Self {
-        self.recording_type = RecordingType::Blueprint;
         self
     }
 
@@ -260,7 +252,6 @@ impl RecordingStreamBuilder {
             enabled,
             batcher_config,
             is_official_example,
-            recording_type,
         } = self;
 
         let enabled = enabled.unwrap_or_else(|| crate::decide_logging_enabled(default_enabled));
@@ -276,7 +267,6 @@ impl RecordingStreamBuilder {
             is_official_example,
             started: Time::now(),
             recording_source,
-            recording_type,
         };
 
         let batcher_config = batcher_config
@@ -359,8 +349,6 @@ impl RecordingStreamInner {
         sink: Box<dyn LogSink>,
     ) -> RecordingStreamResult<Self> {
         let batcher = DataTableBatcher::new(batcher_config)?;
-
-        // TODO(cmc): BeginRecordingMsg is a misnomer; it's idempotent.
 
         let (cmds_tx, cmds_rx) = crossbeam::channel::unbounded();
 


### PR DESCRIPTION
### What

Although the recording id is idempotent from a store perspective, it has a side-effect on the UI of switching to a new recording/blueprint. Not doing this until we send the first "real" message means we don't need the user to explicitly opt in/out during init, which was one of the pain-points of the blueprint API.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2058
