### PR TITLE
Work around https://github.com/sebcrozet/instant/issues/49

### DIFF
--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -7,10 +7,22 @@ use time::OffsetDateTime;
 pub struct Time(i64);
 
 impl Time {
+    // NOTE: Even though `instant` should work on wasm, `elapsed` is broken.
+    // See: https://github.com/sebcrozet/instant/issues/49
+    // We would like to switch to `web-time`, but that's broken in a different way
+    // See issues in: https://github.com/rerun-io/rerun/pull/2093
+    //
+    // So we implement what elapsed is supposed to do ourselves.
     #[inline]
     pub fn now() -> Self {
+        /*
         let nanos_since_epoch = instant::SystemTime::UNIX_EPOCH
             .elapsed()
+            .expect("Expected system clock to be set to after 1970")
+            .as_nanos() as _;
+        */
+        let nanos_since_epoch = instant::SystemTime::now()
+            .duration_since(instant::SystemTime::UNIX_EPOCH)
             .expect("Expected system clock to be set to after 1970")
             .as_nanos() as _;
         Self(nanos_since_epoch)

--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -7,14 +7,12 @@ use time::OffsetDateTime;
 pub struct Time(i64);
 
 impl Time {
-    // NOTE: Even though `instant` should work on wasm, `elapsed` is broken.
-    // See: https://github.com/sebcrozet/instant/issues/49
-    // We would like to switch to `web-time`, but that's broken in a different way
-    // See issues in: https://github.com/rerun-io/rerun/pull/2093
-    //
-    // So we implement what elapsed is supposed to do ourselves.
     #[inline]
     pub fn now() -> Self {
+        // TODO(https://github.com/rerun-io/rerun/issues/2105): Even though `instant` should work on wasm,
+        // `elapsed` is broken.  See: https://github.com/sebcrozet/instant/issues/49
+        //
+        // For now, we implement what elapsed is supposed to do ourselves.
         /*
         let nanos_since_epoch = instant::SystemTime::UNIX_EPOCH
             .elapsed()


### PR DESCRIPTION
Even though `instant` should work on wasm, `elapsed` is broken. See:
 - https://github.com/sebcrozet/instant/issues/49

We would like to switch to `web-time`, but that's broken in a different way. See issues in:
 - https://github.com/rerun-io/rerun/pull/2093
  
Fortunately elapsed isn't all that magical, so this is a good enough stop-gap for the time being.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2094
