### PR TITLE
Python `log_mesh_file`: accept either path or bytes

### DIFF
--- a/examples/python/deep_sdf/main.py
+++ b/examples/python/deep_sdf/main.py
@@ -67,7 +67,7 @@ def get_mesh_format(mesh: Trimesh) -> rr.MeshFormat:
     try:
         return {
             ".glb": rr.MeshFormat.GLB,
-            # ".gltf": MeshFormat.GLTF,
+            # ".gltf": rr.MeshFormat.GLTF,
             ".obj": rr.MeshFormat.OBJ,
         }[ext]
     except Exception:
@@ -104,15 +104,14 @@ def log_mesh(path: Path, mesh: Trimesh) -> None:
     bs2 = mesh_to_sdf.scale_to_unit_sphere(mesh).bounding_sphere
     mesh_format = get_mesh_format(mesh)
 
-    with open(path, mode="rb") as file:
-        scale = bs2.scale / bs1.scale
-        center = bs2.center - bs1.center * scale
-        rr.log_mesh_file(
-            "world/mesh",
-            mesh_format,
-            file.read(),
-            transform=np.array([[scale, 0, 0, center[0]], [0, scale, 0, center[1]], [0, 0, scale, center[2]]]),
-        )
+    scale = bs2.scale / bs1.scale
+    center = bs2.center - bs1.center * scale
+    rr.log_mesh_file(
+        "world/mesh",
+        mesh_format,
+        mesh_path=path,
+        transform=np.array([[scale, 0, 0, center[0]], [0, scale, 0, center[1]], [0, 0, scale, center[2]]]),
+    )
 
 
 def log_sampled_sdf(points: npt.NDArray[np.float32], sdf: npt.NDArray[np.float32]) -> None:

--- a/rerun_py/rerun_sdk/rerun/log/file.py
+++ b/rerun_py/rerun_sdk/rerun/log/file.py
@@ -44,13 +44,16 @@ class ImageFormat(Enum):
 def log_mesh_file(
     entity_path: str,
     mesh_format: MeshFormat,
-    mesh_file: bytes,
     *,
+    mesh_bytes: Optional[bytes] = None,
+    mesh_path: Optional[Path] = None,
     transform: Optional[npt.ArrayLike] = None,
     timeless: bool = False,
 ) -> None:
     """
     Log the contents of a mesh file (.gltf, .glb, .obj, …).
+
+    You must pass either `mesh_bytes` or `mesh_path`.
 
     You can also use [`rerun.log_mesh`] to log raw mesh data.
 
@@ -70,8 +73,10 @@ def log_mesh_file(
         Path to the mesh in the space hierarchy
     mesh_format:
         Format of the mesh file
-    mesh_file:
-        Contents of the mesh file
+    mesh_bytes:
+        Content of an mesh file, e.g. a `.glb`.
+    mesh_path:
+        Path to an mesh file, e.g. a `.glb`.
     transform:
         Optional 3x4 affine transform matrix applied to the mesh
     timeless:
@@ -85,7 +90,14 @@ def log_mesh_file(
         transform = np.require(transform, dtype="float32")
 
     # Mesh arrow handling happens inside the python bridge
-    bindings.log_mesh_file(entity_path, mesh_format.value, mesh_file, transform, timeless)
+    bindings.log_mesh_file(
+        entity_path,
+        mesh_format=mesh_format.value,
+        mesh_bytes=mesh_bytes,
+        mesh_path=mesh_path,
+        transform=transform,
+        timeless=timeless,
+    )
 
 
 @log_decorator

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -871,9 +871,10 @@ fn log_meshes(
 fn log_mesh_file(
     entity_path_str: &str,
     mesh_format: &str,
-    bytes: &[u8],
     transform: numpy::PyReadonlyArray2<'_, f32>,
     timeless: bool,
+    mesh_bytes: Option<Vec<u8>>,
+    mesh_path: Option<PathBuf>,
 ) -> PyResult<()> {
     let data_stream = global_data_stream();
     let Some(data_stream) = data_stream.as_ref() else {
@@ -882,6 +883,7 @@ fn log_mesh_file(
     };
 
     let entity_path = parse_entity_path(entity_path_str)?;
+
     let format = match mesh_format {
         "GLB" => MeshFormat::Glb,
         "GLTF" => MeshFormat::Gltf,
@@ -893,7 +895,18 @@ fn log_mesh_file(
             )));
         }
     };
-    let bytes: Vec<u8> = bytes.into();
+
+    let mesh_bytes = match (mesh_bytes, mesh_path) {
+        (Some(mesh_bytes), None) => mesh_bytes,
+        (None, Some(mesh_path)) => std::fs::read(mesh_path)?,
+        (None, None) => Err(PyTypeError::new_err(
+            "log_mesh_file: You must pass either mesh_bytes or mesh_path",
+        ))?,
+        (Some(_), Some(_)) => Err(PyTypeError::new_err(
+            "log_mesh_file: You must pass either mesh_bytes or mesh_path, but not both!",
+        ))?,
+    };
+
     let transform = if transform.is_empty() {
         [
             [1.0, 0.0, 0.0], // col 0
@@ -924,7 +937,7 @@ fn log_mesh_file(
     let mesh3d = Mesh3D::Encoded(EncodedMesh3D {
         mesh_id: MeshId::random(),
         format,
-        bytes: bytes.into(),
+        bytes: mesh_bytes.into(),
         transform,
     });
 


### PR DESCRIPTION
We had a user who accidentally passed in a path instead of bytes.

That is an argument for named arguments, and for supporting both paths and file contents.

This is a breaking change, but one that `mypy` catches:

```
mypy --no-warn-unused-ignore
examples/python/deep_sdf/main.py:110: error: Too many positional arguments for "log_mesh_file"  [misc]
```

…so let's hope our users uses `mypy`!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2098
