### PR TITLE
Switch from egui_dock to egui_tiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,13 +1371,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui_tile_tree"
+name = "egui_tiles"
 version = "0.1.0-alpha.1"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=9a6ed5852a0d2f3b18db0c7b8fb1b1bf904b0a51#9a6ed5852a0d2f3b18db0c7b8fb1b1bf904b0a51"
 dependencies = [
  "egui",
  "getrandom",
  "itertools",
  "log",
+ "nohash-hasher",
  "rand",
  "serde",
 ]
@@ -4072,7 +4074,7 @@ dependencies = [
  "eframe",
  "egui",
  "egui_extras",
- "egui_tile_tree",
+ "egui_tiles",
  "image",
  "parking_lot 0.12.1",
  "re_log",
@@ -4097,7 +4099,7 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "egui_extras",
- "egui_tile_tree",
+ "egui_tiles",
  "enumset",
  "glam",
  "half 2.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,16 +1345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui_dock"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f86bdfe987f753ffcdf896932f09babfc63580b21e1899c304166f0befc85c8"
-dependencies = [
- "egui",
- "serde",
-]
-
-[[package]]
 name = "egui_extras"
 version = "0.21.0"
 source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
@@ -1383,7 +1373,6 @@ dependencies = [
 [[package]]
 name = "egui_tile_tree"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/rerun-io/egui_tile_tree?rev=4589ef321ecbe08ae6ec2a101c2255b233b2d6d0#4589ef321ecbe08ae6ec2a101c2255b233b2d6d0"
 dependencies = [
  "egui",
  "getrandom",
@@ -4082,7 +4071,6 @@ version = "0.6.0-alpha.0"
 dependencies = [
  "eframe",
  "egui",
- "egui_dock",
  "egui_extras",
  "egui_tile_tree",
  "image",
@@ -4108,8 +4096,8 @@ dependencies = [
  "eframe",
  "egui",
  "egui-wgpu",
- "egui_dock",
  "egui_extras",
+ "egui_tile_tree",
  "enumset",
  "glam",
  "half 2.2.1",
@@ -6339,7 +6327,3 @@ dependencies = [
  "quote",
  "syn 1.0.103",
 ]
-
-[[patch.unused]]
-name = "egui_tile_tree"
-version = "0.1.0-alpha.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 [[package]]
 name = "ecolor"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.21.3"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "accesskit",
  "ahash 0.8.2",
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "bytemuck",
  "epaint",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.21.1"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "arboard",
  "egui",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "egui",
  "log",
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1378,6 +1378,19 @@ dependencies = [
  "puffin",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "egui_tile_tree"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/rerun-io/egui_tile_tree?rev=4589ef321ecbe08ae6ec2a101c2255b233b2d6d0#4589ef321ecbe08ae6ec2a101c2255b233b2d6d0"
+dependencies = [
+ "egui",
+ "getrandom",
+ "itertools",
+ "log",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -1402,7 +1415,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "emath"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1483,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=f76eefb98d23cbf71989255aafe75a07d343f6ed#f76eefb98d23cbf71989255aafe75a07d343f6ed"
+source = "git+https://github.com/emilk/egui?rev=e9fa6c8ff68a0257ce0f2801446ba701917b7ae9#e9fa6c8ff68a0257ce0f2801446ba701917b7ae9"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.2",
@@ -4071,6 +4084,7 @@ dependencies = [
  "egui",
  "egui_dock",
  "egui_extras",
+ "egui_tile_tree",
  "image",
  "parking_lot 0.12.1",
  "re_log",
@@ -6325,3 +6339,7 @@ dependencies = [
  "quote",
  "syn 1.0.103",
 ]
+
+[[patch.unused]]
+name = "egui_tile_tree"
+version = "0.1.0-alpha.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ ctrlc = { version = "3.0", features = ["termination"] }
 ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = { version = "0.21.0", features = ["extra_debug_asserts", "log"] }
-egui_dock = "0.4"
 egui_extras = { version = "0.21.0", features = ["log"] }
-egui_tile_tree = { git = "https://github.com/rerun-io/egui_tile_tree", rev = "4589ef321ecbe08ae6ec2a101c2255b233b2d6d0" }
+# egui_tile_tree = { git = "https://github.com/rerun-io/egui_tile_tree", rev = "f5e5207c1faa9e9cab4317a674d225611bc82c72" }
+egui_tile_tree = { path = "../egui_tile_tree" }
 egui-wgpu = "0.21.0"
 emath = "0.21.0"
 enumset = "1.0.12"
@@ -138,3 +138,5 @@ emath = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726
 wgpu = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
 wgpu-core = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
+
+egui_tile_tree = { path = "../egui_tile_tree" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ eframe = { version = "0.21.3", default-features = false }
 egui = { version = "0.21.0", features = ["extra_debug_asserts", "log"] }
 egui_dock = "0.4"
 egui_extras = { version = "0.21.0", features = ["log"] }
+egui_tile_tree = { git = "https://github.com/rerun-io/egui_tile_tree", rev = "4589ef321ecbe08ae6ec2a101c2255b233b2d6d0" }
 egui-wgpu = "0.21.0"
 emath = "0.21.0"
 enumset = "1.0.12"
@@ -125,13 +126,13 @@ debug = true
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
 # TODO(andreas/emilk): Update to a stable egui version
-# wgpu 0.16 support, device configuration dependent on adapter
-ecolor = { git = "https://github.com/emilk/egui", rev = "f76eefb98d23cbf71989255aafe75a07d343f6ed" }
-eframe = { git = "https://github.com/emilk/egui", rev = "f76eefb98d23cbf71989255aafe75a07d343f6ed" }
-egui = { git = "https://github.com/emilk/egui", rev = "f76eefb98d23cbf71989255aafe75a07d343f6ed" }
-egui-wgpu = { git = "https://github.com/emilk/egui", rev = "f76eefb98d23cbf71989255aafe75a07d343f6ed" }
-egui_extras = { git = "https://github.com/emilk/egui", rev = "f76eefb98d23cbf71989255aafe75a07d343f6ed" }
-emath = { git = "https://github.com/emilk/egui", rev = "f76eefb98d23cbf71989255aafe75a07d343f6ed" }
+# wgpu 0.16 support, device configuration dependent on adapter, and some additions to help re_dock
+ecolor = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
+eframe = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
+egui = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
+emath = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
 
 # TODO(andreas): Either work around this issue in wgpu-egui (never discard command buffers) or wait for wgpu patch release.
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ debug = true
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
 # TODO(andreas/emilk): Update to a stable egui version
-# wgpu 0.16 support, device configuration dependent on adapter, and some additions to help re_dock
+# wgpu 0.16 support, device configuration dependent on adapter, and some additions to help egui_tiles
 ecolor = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
 eframe = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }
 egui = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801446ba701917b7ae9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,7 @@ ecolor = "0.21.0"
 eframe = { version = "0.21.3", default-features = false }
 egui = { version = "0.21.0", features = ["extra_debug_asserts", "log"] }
 egui_extras = { version = "0.21.0", features = ["log"] }
-# egui_tile_tree = { git = "https://github.com/rerun-io/egui_tile_tree", rev = "f5e5207c1faa9e9cab4317a674d225611bc82c72" }
-egui_tile_tree = { path = "../egui_tile_tree" }
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "9a6ed5852a0d2f3b18db0c7b8fb1b1bf904b0a51" }
 egui-wgpu = "0.21.0"
 emath = "0.21.0"
 enumset = "1.0.12"
@@ -138,5 +137,3 @@ emath = { git = "https://github.com/emilk/egui", rev = "e9fa6c8ff68a0257ce0f2801
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726
 wgpu = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
 wgpu-core = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
-
-egui_tile_tree = { path = "../egui_tile_tree" }

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -44,5 +44,5 @@ eframe = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }
-egui_tile_tree.workspace = true
+egui_tiles.workspace = true
 re_log.workspace = true

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -46,4 +46,5 @@ egui_dock = { workspace = true, optional = true, features = ["serde"] }
 
 [dev-dependencies]
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }
+egui_tile_tree.workspace = true
 re_log.workspace = true

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -23,10 +23,9 @@ all-features = true
 
 
 [features]
-default = ["eframe", "egui_dock"]
+default = ["eframe"]
 
 eframe = ["dep:eframe"]
-egui_dock = ["dep:egui_dock"]
 
 
 [dependencies]
@@ -42,7 +41,6 @@ sublime_fuzzy = "0.7"
 
 ## Optional dependencies:
 eframe = { workspace = true, optional = true, default-features = false }
-egui_dock = { workspace = true, optional = true, features = ["serde"] }
 
 [dev-dependencies]
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -36,7 +36,7 @@ pub struct ExampleApp {
     /// Listens to the local text log stream
     text_log_rx: std::sync::mpsc::Receiver<re_log::LogMsg>,
 
-    tree: egui_dock::Tree<Tab>,
+    tree: egui_tile_tree::Tree<Tab>,
 
     left_panel: bool,
     right_panel: bool,
@@ -56,7 +56,7 @@ impl ExampleApp {
         let (logger, text_log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Info);
         re_log::add_boxed_logger(Box::new(logger)).unwrap();
 
-        let tree = egui_dock::Tree::new(vec![1, 2, 3]);
+        let tree = egui_tile_tree::Tree::new_tabs(vec![1, 2, 3]);
 
         Self {
             re_ui,
@@ -337,27 +337,51 @@ fn selection_buttons(ui: &mut egui::Ui) {
     });
 }
 
-fn tabs_ui(ui: &mut egui::Ui, tree: &mut egui_dock::Tree<Tab>) {
-    let mut my_tab_viewer = MyTabViewer {};
-    egui_dock::DockArea::new(tree)
-        .style(re_ui::egui_dock_style(ui.style()))
-        .show_inside(ui, &mut my_tab_viewer);
+fn tabs_ui(ui: &mut egui::Ui, tree: &mut egui_tile_tree::Tree<Tab>) {
+    tree.ui(&mut MyTileTreeBehavior {}, ui);
 }
 
 pub type Tab = i32;
 
-struct MyTabViewer {}
+struct MyTileTreeBehavior {}
 
-impl egui_dock::TabViewer for MyTabViewer {
-    type Tab = Tab;
-
-    fn ui(&mut self, ui: &mut egui::Ui, _tab: &mut Self::Tab) {
+impl egui_tile_tree::Behavior<Tab> for MyTileTreeBehavior {
+    fn pane_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _tile_id: egui_tile_tree::TileId,
+        _pane: &mut Tab,
+    ) -> egui_tile_tree::UiResponse {
         egui::warn_if_debug_build(ui);
         ui.label("Hover me for a tooltip")
             .on_hover_text("This is a tooltip");
+
+        Default::default()
     }
 
-    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
-        format!("This is tab {tab}").into()
+    fn tab_title_for_pane(&mut self, pane: &Tab) -> egui::WidgetText {
+        format!("This is tab {pane}").into()
+    }
+
+    fn tab_outline_stroke(
+        &self,
+        _visuals: &egui::Visuals,
+        _tile_id: egui_tile_tree::TileId,
+        _active: bool,
+    ) -> egui::Stroke {
+        egui::Stroke::NONE
+    }
+
+    /// The height of the bar holding tab titles.
+    fn tab_bar_height(&self, _style: &egui::Style) -> f32 {
+        re_ui::ReUi::title_bar_height()
+    }
+
+    /// What are the rules for simplifying the tree?
+    fn simplification_options(&self) -> egui_tile_tree::SimplificationOptions {
+        egui_tile_tree::SimplificationOptions {
+            all_panes_must_have_tabs: true,
+            ..Default::default()
+        }
     }
 }

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -36,7 +36,7 @@ pub struct ExampleApp {
     /// Listens to the local text log stream
     text_log_rx: std::sync::mpsc::Receiver<re_log::LogMsg>,
 
-    tree: egui_tile_tree::Tree<Tab>,
+    tree: egui_tiles::Tree<Tab>,
 
     left_panel: bool,
     right_panel: bool,
@@ -56,7 +56,7 @@ impl ExampleApp {
         let (logger, text_log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Info);
         re_log::add_boxed_logger(Box::new(logger)).unwrap();
 
-        let tree = egui_tile_tree::Tree::new_tabs(vec![1, 2, 3]);
+        let tree = egui_tiles::Tree::new_tabs(vec![1, 2, 3]);
 
         Self {
             re_ui,
@@ -337,7 +337,7 @@ fn selection_buttons(ui: &mut egui::Ui) {
     });
 }
 
-fn tabs_ui(ui: &mut egui::Ui, tree: &mut egui_tile_tree::Tree<Tab>) {
+fn tabs_ui(ui: &mut egui::Ui, tree: &mut egui_tiles::Tree<Tab>) {
     tree.ui(&mut MyTileTreeBehavior {}, ui);
 }
 
@@ -345,13 +345,13 @@ pub type Tab = i32;
 
 struct MyTileTreeBehavior {}
 
-impl egui_tile_tree::Behavior<Tab> for MyTileTreeBehavior {
+impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
     fn pane_ui(
         &mut self,
         ui: &mut egui::Ui,
-        _tile_id: egui_tile_tree::TileId,
+        _tile_id: egui_tiles::TileId,
         _pane: &mut Tab,
-    ) -> egui_tile_tree::UiResponse {
+    ) -> egui_tiles::UiResponse {
         egui::warn_if_debug_build(ui);
         ui.label("Hover me for a tooltip")
             .on_hover_text("This is a tooltip");
@@ -368,7 +368,7 @@ impl egui_tile_tree::Behavior<Tab> for MyTileTreeBehavior {
     fn tab_outline_stroke(
         &self,
         _visuals: &egui::Visuals,
-        _tile_id: egui_tile_tree::TileId,
+        _tile_id: egui_tiles::TileId,
         _active: bool,
     ) -> egui::Stroke {
         egui::Stroke::NONE
@@ -380,8 +380,8 @@ impl egui_tile_tree::Behavior<Tab> for MyTileTreeBehavior {
     }
 
     /// What are the rules for simplifying the tree?
-    fn simplification_options(&self) -> egui_tile_tree::SimplificationOptions {
-        egui_tile_tree::SimplificationOptions {
+    fn simplification_options(&self) -> egui_tiles::SimplificationOptions {
+        egui_tiles::SimplificationOptions {
             all_panes_must_have_tabs: true,
             ..Default::default()
         }

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -363,6 +363,8 @@ impl egui_tile_tree::Behavior<Tab> for MyTileTreeBehavior {
         format!("This is tab {pane}").into()
     }
 
+    // Styling:
+
     fn tab_outline_stroke(
         &self,
         _visuals: &egui::Visuals,

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -610,41 +610,6 @@ impl ReUi {
 
 // ----------------------------------------------------------------------------
 
-#[cfg(feature = "egui_dock")]
-pub fn egui_dock_style(style: &egui::Style) -> egui_dock::Style {
-    let mut dock_style = egui_dock::Style::from_egui(style);
-    dock_style.separator_width = 2.0;
-    dock_style.tab_bar_height = ReUi::title_bar_height();
-    dock_style.default_inner_margin = 0.0.into();
-    dock_style.show_close_buttons = false;
-    dock_style.tab_include_scrollarea = false;
-    dock_style.show_context_menu = false;
-    dock_style.expand_tabs = false; // expand_tabs looks good, but decreases readability
-
-    // Tabs can be "focused", meaning it was the last clicked (of any tab). We don't care about that.
-    // Tabs can also be "active", meaning it is the selected tab within its sibling tabs. We want to highlight that.
-    let inactive_text_color = style.visuals.widgets.noninteractive.text_color();
-    let active_text_color = style.visuals.widgets.active.text_color();
-
-    dock_style.tab_text_color_unfocused = inactive_text_color;
-    dock_style.tab_text_color_focused = inactive_text_color;
-    dock_style.tab_text_color_active_unfocused = active_text_color;
-    dock_style.tab_text_color_active_focused = active_text_color;
-
-    // Don't show tabs
-    dock_style.tab_bar_background_color = style.visuals.panel_fill;
-    dock_style.tab_background_color = style.visuals.panel_fill;
-
-    dock_style.hline_color = style.visuals.widgets.noninteractive.bg_stroke.color;
-
-    // The active tab has no special outline:
-    dock_style.tab_outline_color = Color32::TRANSPARENT;
-
-    dock_style
-}
-
-// ----------------------------------------------------------------------------
-
 /// Show some close/maximize/minimize buttons for the native window.
 ///
 /// Assumes it is in a right-to-left layout.

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -78,7 +78,7 @@ eframe = { workspace = true, default-features = false, features = [
 ] }
 egui.workspace = true
 egui_extras.workspace = true
-egui_tile_tree.workspace = true
+egui_tiles.workspace = true
 egui-wgpu.workspace = true
 enumset.workspace = true
 glam = { workspace = true, features = [

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -57,7 +57,7 @@ re_renderer = { workspace = true, default-features = false, features = [
 ] }
 re_smart_channel.workspace = true
 re_tensor_ops.workspace = true
-re_ui = { workspace = true, features = ["eframe", "egui_dock"] }
+re_ui = { workspace = true, features = ["eframe"] }
 re_viewer_context.workspace = true
 re_ws_comms = { workspace = true, features = ["client"] }
 
@@ -77,8 +77,8 @@ eframe = { workspace = true, default-features = false, features = [
   "wgpu",
 ] }
 egui.workspace = true
-egui_dock = { workspace = true, features = ["serde"] }
 egui_extras.workspace = true
+egui_tile_tree.workspace = true
 egui-wgpu.workspace = true
 enumset.workspace = true
 glam = { workspace = true, features = [

--- a/crates/re_viewer/src/ui/auto_layout.rs
+++ b/crates/re_viewer/src/ui/auto_layout.rs
@@ -48,7 +48,7 @@ pub(crate) fn tree_from_space_views(
     viewport_size: egui::Vec2,
     visible: &std::collections::BTreeSet<SpaceViewId>,
     space_views: &HashMap<SpaceViewId, SpaceView>,
-) -> egui_tile_tree::Tree<SpaceViewId> {
+) -> egui_tiles::Tree<SpaceViewId> {
     let mut space_make_infos = space_views
         .iter()
         .filter(|(space_view_id, _space_view)| visible.contains(space_view_id))
@@ -91,32 +91,32 @@ pub(crate) fn tree_from_space_views(
         .collect_vec();
 
     if space_make_infos.is_empty() {
-        egui_tile_tree::Tree::empty()
+        egui_tiles::Tree::empty()
     } else {
-        let mut tiles = egui_tile_tree::Tiles::default();
+        let mut tiles = egui_tiles::Tiles::default();
         // Users often organize by path prefix, so we start by splitting along that
         let layout = layout_by_path_prefix(viewport_size, &mut space_make_infos);
         let root = tree_from_split(&mut tiles, &layout);
-        egui_tile_tree::Tree::new(root, tiles)
+        egui_tiles::Tree::new(root, tiles)
     }
 }
 
 fn tree_from_split(
-    tiles: &mut egui_tile_tree::Tiles<SpaceViewId>,
+    tiles: &mut egui_tiles::Tiles<SpaceViewId>,
     split: &LayoutSplit,
-) -> egui_tile_tree::TileId {
+) -> egui_tiles::TileId {
     match split {
         LayoutSplit::LeftRight(left, fraction, right) => {
-            let container = egui_tile_tree::Linear::new_binary(
-                egui_tile_tree::LinearDir::Horizontal,
+            let container = egui_tiles::Linear::new_binary(
+                egui_tiles::LinearDir::Horizontal,
                 [tree_from_split(tiles, left), tree_from_split(tiles, right)],
                 *fraction,
             );
             tiles.insert_container(container)
         }
         LayoutSplit::TopBottom(top, fraction, bottom) => {
-            let container = egui_tile_tree::Linear::new_binary(
-                egui_tile_tree::LinearDir::Vertical,
+            let container = egui_tiles::Linear::new_binary(
+                egui_tiles::LinearDir::Vertical,
                 [tree_from_split(tiles, top), tree_from_split(tiles, bottom)],
                 *fraction,
             );

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -39,7 +39,7 @@ pub struct Viewport {
     /// One for each combination of what views are visible.
     /// So if a user toggles the visibility of one SpaceView, we
     /// switch which layout we are using. This is somewhat hacky.
-    trees: HashMap<VisibilitySet, egui_tile_tree::Tree<SpaceViewId>>,
+    trees: HashMap<VisibilitySet, egui_tiles::Tree<SpaceViewId>>,
 
     /// Show one tab as maximized?
     maximized: Option<SpaceViewId>,
@@ -619,13 +619,13 @@ struct TabViewer<'a, 'b> {
     maximized: &'a mut Option<SpaceViewId>,
 }
 
-impl<'a, 'b> egui_tile_tree::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
+impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
     fn pane_ui(
         &mut self,
         ui: &mut egui::Ui,
-        _tile_id: egui_tile_tree::TileId,
+        _tile_id: egui_tiles::TileId,
         space_view_id: &mut SpaceViewId,
-    ) -> egui_tile_tree::UiResponse {
+    ) -> egui_tiles::UiResponse {
         crate::profile_function!();
 
         let highlights =
@@ -665,12 +665,12 @@ impl<'a, 'b> egui_tile_tree::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
     fn on_tab_button(
         &mut self,
-        tiles: &egui_tile_tree::Tiles<SpaceViewId>,
-        tile_id: egui_tile_tree::TileId,
+        tiles: &egui_tiles::Tiles<SpaceViewId>,
+        tile_id: egui_tiles::TileId,
         button_response: &egui::Response,
     ) {
         if button_response.clicked() {
-            if let Some(egui_tile_tree::Tile::Pane(space_view_id)) = tiles.get(tile_id) {
+            if let Some(egui_tiles::Tile::Pane(space_view_id)) = tiles.get(tile_id) {
                 self.ctx
                     .set_single_selection(Item::SpaceView(*space_view_id));
             }
@@ -679,13 +679,13 @@ impl<'a, 'b> egui_tile_tree::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
     fn top_bar_rtl_ui(
         &mut self,
-        tiles: &egui_tile_tree::Tiles<SpaceViewId>,
+        tiles: &egui_tiles::Tiles<SpaceViewId>,
         ui: &mut egui::Ui,
-        _tile_id: egui_tile_tree::TileId,
-        tabs: &egui_tile_tree::Tabs,
+        _tile_id: egui_tiles::TileId,
+        tabs: &egui_tiles::Tabs,
     ) {
         let Some(active) = tiles.get(tabs.active) else { return; };
-        let egui_tile_tree::Tile::Pane(space_view_id) = active else { return; };
+        let egui_tiles::Tile::Pane(space_view_id) = active else { return; };
         let space_view_id = *space_view_id;
 
         let Some(space_view) = self.space_views.get(&space_view_id) else { return; };
@@ -729,7 +729,7 @@ impl<'a, 'b> egui_tile_tree::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
     fn tab_outline_stroke(
         &self,
         _visuals: &egui::Visuals,
-        _tile_id: egui_tile_tree::TileId,
+        _tile_id: egui_tiles::TileId,
         _active: bool,
     ) -> egui::Stroke {
         egui::Stroke::NONE
@@ -741,8 +741,8 @@ impl<'a, 'b> egui_tile_tree::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
     }
 
     /// What are the rules for simplifying the tree?
-    fn simplification_options(&self) -> egui_tile_tree::SimplificationOptions {
-        egui_tile_tree::SimplificationOptions {
+    fn simplification_options(&self) -> egui_tiles::SimplificationOptions {
+        egui_tiles::SimplificationOptions {
             all_panes_must_have_tabs: true,
             ..Default::default()
         }
@@ -780,9 +780,9 @@ fn space_view_ui(
 
 // ----------------------------------------------------------------------------
 
-fn focus_tab(tree: &mut egui_tile_tree::Tree<SpaceViewId>, tab: &SpaceViewId) {
+fn focus_tab(tree: &mut egui_tiles::Tree<SpaceViewId>, tab: &SpaceViewId) {
     tree.make_active(|tile| match tile {
-        egui_tile_tree::Tile::Pane(space_view_id) => space_view_id == tab,
-        egui_tile_tree::Tile::Container(_) => false,
+        egui_tiles::Tile::Pane(space_view_id) => space_view_id == tab,
+        egui_tiles::Tile::Container(_) => false,
     });
 }

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -39,7 +39,7 @@ pub struct Viewport {
     /// One for each combination of what views are visible.
     /// So if a user toggles the visibility of one SpaceView, we
     /// switch which layout we are using. This is somewhat hacky.
-    trees: HashMap<VisibilitySet, egui_dock::Tree<SpaceViewId>>,
+    trees: HashMap<VisibilitySet, egui_tile_tree::Tree<SpaceViewId>>,
 
     /// Show one tab as maximized?
     maximized: Option<SpaceViewId>,
@@ -422,8 +422,6 @@ impl Viewport {
             return;
         }
 
-        self.trees.retain(|_, tree| is_tree_valid(tree));
-
         if let Some(space_view_id) = self.maximized {
             if !self.space_views.contains_key(&space_view_id) {
                 self.maximized = None; // protect against bad deserialized data
@@ -448,57 +446,15 @@ impl Viewport {
                 )
             });
 
-        let num_space_views = tree.num_tabs();
-        if num_space_views == 0 {
-            return;
-        }
-
-        let mut tab_viewer = TabViewer {
-            ctx,
-            space_views: &mut self.space_views,
-        };
-
         ui.scope(|ui| {
-            // we need a scope, because egui_dock unfortunately messes with the ui clip rect
-
+            let mut tab_viewer = TabViewer {
+                ctx,
+                space_views: &mut self.space_views,
+                maximized: &mut self.maximized,
+            };
             ui.spacing_mut().item_spacing.x = re_ui::ReUi::view_padding();
-
-            egui_dock::DockArea::new(tree)
-                .style(re_ui::egui_dock_style(ui.style()))
-                .show_inside(ui, &mut tab_viewer);
+            tree.ui(&mut tab_viewer, ui);
         });
-
-        // Two passes so we avoid borrowing issues:
-        let tab_bars = tree
-            .iter()
-            .filter_map(|node| {
-                let egui_dock::Node::Leaf {
-                        rect,
-                        viewport,
-                        tabs,
-                        active,
-                    } = node else {
-                        return None;
-                    };
-
-                let space_view_id = tabs.get(active.0)?;
-
-                // `rect` includes the tab area, while `viewport` is just the tab body.
-                // so the tab bar rect is:
-                let tab_bar_rect =
-                    egui::Rect::from_x_y_ranges(rect.x_range(), rect.top()..=viewport.top());
-
-                // rect/viewport can be invalid for the first frame
-                tab_bar_rect
-                    .is_finite()
-                    .then_some((*space_view_id, tab_bar_rect))
-            })
-            .collect_vec();
-
-        for (space_view_id, tab_bar_rect) in tab_bars {
-            // rect/viewport can be invalid for the first frame
-            space_view_options_ui(ctx, ui, self, tab_bar_rect, space_view_id, num_space_views);
-        }
     }
 
     pub fn add_new_spaceview_button_ui(
@@ -660,12 +616,16 @@ fn visibility_button_ui(
 struct TabViewer<'a, 'b> {
     ctx: &'a mut ViewerContext<'b>,
     space_views: &'a mut HashMap<SpaceViewId, SpaceView>,
+    maximized: &'a mut Option<SpaceViewId>,
 }
 
-impl<'a, 'b> egui_dock::TabViewer for TabViewer<'a, 'b> {
-    type Tab = SpaceViewId;
-
-    fn ui(&mut self, ui: &mut egui::Ui, space_view_id: &mut Self::Tab) {
+impl<'a, 'b> egui_tile_tree::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
+    fn pane_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _tile_id: egui_tile_tree::TileId,
+        space_view_id: &mut SpaceViewId,
+    ) -> egui_tile_tree::UiResponse {
         crate::profile_function!();
 
         let highlights =
@@ -676,18 +636,24 @@ impl<'a, 'b> egui_dock::TabViewer for TabViewer<'a, 'b> {
             .expect("Should have been populated beforehand");
 
         space_view_ui(self.ctx, ui, space_view, &highlights);
+
+        Default::default()
     }
 
-    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+    fn tab_title_for_pane(&mut self, space_view_id: &SpaceViewId) -> egui::WidgetText {
         let space_view = self
             .space_views
-            .get_mut(tab)
+            .get_mut(space_view_id)
             .expect("Should have been populated beforehand");
 
         let mut text =
             egui::WidgetText::RichText(egui::RichText::new(space_view.display_name.clone()));
 
-        if self.ctx.selection().contains(&Item::SpaceView(*tab)) {
+        if self
+            .ctx
+            .selection()
+            .contains(&Item::SpaceView(*space_view_id))
+        {
             // Show that it is selected:
             let egui_ctx = &self.ctx.re_ui.egui_ctx;
             let selection_bg_color = egui_ctx.style().visuals.selection.bg_fill;
@@ -697,9 +663,88 @@ impl<'a, 'b> egui_dock::TabViewer for TabViewer<'a, 'b> {
         text
     }
 
-    fn on_tab_button(&mut self, tab: &mut Self::Tab, response: &egui::Response) {
-        if response.clicked() {
-            self.ctx.set_single_selection(Item::SpaceView(*tab));
+    fn on_tab_button(
+        &mut self,
+        tiles: &egui_tile_tree::Tiles<SpaceViewId>,
+        tile_id: egui_tile_tree::TileId,
+        button_response: &egui::Response,
+    ) {
+        if button_response.clicked() {
+            if let Some(egui_tile_tree::Tile::Pane(space_view_id)) = tiles.get(tile_id) {
+                self.ctx
+                    .set_single_selection(Item::SpaceView(*space_view_id));
+            }
+        }
+    }
+
+    fn top_bar_rtl_ui(
+        &mut self,
+        tiles: &egui_tile_tree::Tiles<SpaceViewId>,
+        ui: &mut egui::Ui,
+        _tile_id: egui_tile_tree::TileId,
+        tabs: &egui_tile_tree::Tabs,
+    ) {
+        let Some(active) = tiles.get(tabs.active) else { return; };
+        let egui_tile_tree::Tile::Pane(space_view_id) = active else { return; };
+        let space_view_id = *space_view_id;
+
+        let Some(space_view) = self.space_views.get(&space_view_id) else { return; };
+
+        let num_space_views = tiles.tiles.values().filter(|tile| tile.is_pane()).count();
+
+        ui.add_space(4.0); // margin within the frame
+
+        if *self.maximized == Some(space_view_id) {
+            // Show minimize-button:
+            if self
+                .ctx
+                .re_ui
+                .small_icon_button(ui, &re_ui::icons::MINIMIZE)
+                .on_hover_text("Restore - show all spaces")
+                .clicked()
+            {
+                *self.maximized = None;
+            }
+        } else if num_space_views > 1 {
+            // Show maximize-button:
+            if self
+                .ctx
+                .re_ui
+                .small_icon_button(ui, &re_ui::icons::MAXIMIZE)
+                .on_hover_text("Maximize Space View")
+                .clicked()
+            {
+                *self.maximized = Some(space_view_id);
+                self.ctx
+                    .set_single_selection(Item::SpaceView(space_view_id));
+            }
+        }
+
+        // Show help last, since not all space views have help text
+        help_text_ui(ui, space_view);
+    }
+
+    // Styling:
+
+    fn tab_outline_stroke(
+        &self,
+        _visuals: &egui::Visuals,
+        _tile_id: egui_tile_tree::TileId,
+        _active: bool,
+    ) -> egui::Stroke {
+        egui::Stroke::NONE
+    }
+
+    /// The height of the bar holding tab titles.
+    fn tab_bar_height(&self, _style: &egui::Style) -> f32 {
+        re_ui::ReUi::title_bar_height()
+    }
+
+    /// What are the rules for simplifying the tree?
+    fn simplification_options(&self) -> egui_tile_tree::SimplificationOptions {
+        egui_tile_tree::SimplificationOptions {
+            all_panes_must_have_tabs: true,
+            ..Default::default()
         }
     }
 }
@@ -715,65 +760,6 @@ fn help_text_ui(ui: &mut egui::Ui, space_view: &SpaceView) {
     if let Some(help_text) = help_text {
         crate::misc::help_hover_button(ui).on_hover_text(help_text);
     }
-}
-
-/// Shown in the right of the tab panel
-fn space_view_options_ui(
-    ctx: &mut ViewerContext<'_>,
-    ui: &mut egui::Ui,
-    viewport: &mut Viewport,
-    tab_bar_rect: egui::Rect,
-    space_view_id: SpaceViewId,
-    num_space_views: usize,
-) {
-    let Some(space_view) = viewport.space_views.get(&space_view_id) else { return; };
-
-    let tab_bar_rect = tab_bar_rect.shrink2(egui::vec2(4.0, 0.0)); // Add some side margin outside the frame
-
-    ui.allocate_ui_at_rect(tab_bar_rect, |ui| {
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            let where_to_put_background = ui.painter().add(egui::Shape::Noop);
-
-            ui.add_space(4.0); // margin within the frame
-
-            if viewport.maximized == Some(space_view_id) {
-                // Show minimize-button:
-                if ctx
-                    .re_ui
-                    .small_icon_button(ui, &re_ui::icons::MINIMIZE)
-                    .on_hover_text("Restore - show all spaces")
-                    .clicked()
-                {
-                    viewport.maximized = None;
-                }
-            } else if num_space_views > 1 {
-                // Show maximize-button:
-                if ctx
-                    .re_ui
-                    .small_icon_button(ui, &re_ui::icons::MAXIMIZE)
-                    .on_hover_text("Maximize Space View")
-                    .clicked()
-                {
-                    viewport.maximized = Some(space_view_id);
-                    ctx.set_single_selection(Item::SpaceView(space_view_id));
-                }
-            }
-
-            // Show help last, since not all space views have help text
-            help_text_ui(ui, space_view);
-
-            // Put a frame so that the buttons cover any labels they intersect with:
-            let rect = ui.min_rect().expand2(egui::vec2(1.0, -2.0));
-            ui.painter().set(
-                where_to_put_background,
-                egui::Shape::rect_filled(
-                    rect,
-                    0.0,
-                    re_ui::egui_dock_style(ui.style()).tab_bar_background_color,
-                ),
-            );
-        });
-    });
 }
 
 fn space_view_ui(
@@ -794,17 +780,9 @@ fn space_view_ui(
 
 // ----------------------------------------------------------------------------
 
-fn focus_tab(tree: &mut egui_dock::Tree<SpaceViewId>, tab: &SpaceViewId) {
-    if let Some((node_index, tab_index)) = tree.find_tab(tab) {
-        tree.set_focused_node(node_index);
-        tree.set_active_tab(node_index, tab_index);
-    }
-}
-
-fn is_tree_valid(tree: &egui_dock::Tree<SpaceViewId>) -> bool {
-    tree.iter().all(|node| match node {
-        egui_dock::Node::Vertical { rect: _, fraction }
-        | egui_dock::Node::Horizontal { rect: _, fraction } => fraction.is_finite(),
-        _ => true,
-    })
+fn focus_tab(tree: &mut egui_tile_tree::Tree<SpaceViewId>, tab: &SpaceViewId) {
+    tree.make_active(|tile| match tile {
+        egui_tile_tree::Tile::Pane(space_view_id) => space_view_id == tab,
+        egui_tile_tree::Tile::Container(_) => false,
+    });
 }

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -692,7 +692,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
         let num_space_views = tiles.tiles.values().filter(|tile| tile.is_pane()).count();
 
-        ui.add_space(4.0); // margin within the frame
+        ui.add_space(8.0); // margin within the frame
 
         if *self.maximized == Some(space_view_id) {
             // Show minimize-button:


### PR DESCRIPTION
Closes #1897

![egui_tiles](https://github.com/rerun-io/rerun/assets/1148717/65685d31-9f52-46b5-bbc7-7b47f1a872e3)

### What
Replaces egui_dock with our new crate [`egui_tiles`](https://github.com/rerun-io/egui_tiles).

Functionality-wise extremely similar at this point, but perhaps with slightly nicer drag-and-drop.

Future PR:s will:
* Show the tile tree hierarchy in the blueprint view
* Use dynamic grid layouts instead of binary splits as the default heuristic

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2082
