### PR TITLE
Show meshes and images with `rerun foo.obj bar.png`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,6 +4287,8 @@ dependencies = [
  "libc",
  "mimalloc",
  "parking_lot 0.12.1",
+ "puffin",
+ "rayon",
  "re_analytics",
  "re_build_build_info",
  "re_build_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ polars-core = "0.29"
 polars-lazy = "0.29"
 polars-ops = "0.29"
 puffin = "0.14"
+rayon = "1.7"
 rfd = { version = "0.11.3", default_features = false, features = [
   "xdg-portal",
 ] }

--- a/crates/re_log_types/src/component_types/tensor.rs
+++ b/crates/re_log_types/src/component_types/tensor.rs
@@ -776,13 +776,6 @@ pub enum TensorImageLoadError {
         expected: Vec<TensorDimension>,
         found: Vec<TensorDimension>,
     },
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[error("Unsupported file extension '{extension}' for file {path:?}")]
-    UnknownExtension {
-        extension: String,
-        path: std::path::PathBuf,
-    },
 }
 
 #[cfg(feature = "image")]

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -590,7 +590,7 @@ impl DataCellInner {
 // ----------------------------------------------------------------------------
 
 #[cfg(not(target_arch = "wasm32"))]
-/// Errors from [`MsgSender::from_file_path`]
+/// Errors from [`DataCell::from_file_path`]
 #[derive(thiserror::Error, Debug)]
 pub enum FromFileError {
     #[error(transparent)]

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -587,6 +587,95 @@ impl DataCellInner {
     }
 }
 
+// ----------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Errors from [`MsgSender::from_file_path`]
+#[derive(thiserror::Error, Debug)]
+pub enum FromFileError {
+    #[error(transparent)]
+    FileRead(#[from] std::io::Error),
+
+    #[error(transparent)]
+    DataCellError(#[from] crate::DataCellError),
+
+    #[cfg(feature = "image")]
+    #[error(transparent)]
+    TensorImageLoad(#[from] crate::component_types::TensorImageLoadError),
+
+    #[error("Unsupported file extension '{extension}' for file {path:?}. To load image files, make sure you compile with the 'image' feature")]
+    UnknownExtension {
+        extension: String,
+        path: std::path::PathBuf,
+    },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl DataCell {
+    /// Read the file at the given path.
+    ///
+    /// Supported file extensions are:
+    ///  * `glb`, `gltf`, `obj`: encoded meshes, leaving it to the viewer to decode
+    ///  * `jpg`, `jpeg`: encoded JPEG, leaving it to the viewer to decode. Requires the `image` feature.
+    ///  * `png` and other image formats: decoded here. Requires the `image` feature.
+    ///
+    /// All other extensions will return an error.
+    pub fn from_file_path(file_path: &std::path::Path) -> Result<Self, FromFileError> {
+        let extension = file_path
+            .extension()
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .to_string_lossy()
+            .to_string();
+
+        match extension.as_str() {
+            "glb" => Self::from_mesh_file_path(file_path, crate::MeshFormat::Glb),
+            "glft" => Self::from_mesh_file_path(file_path, crate::MeshFormat::Gltf),
+            "obj" => Self::from_mesh_file_path(file_path, crate::MeshFormat::Obj),
+
+            #[cfg(feature = "image")]
+            _ => {
+                // Assume and image (there are so many image extensions):
+                let tensor = crate::Tensor::from_image_file(file_path)?;
+                Ok(Self::try_from_native(std::iter::once(&tensor))?)
+            }
+
+            #[cfg(not(feature = "image"))]
+            _ => Err(FromFileError::UnknownExtension {
+                extension,
+                path: file_path.to_owned(),
+            }),
+        }
+    }
+
+    /// Read the mesh file at the given path.
+    ///
+    /// Supported file extensions are:
+    ///  * `glb`, `gltf`, `obj`: encoded meshes, leaving it to the viewer to decode
+    ///
+    /// All other extensions will return an error.
+    pub fn from_mesh_file_path(
+        file_path: &std::path::Path,
+        format: crate::MeshFormat,
+    ) -> Result<Self, FromFileError> {
+        let mesh = crate::EncodedMesh3D {
+            mesh_id: crate::MeshId::random(),
+            format,
+            bytes: std::fs::read(file_path)?.into(),
+            transform: [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0],
+            ],
+        };
+        let mesh = crate::Mesh3D::Encoded(mesh);
+        Ok(Self::try_from_native(std::iter::once(&mesh))?)
+    }
+}
+
+// ----------------------------------------------------------------------------
+
 #[test]
 fn data_cell_sizes() {
     use crate::{component_types::InstanceKey, Component as _};

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::component_types::DrawOrder;
 pub use self::component_types::{EncodedMesh3D, Mesh3D, MeshFormat, MeshId, RawMesh3D};
 pub use self::component_types::{Tensor, ViewCoordinates};
 pub use self::data::*;
-pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult, FromFileError};
+pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult};
 pub use self::data_row::{DataRow, DataRowError, DataRowResult, RowId};
 pub use self::data_table::{
     DataCellColumn, DataCellOptVec, DataTable, DataTableError, DataTableResult, EntityPathVec,
@@ -57,6 +57,9 @@ pub use self::time::{Duration, Time};
 pub use self::time_point::{TimeInt, TimePoint, TimeType, Timeline, TimelineName};
 pub use self::time_range::{TimeRange, TimeRangeF};
 pub use self::time_real::TimeReal;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::data_cell::FromFileError;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::data_table_batcher::{

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::component_types::DrawOrder;
 pub use self::component_types::{EncodedMesh3D, Mesh3D, MeshFormat, MeshId, RawMesh3D};
 pub use self::component_types::{Tensor, ViewCoordinates};
 pub use self::data::*;
-pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult};
+pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult, FromFileError};
 pub use self::data_row::{DataRow, DataRowError, DataRowResult, RowId};
 pub use self::data_table::{
     DataCellColumn, DataCellOptVec, DataTable, DataTableError, DataTableResult, EntityPathVec,

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -97,6 +97,16 @@ impl EntityPath {
         Self::from(parts)
     }
 
+    /// Treat the file path as one opaque string.
+    ///
+    /// The file path separators will NOT become splits in the new path.
+    /// The returned path will only have one part.
+    pub fn from_file_path(file_path: &std::path::Path) -> Self {
+        Self::new(vec![EntityPathPart::Index(crate::Index::String(
+            file_path.to_string_lossy().to_string(),
+        ))])
+    }
+
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &EntityPathPart> {
         self.path.iter()

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -101,7 +101,7 @@ impl EntityPath {
     ///
     /// The file path separators will NOT become splits in the new path.
     /// The returned path will only have one part.
-    pub fn from_file_path(file_path: &std::path::Path) -> Self {
+    pub fn from_file_path_as_single_string(file_path: &std::path::Path) -> Self {
         Self::new(vec![EntityPathPart::Index(crate::Index::String(
             file_path.to_string_lossy().to_string(),
         ))])

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -101,6 +101,7 @@ impl EntityPath {
     ///
     /// The file path separators will NOT become splits in the new path.
     /// The returned path will only have one part.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_file_path_as_single_string(file_path: &std::path::Path) -> Self {
         Self::new(vec![EntityPathPart::Index(crate::Index::String(
             file_path.to_string_lossy().to_string(),

--- a/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/buffer_pool.rs
@@ -60,7 +60,9 @@ impl GpuBufferPool {
     /// For more efficient allocation (faster, less fragmentation) you should sub-allocate buffers whenever possible
     /// either manually or using a higher level allocator.
     pub fn alloc(&self, device: &wgpu::Device, desc: &BufferDesc) -> GpuBuffer {
+        crate::profile_function!();
         self.pool.alloc(desc, |desc| {
+            crate::profile_scope!("create_buffer");
             device.create_buffer(&wgpu::BufferDescriptor {
                 label: desc.label.get(),
                 size: desc.size,

--- a/crates/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
@@ -108,7 +108,10 @@ where
 
         // Otherwise create a new resource
         re_log::trace!(?desc, "Allocated new resource");
-        let inner_resource = creation_func(desc);
+        let inner_resource = {
+            crate::profile_scope!("creation_func");
+            creation_func(desc)
+        };
         self.total_resource_size_in_bytes.fetch_add(
             desc.resource_size_in_bytes(),
             std::sync::atomic::Ordering::Relaxed,

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -1,4 +1,4 @@
-use re_log_types::{component_types::InstanceKey, DataRow, DataTableError, RowId};
+use re_log_types::{component_types::InstanceKey, DataRow, DataTableError, RecordingId, RowId};
 
 use crate::{
     log::DataCell,
@@ -328,6 +328,19 @@ impl MsgSender {
         }
 
         Ok(())
+    }
+
+    /// Turns the current message into a single [`re_log_types::LogMsg`]
+    pub fn into_log_msg(
+        self,
+        recording_id: RecordingId,
+    ) -> Result<re_log_types::LogMsg, DataTableError> {
+        let data_table = re_log_types::DataTable::from_rows(
+            re_log_types::TableId::random(),
+            self.into_rows().into_iter().flatten(),
+        );
+        let arrow_msg = data_table.to_arrow_msg()?;
+        Ok(re_log_types::LogMsg::ArrowMsg(recording_id, arrow_msg))
     }
 
     fn into_rows(self) -> [Option<DataRow>; 2] {

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -188,7 +188,17 @@ impl MsgSender {
         self.with_cell(cell)
     }
 
-    fn with_cell(mut self, cell: DataCell) -> Result<MsgSender, MsgSenderError> {
+    /// Appends a component collection to the current message.
+    ///
+    /// All component collections stored in the message must have the same row-length (i.e. number
+    /// of instances)!
+    /// The row-length of the first appended collection is used as ground truth.
+    ///
+    /// ⚠ This can only be called once per type of component!
+    /// The SDK does not yet support batch insertions, which are semantically identical to adding
+    /// the same component type multiple times in a single message.
+    /// Doing so will return an error when trying to `send()` the message.
+    pub fn with_cell(mut self, cell: DataCell) -> Result<MsgSender, MsgSenderError> {
         let num_instances = cell.num_instances();
 
         if let Some(cur_num_instances) = self.num_instances {

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -113,7 +113,7 @@ impl MsgSender {
     pub fn from_file_path(
         file_path: &std::path::Path,
     ) -> Result<Self, re_log_types::FromFileError> {
-        let ent_path = re_log_types::EntityPath::from_file_path(file_path);
+        let ent_path = re_log_types::EntityPath::from_file_path_as_single_string(file_path);
         let cell = DataCell::from_file_path(file_path)?;
         Ok(Self {
             num_instances: Some(cell.num_instances()),

--- a/crates/re_smart_channel/src/lib.rs
+++ b/crates/re_smart_channel/src/lib.rs
@@ -14,6 +14,7 @@ pub use crossbeam::channel::{RecvError, RecvTimeoutError, SendError, TryRecvErro
 pub enum Source {
     /// The source is one or more files on disk.
     /// This could be `.rrd` files, or `.glb`, `.png`, …
+    // TODO(#2121): Remove this
     Files { paths: Vec<std::path::PathBuf> },
 
     /// Streaming an `.rrd` file over http.

--- a/crates/re_smart_channel/src/lib.rs
+++ b/crates/re_smart_channel/src/lib.rs
@@ -13,7 +13,7 @@ pub use crossbeam::channel::{RecvError, RecvTimeoutError, SendError, TryRecvErro
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Source {
     /// The source is one or more files on disk.
-    /// This could be `.rrf` files, or `.glb`, `.png`, …
+    /// This could be `.rrd` files, or `.glb`, `.png`, …
     Files { paths: Vec<std::path::PathBuf> },
 
     /// Streaming an `.rrd` file over http.

--- a/crates/re_smart_channel/src/lib.rs
+++ b/crates/re_smart_channel/src/lib.rs
@@ -12,8 +12,9 @@ pub use crossbeam::channel::{RecvError, RecvTimeoutError, SendError, TryRecvErro
 /// Where is the messages coming from?
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Source {
-    /// The source if a file on disk
-    File { path: std::path::PathBuf },
+    /// The source is one or more files on disk.
+    /// This could be `.rrf` files, or `.glb`, `.png`, …
+    Files { paths: Vec<std::path::PathBuf> },
 
     /// Streaming an `.rrd` file over http.
     RrdHttpStream { url: String },
@@ -41,7 +42,7 @@ pub enum Source {
 impl Source {
     pub fn is_network(&self) -> bool {
         match self {
-            Self::File { .. } | Self::Sdk | Self::RrdWebEventListener => false,
+            Self::Files { .. } | Self::Sdk | Self::RrdWebEventListener => false,
             Self::RrdHttpStream { .. } | Self::WsClient { .. } | Self::TcpServer { .. } => true,
         }
     }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -638,8 +638,13 @@ fn wait_screen_ui(ui: &mut egui::Ui, rx: &Receiver<LogMsg>) {
         }
 
         match rx.source() {
-            re_smart_channel::Source::File { path } => {
-                ui.strong(format!("Loading {}…", path.display()));
+            re_smart_channel::Source::Files { paths } => {
+                ui.strong(format!(
+                    "Loading {}…",
+                    paths
+                        .iter()
+                        .format_with(", ", |path, f| f(&format_args!("{}", path.display())))
+                ));
             }
             re_smart_channel::Source::RrdHttpStream { url } => {
                 ui.strong(format!("Loading {url}…"));
@@ -1904,7 +1909,9 @@ fn load_file_path(path: &std::path::Path) -> Option<LogDb> {
     match load_file_path_impl(path) {
         Ok(mut new_log_db) => {
             re_log::info!("Loaded {path:?}");
-            new_log_db.data_source = Some(re_smart_channel::Source::File { path: path.into() });
+            new_log_db.data_source = Some(re_smart_channel::Source::Files {
+                paths: vec![path.into()],
+            });
             Some(new_log_db)
         }
         Err(err) => {
@@ -1924,7 +1931,9 @@ fn load_file_contents(name: &str, read: impl std::io::Read) -> Option<LogDb> {
     match load_rrd_to_log_db(read) {
         Ok(mut log_db) => {
             re_log::info!("Loaded {name:?}");
-            log_db.data_source = Some(re_smart_channel::Source::File { path: name.into() });
+            log_db.data_source = Some(re_smart_channel::Source::Files {
+                paths: vec![name.into()],
+            });
             Some(log_db)
         }
         Err(err) => {
@@ -1957,7 +1966,7 @@ fn new_recording_confg(
     let play_state = match data_source {
         // Play files from the start by default - it feels nice and alive./
         // RrdHttpStream downloads the whole file before decoding it, so we treat it the same as a file.
-        re_smart_channel::Source::File { .. }
+        re_smart_channel::Source::Files { .. }
         | re_smart_channel::Source::RrdHttpStream { .. }
         | re_smart_channel::Source::RrdWebEventListener => PlayState::Playing,
 

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -182,7 +182,7 @@ impl ViewerAnalytics {
 
         if let Some(data_source) = &log_db.data_source {
             let data_source = match data_source {
-                re_smart_channel::Source::File { .. } => "file", // .rrd
+                re_smart_channel::Source::Files { .. } => "file", // .rrd, .png, .glb, …
                 re_smart_channel::Source::RrdHttpStream { .. } => "http",
                 re_smart_channel::Source::RrdWebEventListener { .. } => "web_event",
                 re_smart_channel::Source::Sdk => "sdk", // show()

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -50,7 +50,7 @@ glam = ["re_sdk?/glam"]
 global_session = ["re_sdk?/global_session"]
 
 ## Integration with the [`image`](https://crates.io/crates/image/) crate.
-image = ["re_log_types/image"]
+image = ["re_log_types/image", "re_sdk?/image"]
 
 ## Support spawning a native viewer.
 ## This adds a lot of extra dependencies, so only enable this feature if you need it!

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -105,8 +105,10 @@ webbrowser = { version = "0.8", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = "0.3"
 clap = { workspace = true, features = ["derive"] }
-mimalloc.workspace = true
 ctrlc.workspace = true
+mimalloc.workspace = true
+puffin.workspace = true
+rayon.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # Native unix dependencies:

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -326,7 +326,8 @@ async fn run_impl(
                         re_smart_channel::smart_channel(re_smart_channel::Source::Files {
                             paths: vec![path.clone()],
                         });
-                    let recording_id = re_log_types::RecordingId::random();
+                    let recording_id =
+                        re_log_types::RecordingId::random(re_log_types::RecordingType::Data);
                     load_file_to_channel_at(recording_id, &path, tx)
                         .with_context(|| format!("{path:?}"))?;
                     rx
@@ -386,7 +387,7 @@ async fn run_impl(
                 paths: paths.clone(),
             });
 
-            let recording_id = re_log_types::RecordingId::random();
+            let recording_id = re_log_types::RecordingId::random(re_log_types::RecordingType::Data);
 
             // Load the files in parallel, and log errors.
             // Failing to log one out of many files is not a big deal.

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -1,5 +1,6 @@
 use std::sync::{atomic::AtomicBool, Arc};
 
+use itertools::Itertools;
 use re_log_types::{LogMsg, PythonVersion};
 use re_smart_channel::Receiver;
 
@@ -96,11 +97,13 @@ struct Args {
     #[clap(long)]
     test_receive: bool,
 
-    /// Either a path to a `.rrd` file to load, an http url to an `.rrd` file,
+    /// Either: a path to `.rrd` file(s) to load,
+    /// some mesh or image files to show,
+    /// an http url to an `.rrd` file,
     /// or a websocket url to a Rerun Server from which to read data
     ///
     /// If none is given, a server will be hosted which the Rerun SDK can connect to.
-    url_or_path: Option<String>,
+    url_or_paths: Vec<String>,
 
     /// Print version and quit
     #[clap(long)]
@@ -305,50 +308,83 @@ async fn run_impl(
     let (shutdown_rx, shutdown_bool) = setup_ctrl_c_handler();
 
     // Where do we get the data from?
-    let rx = if let Some(url_or_path) = args.url_or_path.clone() {
-        match categorize_argument(url_or_path) {
-            ArgumentCategory::RrdHttpUrl(url) => {
-                re_log_encoding::stream_rrd_from_http::stream_rrd_from_http_to_channel(url)
-            }
-            ArgumentCategory::RrdFilePath(path) => {
-                re_log::info!("Loading {path:?}…");
-                load_file_to_channel(&path).with_context(|| format!("{path:?}"))?
-            }
-            ArgumentCategory::WebSocketAddr(rerun_server_ws_url) => {
-                // We are connecting to a server at a websocket address:
+    let rx = if !args.url_or_paths.is_empty() {
+        if 1 < args.url_or_paths.len() {
+            // Load many files:
+            let paths = args
+                .url_or_paths
+                .iter()
+                .map(std::path::PathBuf::from)
+                .collect_vec();
+            let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::Files {
+                paths: paths.clone(),
+            });
 
-                if args.web_viewer {
-                    #[cfg(feature = "web_viewer")]
-                    {
-                        let web_viewer = host_web_viewer(
-                            args.web_viewer_port,
-                            true,
+            let recording_id = re_log_types::RecordingId::random();
+
+            // Load the files in parallel, and log errors.
+            // Failing to log one out of many files is not a big deal.
+            for path in paths {
+                let tx = tx.clone();
+                let recording_id = recording_id.clone();
+                rayon::spawn(move || {
+                    if let Err(err) = load_file_to_channel_at(recording_id, &path, tx) {
+                        re_log::error!("Failed to load {path:?}: {err}");
+                    }
+                });
+            }
+            rx
+        } else {
+            match categorize_argument(args.url_or_paths[0].clone()) {
+                ArgumentCategory::RrdHttpUrl(url) => {
+                    re_log_encoding::stream_rrd_from_http::stream_rrd_from_http_to_channel(url)
+                }
+                ArgumentCategory::FilePath(path) => {
+                    let (tx, rx) =
+                        re_smart_channel::smart_channel(re_smart_channel::Source::Files {
+                            paths: vec![path.clone()],
+                        });
+                    let recording_id = re_log_types::RecordingId::random();
+                    load_file_to_channel_at(recording_id, &path, tx)
+                        .with_context(|| format!("{path:?}"))?;
+                    rx
+                }
+                ArgumentCategory::WebSocketAddr(rerun_server_ws_url) => {
+                    // We are connecting to a server at a websocket address:
+
+                    if args.web_viewer {
+                        #[cfg(feature = "web_viewer")]
+                        {
+                            let web_viewer = host_web_viewer(
+                                args.web_viewer_port,
+                                true,
+                                rerun_server_ws_url,
+                                shutdown_rx.resubscribe(),
+                            );
+                            // We return here because the running [`WebViewerServer`] is all we need.
+                            // The page we open will be pointed at a websocket url hosted by a *different* server.
+                            return web_viewer.await;
+                        }
+                        #[cfg(not(feature = "web_viewer"))]
+                        {
+                            _ = (rerun_server_ws_url, shutdown_rx);
+                            panic!("Can't host web-viewer - rerun was not compiled with the 'web_viewer' feature");
+                        }
+                    } else {
+                        #[cfg(feature = "native_viewer")]
+                        return native_viewer_connect_to_ws_url(
+                            _build_info,
+                            call_source.app_env(),
+                            startup_options,
+                            profiler,
                             rerun_server_ws_url,
-                            shutdown_rx.resubscribe(),
                         );
-                        // We return here because the running [`WebViewerServer`] is all we need.
-                        // The page we open will be pointed at a websocket url hosted by a *different* server.
-                        return web_viewer.await;
-                    }
-                    #[cfg(not(feature = "web_viewer"))]
-                    {
-                        _ = (rerun_server_ws_url, shutdown_rx);
-                        panic!("Can't host web-viewer - rerun was not compiled with the 'web_viewer' feature");
-                    }
-                } else {
-                    #[cfg(feature = "native_viewer")]
-                    return native_viewer_connect_to_ws_url(
-                        _build_info,
-                        call_source.app_env(),
-                        startup_options,
-                        profiler,
-                        rerun_server_ws_url,
-                    );
 
-                    #[cfg(not(feature = "native_viewer"))]
-                    {
-                        _ = (call_source, rerun_server_ws_url);
-                        anyhow::bail!("Can't start viewer - rerun was compiled without the 'native_viewer' feature");
+                        #[cfg(not(feature = "native_viewer"))]
+                        {
+                            _ = (call_source, rerun_server_ws_url);
+                            anyhow::bail!("Can't start viewer - rerun was compiled without the 'native_viewer' feature");
+                        }
                     }
                 }
             }
@@ -379,7 +415,7 @@ async fn run_impl(
         #[cfg(feature = "web_viewer")]
         {
             #[cfg(feature = "server")]
-            if args.url_or_path.is_none()
+            if args.url_or_paths.is_empty()
                 && (args.port == args.web_viewer_port.0 || args.port == args.ws_server_port.0)
             {
                 anyhow::bail!(
@@ -497,7 +533,7 @@ enum ArgumentCategory {
     RrdHttpUrl(String),
 
     /// A path to a local file.
-    RrdFilePath(std::path::PathBuf),
+    FilePath(std::path::PathBuf),
 
     /// A remote Rerun server.
     WebSocketAddr(String),
@@ -506,12 +542,12 @@ enum ArgumentCategory {
 fn categorize_argument(mut uri: String) -> ArgumentCategory {
     let path = std::path::Path::new(&uri).to_path_buf();
 
-    if uri.starts_with("http") {
+    if uri.starts_with("file://") || path.exists() {
+        ArgumentCategory::FilePath(path)
+    } else if uri.starts_with("http") {
         ArgumentCategory::RrdHttpUrl(uri)
     } else if uri.starts_with("ws") {
         ArgumentCategory::WebSocketAddr(uri)
-    } else if uri.starts_with("file://") || path.exists() || uri.ends_with(".rrd") {
-        ArgumentCategory::RrdFilePath(path)
     } else {
         // If this is sometyhing like `foo.com` we can't know what it is until we connect to it.
         // We could/should connect and see what it is, but for now we just take a wild guess instead:
@@ -547,33 +583,61 @@ fn native_viewer_connect_to_ws_url(
     Ok(())
 }
 
-fn load_file_to_channel(path: &std::path::Path) -> anyhow::Result<Receiver<LogMsg>> {
+fn load_file_to_channel_at(
+    recording_id: re_log_types::RecordingId,
+    path: &std::path::Path,
+    tx: re_smart_channel::Sender<LogMsg>,
+) -> Result<(), anyhow::Error> {
+    puffin::profile_function!(path.to_string_lossy());
+    re_log::info!("Loading {path:?}…");
+
+    let extension = path
+        .extension()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .to_string_lossy()
+        .to_string();
+
+    if extension == "rrd" {
+        load_rrd_file_to_channel(path.to_owned(), tx)
+    } else {
+        #[cfg(feature = "sdk")]
+        {
+            let log_msg = re_sdk::MsgSender::from_file_path(path)?.into_log_msg(recording_id)?;
+            tx.send(log_msg).ok();
+            Ok(())
+        }
+
+        #[cfg(not(feature = "sdk"))]
+        {
+            _ = recording_id;
+            anyhow::bail!("Unsupported file extension: '{extension}' for path {path:?}. Try enabvling the 'sdk' feature of 'rerun'.");
+        }
+    }
+}
+
+fn load_rrd_file_to_channel(
+    path: std::path::PathBuf,
+    tx: re_smart_channel::Sender<LogMsg>,
+) -> anyhow::Result<()> {
     use anyhow::Context as _;
-    let file = std::fs::File::open(path).context("Failed to open file")?;
+    let file = std::fs::File::open(&path).context("Failed to open file")?;
     let decoder = re_log_encoding::decoder::Decoder::new(file)?;
 
-    let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::File {
-        path: path.to_owned(),
-    });
-
-    let path = path.to_owned();
-    std::thread::Builder::new()
-        .name("rrd_file_reader".into())
-        .spawn(move || {
-            for msg in decoder {
-                match msg {
-                    Ok(msg) => {
-                        tx.send(msg).ok();
-                    }
-                    Err(err) => {
-                        re_log::warn_once!("Failed to decode message in {path:?}: {err}");
-                    }
+    rayon::spawn(move || {
+        for msg in decoder {
+            match msg {
+                Ok(msg) => {
+                    tx.send(msg).ok();
+                }
+                Err(err) => {
+                    re_log::warn_once!("Failed to decode message in {path:?}: {err}");
                 }
             }
-        })
-        .expect("Failed to spawn thread");
+        }
+    });
 
-    Ok(rx)
+    Ok(())
 }
 
 fn stream_to_rrd(

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -583,6 +583,7 @@ fn native_viewer_connect_to_ws_url(
     Ok(())
 }
 
+#[allow(clippy::needless-pass-by-value)] // false positive on some feature flags
 fn load_file_to_channel_at(
     recording_id: re_log_types::RecordingId,
     path: &std::path::Path,

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -311,7 +311,8 @@ async fn run_impl(
     let rx = if !args.url_or_paths.is_empty() {
         let arguments = args
             .url_or_paths
-            .into_iter()
+            .iter()
+            .cloned()
             .map(categorize_argument)
             .collect_vec();
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -583,7 +583,7 @@ fn native_viewer_connect_to_ws_url(
     Ok(())
 }
 
-#[allow(clippy::needless-pass-by-value)] // false positive on some feature flags
+#[allow(clippy::needless_pass_by_value)] // false positive on some feature flags
 fn load_file_to_channel_at(
     recording_id: re_log_types::RecordingId,
     path: &std::path::Path,

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -605,7 +605,7 @@ fn load_file_to_channel_at(
         #[cfg(feature = "sdk")]
         {
             let log_msg = re_sdk::MsgSender::from_file_path(path)?.into_log_msg(recording_id)?;
-            tx.send(log_msg).ok();
+            tx.send(log_msg).ok(); // .ok(): we may be running in a background thread, so who knows if the receiver is still open
             Ok(())
         }
 
@@ -629,7 +629,7 @@ fn load_rrd_file_to_channel(
         for msg in decoder {
             match msg {
                 Ok(msg) => {
-                    tx.send(msg).ok();
+                    tx.send(msg).ok(); // .ok(): we're running in a background thread, so who knows if the receiver is still open
                 }
                 Err(err) => {
                     re_log::warn_once!("Failed to decode message in {path:?}: {err}");

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -612,7 +612,7 @@ fn load_file_to_channel_at(
         #[cfg(not(feature = "sdk"))]
         {
             _ = recording_id;
-            anyhow::bail!("Unsupported file extension: '{extension}' for path {path:?}. Try enabvling the 'sdk' feature of 'rerun'.");
+            anyhow::bail!("Unsupported file extension: '{extension}' for path {path:?}. Try enabling the 'sdk' feature of 'rerun'.");
         }
     }
 }


### PR DESCRIPTION
### What
I was investigating a performance issue when loading `.glb` files and wanted a simple way to test this. So now you can run `rerun foo.obj` to quickly show a `glb`, `gltf`, `obj`, `jpeg`, or `png` file. Other image file types will also work if you enable their features in the `image` crate. You can also load multiple files at once, e.g. `rerun *.rrd`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2060
