### PR TITLE
Replace complex uses of `query_entity_with_primary` with `query_latest_single`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,6 +3793,7 @@ name = "re_error"
 version = "0.6.0-alpha.0"
 dependencies = [
  "anyhow",
+ "re_log",
 ]
 
 [[package]]

--- a/crates/re_error/Cargo.toml
+++ b/crates/re_error/Cargo.toml
@@ -16,5 +16,8 @@ version.workspace = true
 all-features = true
 
 
+[dependencies]
+re_log.workspace = true
+
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/re_error/src/lib.rs
+++ b/crates/re_error/src/lib.rs
@@ -27,3 +27,20 @@ fn test_format() {
     // Now we do:
     assert_eq!(format(&err), "outer_context -> inner_context -> root_cause");
 }
+
+pub trait ResultExt<T> {
+    fn warn_on_err_once(self, msg: impl std::fmt::Display) -> Option<T>;
+}
+
+impl<T, E: std::fmt::Display> ResultExt<T> for Result<T, E> {
+    /// Log a warning if there is an `Err`, but only log the exact same message once.
+    fn warn_on_err_once(self, msg: impl std::fmt::Display) -> Option<T> {
+        match self {
+            Ok(value) => Some(value),
+            Err(err) => {
+                re_log::warn_once!("{msg}: {err}");
+                None
+            }
+        }
+    }
+}

