### PR TITLE
`native_viewer` is now an opt-in feature of the `rerun` library

### DIFF
--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -20,13 +20,20 @@ all-features = true
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
+[[bin]]
+# For the `rerun` binary, always add the `native_viewer` feature.
+# See https://github.com/rerun-io/rerun/issues/1997
+name = "rerun"
+required-features = ["native_viewer"]
+
+
 [features]
 default = [
+  # We omit `native_viewer` to improve the default compile times.
   "analytics",
   "demo",
   "glam",
   "image",
-  "native_viewer",
   "server",
   "sdk",
 ]
@@ -75,6 +82,7 @@ web_viewer = [
   "dep:webbrowser",
   "re_ws_comms/server",
 ]
+
 
 [dependencies]
 re_build_info.workspace = true

--- a/examples/rust/api_demo/Cargo.toml
+++ b/examples/rust/api_demo/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }
 
 itertools = "0.10"
 rand = "0.8"

--- a/examples/rust/minimal/Cargo.toml
+++ b/examples/rust/minimal/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun" }
+rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -8,7 +8,10 @@ publish = false
 
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 bytes = "1.3"


### PR DESCRIPTION
### What

This improves compile-times for users that use an external `rerun` binary. If you want to use `spawn` or `show` you now have to add the `native_viewer` feature:

`rerun = { version = "0.6.0", features = ["native_viewer"] }`

The `rerun` binary, on the other hand, now has `native_viewer` as a _required_ feature.

In is an unhappy compromise.

Closes https://github.com/rerun-io/rerun/issues/1997

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2064
