### PR TITLE
Revert "`native_viewer` is now an opt-in feature of the `rerun` library"

### DIFF
--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -20,20 +20,13 @@ all-features = true
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
-[[bin]]
-# For the `rerun` binary, always add the `native_viewer` feature.
-# See https://github.com/rerun-io/rerun/issues/1997
-name = "rerun"
-required-features = ["native_viewer"]
-
-
 [features]
 default = [
-  # We omit `native_viewer` to improve the default compile times.
   "analytics",
   "demo",
   "glam",
   "image",
+  "native_viewer",
   "server",
   "sdk",
 ]
@@ -82,7 +75,6 @@ web_viewer = [
   "dep:webbrowser",
   "re_ws_comms/server",
 ]
-
 
 [dependencies]
 re_build_info.workspace = true

--- a/examples/rust/api_demo/Cargo.toml
+++ b/examples/rust/api_demo/Cargo.toml
@@ -7,10 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -7,10 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 itertools = "0.10"
 rand = "0.8"

--- a/examples/rust/minimal/Cargo.toml
+++ b/examples/rust/minimal/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../crates/rerun" }

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -7,10 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -8,10 +8,7 @@ publish = false
 
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,10 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 anyhow = "1.0"
 bytes = "1.3"


### PR DESCRIPTION
Reverts rerun-io/rerun#2064

Turns out `cargo r -p rerun` will no longer work, you need to run `cargo r -p rerun --features native_viewer`. Same for `cargo install rerun` for our users. This sucks.

```
> cargo r -p rerun
error: target `rerun` in package `rerun` requires the features: `native_viewer`
Consider enabling them by passing, e.g., `--features="native_viewer"`
```

Re-opens https://github.com/rerun-io/rerun/issues/1997