### PR TITLE
Flush before generating the html

### DIFF
--- a/rerun_py/rerun_sdk/rerun/recording.py
+++ b/rerun_py/rerun_sdk/rerun/recording.py
@@ -48,6 +48,11 @@ class MemoryRecording:
         # Use a random presentation ID to avoid collisions when multiple recordings are shown in the same notebook.
         presentation_id = "".join(random.choice(string.ascii_letters) for i in range(6))
 
+        # TODO(jleibs): flush the specific recording instead of all recordings
+        # This is more evidence we we want this to be a handle to the stream and not just
+        # the storage.
+        bindings.flush()
+
         base64_data = base64.b64encode(self.storage.get_rrd_as_bytes()).decode("utf-8")
 
         html_template = f"""

--- a/rerun_py/rerun_sdk/rerun/recording.py
+++ b/rerun_py/rerun_sdk/rerun/recording.py
@@ -48,7 +48,7 @@ class MemoryRecording:
         # Use a random presentation ID to avoid collisions when multiple recordings are shown in the same notebook.
         presentation_id = "".join(random.choice(string.ascii_letters) for i in range(6))
 
-        # TODO(jleibs): flush the specific recording instead of all recordings
+        # TODO(#1903): flush the specific recording instead of all recordings
         # This is more evidence we we want this to be a handle to the stream and not just
         # the storage.
         bindings.flush()


### PR DESCRIPTION
This avoids a race-condition where the generated html is missing some (or all) of the logged messages.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2073
