### PR TITLE
Use instant for Time::now()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,6 +3868,7 @@ dependencies = [
  "glam",
  "half 2.2.1",
  "image",
+ "instant",
  "itertools",
  "lazy_static",
  "macaw",

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -65,6 +65,7 @@ document-features = "0.2"
 fixed = { version = "1.17", default-features = false, features = ["serde"] }
 half = { workspace = true, features = ["bytemuck"] }
 itertools = { workspace = true }
+instant = { version = "0.1" }
 lazy_static.workspace = true
 ndarray.workspace = true
 nohash-hasher = "0.2"

--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -7,10 +7,9 @@ use time::OffsetDateTime;
 pub struct Time(i64);
 
 impl Time {
-    #[cfg(not(target_arch = "wasm32"))]
     #[inline]
     pub fn now() -> Self {
-        let nanos_since_epoch = std::time::SystemTime::UNIX_EPOCH
+        let nanos_since_epoch = instant::SystemTime::UNIX_EPOCH
             .elapsed()
             .expect("Expected system clock to be set to after 1970")
             .as_nanos() as _;
@@ -152,6 +151,18 @@ impl TryFrom<std::time::SystemTime> for Time {
 
     fn try_from(time: std::time::SystemTime) -> Result<Time, Self::Error> {
         time.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .map(|duration_since_epoch| Time(duration_since_epoch.as_nanos() as _))
+    }
+}
+
+// On non-wasm32 builds, `instant::SystemTime` is a re-export of `std::time::SystemTime`,
+// so it's covered by the above `TryFrom`.
+#[cfg(target_arch = "wasm32")]
+impl TryFrom<instant::SystemTime> for Time {
+    type Error = ();
+
+    fn try_from(time: instant::SystemTime) -> Result<Time, Self::Error> {
+        time.duration_since(instant::SystemTime::UNIX_EPOCH)
             .map(|duration_since_epoch| Time(duration_since_epoch.as_nanos() as _))
     }
 }


### PR DESCRIPTION
### What
The rerun viewer wants to use Time::now() when creating a blueprint on-demand.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2090
