### PR TITLE
Make every RecordingId typed and preclude the existence of 'Defaults'

### DIFF
--- a/crates/re_data_store/examples/memory_usage.rs
+++ b/crates/re_data_store/examples/memory_usage.rs
@@ -48,7 +48,7 @@ fn live_bytes() -> usize {
 
 // ----------------------------------------------------------------------------
 
-use re_log_types::{entity_path, DataRow, RecordingId, RowId};
+use re_log_types::{entity_path, DataRow, RecordingId, RecordingType, RowId};
 
 fn main() {
     log_messages();
@@ -91,7 +91,7 @@ fn log_messages() {
 
     const NUM_POINTS: usize = 1_000;
 
-    let recording_id = RecordingId::random();
+    let recording_id = RecordingId::random(RecordingType::Data);
     let timeline = Timeline::new_sequence("frame_nr");
     let mut time_point = TimePoint::default();
     time_point.insert(timeline, TimeInt::from(0));

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -159,8 +159,10 @@ impl EntityDb {
 // ----------------------------------------------------------------------------
 
 /// A in-memory database built from a stream of [`LogMsg`]es.
-#[derive(Default)]
 pub struct LogDb {
+    /// The recording id for this log.
+    recording_id: RecordingId,
+
     /// All [`EntityPathOpMsg`]s ever received.
     entity_op_msgs: BTreeMap<RowId, EntityPathOpMsg>,
 
@@ -175,6 +177,16 @@ pub struct LogDb {
 }
 
 impl LogDb {
+    pub fn new(recording_id: RecordingId) -> Self {
+        Self {
+            recording_id,
+            entity_op_msgs: Default::default(),
+            data_source: None,
+            recording_msg: None,
+            entity_db: Default::default(),
+        }
+    }
+
     pub fn recording_msg(&self) -> Option<&BeginRecordingMsg> {
         self.recording_msg.as_ref()
     }
@@ -183,12 +195,8 @@ impl LogDb {
         self.recording_msg().map(|msg| &msg.info)
     }
 
-    pub fn recording_id(&self) -> RecordingId {
-        if let Some(msg) = &self.recording_msg {
-            msg.info.recording_id.clone()
-        } else {
-            RecordingId::unknown()
-        }
+    pub fn recording_id(&self) -> &RecordingId {
+        &self.recording_id
     }
 
     pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {
@@ -208,7 +216,7 @@ impl LogDb {
             + self.entity_db.data_store.num_temporal_rows() as usize
     }
 
-    pub fn is_default(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.recording_msg.is_none() && self.num_rows() == 0
     }
 
@@ -227,7 +235,7 @@ impl LogDb {
                 self.entity_db.add_path_op(*row_id, time_point, path_op);
             }
             LogMsg::ArrowMsg(_, inner) => self.entity_db.try_add_arrow_msg(inner)?,
-            LogMsg::Goodbye(_) => {}
+            LogMsg::Goodbye(_, _) => {}
         }
 
         Ok(())
@@ -264,6 +272,7 @@ impl LogDb {
         let cutoff_times = self.entity_db.data_store.oldest_time_per_timeline();
 
         let Self {
+            recording_id: _,
             entity_op_msgs,
             data_source: _,
             recording_msg: _,

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -18,7 +18,7 @@ impl DataUi for LogMsg {
             LogMsg::BeginRecordingMsg(msg) => msg.data_ui(ctx, ui, verbosity, query),
             LogMsg::EntityPathOpMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
             LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
-            LogMsg::Goodbye(_) => {
+            LogMsg::Goodbye(_, _) => {
                 ui.label("Goodbye");
             }
         }

--- a/crates/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -6,7 +6,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use re_log_types::{
     datagen::{build_frame_nr, build_some_colors, build_some_point2d},
-    entity_path, DataRow, DataTable, Index, LogMsg, RecordingId, RowId, TableId,
+    entity_path, DataRow, DataTable, Index, LogMsg, RecordingId, RecordingType, RowId, TableId,
 };
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -81,7 +81,7 @@ fn mono_points_arrow(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random();
+        let recording_id = RecordingId::random(RecordingType::Data);
         let mut group = c.benchmark_group("mono_points_arrow");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -137,7 +137,7 @@ fn mono_points_arrow_batched(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random();
+        let recording_id = RecordingId::random(RecordingType::Data);
         let mut group = c.benchmark_group("mono_points_arrow_batched");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -194,7 +194,7 @@ fn batch_points_arrow(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random();
+        let recording_id = RecordingId::random(RecordingType::Data);
         let mut group = c.benchmark_group("batch_points_arrow");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {

--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -184,14 +184,14 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 fn test_encode_decode() {
     use re_log_types::{
         ApplicationId, BeginRecordingMsg, LogMsg, RecordingId, RecordingInfo, RecordingSource,
-        RowId, Time,
+        RecordingType, RowId, Time,
     };
 
     let messages = vec![LogMsg::BeginRecordingMsg(BeginRecordingMsg {
         row_id: RowId::random(),
         info: RecordingInfo {
             application_id: ApplicationId("test".to_owned()),
-            recording_id: RecordingId::random(),
+            recording_id: RecordingId::random(RecordingType::Data),
             is_official_example: true,
             started: Time::now(),
             recording_source: RecordingSource::RustSdk {

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -89,78 +89,63 @@ macro_rules! impl_into_enum {
 
 // ----------------------------------------------------------------------------
 
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum RecordingType {
+    Data,
+    Blueprint,
+}
+
+impl std::fmt::Display for RecordingType {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Data => "Data".fmt(f),
+            Self::Blueprint => "Blueprint".fmt(f),
+        }
+    }
+}
+
 /// A unique id per recording (a stream of [`LogMsg`]es).
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct RecordingId(Arc<String>);
-
-impl Default for RecordingId {
-    fn default() -> Self {
-        Self::unknown()
-    }
+pub struct RecordingId {
+    variant: RecordingType,
+    id: Arc<String>,
 }
 
 impl RecordingId {
     #[inline]
-    pub fn unknown() -> Self {
-        "UNKNOWN".into()
+    pub fn random(variant: RecordingType) -> Self {
+        Self {
+            variant,
+            id: Arc::new(uuid::Uuid::new_v4().to_string()),
+        }
     }
 
     #[inline]
-    pub fn random() -> Self {
-        Self(Arc::new(uuid::Uuid::new_v4().to_string()))
+    pub fn from_uuid(variant: RecordingType, uuid: uuid::Uuid) -> Self {
+        Self {
+            variant,
+            id: Arc::new(uuid.to_string()),
+        }
     }
 
     #[inline]
-    pub fn from_uuid(uuid: uuid::Uuid) -> Self {
-        Self(Arc::new(uuid.to_string()))
+    pub fn from_string(variant: RecordingType, str: String) -> Self {
+        Self {
+            variant,
+            id: Arc::new(str),
+        }
     }
 }
 
 impl std::fmt::Display for RecordingId {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<&str> for RecordingId {
-    fn from(s: &str) -> Self {
-        Self(Arc::new(s.to_owned()))
-    }
-}
-
-impl From<String> for RecordingId {
-    fn from(s: String) -> Self {
-        Self(Arc::new(s))
-    }
-}
-
-impl RecordingId {
-    #[inline]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl AsRef<str> for RecordingId {
-    #[inline]
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl std::borrow::Borrow<str> for RecordingId {
-    #[inline]
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl std::ops::Deref for RecordingId {
-    type Target = str;
-    #[inline]
-    fn deref(&self) -> &str {
-        self.as_str()
+        let Self { variant, id } = self;
+        f.write_fmt(format_args!("{variant}:{id}"))?;
+        Ok(())
     }
 }
 
@@ -221,17 +206,17 @@ pub enum LogMsg {
     ArrowMsg(RecordingId, ArrowMsg),
 
     /// Sent when the client shuts down the connection.
-    Goodbye(RowId),
+    Goodbye(RecordingId, RowId),
 }
 
 impl LogMsg {
-    pub fn recording_id(&self) -> Option<&RecordingId> {
+    pub fn recording_id(&self) -> &RecordingId {
         match self {
-            Self::BeginRecordingMsg(msg) => Some(&msg.info.recording_id),
+            Self::BeginRecordingMsg(msg) => &msg.info.recording_id,
             Self::EntityPathOpMsg(recording_id, _) | Self::ArrowMsg(recording_id, _) => {
-                Some(recording_id)
+                recording_id
             }
-            Self::Goodbye(_) => None,
+            Self::Goodbye(recording_id, _) => recording_id,
         }
     }
 }

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -19,6 +19,7 @@ mod recording_stream;
 pub use self::msg_sender::{MsgSender, MsgSenderError};
 pub use self::recording_stream::{RecordingStream, RecordingStreamBuilder};
 
+use re_log_types::RecordingType;
 pub use re_sdk_comms::default_server_addr;
 
 pub use re_log_types::{
@@ -155,7 +156,7 @@ pub fn new_recording_info(
 ) -> re_log_types::RecordingInfo {
     re_log_types::RecordingInfo {
         application_id: application_id.into(),
-        recording_id: RecordingId::random(),
+        recording_id: RecordingId::random(RecordingType::Data),
         is_official_example: called_from_official_rust_example(),
         started: re_log_types::Time::now(),
         recording_source: re_log_types::RecordingSource::RustSdk {

--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use re_log_types::LogMsg;
+use re_log_types::{LogMsg, RecordingId};
 
 /// Where the SDK sends its log messages.
 pub trait LogSink: Send + Sync + 'static {
@@ -145,9 +145,9 @@ impl TcpSink {
     /// Connect to the given address in a background thread.
     /// Retries until successful.
     #[inline]
-    pub fn new(addr: std::net::SocketAddr) -> Self {
+    pub fn new(recording_id: RecordingId, addr: std::net::SocketAddr) -> Self {
         Self {
-            client: re_sdk_comms::Client::new(addr),
+            client: re_sdk_comms::Client::new(recording_id, addr),
         }
     }
 }

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -156,7 +156,7 @@ async fn run_client(
         congestion_manager.register_latency(tx.latency_sec());
 
         for msg in re_log_encoding::decoder::decode_bytes(&packet)? {
-            if matches!(msg, LogMsg::Goodbye(_)) {
+            if matches!(msg, LogMsg::Goodbye(_, _)) {
                 re_log::debug!("Received goodbye message.");
                 tx.send(msg)?;
                 return Ok(());
@@ -210,9 +210,9 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::BeginRecordingMsg(_) | LogMsg::EntityPathOpMsg(_, _) | LogMsg::Goodbye(_) => {
-                true
-            }
+            LogMsg::BeginRecordingMsg(_)
+            | LogMsg::EntityPathOpMsg(_, _)
+            | LogMsg::Goodbye(_, _) => true,
 
             LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1,6 +1,7 @@
 use std::{any::Any, hash::Hash};
 
 use ahash::HashMap;
+use anyhow::Context;
 use egui::NumExt as _;
 use instant::Instant;
 use itertools::Itertools as _;
@@ -218,16 +219,18 @@ impl App {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn loop_selection(&self) -> Option<(re_data_store::Timeline, TimeRangeF)> {
-        self.state
-            .recording_configs
-            .get(&self.state.selected_rec_id)
-            // is there an active loop selection?
-            .and_then(|rec_cfg| {
-                rec_cfg
-                    .time_ctrl
-                    .loop_selection()
-                    .map(|q| (*rec_cfg.time_ctrl.timeline(), q))
-            })
+        self.state.selected_rec_id.as_ref().and_then(|rec_id| {
+            self.state
+                .recording_configs
+                .get(rec_id)
+                // is there an active loop selection?
+                .and_then(|rec_cfg| {
+                    rec_cfg
+                        .time_ctrl
+                        .loop_selection()
+                        .map(|q| (*rec_cfg.time_ctrl.timeline(), q))
+                })
+        })
     }
 
     fn run_pending_commands(&mut self, egui_ctx: &egui::Context, frame: &mut eframe::Frame) {
@@ -311,13 +314,21 @@ impl App {
 
             Command::SelectionPrevious => {
                 let state = &mut self.state;
-                if let Some(rec_cfg) = state.recording_configs.get_mut(&state.selected_rec_id) {
+                if let Some(rec_cfg) = state
+                    .selected_rec_id
+                    .as_ref()
+                    .and_then(|rec_id| state.recording_configs.get_mut(rec_id))
+                {
                     rec_cfg.selection_state.select_previous();
                 }
             }
             Command::SelectionNext => {
                 let state = &mut self.state;
-                if let Some(rec_cfg) = state.recording_configs.get_mut(&state.selected_rec_id) {
+                if let Some(rec_cfg) = state
+                    .selected_rec_id
+                    .as_ref()
+                    .and_then(|rec_id| state.recording_configs.get_mut(rec_id))
+                {
                     rec_cfg.selection_state.select_next();
                 }
             }
@@ -344,7 +355,7 @@ impl App {
     }
 
     fn run_time_control_command(&mut self, command: TimeControlCommand) {
-        let rec_id = &self.state.selected_rec_id;
+        let Some(rec_id) = &self.state.selected_rec_id else {return;};
         let Some(rec_cfg) = self.state.recording_configs.get_mut(rec_id) else {return;};
         let time_ctrl = &mut rec_cfg.time_ctrl;
 
@@ -371,7 +382,7 @@ impl App {
     }
 
     fn selected_app_id(&self) -> ApplicationId {
-        if let Some(log_db) = self.log_dbs.get(&self.state.selected_rec_id) {
+        if let Some(log_db) = self.log_db() {
             log_db
                 .recording_info()
                 .map_or_else(ApplicationId::unknown, |rec_info| {
@@ -474,8 +485,15 @@ impl eframe::App for App {
             render_ctx.gpu_resources.statistics()
         };
 
-        let store_config = self.log_db().entity_db.data_store.config().clone();
-        let store_stats = DataStoreStats::from_store(&self.log_db().entity_db.data_store);
+        let store_config = self
+            .log_db()
+            .map(|log_db| log_db.entity_db.data_store.config().clone())
+            .unwrap_or_default();
+
+        let store_stats = self
+            .log_db()
+            .map(|log_db| DataStoreStats::from_store(&log_db.entity_db.data_store))
+            .unwrap_or_default();
 
         // do first, before doing too many allocations
         self.memory_panel.update(&gpu_resource_stats, &store_stats);
@@ -509,31 +527,32 @@ impl eframe::App for App {
 
                 self.memory_panel_ui(ui, &gpu_resource_stats, &store_config, &store_stats);
 
-                let log_db = self
-                    .log_dbs
-                    .entry(self.state.selected_rec_id.clone())
-                    .or_default();
-                let selected_app_id = log_db
-                    .recording_info()
-                    .map_or_else(ApplicationId::unknown, |rec_info| {
-                        rec_info.application_id.clone()
-                    });
-                let blueprint = self
+                if let Some(log_db) = self
                     .state
-                    .blueprints
-                    .entry(selected_app_id)
-                    .or_insert_with(|| Blueprint::new(egui_ctx));
-
-                recording_config_entry(
-                    &mut self.state.recording_configs,
-                    self.state.selected_rec_id.clone(),
-                    self.rx.source(),
-                    log_db,
-                )
-                .selection_state
-                .on_frame_start(|item| blueprint.is_item_valid(item));
-
+                    .selected_rec_id
+                    .as_ref()
+                    .and_then(|rec_id| self.log_dbs.get(rec_id))
                 {
+                    let selected_app_id = log_db
+                        .recording_info()
+                        .map_or_else(ApplicationId::unknown, |rec_info| {
+                            rec_info.application_id.clone()
+                        });
+                    let blueprint = self
+                        .state
+                        .blueprints
+                        .entry(selected_app_id)
+                        .or_insert_with(|| Blueprint::new(egui_ctx));
+
+                    recording_config_entry(
+                        &mut self.state.recording_configs,
+                        log_db.recording_id().clone(),
+                        self.rx.source(),
+                        log_db,
+                    )
+                    .selection_state
+                    .on_frame_start(|item| blueprint.is_item_valid(item));
+
                     // TODO(andreas): store the re_renderer somewhere else.
                     let egui_renderer = {
                         let render_state = frame.wgpu_render_state().unwrap();
@@ -545,7 +564,7 @@ impl eframe::App for App {
                         .unwrap();
                     render_ctx.begin_frame();
 
-                    if log_db.is_default() {
+                    if log_db.is_empty() {
                         wait_screen_ui(ui, &self.rx);
                     } else {
                         self.state.show(
@@ -556,9 +575,11 @@ impl eframe::App for App {
                             &self.component_ui_registry,
                             &self.rx,
                         );
-                    }
 
-                    render_ctx.before_submit();
+                        render_ctx.before_submit();
+                    }
+                } else {
+                    wait_screen_ui(ui, &self.rx);
                 }
             });
 
@@ -695,37 +716,39 @@ impl App {
         let start = instant::Instant::now();
 
         while let Ok(msg) = self.rx.try_recv() {
-            // All messages except [`LogMsg::GoodBye`] should have an associated recording id
-            if let Some(recording_id) = msg.recording_id() {
-                let is_new_recording = if let LogMsg::BeginRecordingMsg(msg) = &msg {
-                    re_log::debug!("Opening a new recording: {:?}", msg.info);
-                    self.state.selected_rec_id = msg.info.recording_id.clone();
-                    true
-                } else {
-                    false
-                };
+            let recording_id = msg.recording_id();
 
-                let log_db = self.log_dbs.entry(recording_id.clone()).or_default();
+            let is_new_recording = if let LogMsg::BeginRecordingMsg(msg) = &msg {
+                re_log::debug!("Opening a new recording: {:?}", msg.info);
+                self.state.selected_rec_id = Some(recording_id.clone());
+                true
+            } else {
+                false
+            };
 
-                if log_db.data_source.is_none() {
-                    log_db.data_source = Some(self.rx.source().clone());
-                }
+            let log_db = self
+                .log_dbs
+                .entry(recording_id.clone())
+                .or_insert_with(|| LogDb::new(recording_id.clone()));
 
-                if let Err(err) = log_db.add(&msg) {
-                    re_log::error!("Failed to add incoming msg: {err}");
-                };
+            if log_db.data_source.is_none() {
+                log_db.data_source = Some(self.rx.source().clone());
+            }
 
-                if is_new_recording {
-                    // Do analytics after ingesting the new message,
-                    // because thats when the `log_db.recording_info` is set,
-                    // which we use in the analytics call.
-                    self.analytics.on_open_recording(log_db);
-                }
+            if let Err(err) = log_db.add(&msg) {
+                re_log::error!("Failed to add incoming msg: {err}");
+            };
 
-                if start.elapsed() > instant::Duration::from_millis(10) {
-                    egui_ctx.request_repaint(); // make sure we keep receiving messages asap
-                    break; // don't block the main thread for too long
-                }
+            if is_new_recording {
+                // Do analytics after ingesting the new message,
+                // because thats when the `log_db.recording_info` is set,
+                // which we use in the analytics call.
+                self.analytics.on_open_recording(log_db);
+            }
+
+            if start.elapsed() > instant::Duration::from_millis(10) {
+                egui_ctx.request_repaint(); // make sure we keep receiving messages asap
+                break; // don't block the main thread for too long
             }
         }
     }
@@ -733,10 +756,15 @@ impl App {
     fn cleanup(&mut self) {
         crate::profile_function!();
 
-        self.log_dbs.retain(|_, log_db| !log_db.is_default());
+        self.log_dbs.retain(|_, log_db| !log_db.is_empty());
 
-        if !self.log_dbs.contains_key(&self.state.selected_rec_id) {
-            self.state.selected_rec_id = self.log_dbs.keys().next().cloned().unwrap_or_default();
+        if !self
+            .state
+            .selected_rec_id
+            .as_ref()
+            .map_or(false, |rec_id| self.log_dbs.contains_key(rec_id))
+        {
+            self.state.selected_rec_id = self.log_dbs.keys().next().cloned();
         }
 
         self.state
@@ -838,21 +866,20 @@ impl App {
 
     /// Do we have an open `LogDb` that is non-empty?
     fn log_db_is_nonempty(&self) -> bool {
-        self.log_dbs
-            .get(&self.state.selected_rec_id)
-            .map_or(false, |log_db| !log_db.is_default())
+        self.log_db().map_or(false, |log_db| !log_db.is_empty())
     }
 
-    fn log_db(&mut self) -> &mut LogDb {
-        self.log_dbs
-            .entry(self.state.selected_rec_id.clone())
-            .or_default()
+    fn log_db(&self) -> Option<&LogDb> {
+        self.state
+            .selected_rec_id
+            .as_ref()
+            .and_then(|rec_id| self.log_dbs.get(rec_id))
     }
 
     fn show_log_db(&mut self, log_db: LogDb) {
         self.analytics.on_open_recording(&log_db);
-        self.state.selected_rec_id = log_db.recording_id();
-        self.log_dbs.insert(log_db.recording_id(), log_db);
+        self.state.selected_rec_id = Some(log_db.recording_id().clone());
+        self.log_dbs.insert(log_db.recording_id().clone(), log_db);
     }
 
     fn handle_dropping_files(&mut self, egui_ctx: &egui::Context) {
@@ -937,7 +964,7 @@ struct AppState {
     #[serde(skip)]
     cache: Caches,
 
-    selected_rec_id: RecordingId,
+    selected_rec_id: Option<RecordingId>,
 
     /// Configuration for the current recording (found in [`LogDb`]).
     recording_configs: HashMap<RecordingId, RecordingConfig>,
@@ -971,7 +998,7 @@ impl AppState {
         let Self {
             app_options: options,
             cache,
-            selected_rec_id,
+            selected_rec_id: _,
             recording_configs,
             panel_selection,
             blueprints,
@@ -983,7 +1010,7 @@ impl AppState {
 
         let rec_cfg = recording_config_entry(
             recording_configs,
-            selected_rec_id.clone(),
+            log_db.recording_id().clone(),
             rx.source(),
             log_db,
         );
@@ -1253,7 +1280,13 @@ fn top_bar_ui(
         input_latency_label_ui(ui, app);
     }
 
-    if let Some(log_db) = app.log_dbs.get(&app.state.selected_rec_id) {
+    // TODO(jleibs) it's obnoxious we can't use self.log_db() here due to borrow checker
+    if let Some(log_db) = app
+        .state
+        .selected_rec_id
+        .as_ref()
+        .and_then(|rec_id| app.log_dbs.get(rec_id))
+    {
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             let selected_app_id = log_db
                 .recording_info()
@@ -1586,6 +1619,11 @@ fn open(app: &mut App) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn save(app: &mut App, loop_selection: Option<(re_data_store::Timeline, TimeRangeF)>) {
+    let Some(log_db) = app.log_db() else {
+        re_log::error!("No data to save!");
+        return;
+    };
+
     let title = if loop_selection.is_some() {
         "Save loop selection"
     } else {
@@ -1597,7 +1635,7 @@ fn save(app: &mut App, loop_selection: Option<(re_data_store::Timeline, TimeRang
         .set_title(title)
         .save_file()
     {
-        let f = match save_database_to_file(app.log_db(), path, loop_selection) {
+        let f = match save_database_to_file(log_db, path, loop_selection) {
             Ok(f) => f,
             Err(err) => {
                 re_log::error!("File saving failed: {err}");
@@ -1654,10 +1692,13 @@ fn recordings_menu(ui: &mut egui::Ui, app: &mut App) {
             "<UNKNOWN>".to_owned()
         };
         if ui
-            .radio(app.state.selected_rec_id == log_db.recording_id(), info)
+            .radio(
+                app.state.selected_rec_id.as_ref() == Some(log_db.recording_id()),
+                info,
+            )
             .clicked()
         {
-            app.state.selected_rec_id = log_db.recording_id();
+            app.state.selected_rec_id = Some(log_db.recording_id().clone());
         }
     }
 }
@@ -1841,7 +1882,7 @@ fn save_database_to_file(
 
     let ent_op_msgs = log_db
         .iter_entity_op_msgs()
-        .map(|msg| LogMsg::EntityPathOpMsg(log_db.recording_id(), msg.clone()))
+        .map(|msg| LogMsg::EntityPathOpMsg(log_db.recording_id().clone(), msg.clone()))
         .collect_vec();
 
     let time_filter = time_selection.map(|(timeline, range)| {
@@ -1857,7 +1898,7 @@ fn save_database_to_file(
         .map(|table| {
             table
                 .to_arrow_msg()
-                .map(|msg| LogMsg::ArrowMsg(log_db.recording_id(), msg))
+                .map(|msg| LogMsg::ArrowMsg(log_db.recording_id().clone(), msg))
         })
         .collect();
 
@@ -1886,9 +1927,13 @@ fn save_database_to_file(
 fn load_rrd_to_log_db(mut read: impl std::io::Read) -> anyhow::Result<LogDb> {
     crate::profile_function!();
 
-    let decoder = re_log_encoding::decoder::Decoder::new(read)?;
+    let mut decoder = re_log_encoding::decoder::Decoder::new(read)?;
 
-    let mut log_db = LogDb::default();
+    let first = decoder.next().context("no messages in recording")??;
+
+    let mut log_db = LogDb::new(first.recording_id().clone());
+    log_db.add(&first)?;
+
     for msg in decoder {
         log_db.add(&msg?)?;
     }

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -102,7 +102,10 @@ impl RerunArgs {
         }
 
         let sink: Box<dyn re_sdk::sink::LogSink> = match self.to_behavior()? {
-            RerunBehavior::Connect(addr) => Box::new(crate::sink::TcpSink::new(addr)),
+            RerunBehavior::Connect(addr) => Box::new(crate::sink::TcpSink::new(
+                recording_info.recording_id.clone(),
+                addr,
+            )),
 
             RerunBehavior::Save(path) => Box::new(crate::sink::FileSink::new(path)?),
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -11,7 +11,7 @@ use pyo3::{
     types::{PyBytes, PyDict},
 };
 
-use re_log_types::DataRow;
+use re_log_types::{DataRow, RecordingType};
 use rerun::{
     log::{PathOp, RowId},
     sink::MemorySinkStorage,
@@ -186,7 +186,7 @@ fn init(
     });
 
     let recording_id = if let Some(recording_id) = recording_id {
-        recording_id.into()
+        RecordingId::from_string(RecordingType::Data, recording_id)
     } else {
         default_recording_id(py)
     };
@@ -234,7 +234,7 @@ fn default_recording_id(py: Python<'_>) -> RecordingId {
     salt.hash(&mut hasher);
     let mut rng = rand::rngs::StdRng::seed_from_u64(hasher.finish());
     let uuid = uuid::Builder::from_random_bytes(rng.gen()).into_uuid();
-    RecordingId::from_uuid(uuid)
+    RecordingId::from_uuid(RecordingType::Data, uuid)
 }
 
 fn authkey(py: Python<'_>) -> Vec<u8> {


### PR DESCRIPTION
### What
After talking over the confusing edge cases with @teh-cmc around "where/how do we end up with unknown recording types and unknown recording-ids" I decided to go ahead and force everything to be explicit. This simplifies a number of edge-cases related to blueprint-recordings.

 - Every RecordingId now includes the RecordingType. You cannot create a RecordingId without specifying the type. There is no default for RecordingId.
 - Every LogDb also knows it's RecordingId. You cannot create a LogDb without knowing it's RecordingId.  This adds a bit more pain to the process of creating a LogDb, but again means you don't have to worry about having a LogDb instance and not knowing it's id / type.
 - Every LogMsg must have a RecordingId. This meant adding a RecordingId to the Goodbye message.
 - The selected_recording_id instead is now Optional. You can only select a valid recording.

Overall, this makes some things a bit more verbose, but generally seems to improve the clarity by reducing the number of places we end up doing work with unexpected ephemeral log-dbs for an unknown recording of an unknown type.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
