### PR TITLE
`RecordingStream`: automatic `log_tick` timeline

### DIFF
--- a/crates/re_arrow_store/tests/dump.rs
+++ b/crates/re_arrow_store/tests/dump.rs
@@ -133,7 +133,7 @@ fn data_store_dump_filtered() {
 
 fn data_store_dump_filtered_impl(store1: &mut DataStore, store2: &mut DataStore) {
     let timeline_frame_nr = Timeline::new_sequence("frame_nr");
-    let timeline_log_time = Timeline::new_temporal("log_time");
+    let timeline_log_time = Timeline::log_time();
     let frame1: TimeInt = 1.into();
     let frame2: TimeInt = 2.into();
     let frame3: TimeInt = 3.into();

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1071,15 +1071,19 @@ impl DataTable {
 
         let table_id = TableId::random();
 
-        let timepoint = |frame_nr: i64| {
-            if timeless {
+        let mut tick = 0i64;
+        let mut timepoint = |frame_nr: i64| {
+            let tp = if timeless {
                 TimePoint::timeless()
             } else {
                 TimePoint::from([
                     (Timeline::log_time(), Time::now().into()),
+                    (Timeline::log_tick(), tick.into()),
                     (Timeline::new_sequence("frame_nr"), frame_nr.into()),
                 ])
-            }
+            };
+            tick += 1;
+            tp
         };
 
         let row0 = {

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1076,7 +1076,7 @@ impl DataTable {
                 TimePoint::timeless()
             } else {
                 TimePoint::from([
-                    (Timeline::new_temporal("log_time"), Time::now().into()),
+                    (Timeline::log_time(), Time::now().into()),
                     (Timeline::new_sequence("frame_nr"), frame_nr.into()),
                 ])
             }

--- a/crates/re_log_types/src/data_table_batcher.rs
+++ b/crates/re_log_types/src/data_table_batcher.rs
@@ -744,7 +744,7 @@ mod tests {
 
         let timepoint = |frame_nr: i64| {
             TimePoint::from([
-                (Timeline::new_temporal("log_time"), Time::now().into()),
+                (Timeline::log_time(), Time::now().into()),
                 (Timeline::new_sequence("frame_nr"), frame_nr.into()),
             ])
         };

--- a/crates/re_log_types/src/time_point/timeline.rs
+++ b/crates/re_log_types/src/time_point/timeline.rs
@@ -77,6 +77,12 @@ impl Timeline {
         Timeline::new("log_time", TimeType::Time)
     }
 
+    /// The log tick timeline to which all API functions will always log.
+    #[inline]
+    pub fn log_tick() -> Self {
+        Timeline::new("log_tick", TimeType::Sequence)
+    }
+
     /// Returns a formatted string of `time_range` on this `Timeline`.
     #[inline]
     pub fn format_time_range(&self, time_range: &TimeRange) -> String {

--- a/crates/re_log_types/src/time_point/timeline.rs
+++ b/crates/re_log_types/src/time_point/timeline.rs
@@ -72,12 +72,20 @@ impl Timeline {
     }
 
     /// The log time timeline to which all API functions will always log.
+    ///
+    /// This timeline is automatically maintained by the SDKs and captures the wall-clock time at
+    /// which point the data was logged (according to the client's wall-clock).
     #[inline]
     pub fn log_time() -> Self {
         Timeline::new("log_time", TimeType::Time)
     }
 
     /// The log tick timeline to which all API functions will always log.
+    ///
+    /// This timeline is automatically maintained by the SDKs and captures the logging tick at
+    /// which point the data was logged.
+    /// The logging tick is monotically incremented each time the client calls one of the logging
+    /// methods on a `RecordingStream`.
     #[inline]
     pub fn log_tick() -> Self {
         Timeline::new("log_tick", TimeType::Sequence)

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -620,7 +620,7 @@ impl RecordingStream {
             return;
         };
 
-        // TODO(xxx): Adding a timeline to something timeless would suddenly make it not
+        // TODO(#2074): Adding a timeline to something timeless would suddenly make it not
         // timeless... so for now it cannot even have a tick :/
         //
         // NOTE: We're incrementing the current tick still.

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -620,8 +620,14 @@ impl RecordingStream {
             return;
         };
 
+        // TODO(xxx): Adding a timeline to something timeless would suddenly make it not
+        // timeless... so for now it cannot even have a tick :/
+        //
+        // NOTE: We're incrementing the current tick still.
         let tick = this.tick.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        row.timepoint.insert(Timeline::log_tick(), tick.into());
+        if !row.timepoint().is_timeless() {
+            row.timepoint.insert(Timeline::log_tick(), tick.into());
+        }
 
         this.batcher.push_row(row);
     }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicI64, Arc};
 
 use ahash::HashMap;
 use crossbeam::channel::{Receiver, Sender};
@@ -319,6 +319,7 @@ pub struct RecordingStream {
 
 struct RecordingStreamInner {
     info: RecordingInfo,
+    tick: AtomicI64,
 
     /// The one and only entrypoint into the pipeline: this is _never_ cloned nor publicly exposed,
     /// therefore the `Drop` implementation is guaranteed that no more data can come in while it's
@@ -385,6 +386,7 @@ impl RecordingStreamInner {
 
         Ok(RecordingStreamInner {
             info,
+            tick: AtomicI64::new(0),
             cmds_tx,
             batcher,
             batcher_to_sink_handle: Some(batcher_to_sink_handle),
@@ -580,6 +582,7 @@ impl RecordingStream {
         // fail.
 
         this.cmds_tx.send(Command::RecordMsg(msg)).ok();
+        this.tick.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Records a [`re_log_types::PathOp`].
@@ -611,11 +614,14 @@ impl RecordingStream {
     /// Internally, incoming [`DataRow`]s are automatically coalesced into larger [`DataTable`]s to
     /// optimize for transport.
     #[inline]
-    pub fn record_row(&self, row: DataRow) {
+    pub fn record_row(&self, mut row: DataRow) {
         let Some(this) = &*self.inner else {
             re_log::warn_once!("Recording disabled - call to record_row() ignored");
             return;
         };
+
+        let tick = this.tick.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        row.timepoint.insert(Timeline::log_tick(), tick.into());
 
         this.batcher.push_row(row);
     }

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -375,7 +375,7 @@ impl TimeControl {
                 return; // it's valid
             }
         }
-        if let Some(timeline) = default_time_line(times_per_timeline.timelines()) {
+        if let Some(timeline) = default_timeline(times_per_timeline.timelines()) {
             self.timeline = *timeline;
         } else {
             self.timeline = Default::default();
@@ -519,13 +519,13 @@ fn range(values: &BTreeSet<TimeInt>) -> TimeRange {
 }
 
 /// Pick the timeline that should be the default, prioritizing user-defined ones.
-fn default_time_line<'a>(timelines: impl Iterator<Item = &'a Timeline>) -> Option<&'a Timeline> {
+fn default_timeline<'a>(timelines: impl Iterator<Item = &'a Timeline>) -> Option<&'a Timeline> {
     let mut log_time_timeline = None;
 
     for timeline in timelines {
         if timeline.name().as_str() == "log_time" {
             log_time_timeline = Some(timeline);
-        } else {
+        } else if timeline.name().as_str() != "log_tick" {
             return Some(timeline); // user timeline - always prefer!
         }
     }

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -523,9 +523,9 @@ fn default_timeline<'a>(timelines: impl Iterator<Item = &'a Timeline>) -> Option
     let mut log_time_timeline = None;
 
     for timeline in timelines {
-        if timeline.name().as_str() == "log_time" {
+        if timeline == &Timeline::log_time() {
             log_time_timeline = Some(timeline);
-        } else if timeline.name().as_str() != "log_tick" {
+        } else if timeline != &Timeline::log_tick() {
             return Some(timeline); // user timeline - always prefer!
         }
     }


### PR DESCRIPTION
Introduces a new **per-recording per-process** `log_tick` timeline, automatically derived on behalf of the user.

Future work:
- Pick the right timeline from blueprint and/or based on context!

#2042 