### PR TITLE
Use the same RRD encoding for the SDK comms as for everything else

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,6 +4131,7 @@ dependencies = [
  "document-features",
  "rand",
  "re_log",
+ "re_log_encoding",
  "re_log_types",
  "re_smart_channel",
  "tokio",

--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -49,6 +49,17 @@ pub enum DecodeError {
 }
 
 // ----------------------------------------------------------------------------
+
+pub fn decode_bytes(bytes: &[u8]) -> Result<Vec<LogMsg>, DecodeError> {
+    let decoder = Decoder::new(std::io::Cursor::new(bytes))?;
+    let mut msgs = vec![];
+    for msg in decoder {
+        msgs.push(msg?);
+    }
+    Ok(msgs)
+}
+
+// ----------------------------------------------------------------------------
 // native decode:
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -26,6 +26,7 @@ server = []
 
 [dependencies]
 re_log.workspace = true
+re_log_encoding.workspace = true
 re_log_types = { workspace = true, features = ["serde"] }
 re_smart_channel.workspace = true
 

--- a/crates/re_sdk_comms/src/buffered_client.rs
+++ b/crates/re_sdk_comms/src/buffered_client.rs
@@ -188,35 +188,35 @@ fn msg_encode(
     loop {
         select! {
             recv(msg_rx) -> msg_msg => {
-                if let Ok(msg_msg) = msg_msg {
-                    let packet_msg = match &msg_msg {
-                        MsgMsg::LogMsg(log_msg) => {
-                            match re_log_encoding::encoder::encode_to_bytes(std::iter::once(log_msg)) {
-                                Ok(packet) => {
-                                    re_log::trace!("Encoded message of size {}", packet.len());
-                                    Some(PacketMsg::Packet(packet))
-                                }
-                                Err(err) => {
-                                    re_log::error_once!("Failed to encode log message: {err}");
-                                    None
-                                }
+                let Ok(msg_msg) = msg_msg else {
+                    return; // channel has closed
+                };
+
+                let packet_msg = match &msg_msg {
+                    MsgMsg::LogMsg(log_msg) => {
+                        match re_log_encoding::encoder::encode_to_bytes(std::iter::once(log_msg)) {
+                            Ok(packet) => {
+                                re_log::trace!("Encoded message of size {}", packet.len());
+                                Some(PacketMsg::Packet(packet))
+                            }
+                            Err(err) => {
+                                re_log::error_once!("Failed to encode log message: {err}");
+                                None
                             }
                         }
-                        MsgMsg::Flush => Some(PacketMsg::Flush),
-                    };
-
-                    if let Some(packet_msg) = packet_msg {
-                        if packet_tx.send(packet_msg).is_err() {
-                            re_log::error!("Failed to send message to tcp_sender thread. Likely a shutdown race-condition.");
-                            return;
-                        }
                     }
-                    if msg_drop_tx.send(msg_msg).is_err() {
-                        re_log::error!("Failed to send message to msg_drop thread. Likely a shutdown race-condition");
+                    MsgMsg::Flush => Some(PacketMsg::Flush),
+                };
+
+                if let Some(packet_msg) = packet_msg {
+                    if packet_tx.send(packet_msg).is_err() {
+                        re_log::error!("Failed to send message to tcp_sender thread. Likely a shutdown race-condition.");
                         return;
                     }
-                } else {
-                    return; // channel has closed
+                }
+                if msg_drop_tx.send(msg_msg).is_err() {
+                    re_log::error!("Failed to send message to msg_drop thread. Likely a shutdown race-condition");
+                    return;
                 }
             }
             recv(quit_rx) -> _quit_msg => {

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -19,8 +19,6 @@ mod server;
 #[cfg(feature = "server")]
 pub use server::{serve, ServerOptions};
 
-use re_log_types::LogMsg;
-
 pub type Result<T> = anyhow::Result<T>;
 
 pub const PROTOCOL_VERSION: u16 = 0;
@@ -30,27 +28,4 @@ pub const DEFAULT_SERVER_PORT: u16 = 9876;
 /// The default address of a Rerun TCP server which an SDK connects to.
 pub fn default_server_addr() -> std::net::SocketAddr {
     std::net::SocketAddr::from(([127, 0, 0, 1], DEFAULT_SERVER_PORT))
-}
-
-const PREFIX: [u8; 4] = *b"RR00";
-
-pub fn encode_log_msg(log_msg: &LogMsg) -> Vec<u8> {
-    use bincode::Options as _;
-    let mut bytes = PREFIX.to_vec();
-    bincode::DefaultOptions::new()
-        .serialize_into(&mut bytes, log_msg)
-        .unwrap();
-    bytes
-}
-
-pub fn decode_log_msg(data: &[u8]) -> Result<LogMsg> {
-    let payload = data
-        .strip_prefix(&PREFIX)
-        .ok_or_else(|| anyhow::format_err!("Message didn't start with the correct prefix"))?;
-
-    use anyhow::Context as _;
-    use bincode::Options as _;
-    bincode::DefaultOptions::new()
-        .deserialize(payload)
-        .context("bincode")
 }


### PR DESCRIPTION
This comes with two benefits:
* We get nice error messages on version mismatch
* We get compression of the TCP stream

There is also a downside: we need to pay for the slow zstd encoding and decoding.

Closes https://github.com/rerun-io/rerun/issues/2003

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2065
