### PR TITLE
Improve UI for keypoint and class-ids of annotations contexts

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -8,6 +8,44 @@ use super::DataUi;
 
 const TABLE_SCROLL_AREA_HEIGHT: f32 = 500.0; // add scroll-bars when we get to this height
 
+impl crate::EntityDataUi for re_log_types::component_types::ClassId {
+    fn entity_data_ui(
+        &self,
+        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        verbosity: re_viewer_context::UiVerbosity,
+        entity_path: &re_log_types::EntityPath,
+        query: &re_arrow_store::LatestAtQuery,
+    ) {
+        let annotations = crate::annotations(ctx, query, entity_path);
+        let class = annotations.class_description(Some(*self)).class_description;
+        if let Some(class) = class {
+            let response = ui.horizontal(|ui| {
+                ui.label(format!("{}", self.0));
+                if let Some(label) = &class.info.label {
+                    ui.label(label.as_str());
+                }
+                color_ui(ui, &class.info, re_ui::ReUi::table_line_height());
+            });
+
+            match verbosity {
+                UiVerbosity::Small => {
+                    if !class.keypoint_connections.is_empty() || !class.keypoint_map.is_empty() {
+                        response.response.on_hover_ui(|ui| {
+                            class_description_ui(ui, class, *self);
+                        });
+                    }
+                }
+                UiVerbosity::Reduced | UiVerbosity::All => {
+                    class_description_ui(ui, class, *self);
+                }
+            }
+        } else {
+            ui.label(format!("{}", self.0));
+        }
+    }
+}
+
 impl DataUi for AnnotationContext {
     fn data_ui(
         &self,

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -21,11 +21,12 @@ impl crate::EntityDataUi for re_log_types::component_types::ClassId {
         let class = annotations.class_description(Some(*self)).class_description;
         if let Some(class) = class {
             let response = ui.horizontal(|ui| {
+                // Color first, to keep subsequent rows of the same things aligned
+                small_color_ui(ui, &class.info);
                 ui.label(format!("{}", self.0));
                 if let Some(label) = &class.info.label {
                     ui.label(label.as_str());
                 }
-                color_ui(ui, &class.info, re_ui::ReUi::table_line_height());
             });
 
             match verbosity {
@@ -57,11 +58,12 @@ impl crate::EntityDataUi for re_log_types::component_types::KeypointId {
     ) {
         if let Some(info) = annotation_info(ctx, entity_path, query, self) {
             ui.horizontal(|ui| {
+                // Color first, to keep subsequent rows of the same things aligned
+                small_color_ui(ui, &info);
                 ui.label(format!("{}", self.0));
                 if let Some(label) = &info.label {
                     ui.label(label.as_str());
                 }
-                color_ui(ui, &info, re_ui::ReUi::table_line_height());
             });
         } else {
             ui.label(format!("{}", self.0));
@@ -239,23 +241,37 @@ fn annotation_info_table_ui<'a>(
                         ui.label(label);
                     });
                     row.col(|ui| {
-                        color_ui(ui, info, row_height);
+                        color_ui(ui, info, Vec2::new(64.0, row_height));
                     });
                 });
             }
         });
 }
 
-fn color_ui(ui: &mut egui::Ui, info: &AnnotationInfo, row_height: f32) {
+fn color_ui(ui: &mut egui::Ui, info: &AnnotationInfo, size: Vec2) {
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 8.0;
         let color = info
             .color
             .map_or_else(|| auto_color(info.id), |color| color.into());
-        color_picker::show_color(ui, color, Vec2::new(64.0, row_height));
+        color_picker::show_color(ui, color, size);
         if info.color.is_none() {
             ui.weak("(auto)")
                 .on_hover_text("Color chosen automatically, since it was not logged.");
         }
     });
+}
+
+fn small_color_ui(ui: &mut egui::Ui, info: &AnnotationInfo) {
+    let size = egui::Vec2::splat(re_ui::ReUi::table_line_height());
+
+    let color = info
+        .color
+        .map_or_else(|| auto_color(info.id), |color| color.into());
+
+    let response = color_picker::show_color(ui, color, size);
+
+    if info.color.is_none() {
+        response.on_hover_text("Color chosen automatically, since it was not logged.");
+    }
 }

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -46,6 +46,43 @@ impl crate::EntityDataUi for re_log_types::component_types::ClassId {
     }
 }
 
