### PR TITLE
Stop playback when we reach the end of the data

### DIFF
--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -142,9 +142,9 @@ impl TimeControl {
                     .or_insert_with(|| TimeState::new(full_range.min));
 
                 if self.looping == Looping::Off && state.time >= full_range.max {
-                    // Don't pause or rewind, just stop moving time forward
-                    // until we receive more data!
-                    // This is important for "live view".
+                    // We've reached the end - stop playing.
+                    state.time = full_range.max.into();
+                    self.pause();
                     return;
                 }
 


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2077
Closes https://github.com/rerun-io/rerun/issues/2083

### What
Previously we would get stuck in "Play" mode, which is both weird and wasteful

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2085
