### PR TITLE
Remove `Clipboard::set_text`

### DIFF
--- a/crates/re_viewer/src/misc/profiler.rs
+++ b/crates/re_viewer/src/misc/profiler.rs
@@ -45,7 +45,6 @@ fn start_puffin_viewer() {
 
     if let Err(err) = child {
         let cmd = format!("cargo install puffin_viewer && puffin_viewer --url {url}",);
-        re_viewer_context::Clipboard::with(|clipboard| clipboard.set_text(cmd.clone()));
         re_log::warn!("Failed to start puffin_viewer: {err}. Try connecting manually with:  {cmd}");
 
         rfd::MessageDialog::new()

--- a/crates/re_viewer_context/src/clipboard.rs
+++ b/crates/re_viewer_context/src/clipboard.rs
@@ -10,17 +10,6 @@ impl Clipboard {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))] // only used sometimes
-    pub fn set_text(&mut self, text: String) {
-        if let Some(clipboard) = &mut self.arboard {
-            if let Err(err) = clipboard.set_text(text) {
-                re_log::error!("Failed to copy text to clipboard: {err}",);
-            } else {
-                re_log::info!("Text copied to clipboard");
-            }
-        }
-    }
-
     pub fn set_image(&mut self, size: [usize; 2], rgba_unmultiplied: &[u8]) {
         let [width, height] = size;
         assert_eq!(width * height * 4, rgba_unmultiplied.len());


### PR DESCRIPTION
Motivation: https://github.com/rerun-io/rerun/pull/2069#discussion_r1188955536
> `re_viewer_context::Clipboard` is for copying images. We should probably remove the `set_text` footgun in it. egui/eframe supports copy-and paste on web