+impl crate::EntityDataUi for re_log_types::component_types::KeypointId {
+    fn entity_data_ui(
+        &self,
+        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        _verbosity: re_viewer_context::UiVerbosity,
+        entity_path: &re_log_types::EntityPath,
+        query: &re_arrow_store::LatestAtQuery,
+    ) {
+        if let Some(info) = annotation_info(ctx, entity_path, query, self) {
+            ui.horizontal(|ui| {
+                ui.label(format!("{}", self.0));
+                if let Some(label) = &info.label {
+                    ui.label(label.as_str());
+                }
+                color_ui(ui, &info, re_ui::ReUi::table_line_height());
+            });
+        } else {
+            ui.label(format!("{}", self.0));
+        }
+    }
+}
+
+fn annotation_info(
+    ctx: &mut re_viewer_context::ViewerContext<'_>,
+    entity_path: &re_log_types::EntityPath,
+    query: &re_arrow_store::LatestAtQuery,
+    keypoint_id: &re_log_types::component_types::KeypointId,
+) -> Option<re_log_types::context::AnnotationInfo> {
+    let class_id = re_data_store::query_latest_single(&ctx.log_db.entity_db, entity_path, query)?;
+    let annotations = crate::annotations(ctx, query, entity_path);
+    let class = annotations
+        .class_description(Some(class_id))
+        .class_description?;
+    class.keypoint_map.get(keypoint_id).cloned()
+}
+
 impl DataUi for AnnotationContext {
     fn data_ui(
         &self,

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -41,7 +41,7 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
     add::<re_log_types::component_types::AnnotationContext>(&mut registry);
     // add::<re_log_types::component_types::Arrow3D>(&mut registry);
     // add::<re_log_types::component_types::Box3D>(&mut registry);
-    // add::<re_log_types::component_types::ClassId>(&mut registry);
+    add::<re_log_types::component_types::ClassId>(&mut registry);
     add::<re_log_types::component_types::ColorRGBA>(&mut registry);
     // add::<re_log_types::component_types::InstanceKey>(&mut registry);
     // add::<re_log_types::component_types::KeypointId>(&mut registry);

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -44,7 +44,7 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
     add::<re_log_types::component_types::ClassId>(&mut registry);
     add::<re_log_types::component_types::ColorRGBA>(&mut registry);
     // add::<re_log_types::component_types::InstanceKey>(&mut registry);
-    // add::<re_log_types::component_types::KeypointId>(&mut registry);
+    add::<re_log_types::component_types::KeypointId>(&mut registry);
     // add::<re_log_types::component_types::Label>(&mut registry);
     add::<re_log_types::component_types::LineStrip2D>(&mut registry);
     add::<re_log_types::component_types::LineStrip3D>(&mut registry);

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -33,7 +33,16 @@ impl EntityDataUi for Tensor {
 
         match ctx.cache.entry::<TensorDecodeCache>().entry(self.clone()) {
             Ok(decoded) => {
-                tensor_ui(ctx, ui, verbosity, entity_path, query, self, &decoded);
+                let annotations = crate::annotations(ctx, query, entity_path);
+                tensor_ui(
+                    ctx,
+                    ui,
+                    verbosity,
+                    entity_path,
+                    &annotations,
+                    self,
+                    &decoded,
+                );
             }
             Err(err) => {
                 ui.label(ctx.re_ui.error_text(err.to_string()));
@@ -47,21 +56,20 @@ fn tensor_ui(
     ui: &mut egui::Ui,
     verbosity: UiVerbosity,
     entity_path: &re_data_store::EntityPath,
-    query: &re_arrow_store::LatestAtQuery,
+    annotations: &Annotations,
     _encoded_tensor: &Tensor,
     tensor: &DecodedTensor,
 ) {
     // See if we can convert the tensor to a GPU texture.
     // Even if not, we will show info about the tensor.
     let tensor_stats = *ctx.cache.entry::<TensorStatsCache>().entry(tensor);
-    let annotations = crate::annotations(ctx, query, entity_path);
     let debug_name = entity_path.to_string();
     let texture_result = gpu_bridge::tensor_to_gpu(
         ctx.render_ctx,
         &debug_name,
         tensor,
         &tensor_stats,
-        &annotations,
+        annotations,
     )
     .ok();
 
@@ -129,7 +137,7 @@ fn tensor_ui(
                             response,
                             tensor,
                             &tensor_stats,
-                            &annotations,
+                            annotations,
                             tensor.meter,
                             &debug_name,
                             image_rect,

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -8,8 +8,8 @@ use re_log_types::{
 use re_renderer::renderer::ColormappedTexture;
 use re_ui::ReUi;
 use re_viewer_context::{
-    gpu_bridge, AnnotationMap, Annotations, SceneQuery, TensorDecodeCache, TensorStats,
-    TensorStatsCache, UiVerbosity, ViewerContext,
+    gpu_bridge, Annotations, TensorDecodeCache, TensorStats, TensorStatsCache, UiVerbosity,
+    ViewerContext,
 };
 
 use super::EntityDataUi;
@@ -54,7 +54,7 @@ fn tensor_ui(
     // See if we can convert the tensor to a GPU texture.
     // Even if not, we will show info about the tensor.
     let tensor_stats = *ctx.cache.entry::<TensorStatsCache>().entry(tensor);
-    let annotations = annotations(ctx, query, entity_path);
+    let annotations = crate::annotations(ctx, query, entity_path);
     let debug_name = entity_path.to_string();
     let texture_result = gpu_bridge::tensor_to_gpu(
         ctx.render_ctx,
@@ -159,24 +159,6 @@ fn tensor_ui(
             });
         }
     }
-}
-
-fn annotations(
-    ctx: &mut ViewerContext<'_>,
-    query: &re_arrow_store::LatestAtQuery,
-    entity_path: &re_data_store::EntityPath,
-) -> std::sync::Arc<Annotations> {
-    let mut annotation_map = AnnotationMap::default();
-    let entity_paths: nohash_hasher::IntSet<_> = std::iter::once(entity_path.clone()).collect();
-    let entity_props_map = re_data_store::EntityPropertyMap::default();
-    let scene_query = SceneQuery {
-        entity_paths: &entity_paths,
-        timeline: query.timeline,
-        latest_at: query.at,
-        entity_props_map: &entity_props_map,
-    };
-    annotation_map.load(ctx, &scene_query);
-    annotation_map.find(entity_path)
 }
 
 fn texture_size(colormapped_texture: &ColormappedTexture) -> Vec2 {

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -16,7 +16,6 @@ mod image;
 mod instance_path;
 mod item;
 pub mod item_ui;
-mod keypoint_id;
 mod log_msg;
 
 pub use crate::image::{
@@ -153,6 +152,7 @@ pub fn annotations(
     query: &re_arrow_store::LatestAtQuery,
     entity_path: &re_data_store::EntityPath,
 ) -> std::sync::Arc<re_viewer_context::Annotations> {
+    crate::profile_function!();
     let mut annotation_map = re_viewer_context::AnnotationMap::default();
     let entity_paths: nohash_hasher::IntSet<_> = std::iter::once(entity_path.clone()).collect();
     let entity_props_map = re_data_store::EntityPropertyMap::default();

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -16,6 +16,7 @@ mod image;
 mod instance_path;
 mod item;
 pub mod item_ui;
+mod keypoint_id;
 mod log_msg;
 
 pub use crate::image::{
@@ -143,6 +144,26 @@ impl DataUi for PathOp {
             }
         };
     }
+}
+
+// ---------------------------------------------------------------------------
+
+pub fn annotations(
+    ctx: &mut ViewerContext<'_>,
+    query: &re_arrow_store::LatestAtQuery,
+    entity_path: &re_data_store::EntityPath,
+) -> std::sync::Arc<re_viewer_context::Annotations> {
+    let mut annotation_map = re_viewer_context::AnnotationMap::default();
+    let entity_paths: nohash_hasher::IntSet<_> = std::iter::once(entity_path.clone()).collect();
+    let entity_props_map = re_data_store::EntityPropertyMap::default();
+    let scene_query = re_viewer_context::SceneQuery {
+        entity_paths: &entity_paths,
+        timeline: query.timeline,
+        latest_at: query.at,
+        entity_props_map: &entity_props_map,
+    };
+    annotation_map.load(ctx, &scene_query);
+    annotation_map.find(entity_path)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/re_log_types/src/component_types/label.rs
+++ b/crates/re_log_types/src/component_types/label.rs
@@ -16,6 +16,13 @@ use crate::Component;
 #[arrow_field(transparent)]
 pub struct Label(pub String);
 
+impl Label {
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
 impl Component for Label {
     #[inline]
     fn name() -> crate::ComponentName {
@@ -34,5 +41,27 @@ impl From<Label> for String {
     #[inline]
     fn from(value: Label) -> Self {
         value.0
+    }
+}
+
+impl AsRef<str> for Label {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::borrow::Borrow<str> for Label {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::ops::Deref for Label {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
     }
 }


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/860

### What
We used to only show the integer value of `class_id` and `keypoint_id`. Now we show labels and colors:

![image](https://github.com/rerun-io/rerun/assets/1148717/c2e2545b-d26c-4007-a0d5-4154beb611e3)

![image](https://github.com/rerun-io/rerun/assets/1148717/c70440a1-ea17-4485-81fc-7160083ab7e9)

I also fixed a bug that caused the annotation context ui to be empty unless there where some keypoint connection in it 🤦 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2071
