### PR TITLE
Python SDK: Add `rr.version()`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -201,6 +201,15 @@ def init(
         _spawn()
 
 
+def version() -> str:
+    """
+    Returns a verbose version string of the Rerun SDK.
+
+    Example: `rerun_py 0.6.0-alpha.0 [rustc 1.69.0 (84c898d65 2023-04-16), LLVM 15.0.7] aarch64-apple-darwin main bd8a072, built 2023-05-11T08:25:17Z`
+    """  # noqa: E501 line too long
+    return bindings.version()  # type: ignore[no-any-return]
+
+
 def is_enabled() -> bool:
     """
     Is the Rerun SDK enabled.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -103,6 +103,7 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 
     // init
     m.add_function(wrap_pyfunction!(init, m)?)?;
+    m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(is_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(shutdown, m)?)?;
 
@@ -255,6 +256,12 @@ authkey = multiprocessing.current_process().authkey
     let authkey = locals.get_item("authkey").unwrap();
     let authkey: &PyBytes = authkey.downcast().unwrap();
     authkey.as_bytes().to_vec()
+}
+
+/// Return a verbose version string
+#[pyfunction]
+fn version() -> String {
+    re_build_info::build_info!().to_string()
 }
 
 /// Is logging enabled in the global recording?


### PR DESCRIPTION
I was trying to figure out what version of rerun was being run in a notebook, and I realized there was no way to know. Now there is!

### What
```py
>>> rr.version()
'rerun_py 0.6.0-alpha.0 [rustc 1.69.0 (84c898d65 2023-04-16), LLVM 15.0.7] aarch64-apple-darwin emilk/rr_version bd8a072, built 2023-05-11T08:40:06Z'
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
