### PR TITLE
try adding linux-arm target to CI

### DIFF
--- a/.github/workflows/manual_build_wheels_for_pr.yml
+++ b/.github/workflows/manual_build_wheels_for_pr.yml
@@ -38,6 +38,17 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
 
+  build-linux-arm:
+    needs: [check-for-pr]
+    name: 'Linux-Arm: Build/Test Wheels'
+    uses: ./.github/workflows/reusable_build_and_test_wheels.yml
+    with:
+      CONCURRENCY: manual-wheels-linux-arm-${{ needs.check-for-pr.outputs.PR_NUMBER }}
+      PLATFORM: linux-arm
+      WHEEL_ARTIFACT_NAME: linux-arm-wheel
+      RRD_ARTIFACT_NAME: linux-arm-rrd
+    secrets: inherit
+
   build-windows:
     needs: [check-for-pr]
     name: 'Windows: Build/Test Wheels'
@@ -81,6 +92,16 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd
     secrets: inherit
 
+  upload-wheels-linux-arm:
+    name: 'Linux-Arm: Upload Wheels'
+    needs: [build-linux]
+    uses: ./.github/workflows/reusable_upload_wheels.yml
+    with:
+      CONCURRENCY: manual-wheels-linux-arm-${{ needs.check-for-pr.outputs.PR_NUMBER }}
+      WHEEL_ARTIFACT_NAME: linux-arm-wheel
+      RRD_ARTIFACT_NAME: linux-arm-rrd
+    secrets: inherit
+
   upload-wheels-windows:
     name: 'Windows: Upload Wheels'
     needs: [build-linux, build-windows]
@@ -113,7 +134,7 @@ jobs:
 
   generate-wheel-index:
     name: 'Generate Pip Index'
-    needs: [check-for-pr, upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
+    needs: [check-for-pr, upload-wheels-linux, upload-wheels-linux-arm, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
     uses: ./.github/workflows/reusable_pip_index.yml
     with:
       CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}
@@ -121,7 +142,7 @@ jobs:
 
   update-pr-summary:
     name: 'Update PR Summary'
-    needs: [check-for-pr, upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
+    needs: [check-for-pr, upload-wheels-linux, upload-wheels-linux-arm, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
     uses: ./.github/workflows/reusable_pr_summary.yml
     with:
       CONCURRENCY: manual-wheels-${{ needs.check-for-pr.outputs.PR_NUMBER }}

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -74,6 +74,12 @@ jobs:
               run_tests="true"
               container="{'image': 'rerunio/ci_docker:0.6'}"
               ;;
+            linux-arm)
+              runner="ubuntu-latest"
+              target="aarch64-unknown-linux-gnu"
+              run_tests="false"
+              container="{'image': 'rerunio/ci_docker:0.6'}"
+              ;;
             windows)
               runner="windows-latest"
               target="x86_64-pc-windows-msvc"


### PR DESCRIPTION
Hopefully useful for Raspberry Pi and docker-for-mac. I have no idea whether this will work, or whether it is even a desirable thing to have.

<details><summary>backstory</summary>
I have been following rerun.io's progress for a while, and replicating your demos on my local machine whenever an interesting demo comes out.

The announcement of https://twitter.com/rerundotio/status/1657027100438675458 was quite exciting for me because I have some videos from house viewings that might be interesting to view as 3D maps.

1. I tried checking out your copy of the repo, but the instructions didn't work: conda fails on arm macos with:

```
ResolvePackageNotFound: 
  - cudatoolkit=11.3
  - torchvision=0.11.1
```
(which is not that surprising)

2. I tried relaxing the version of torchvision and removing cudatoolkit. This tried to install `numpy==1.20.0` from source (which fails for reasons that I didn't bother trying to debug). The underlying problem there was the ancient fork of https://github.com/JamieWatson683/scikit-image/archive/single_mesh.zip but I didn't find that out until later. WIP on this approach can be found in https://github.com/rerun-io/simplerecon/pull/1 .

3. I tried spinning up a docker container, but rerun-sdk is not compiled for linux-arm, so it got a bit further but then bombed out trying to install rerun-sdk.

4. I tried using an intel base image, but that was unacceptably slow at doing anything, so I backed up and threw this PR together. I have no idea whether it will work.

</details>

### What

I basically grepped for `macos-arm`, and applied the logic "`linux-arm` is to `linux` as `macos-arm` is to `macos-intel`". Maybe it will work, maybe it won't ¯\\_(ツ)_/¯ 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