--- a/crates/re_log_types/src/component_types/tensor.rs
+++ b/crates/re_log_types/src/component_types/tensor.rs
@@ -340,6 +340,9 @@ pub enum TensorDataMeaning {
 ///
 /// All clones are shallow.
 ///
+/// The `Tensor` component is special, as you can only have one instance of it per entity.
+/// This is because each element in a tensor is considered to be a separate component.
+///
 /// ## Examples
 ///
 /// ```

--- a/crates/re_log_types/src/component_types/transform.rs
+++ b/crates/re_log_types/src/component_types/transform.rs
@@ -193,6 +193,13 @@ impl Pinhole {
 
 /// A transform between two spaces.
 ///
+/// The [`Transform`] component is special, as all instances of
+/// an Entity always share the same transform.
+/// In other words, a [`Transform`] component must always be a splat.
+/// This is because each entity must have a unique transform chain,
+/// e.g. the entity `foo/bar/baz` is has the transform that is the product of
+/// `foo.transform * foo/bar.transform * foo/bar/baz.transform`.
+///
 /// ```
 /// use re_log_types::component_types::{Transform, Rigid3, Pinhole};
 /// use arrow2_convert::field::ArrowField;

--- a/crates/re_log_types/src/path/entity_path_impl.rs
+++ b/crates/re_log_types/src/path/entity_path_impl.rs
@@ -78,7 +78,9 @@ where
 
 impl std::fmt::Debug for EntityPathImpl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "EntityPath({self})")
+        // Show the nicely formatted entity path, but surround with quotes and escape
+        // troublesome characters such as back-slashes and newlines.
+        write!(f, "{:?}", self.to_string())
     }
 }
 

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -78,6 +78,8 @@ pub fn get_component_with_instances(
 /// available, they are implicitly treated as an integer sequence of the correct
 /// length.
 ///
+/// If you expect only one instance and have no additional components you can use [`re_data_store::query_latest_single`] instead.
+///
 /// ```
 /// # use re_arrow_store::LatestAtQuery;
 /// # use re_log_types::{Timeline, component_types::{Point2D, ColorRGBA}, Component};

--- a/crates/re_viewer/src/misc/space_info.rs
+++ b/crates/re_viewer/src/misc/space_info.rs
@@ -5,7 +5,6 @@ use nohash_hasher::IntSet;
 use re_arrow_store::{LatestAtQuery, TimeInt, Timeline};
 use re_data_store::{log_db::EntityDb, query_latest_single, EntityPath, EntityTree};
 use re_log_types::{Transform, ViewCoordinates};
-use re_query::query_entity_with_primary;
 
 use super::UnreachableTransform;
 
@@ -274,18 +273,5 @@ pub fn query_view_coordinates(
     ent_path: &EntityPath,
     query: &LatestAtQuery,
 ) -> Option<re_log_types::ViewCoordinates> {
-    let data_store = &entity_db.data_store;
-
-    let entity_view =
-        query_entity_with_primary::<ViewCoordinates>(data_store, query, ent_path, &[]).ok()?;
-
-    let mut iter = entity_view.iter_primary().ok()?;
-
-    let view_coords = iter.next()?;
-
-    if iter.next().is_some() {
-        re_log::warn_once!("Unexpected batch for ViewCoordinates at: {}", ent_path);
-    }
-
-    view_coords
+    query_latest_single::<ViewCoordinates>(entity_db, ent_path, query)
 }

--- a/crates/re_viewer/src/ui/space_view_heuristics.rs
+++ b/crates/re_viewer/src/ui/space_view_heuristics.rs
@@ -49,12 +49,11 @@ fn contains_any_image(
     entity_db: &EntityDb,
     query: &LatestAtQuery,
 ) -> bool {
-    re_query::query_entity_with_primary::<Tensor>(&entity_db.data_store, query, entity_path, &[])
-        .map_or(false, |entity_view| {
-            entity_view
-                .iter_primary_flattened()
-                .any(|tensor| tensor.is_shaped_like_an_image())
-        })
+    if let Some(tensor) = query_latest_single::<Tensor>(entity_db, entity_path, query) {
+        tensor.is_shaped_like_an_image()
+    } else {
+        false
+    }
 }
 
 fn is_interesting_space_view_at_root(

--- a/crates/re_viewer/src/ui/space_view_heuristics.rs
+++ b/crates/re_viewer/src/ui/space_view_heuristics.rs
@@ -181,33 +181,27 @@ fn default_created_space_views_from_candidates(
 
             // For this we're only interested in the direct children.
             for entity_path in &candidate.data_blueprint.root_group().entities {
-                if let Ok(entity_view) = re_query::query_entity_with_primary::<Tensor>(
-                    &entity_db.data_store,
-                    &query,
-                    entity_path,
-                    &[],
-                ) {
-                    for tensor in entity_view.iter_primary_flattened() {
-                        if let Some([height, width, _]) = tensor.image_height_width_channels() {
-                            if query_latest_single::<re_log_types::DrawOrder>(
-                                entity_db,
-                                entity_path,
-                                &query,
-                            )
-                            .is_some()
-                            {
-                                // Put everything in the same bucket if it has a draw order.
-                                images_by_bucket
-                                    .entry(ImageBucketing::ExplicitDrawOrder)
-                                    .or_default()
-                                    .push(entity_path.clone());
-                            } else {
-                                // Otherwise, distinguish buckets by image size.
-                                images_by_bucket
-                                    .entry(ImageBucketing::BySize((height, width)))
-                                    .or_default()
-                                    .push(entity_path.clone());
-                            }
+                if let Some(tensor) = query_latest_single::<Tensor>(entity_db, entity_path, &query)
+                {
+                    if let Some([height, width, _]) = tensor.image_height_width_channels() {
+                        if query_latest_single::<re_log_types::DrawOrder>(
+                            entity_db,
+                            entity_path,
+                            &query,
+                        )
+                        .is_some()
+                        {
+                            // Put everything in the same bucket if it has a draw order.
+                            images_by_bucket
+                                .entry(ImageBucketing::ExplicitDrawOrder)
+                                .or_default()
+                                .push(entity_path.clone());
+                        } else {
+                            // Otherwise, distinguish buckets by image size.
+                            images_by_bucket
+                                .entry(ImageBucketing::BySize((height, width)))
+                                .or_default()
+                                .push(entity_path.clone());
                         }
                     }
                 }

--- a/crates/re_viewer/src/ui/view_bar_chart/scene.rs
+++ b/crates/re_viewer/src/ui/view_bar_chart/scene.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
-use re_log::warn_once;
+use re_error::ResultExt as _;
 use re_log_types::component_types::{self, InstanceKey, Tensor};
 use re_query::query_entity_with_primary;
 use re_viewer_context::{SceneQuery, ViewerContext};
@@ -33,16 +33,13 @@ impl SceneBarChart {
             let query = LatestAtQuery::new(query.timeline, query.latest_at);
             let ent_view =
                 query_entity_with_primary::<component_types::Tensor>(store, &query, ent_path, &[]);
-            let Ok(ent_view) = ent_view else {
-                warn_once!("bar chart query failed for {ent_path:?}");
+            let Some(ent_view) = ent_view.warn_on_err_once(format!("Bar chart query failed for {ent_path:?}")) else {
                 continue;
             };
-            let Ok(instance_keys) = ent_view.iter_instance_keys() else {
-                warn_once!("bar chart query failed for {ent_path:?}");
+            let Some(instance_keys) = ent_view.iter_instance_keys().warn_on_err_once(format!("Bar chart query failed for {ent_path:?}")) else {
                 continue;
             };
-            let Ok(tensors) = ent_view.iter_primary() else {
-                warn_once!("bar chart query failed for {ent_path:?}");
+            let Some(tensors) = ent_view.iter_primary().warn_on_err_once(format!("Bar chart query failed for {ent_path:?}")) else {
                 continue;
             };
 

--- a/crates/re_viewer/src/ui/view_bar_chart/scene.rs
+++ b/crates/re_viewer/src/ui/view_bar_chart/scene.rs
@@ -1,10 +1,8 @@
 use std::collections::BTreeMap;
 
 use re_arrow_store::LatestAtQuery;
-use re_data_store::EntityPath;
-use re_error::ResultExt as _;
+use re_data_store::{query_latest_single, EntityPath};
 use re_log_types::component_types::{self, InstanceKey, Tensor};
-use re_query::query_entity_with_primary;
 use re_viewer_context::{SceneQuery, ViewerContext};
 
 /// A bar chart scene, with everything needed to render it.
@@ -23,7 +21,7 @@ impl SceneBarChart {
     fn load_tensors(&mut self, ctx: &mut ViewerContext<'_>, query: &SceneQuery<'_>) {
         crate::profile_function!();
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let entity_db = &ctx.log_db.entity_db;
 
         for (ent_path, props) in query.iter_entities() {
             if !props.visible {
@@ -31,23 +29,13 @@ impl SceneBarChart {
             }
 
             let query = LatestAtQuery::new(query.timeline, query.latest_at);
-            let ent_view =
-                query_entity_with_primary::<component_types::Tensor>(store, &query, ent_path, &[]);
-            let Some(ent_view) = ent_view.warn_on_err_once(format!("Bar chart query failed for {ent_path:?}")) else {
-                continue;
-            };
-            let Some(instance_keys) = ent_view.iter_instance_keys().warn_on_err_once(format!("Bar chart query failed for {ent_path:?}")) else {
-                continue;
-            };
-            let Some(tensors) = ent_view.iter_primary().warn_on_err_once(format!("Bar chart query failed for {ent_path:?}")) else {
-                continue;
-            };
+            let tensor =
+                query_latest_single::<component_types::Tensor>(entity_db, ent_path, &query);
 
-            for (instance_key, tensor) in instance_keys.zip(tensors) {
-                let tensor = tensor.unwrap(); // primary
+            if let Some(tensor) = tensor {
                 if tensor.is_vector() {
                     self.charts.insert(
-                        (ent_path.clone(), instance_key),
+                        (ent_path.clone(), InstanceKey(0)),
                         tensor.clone(), /* shallow */
                     );
                 }

--- a/crates/re_viewer/src/ui/view_category.rs
+++ b/crates/re_viewer/src/ui/view_category.rs
@@ -7,7 +7,6 @@ use re_log_types::{
     },
     Arrow3D, Component, Mesh3D, Transform,
 };
-use re_query::query_entity_with_primary;
 
 #[derive(
     Debug, Default, PartialOrd, Ord, enumset::EnumSetType, serde::Deserialize, serde::Serialize,
@@ -101,22 +100,17 @@ pub fn categorize_entity_path(
         } else if component == Tensor::name() {
             let timeline_query = LatestAtQuery::new(timeline, TimeInt::MAX);
 
-            if let Ok(entity_view) = query_entity_with_primary::<Tensor>(
-                &log_db.entity_db.data_store,
-                &timeline_query,
+            if let Some(tensor) = re_data_store::query_latest_single::<Tensor>(
+                &log_db.entity_db,
                 entity_path,
-                &[],
+                &timeline_query,
             ) {
-                if let Ok(iter) = entity_view.iter_primary() {
-                    for tensor in iter.flatten() {
-                        if tensor.is_vector() {
-                            set.insert(ViewCategory::BarChart);
-                        } else if tensor.is_shaped_like_an_image() {
-                            set.insert(ViewCategory::Spatial);
-                        } else {
-                            set.insert(ViewCategory::Tensor);
-                        }
-                    }
+                if tensor.is_vector() {
+                    set.insert(ViewCategory::BarChart);
+                } else if tensor.is_shaped_like_an_image() {
+                    set.insert(ViewCategory::Spatial);
+                } else {
+                    set.insert(ViewCategory::Tensor);
                 }
             }
         }

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/arrows3d.rs
@@ -71,7 +71,7 @@ impl Arrows3DPart {
                 )
                 .picking_instance_id(instance_key_to_picking_id(
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 ));
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes2d.rs
@@ -54,7 +54,7 @@ impl Boxes2DPart {
                 let instance_hash = instance_path_hash_for_picking(
                     ent_path,
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 );
 
@@ -74,7 +74,7 @@ impl Boxes2DPart {
                     .radius(radius)
                     .picking_instance_id(instance_key_to_picking_id(
                         instance_key,
-                        entity_view,
+                        entity_view.num_instances(),
                         entity_highlight.any_selection_highlight,
                     ));
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/boxes3d.rs
@@ -62,7 +62,7 @@ impl Boxes3DPart {
                 .color(color)
                 .picking_instance_id(instance_key_to_picking_id(
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 ));
 
@@ -78,7 +78,7 @@ impl Boxes3DPart {
                     labeled_instance: instance_path_hash_for_picking(
                         ent_path,
                         instance_key,
-                        entity_view,
+                        entity_view.num_instances(),
                         entity_highlight.any_selection_highlight,
                     ),
                 });

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -157,7 +157,7 @@ impl CamerasPart {
         let instance_path_for_picking = instance_path_hash_for_picking(
             ent_path,
             instance_key,
-            entity_view,
+            entity_view.num_instances(),
             entity_highlight.any_selection_highlight,
         );
         let instance_layer_id = picking_layer_id_from_instance_path_hash(instance_path_for_picking);

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines2d.rs
@@ -55,7 +55,7 @@ impl Lines2DPart {
                 .radius(radius)
                 .picking_instance_id(instance_key_to_picking_id(
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 ));
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/lines3d.rs
@@ -54,7 +54,7 @@ impl Lines3DPart {
                 .flags(re_renderer::renderer::LineStripFlags::FLAG_COLOR_GRADIENT)
                 .picking_instance_id(instance_key_to_picking_id(
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 ));
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/meshes.rs
@@ -34,7 +34,7 @@ impl MeshPart {
                 let picking_instance_hash = instance_path_hash_for_picking(
                     ent_path,
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 );
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/mod.rs
@@ -54,15 +54,15 @@ pub trait ScenePart {
 /// TODO(andreas): Resolve the hash-for-picking when retrieving the picking result instead of doing it ahead of time here to speed up things.
 ///                 (gpu picking would always get the "most fine grained hash" which we could then resolve to groups etc. depending on selection state)
 /// Right now this is a bit hard to do since number of instances depends on the Primary. This is expected to change soon.
-pub fn instance_path_hash_for_picking<C: re_log_types::Component>(
+pub fn instance_path_hash_for_picking(
     ent_path: &EntityPath,
     instance_key: re_log_types::component_types::InstanceKey,
-    entity_view: &re_query::EntityView<C>,
+    num_instances: usize,
     any_part_selected: bool,
 ) -> InstancePathHash {
     InstancePathHash::instance(
         ent_path,
-        instance_key_for_picking(instance_key, entity_view, any_part_selected),
+        instance_key_for_picking(instance_key, num_instances, any_part_selected),
     )
 }
 
@@ -73,15 +73,15 @@ pub fn instance_path_hash_for_picking<C: re_log_types::Component>(
 /// TODO(andreas): Resolve the hash-for-picking when retrieving the picking result instead of doing it ahead of time here to speed up things.
 ///                 (gpu picking would always get the "most fine grained hash" which we could then resolve to groups etc. depending on selection state)
 /// Right now this is a bit hard to do since number of instances depends on the Primary. This is expected to change soon.
-pub fn instance_key_for_picking<C: re_log_types::Component>(
+pub fn instance_key_for_picking(
     instance_key: re_log_types::component_types::InstanceKey,
-    entity_view: &re_query::EntityView<C>,
+    num_instances: usize,
     any_part_selected: bool,
 ) -> re_log_types::component_types::InstanceKey {
     // If no part of the entity is selected or if there is only one instance, selecting
     // should select the entire entity, not the specific instance.
     // (the splat key means that no particular instance is selected but all at once instead)
-    if entity_view.num_instances() == 1 || !any_part_selected {
+    if num_instances == 1 || !any_part_selected {
         re_log_types::component_types::InstanceKey::SPLAT
     } else {
         instance_key
@@ -89,13 +89,13 @@ pub fn instance_key_for_picking<C: re_log_types::Component>(
 }
 
 /// See [`instance_key_for_picking`]
-pub fn instance_key_to_picking_id<C: re_log_types::Component>(
+pub fn instance_key_to_picking_id(
     instance_key: re_log_types::component_types::InstanceKey,
-    entity_view: &re_query::EntityView<C>,
+    num_instances: usize,
     any_part_selected: bool,
 ) -> re_renderer::PickingLayerInstanceId {
     re_renderer::PickingLayerInstanceId(
-        instance_key_for_picking(instance_key, entity_view, any_part_selected).0,
+        instance_key_for_picking(instance_key, num_instances, any_part_selected).0,
     )
 }
 

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points2d.rs
@@ -88,7 +88,7 @@ impl Points2DPart {
                         instance_path_hash_for_picking(
                             ent_path,
                             instance_key,
-                            entity_view,
+                            entity_view.num_instances(),
                             entity_highlight.any_selection_highlight,
                         )
                     })
@@ -127,7 +127,7 @@ impl Points2DPart {
             let picking_instance_ids = entity_view.iter_instance_keys()?.map(|instance_key| {
                 instance_key_to_picking_id(
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 )
             });

--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/points3d.rs
@@ -96,7 +96,7 @@ impl Points3DPart {
                         instance_path_hash_for_picking(
                             ent_path,
                             instance_key,
-                            entity_view,
+                            entity_view.num_instances(),
                             entity_highlight.any_selection_highlight,
                         )
                     })
@@ -131,7 +131,7 @@ impl Points3DPart {
             let picking_instance_ids = entity_view.iter_instance_keys()?.map(|instance_key| {
                 instance_key_to_picking_id(
                     instance_key,
-                    entity_view,
+                    entity_view.num_instances(),
                     entity_highlight.any_selection_highlight,
                 )
             });

--- a/crates/re_viewer/src/ui/view_tensor/scene.rs
+++ b/crates/re_viewer/src/ui/view_tensor/scene.rs
@@ -4,7 +4,6 @@ use re_log_types::{
     component_types::{InstanceKey, Tensor},
     DecodedTensor,
 };
-use re_query::{query_entity_with_primary, EntityView, QueryError};
 use re_viewer_context::{SceneQuery, TensorDecodeCache, ViewerContext};
 
 /// A tensor scene, with everything needed to render it.
@@ -21,18 +20,12 @@ impl SceneTensor {
         for (ent_path, props) in query.iter_entities() {
             let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 
-            match query_entity_with_primary::<Tensor>(
-                &ctx.log_db.entity_db.data_store,
-                &timeline_query,
+            if let Some(tensor) = re_data_store::query_latest_single::<Tensor>(
+                &ctx.log_db.entity_db,
                 ent_path,
-                &[],
-            )
-            .and_then(|entity_view| self.load_tensor_entity(ctx, ent_path, &props, &entity_view))
-            {
-                Ok(_) | Err(QueryError::PrimaryNotFound) => {}
-                Err(err) => {
-                    re_log::error_once!("Unexpected error querying {ent_path:?}: {err}");
-                }
+                &timeline_query,
+            ) {
+                self.load_tensor_entity(ctx, ent_path, &props, tensor);
             }
         }
     }
@@ -42,22 +35,20 @@ impl SceneTensor {
         ctx: &mut ViewerContext<'_>,
         ent_path: &EntityPath,
         _props: &EntityProperties,
-        entity_view: &EntityView<Tensor>,
-    ) -> Result<(), QueryError> {
-        entity_view.visit1(|instance_key: InstanceKey, tensor: Tensor| {
-            if !tensor.is_shaped_like_an_image() {
-                match ctx.cache.entry::<TensorDecodeCache>().entry(tensor) {
-                    Ok(tensor) => {
-                        let instance_path = InstancePath::instance(ent_path.clone(), instance_key);
-                        self.tensors.insert(instance_path, tensor);
-                    }
-                    Err(err) => {
-                        re_log::warn_once!(
-                            "Failed to decode decoding tensor at path {ent_path}: {err}"
-                        );
-                    }
+        tensor: Tensor,
+    ) {
+        if !tensor.is_shaped_like_an_image() {
+            match ctx.cache.entry::<TensorDecodeCache>().entry(tensor) {
+                Ok(tensor) => {
+                    let instance_path = InstancePath::instance(ent_path.clone(), InstanceKey(0));
+                    self.tensors.insert(instance_path, tensor);
+                }
+                Err(err) => {
+                    re_log::warn_once!(
+                        "Failed to decode decoding tensor at path {ent_path}: {err}"
+                    );
                 }
             }
-        })
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2122 by no longer warning on the spurious problem, which has no actual manifestation - it works as expected. I think it is a timing thing (loading the blueprint before any data has been loaded maybe?)

### What
We have some "mono-components" (`Transform`, `Tensor` and `ViewCoordinates`), which we only allow one of per entity. For those we have a nice helper function, `query_latest_single` which is much simpler than `query_entity_with_primary`..

This PR also adds a `result.warn_on_err_once` helper which can be used to quickly log an `Err` and get an `Option`. Much better than ignoring the error. Ultimately i didn't need it in this PR, but I have missed it many other times, so it will come in use, I'm sure.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
