### PR TITLE
`tornado` >6.1 doesn't work with recent `jupyter`

### DIFF
--- a/examples/python/notebook/requirements.txt
+++ b/examples/python/notebook/requirements.txt
@@ -1,3 +1,4 @@
 ipython<=8.12 # ipython 8.13 or greater doesn't work with python 3.8
+tornado<=6.1 # later versions don't work with recent jupyter releases...
 jupyter
 rerun-sdk

--- a/examples/python/notebook/requirements.txt
+++ b/examples/python/notebook/requirements.txt
@@ -1,4 +1,10 @@
 ipython<=8.12 # ipython 8.13 or greater doesn't work with python 3.8
-tornado<=6.1 # later versions don't work with recent jupyter releases...
 jupyter
 rerun-sdk
+
+# Lots of reported incompatibilities across recent versions for these 3 deps.
+# The following seems to be the most recent recommendations for a stable experience.
+# See e.g. https://github.com/jupyter/notebook/issues/6721
+jupyter_client<8
+pyzmq<25
+tornado<=6.1


### PR DESCRIPTION
Any version more recent than that will cause random crashes/deadlocks/etc, see e.g. https://youtrack.jetbrains.com/issue/DS-4883.

And so we pin it...

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2092
