### PR TITLE
Premultiply alpha of RGBA u8 images

### DIFF
--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -78,6 +78,10 @@ fn color_tensor_to_gpu(
                 TextureFormat::Rgba8UnormSrgb,
             ),
             (4, TensorData::U8(buf)) => (
+                // We pre-multiply on the CPU because we currently use hardware texture filtering
+                // in `rectangle_fs.wgsl`, and pre-multiplication needs to happen before filtering.
+                // If we switched our shader to always do software filtering we could do the pre-multiplication
+                // on the GPU instead, saving us some time here!
                 premultiply_alpha(buf.as_slice()).into(),
                 TextureFormat::Rgba8UnormSrgb,
             ),

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -78,8 +78,7 @@ fn color_tensor_to_gpu(
                 TextureFormat::Rgba8UnormSrgb,
             ),
             (4, TensorData::U8(buf)) => (
-                // TODO(emilk): premultiply alpha
-                cast_slice_to_cow(buf.as_slice()),
+                premultiply_alpha(buf.as_slice()).into(),
                 TextureFormat::Rgba8UnormSrgb,
             ),
 
@@ -464,6 +463,15 @@ fn pad_and_narrow_and_cast<T: Copy + Pod>(
         .flat_map(|chunk| [narrow(chunk[0]), narrow(chunk[1]), narrow(chunk[2]), pad])
         .collect();
     pod_collect_to_vec(&floats).into()
+}
+
+fn premultiply_alpha(rgba: &[u8]) -> Vec<u8> {
+    crate::profile_function!();
+    rgba.chunks_exact(4)
+        .flat_map(|rgba| {
+            egui::Color32::from_rgba_unmultiplied(rgba[0], rgba[1], rgba[2], rgba[3]).to_array()
+        })
+        .collect()
 }
 
 // ----------------------------------------------------------------------------;


### PR DESCRIPTION
### What
This makes RGBA u8 images with alpha show up correctly

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2095
