### PR TITLE
Fix problem of rrd playback stopping prematurely.

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🪳 bug, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, 🪳 bug, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, 🦟 regression, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -142,6 +142,13 @@ impl TimeControl {
                     .or_insert_with(|| TimeState::new(full_range.min));
 
                 if self.looping == Looping::Off && state.time >= full_range.max {
+                    // TODO(https://github.com/rerun-io/rerun/issues/2077): We could like to pause
+                    // at this point but only if we know we're guaranteed not to get any more data.
+                    // because we progressively load RRD files this is actually tricky to get right.
+                    //
+                    // See the details in the comment here:
+                    // https://github.com/rerun-io/rerun/issues/2077#issuecomment-1545773200
+
                     // Don't pause or rewind, just stop moving time forward
                     // until we receive more data!
                     // This is important for "live view".

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -146,8 +146,8 @@ impl TimeControl {
                     // at this point but only if we know we're guaranteed not to get any more data.
                     // because we progressively load RRD files this is actually tricky to get right.
                     //
-                    // See the details in the comment here:
-                    // https://github.com/rerun-io/rerun/issues/2077#issuecomment-1545773200
+                    // See the details in the PR here:
+                    // https://github.com/rerun-io/rerun/pull/2103
 
                     // Don't pause or rewind, just stop moving time forward
                     // until we receive more data!

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -142,9 +142,9 @@ impl TimeControl {
                     .or_insert_with(|| TimeState::new(full_range.min));
 
                 if self.looping == Looping::Off && state.time >= full_range.max {
-                    // We've reached the end - stop playing.
-                    state.time = full_range.max.into();
-                    self.pause();
+                    // Don't pause or rewind, just stop moving time forward
+                    // until we receive more data!
+                    // This is important for "live view".
                     return;
                 }
 


### PR DESCRIPTION
### What
https://github.com/rerun-io/rerun/pull/2085 introduced a race condition with playback of RRD files where we would hit the end of the *current* time range, usually right at the beginning of playback, resulting in the viewer stuck in this state:
![image](https://github.com/rerun-io/rerun/assets/3312232/ea5b896a-4085-4643-b3aa-ac25bf8d59e8)

Reverting that for now and adding some more details.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2103
