### PR TITLE
Make sure `rerun/rerun_py/re_viewer` build info is updated on each build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,13 +4184,12 @@ dependencies = [
 name = "re_web_viewer_server"
 version = "0.6.0-alpha.0"
 dependencies = [
- "cargo_metadata",
  "ctrlc",
  "document-features",
  "futures-util",
- "glob",
  "hyper",
  "re_analytics",
+ "re_build_build_info",
  "re_build_web_viewer",
  "re_log",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,7 @@ name = "re_build_build_info"
 version = "0.6.0-alpha.0"
 dependencies = [
  "anyhow",
+ "glob",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,7 +3951,6 @@ dependencies = [
  "enumset",
  "getrandom",
  "glam",
- "glob",
  "gltf",
  "half 2.2.1",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,7 @@ name = "re_build_build_info"
 version = "0.6.0-alpha.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "glob",
  "time",
 ]

--- a/crates/re_analytics/build.rs
+++ b/crates/re_analytics/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    re_build_build_info::rebuild_if_crate_changed("re_analytics");
     re_build_build_info::export_env_vars();
 }

--- a/crates/re_build_build_info/Cargo.toml
+++ b/crates/re_build_build_info/Cargo.toml
@@ -18,5 +18,6 @@ all-features = true
 
 [dependencies]
 anyhow.workspace = true
+cargo_metadata = "0.15"
 glob = "0.3"
 time = { workspace = true, features = ["formatting"] }

--- a/crates/re_build_build_info/Cargo.toml
+++ b/crates/re_build_build_info/Cargo.toml
@@ -18,4 +18,5 @@ all-features = true
 
 [dependencies]
 anyhow.workspace = true
+glob = "0.3"
 time = { workspace = true, features = ["formatting"] }

--- a/crates/re_build_build_info/src/lib.rs
+++ b/crates/re_build_build_info/src/lib.rs
@@ -8,6 +8,10 @@ use anyhow::Context as _;
 
 use std::process::Command;
 
+mod rebuild_detector;
+
+pub use rebuild_detector::rebuild_if_crate_changed;
+
 // Situations to consider
 // ----------------------
 //
@@ -33,7 +37,7 @@ use std::process::Command;
 
 /// Call from the `build.rs` file of any crate you want to generate build info for.
 pub fn export_env_vars() {
-    rebuild_if_any_source_changed();
+    // rebuild_if_any_source_changed();
 
     // target triple
     set_env("RE_BUILD_TARGET_TRIPLE", &std::env::var("TARGET").unwrap());
@@ -148,43 +152,4 @@ fn rust_version() -> anyhow::Result<(String, String)> {
         rustc_version.unwrap_or_else(|| "unknown".to_owned()),
         llvm_version.unwrap_or_else(|| "unknown".to_owned()),
     ))
-}
-
-/// During local development it is useful if the version string (especially build date)
-/// gets updated whenever the binary is re-linked (e.g. when a dependency changes).
-// This is a hack to achieve an approximation of that.
-// See https://github.com/rerun-io/rerun/issues/2086 for more.
-fn rebuild_if_any_source_changed() {
-    if std::env::var("IS_IN_RERUN_WORKSPACE") != Ok("yes".to_owned()) {
-        return;
-    }
-
-    // Mapping to cargo:rerun-if-changed with glob support
-    fn rerun_if_changed(path: &str) {
-        // Workaround for windows verbatim paths not working with glob.
-        // Issue: https://github.com/rust-lang/glob/issues/111
-        // Fix: https://github.com/rust-lang/glob/pull/112
-        // Fixed on upstream, but no release containing the fix as of writing.
-        let path = path.trim_start_matches(r"\\?\");
-
-        for path in glob::glob(path).unwrap() {
-            println!("cargo:rerun-if-changed={}", path.unwrap().to_string_lossy());
-        }
-    }
-
-    // This is a very aproximative hack with a few shortcomings:
-    // 1) It will rebuild even when an unrelated crate changes.
-    // 2) It will not rebuild when an external dependency changes (e.g. a `path` depdnency)
-    // 3) It only catche some file types.
-    // For a more robutst depedency change detection system, see crates/re_web_viewer_server/build.rs
-
-    let workspace_dir = format!(
-        "{}/../..",
-        std::env::current_dir().unwrap().to_string_lossy()
-    );
-    assert!(std::path::Path::new(&format!("{workspace_dir}/Cargo.toml")).exists());
-
-    rerun_if_changed(&format!("{workspace_dir}/**/Cargo.toml"));
-    rerun_if_changed(&format!("{workspace_dir}/crates/**/*.rs"));
-    rerun_if_changed(&format!("{workspace_dir}/crates/**/*.wgsl"));
 }

--- a/crates/re_build_build_info/src/lib.rs
+++ b/crates/re_build_build_info/src/lib.rs
@@ -37,8 +37,6 @@ pub use rebuild_detector::rebuild_if_crate_changed;
 
 /// Call from the `build.rs` file of any crate you want to generate build info for.
 pub fn export_env_vars() {
-    // rebuild_if_any_source_changed();
-
     // target triple
     set_env("RE_BUILD_TARGET_TRIPLE", &std::env::var("TARGET").unwrap());
     set_env("RE_BUILD_GIT_HASH", &git_hash().unwrap_or_default());

--- a/crates/re_build_build_info/src/lib.rs
+++ b/crates/re_build_build_info/src/lib.rs
@@ -72,15 +72,21 @@ pub fn export_env_vars() {
 
     // Make sure we re-run the build script if the branch or commit changes:
     if let Ok(head_path) = git_path("HEAD") {
-        eprintln!("cargo:rerun-if-changed={head_path}"); // Track changes to branch
+        rerun_if_changed(&head_path); // Track changes to branch
         if let Ok(head) = std::fs::read_to_string(&head_path) {
             if let Some(git_file) = head.strip_prefix("ref: ") {
                 if let Ok(path) = git_path(git_file) {
-                    eprintln!("cargo:rerun-if-changed={path}"); // Track changes to commit hash
+                    rerun_if_changed(&path); // Track changes to commit hash
                 }
             }
         }
     }
+}
+
+fn rerun_if_changed(path: &str) {
+    // Make sure the file exists, otherwise we'll be rebuilding all the time.
+    assert!(std::path::Path::new(path).exists(), "Failed to find {path}");
+    println!("cargo:rerun-if-changed={path}");
 }
 
 fn set_env(name: &str, value: &str) {

--- a/crates/re_build_build_info/src/rebuild_detector.rs
+++ b/crates/re_build_build_info/src/rebuild_detector.rs
@@ -7,7 +7,7 @@ use std::{
 
 use cargo_metadata::{CargoOpt, Metadata, MetadataCommand, Package, PackageId};
 
-/// Call from `build.rs` to trigger a rebuild whenever any source file of the given packge
+/// Call from `build.rs` to trigger a rebuild whenever any source file of the given package
 /// _or any of its dependencies_ changes, recursively.
 ///
 /// This will work even if the package depends on crates that are outside of the workspace,

--- a/crates/re_build_build_info/src/rebuild_detector.rs
+++ b/crates/re_build_build_info/src/rebuild_detector.rs
@@ -24,14 +24,14 @@ pub fn rebuild_if_crate_changed(pkg_name: &str) {
     pkgs.track_implicit_dep(pkg_name, &mut files_to_watch);
 
     for path in &files_to_watch {
-        rerun_if_file_changed(path);
+        rerun_if_changed(path);
     }
 }
 
-fn rerun_if_file_changed(path: &std::path::Path) {
+fn rerun_if_changed(path: &std::path::Path) {
     // Make sure the file exists, otherwise we'll be rebuilding all the time.
     assert!(path.exists(), "Failed to find {path:?}");
-    println!("cargo:rerun-if-changed={}", path.to_string_lossy());
+    println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
 }
 
 fn rerun_if_changed_glob(path: &str, files_to_watch: &mut HashSet<PathBuf>) {

--- a/crates/re_build_build_info/src/rebuild_detector.rs
+++ b/crates/re_build_build_info/src/rebuild_detector.rs
@@ -1,0 +1,120 @@
+#![allow(clippy::unwrap_used)]
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
+
+use cargo_metadata::{CargoOpt, Metadata, MetadataCommand, Package, PackageId};
+
+/// Call from `build.rs` to trigger a rebuild whenever any source file of the given packge
+/// _or any of its dependencies_ changes, recursively.
+///
+/// This will work even if the package depends on crates that are outside of the workspace,
+/// included with `path = …`
+pub fn rebuild_if_crate_changed(pkg_name: &str) {
+    let metadata = MetadataCommand::new()
+        .features(CargoOpt::AllFeatures)
+        .exec()
+        .unwrap();
+
+    let mut files_to_watch = Default::default();
+
+    let pkgs = Packages::from_metadata(&metadata);
+    pkgs.track_implicit_dep(pkg_name, &mut files_to_watch);
+
+    for path in &files_to_watch {
+        println!("cargo:rerun-if-changed={}", path.to_string_lossy());
+    }
+}
+
+// Mapping to cargo:rerun-if-changed with glob support
+fn rerun_if_changed(path: &str, files_to_watch: &mut HashSet<PathBuf>) {
+    // Workaround for windows verbatim paths not working with glob.
+    // Issue: https://github.com/rust-lang/glob/issues/111
+    // Fix: https://github.com/rust-lang/glob/pull/112
+    // Fixed on upstream, but no release containing the fix as of writing.
+    let path = path.trim_start_matches(r"\\?\");
+
+    for path in glob::glob(path).unwrap() {
+        files_to_watch.insert(path.unwrap());
+    }
+}
+
+// ---
+
+struct Packages<'a> {
+    pkgs: HashMap<&'a str, &'a Package>,
+}
+
+impl<'a> Packages<'a> {
+    pub fn from_metadata(metadata: &'a Metadata) -> Self {
+        let pkgs = metadata
+            .packages
+            .iter()
+            .map(|pkg| (pkg.name.as_str(), pkg))
+            .collect::<HashMap<_, _>>();
+
+        Self { pkgs }
+    }
+
+    /// Tracks an implicit dependency of the given name.
+    ///
+    /// This will generate all the appropriate `cargo:rerun-if-changed` clauses
+    /// so that package `pkg_name` as well as all of it direct and indirect
+    /// dependencies are properly tracked whether they are remote, in-workspace,
+    /// or locally patched.
+    pub fn track_implicit_dep(&self, pkg_name: &str, files_to_watch: &mut HashSet<PathBuf>) {
+        let pkg = self.pkgs.get(pkg_name).unwrap_or_else(|| {
+            let found_names: Vec<&str> = self.pkgs.values().map(|pkg| pkg.name.as_str()).collect();
+            panic!("Failed to find package {pkg_name:?} among {found_names:?}")
+        });
+
+        // Track the root package itself
+        {
+            let mut path = pkg.manifest_path.clone();
+            path.pop();
+
+            // NOTE: Since we track the cargo manifest, past this point we only need to
+            // account for locally patched dependencies.
+            rerun_if_changed(path.join("Cargo.toml").as_ref(), files_to_watch);
+            rerun_if_changed(path.join("**/*.rs").as_ref(), files_to_watch);
+            rerun_if_changed(path.join("**/*.wgsl").as_ref(), files_to_watch);
+        }
+
+        // Track all direct and indirect dependencies of that root package
+        let mut tracked = HashSet::new();
+        self.track_patched_deps(&mut tracked, pkg, files_to_watch);
+    }
+
+    /// Recursively walk the tree of dependencies of the given `root` package, making sure
+    /// to track all potentially modified, locally patched dependencies.
+    fn track_patched_deps(
+        &self,
+        tracked: &mut HashSet<PackageId>,
+        root: &Package,
+        files_to_watch: &mut HashSet<PathBuf>,
+    ) {
+        for dep_pkg in root
+            .dependencies
+            .iter()
+            // NOTE: We'd like to just use `dep.source`/`dep.path`, unfortunately they do not
+            // account for crate patches at this level, so we build our own little index
+            // and use that instead.
+            .filter_map(|dep| self.pkgs.get(dep.name.as_str()))
+        {
+            let exists_on_local_disk = dep_pkg.source.is_none();
+            if exists_on_local_disk {
+                let mut dep_path = dep_pkg.manifest_path.clone();
+                dep_path.pop();
+
+                rerun_if_changed(dep_path.join("Cargo.toml").as_ref(), files_to_watch); // manifest too!
+                rerun_if_changed(dep_path.join("**/*.rs").as_ref(), files_to_watch);
+            }
+
+            if tracked.insert(dep_pkg.id.clone()) {
+                self.track_patched_deps(tracked, dep_pkg, files_to_watch);
+            }
+        }
+    }
+}

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -117,6 +117,5 @@ web-sys = { version = "0.3.61", features = [
 [build-dependencies]
 anyhow.workspace = true
 clean-path = "0.2"
-glob = "0.3"
 pathdiff = "0.2"
 walkdir = "2.0"

--- a/crates/re_sdk/build.rs
+++ b/crates/re_sdk/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    re_build_build_info::rebuild_if_crate_changed("re_sdk");
     re_build_build_info::export_env_vars();
 }

--- a/crates/re_viewer/build.rs
+++ b/crates/re_viewer/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    re_build_build_info::rebuild_if_crate_changed("re_viewer");
     re_build_build_info::export_env_vars();
 }

--- a/crates/re_viewer/build.rs
+++ b/crates/re_viewer/build.rs
@@ -1,11 +1,3 @@
 fn main() {
-    if std::env::var("IS_IN_RERUN_WORKSPACE") == Ok("yes".to_owned()) {
-        // During local development it is useful if the version string gets updated
-        // whenever the binary is re-linked (e.g. when a dependency changes).
-        // This is a glorious hack to achieve that:
-        println!("cargo:rerun-if-changed=this/path/does/not/exist");
-        // See https://github.com/rerun-io/rerun/issues/2086 for more
-    }
-
     re_build_build_info::export_env_vars();
 }

--- a/crates/re_viewer/build.rs
+++ b/crates/re_viewer/build.rs
@@ -1,3 +1,11 @@
 fn main() {
+    if std::env::var("IS_IN_RERUN_WORKSPACE") == Ok("yes".to_owned()) {
+        // During local development it is useful if the version string gets updated
+        // whenever the binary is re-linked (e.g. when a dependency changes).
+        // This is a glorious hack to achieve that:
+        println!("cargo:rerun-if-changed=this/path/does/not/exist");
+        // See https://github.com/rerun-io/rerun/issues/2086 for more
+    }
+
     re_build_build_info::export_env_vars();
 }

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -61,6 +61,5 @@ re_analytics = { workspace = true, optional = true }
 
 
 [build-dependencies]
-glob = "0.3.0"
-cargo_metadata = "0.15"
+re_build_build_info.workspace = true
 re_build_web_viewer.workspace = true

--- a/crates/re_web_viewer_server/build.rs
+++ b/crates/re_web_viewer_server/build.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::unwrap_used)]
 
 fn rerun_if_changed(path: &str) {
-    // assert!(std::path::Path::new(path).exists(), "Failed to find {path}"); // TODO
-
+    // Make sure the file exists, otherwise we'll be rebuilding all the time.
+    assert!(std::path::Path::new(path).exists(), "Failed to find {path}");
     println!("cargo:rerun-if-changed={path}");
 }
 
@@ -30,7 +30,7 @@ fn main() {
     // Rebuild the web-viewer Wasm,
     // because the web_server library bundles it with `include_bytes!`.
 
-    rerun_if_changed("../../web_viewer/favicon.ico");
+    rerun_if_changed("../../web_viewer/favicon.svg");
     rerun_if_changed("../../web_viewer/index.html");
     rerun_if_changed("../../web_viewer/sw.js");
 

--- a/crates/re_web_viewer_server/build.rs
+++ b/crates/re_web_viewer_server/build.rs
@@ -1,95 +1,9 @@
 #![allow(clippy::unwrap_used)]
 
-use std::collections::{HashMap, HashSet};
-
-use cargo_metadata::{CargoOpt, Metadata, MetadataCommand, Package, PackageId};
-
-// ---
-
-// Mapping to cargo:rerun-if-changed with glob support
 fn rerun_if_changed(path: &str) {
-    // Workaround for windows verbatim paths not working with glob.
-    // Issue: https://github.com/rust-lang/glob/issues/111
-    // Fix: https://github.com/rust-lang/glob/pull/112
-    // Fixed on upstream, but no release containing the fix as of writing.
-    let path = path.trim_start_matches(r"\\?\");
+    // assert!(std::path::Path::new(path).exists(), "Failed to find {path}"); // TODO
 
-    for path in glob::glob(path).unwrap() {
-        println!("cargo:rerun-if-changed={}", path.unwrap().to_string_lossy());
-    }
-}
-
-// ---
-
-struct Packages<'a> {
-    pkgs: HashMap<&'a str, &'a Package>,
-}
-
-impl<'a> Packages<'a> {
-    pub fn from_metadata(metadata: &'a Metadata) -> Self {
-        let pkgs = metadata
-            .packages
-            .iter()
-            .map(|pkg| (pkg.name.as_str(), pkg))
-            .collect::<HashMap<_, _>>();
-
-        Self { pkgs }
-    }
-
-    /// Tracks an implicit dependency of the given name.
-    ///
-    /// This will generate all the appropriate `cargo:rerun-if-changed` clauses
-    /// so that package `pkg_name` as well as all of it direct and indirect
-    /// dependencies are properly tracked whether they are remote, in-workspace,
-    /// or locally patched.
-    pub fn track_implicit_dep(&self, pkg_name: &str) {
-        let pkg = self.pkgs.get(pkg_name).unwrap_or_else(|| {
-            let found_names: Vec<&str> = self.pkgs.values().map(|pkg| pkg.name.as_str()).collect();
-            panic!("Failed to find package {pkg_name:?} among {found_names:?}")
-        });
-
-        // Track the root package itself
-        {
-            let mut path = pkg.manifest_path.clone();
-            path.pop();
-
-            // NOTE: Since we track the cargo manifest, past this point we only need to
-            // account for locally patched dependencies.
-            rerun_if_changed(path.join("Cargo.toml").as_ref());
-            rerun_if_changed(path.join("**/*.rs").as_ref());
-            rerun_if_changed(path.join("**/*.wgsl").as_ref());
-        }
-
-        // Track all direct and indirect dependencies of that root package
-        let mut tracked = HashSet::new();
-        self.track_patched_deps(&mut tracked, pkg);
-    }
-
-    /// Recursively walk the tree of dependencies of the given `root` package, making sure
-    /// to track all potentially modified, locally patched dependencies.
-    fn track_patched_deps(&self, tracked: &mut HashSet<PackageId>, root: &Package) {
-        for dep_pkg in root
-            .dependencies
-            .iter()
-            // NOTE: We'd like to just use `dep.source`/`dep.path`, unfortunately they do not
-            // account for crate patches at this level, so we build our own little index
-            // and use that instead.
-            .filter_map(|dep| self.pkgs.get(dep.name.as_str()))
-        {
-            let exists_on_local_disk = dep_pkg.source.is_none();
-            if exists_on_local_disk {
-                let mut dep_path = dep_pkg.manifest_path.clone();
-                dep_path.pop();
-
-                rerun_if_changed(dep_path.join("Cargo.toml").as_ref()); // manifest too!
-                rerun_if_changed(dep_path.join("**/*.rs").as_ref());
-            }
-
-            if tracked.insert(dep_pkg.id.clone()) {
-                self.track_patched_deps(tracked, dep_pkg);
-            }
-        }
-    }
+    println!("cargo:rerun-if-changed={path}");
 }
 
 fn get_and_track_env_var(env_var_name: &str) -> Result<String, std::env::VarError> {
@@ -116,20 +30,14 @@ fn main() {
     // Rebuild the web-viewer Wasm,
     // because the web_server library bundles it with `include_bytes!`.
 
-    let metadata = MetadataCommand::new()
-        .features(CargoOpt::AllFeatures)
-        .exec()
-        .unwrap();
-
     rerun_if_changed("../../web_viewer/favicon.ico");
     rerun_if_changed("../../web_viewer/index.html");
     rerun_if_changed("../../web_viewer/sw.js");
 
-    let pkgs = Packages::from_metadata(&metadata);
     // We implicitly depend on re_viewer, which means we also implicitly depend on
     // all of its direct and indirect dependencies (which are potentially in-workspace
     // or patched!).
-    pkgs.track_implicit_dep("re_viewer");
+    re_build_build_info::rebuild_if_crate_changed("re_viewer");
 
     if get_and_track_env_var("CARGO_FEATURE___CI").is_ok() {
         // If the `__ci` feature is set we skip building the web viewer wasm, saving a lot of time.

--- a/crates/rerun/build.rs
+++ b/crates/rerun/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    re_build_build_info::rebuild_if_crate_changed("rerun");
     re_build_build_info::export_env_vars();
 }

--- a/crates/rerun/build.rs
+++ b/crates/rerun/build.rs
@@ -1,11 +1,3 @@
 fn main() {
-    if std::env::var("IS_IN_RERUN_WORKSPACE") == Ok("yes".to_owned()) {
-        // During local development it is useful if the version string gets updated
-        // whenever the binary is re-linked (e.g. when a dependency changes).
-        // This is a glorious hack to achieve that:
-        println!("cargo:rerun-if-changed=this/path/does/not/exist");
-        // See https://github.com/rerun-io/rerun/issues/2086 for more
-    }
-
     re_build_build_info::export_env_vars();
 }

--- a/crates/rerun/build.rs
+++ b/crates/rerun/build.rs
@@ -1,3 +1,11 @@
 fn main() {
+    if std::env::var("IS_IN_RERUN_WORKSPACE") == Ok("yes".to_owned()) {
+        // During local development it is useful if the version string gets updated
+        // whenever the binary is re-linked (e.g. when a dependency changes).
+        // This is a glorious hack to achieve that:
+        println!("cargo:rerun-if-changed=this/path/does/not/exist");
+        // See https://github.com/rerun-io/rerun/issues/2086 for more
+    }
+
     re_build_build_info::export_env_vars();
 }

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    // Required for `cargo build` to work on mac: https://pyo3.rs/v0.14.2/building_and_distribution.html#macos
+    pyo3_build_config::add_extension_module_link_args();
+
     re_build_build_info::rebuild_if_crate_changed("rerun_py");
     re_build_build_info::export_env_vars();
 }

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -1,14 +1,3 @@
 fn main() {
-    // Required for `cargo build` to work on mac: https://pyo3.rs/v0.14.2/building_and_distribution.html#macos
-    pyo3_build_config::add_extension_module_link_args();
-
-    if std::env::var("IS_IN_RERUN_WORKSPACE") == Ok("yes".to_owned()) {
-        // During local development it is useful if the version string gets updated
-        // whenever the binary is re-linked (e.g. when a dependency changes).
-        // This is a glorious hack to achieve that:
-        println!("cargo:rerun-if-changed=this/path/does/not/exist");
-        // See https://github.com/rerun-io/rerun/issues/2086 for more
-    }
-
     re_build_build_info::export_env_vars();
 }

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -2,5 +2,13 @@ fn main() {
     // Required for `cargo build` to work on mac: https://pyo3.rs/v0.14.2/building_and_distribution.html#macos
     pyo3_build_config::add_extension_module_link_args();
 
+    if std::env::var("IS_IN_RERUN_WORKSPACE") == Ok("yes".to_owned()) {
+        // During local development it is useful if the version string gets updated
+        // whenever the binary is re-linked (e.g. when a dependency changes).
+        // This is a glorious hack to achieve that:
+        println!("cargo:rerun-if-changed=this/path/does/not/exist");
+        // See https://github.com/rerun-io/rerun/issues/2086 for more
+    }
+
     re_build_build_info::export_env_vars();
 }

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    re_build_build_info::rebuild_if_crate_changed("rerun_py");
     re_build_build_info::export_env_vars();
 }


### PR DESCRIPTION
### What
Closes https://github.com/rerun-io/rerun/issues/2086
Maybe closes https://github.com/rerun-io/rerun/issues/1209

I generalized the rebuild-detection from `re_web_viewer_server` and reused it for other crates to ensure we generate new build info (e.g. the `--version` string) each time a crate is rebuilt. I also improved this code a bit, removing duplicate files from the output (I don't know if this was a problem, but can't hurt).

I also fixed a bug in the `re_web_viewer_server` `build.rs` that caused that crate to always be rebuilt, even if nothing had changed. This was because we did `cargo:rerun-if-env-changed` on a file that was no longer there, `web_viewer/favicon.ico` (should have been `web_viewer/favicon.svg`). I have now protected against future mishaps like that.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2087
