### PR TITLE
Allow users to select the bind address (ip) to use with `--bind`

### DIFF
--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -59,8 +59,8 @@ async fn listen_for_new_clients(
 /// # use re_sdk_comms::{serve, ServerOptions};
 /// #[tokio::main]
 /// async fn main() {
-///     let (sender, receiver) = tokio::sync::broadcast::channel(1);
-///     let log_msg_rx = serve(80, ServerOptions::default(), receiver).await.unwrap();
+///     let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+///     let log_msg_rx = serve("0.0.0.0", 80, ServerOptions::default(), shutdown_rx).await.unwrap();
 /// }
 /// ```
 pub async fn serve(

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -64,13 +64,14 @@ async fn listen_for_new_clients(
 /// }
 /// ```
 pub async fn serve(
+    bind_ip: &str,
     port: u16,
     options: ServerOptions,
     shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> anyhow::Result<Receiver<LogMsg>> {
     let (tx, rx) = re_smart_channel::smart_channel(re_smart_channel::Source::TcpServer { port });
 
-    let bind_addr = format!("0.0.0.0:{port}");
+    let bind_addr = format!("{bind_ip}:{port}");
     let listener = TcpListener::bind(&bind_addr).await.with_context(|| {
         format!(
             "Failed to bind TCP address {bind_addr:?}. Another Rerun instance is probably running."

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -187,7 +187,12 @@ fn get_url(info: &eframe::IntegrationInfo) -> String {
         url = param.clone();
     }
     if url.is_empty() {
-        re_ws_comms::server_url(&info.web_info.location.hostname, Default::default())
+        format!(
+            "{}://{}:{}",
+            re_ws_comms::PROTOCOL,
+            &info.web_info.location.hostname,
+            re_ws_comms::DEFAULT_WS_SERVER_PORT
+        )
     } else {
         url
     }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -274,10 +274,13 @@ impl WebViewerServerHandle {
     /// A port of 0 will let the OS choose a free port.
     ///
     /// The caller needs to ensure that there is a `tokio` runtime running.
-    pub fn new(requested_port: WebViewerServerPort) -> Result<Self, WebViewerServerError> {
+    pub fn new(
+        bind_ip: &str,
+        requested_port: WebViewerServerPort,
+    ) -> Result<Self, WebViewerServerError> {
         let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
 
-        let web_server = WebViewerServer::new("0.0.0.0", requested_port)?;
+        let web_server = WebViewerServer::new(bind_ip, requested_port)?;
 
         let port = web_server.port();
 

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -223,7 +223,7 @@ impl WebViewerServer {
     /// # async fn example() -> Result<(), WebViewerServerError> {
     /// let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
     /// let server = WebViewerServer::new("0.0.0.0", WebViewerServerPort::AUTO)?;
-    /// let local_addr = server.local_addr();
+    /// let server_url = server.server_url();
     /// server.serve(shutdown_rx).await?;
     /// # Ok(()) }
     /// ```

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -222,7 +222,7 @@ impl WebViewerServer {
     /// # async fn example() -> Result<(), WebViewerServerError> {
     /// let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
     /// let server = WebViewerServer::new("0.0.0.0", WebViewerServerPort::AUTO)?;
-    /// let port = server.port();
+    /// let local_addr = server.local_addr();
     /// server.serve(shutdown_rx).await?;
     /// # Ok(()) }
     /// ```

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -175,7 +175,7 @@ impl<T> Service<T> for MakeSvc {
 pub struct WebViewerServerPort(pub u16);
 
 impl WebViewerServerPort {
-    /// Port to use with [`WebViewerServer::port`] when you want the OS to pick a port for you.
+    /// Port to use with [`WebViewerServer::new`] when you want the OS to pick a port for you.
     ///
     /// This is defined as `0`.
     pub const AUTO: Self = Self(0);

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -44,8 +44,7 @@ async fn main() {
     )
     .expect("Could not create web server");
 
-    let port = server.port();
-    let url = format!("http://{bind_ip}:{port}");
+    let url = server.server_url();
     eprintln!("Hosting web-viewer on {url}");
 
     if args.open {

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -76,8 +76,8 @@ impl FromStr for RerunServerPort {
     }
 }
 
-pub fn server_url(hostname: &str, port: RerunServerPort) -> String {
-    format!("{PROTOCOL}://{hostname}:{port}")
+pub fn server_url(local_addr: &std::net::SocketAddr) -> String {
+    format!("{PROTOCOL}://{local_addr}")
 }
 
 const PREFIX: [u8; 4] = *b"RR00";

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -76,8 +76,14 @@ impl FromStr for RerunServerPort {
     }
 }
 
+/// Add a protocol (`ws://` or `wss://`) to the given address.
 pub fn server_url(local_addr: &std::net::SocketAddr) -> String {
-    format!("{PROTOCOL}://{local_addr}")
+    if local_addr.ip().is_unspecified() {
+        // "0.0.0.0"
+        format!("{PROTOCOL}://localhost:{}", local_addr.port())
+    } else {
+        format!("{PROTOCOL}://{local_addr}")
+    }
 }
 
 const PREFIX: [u8; 4] = *b"RR00";

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -21,6 +21,7 @@ use crate::{server_url, RerunServerError, RerunServerPort};
 /// Websocket host for relaying [`LogMsg`]s to a web viewer.
 pub struct RerunServer {
     listener: TcpListener,
+    bind_ip: String,
     port: RerunServerPort,
 }
 
@@ -28,9 +29,10 @@ impl RerunServer {
     /// Create new [`RerunServer`] to relay [`LogMsg`]s to a websocket.
     /// The websocket will be available at `port`.
     ///
+    /// A `bind_ip` of `"0.0.0.0"` is a good default.
     /// A port of 0 will let the OS choose a free port.
-    pub async fn new(port: RerunServerPort) -> Result<Self, RerunServerError> {
-        let bind_addr = format!("0.0.0.0:{port}");
+    pub async fn new(bind_ip: String, port: RerunServerPort) -> Result<Self, RerunServerError> {
+        let bind_addr = format!("{bind_ip}:{port}");
 
         let listener = TcpListener::bind(&bind_addr)
             .await
@@ -43,7 +45,11 @@ impl RerunServer {
             listener.local_addr()?
         );
 
-        Ok(Self { listener, port })
+        Ok(Self {
+            listener,
+            bind_ip,
+            port,
+        })
     }
 
     /// Accept new connections until we get a message on `shutdown_rx`
@@ -75,7 +81,7 @@ impl RerunServer {
     }
 
     pub fn server_url(&self) -> String {
-        server_url("localhost", self.port)
+        server_url(&self.bind_ip, self.port)
     }
 }
 
@@ -83,6 +89,7 @@ impl RerunServer {
 ///
 /// When dropped, the server will be shut down.
 pub struct RerunServerHandle {
+    bind_ip: String,
     port: RerunServerPort,
     shutdown_tx: tokio::sync::broadcast::Sender<()>,
 }
@@ -98,26 +105,33 @@ impl RerunServerHandle {
     /// Create new [`RerunServer`] to relay [`LogMsg`]s to a websocket.
     /// Returns a [`RerunServerHandle`] that will shutdown the server when dropped.
     ///
+    /// A `bind_ip` of `"0.0.0.0"` is a good default.
     /// A port of 0 will let the OS choose a free port.
     ///
     /// The caller needs to ensure that there is a `tokio` runtime running.
     pub fn new(
         rerun_rx: Receiver<LogMsg>,
+        bind_ip: String,
         requested_port: RerunServerPort,
     ) -> Result<Self, RerunServerError> {
         let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
 
         let rt = tokio::runtime::Handle::current();
 
+        let bind_ip_clone = bind_ip.clone();
         let ws_server = rt.block_on(tokio::spawn(async move {
-            RerunServer::new(requested_port).await
+            RerunServer::new(bind_ip_clone, requested_port).await
         }))??;
 
         let port = ws_server.port;
 
         tokio::spawn(async move { ws_server.listen(rerun_rx, shutdown_rx).await });
 
-        Ok(Self { port, shutdown_tx })
+        Ok(Self {
+            bind_ip,
+            port,
+            shutdown_tx,
+        })
     }
 
     /// Get the port where the websocket server is listening
@@ -126,7 +140,7 @@ impl RerunServerHandle {
     }
 
     pub fn server_url(&self) -> String {
-        server_url("localhost", self.port)
+        server_url(&self.bind_ip, self.port)
     }
 }
 

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -78,11 +78,6 @@ impl RerunServer {
         }
     }
 
-    /// Get the local socket addr where the HTTP server is listening
-    pub fn local_addr(&self) -> std::net::SocketAddr {
-        self.local_addr
-    }
-
     /// Contains the `ws://` or `wss://` prefix.
     pub fn server_url(&self) -> String {
         server_url(&self.local_addr)
@@ -133,11 +128,6 @@ impl RerunServerHandle {
             local_addr,
             shutdown_tx,
         })
-    }
-
-    /// Get the local socket addr where the HTTP server is listening
-    pub fn local_addr(&self) -> std::net::SocketAddr {
-        self.local_addr
     }
 
     /// Contains the `ws://` or `wss://` prefix.

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -66,6 +66,10 @@ pub struct RerunArgs {
     #[cfg(feature = "web_viewer")]
     #[clap(long)]
     serve: bool,
+
+    /// What bind address IP to use.
+    #[clap(long, default_value = "0.0.0.0")]
+    bind: String,
 }
 
 impl RerunArgs {
@@ -111,6 +115,7 @@ impl RerunArgs {
                 let open_browser = true;
                 crate::web_viewer::new_sink(
                     open_browser,
+                    &self.bind,
                     WebViewerServerPort::default(),
                     RerunServerPort::default(),
                 )?

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -17,19 +17,21 @@ struct WebViewerSink {
 }
 
 impl WebViewerSink {
+    /// A `bind_ip` of `"0.0.0.0"` is a good default.
     pub fn new(
         open_browser: bool,
+        bind_ip: &str,
         web_port: WebViewerServerPort,
         ws_port: RerunServerPort,
     ) -> anyhow::Result<Self> {
         let (rerun_tx, rerun_rx) = re_smart_channel::smart_channel(re_smart_channel::Source::Sdk);
 
-        let rerun_server = RerunServerHandle::new(rerun_rx, ws_port)?;
-        let webviewer_server = WebViewerServerHandle::new(web_port)?;
+        let rerun_server = RerunServerHandle::new(rerun_rx, bind_ip.to_owned(), ws_port)?;
+        let webviewer_server = WebViewerServerHandle::new(bind_ip, web_port)?;
 
         let web_port = webviewer_server.port();
         let server_url = rerun_server.server_url();
-        let viewer_url = format!("http://127.0.0.1:{web_port}?url={server_url}");
+        let viewer_url = format!("http://{bind_ip}:{web_port}?url={server_url}");
 
         re_log::info!("Web server is running - view it at {viewer_url}");
         if open_browser {
@@ -53,16 +55,17 @@ impl WebViewerSink {
 /// Note: this does not include the websocket server.
 #[cfg(feature = "web_viewer")]
 pub async fn host_web_viewer(
+    bind_ip: String,
     web_port: WebViewerServerPort,
     open_browser: bool,
     source_url: String,
     shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> anyhow::Result<()> {
-    let web_server = re_web_viewer_server::WebViewerServer::new("0.0.0.0", web_port)?;
+    let web_server = re_web_viewer_server::WebViewerServer::new(&bind_ip, web_port)?;
     let port = web_server.port();
     let web_server_handle = web_server.serve(shutdown_rx);
 
-    let viewer_url = format!("http://127.0.0.1:{port}?url={source_url}");
+    let viewer_url = format!("http://{bind_ip}:{port}?url={source_url}");
 
     re_log::info!("Web server is running - view it at {viewer_url}");
     if open_browser {
@@ -100,11 +103,13 @@ impl crate::sink::LogSink for WebViewerSink {
 #[must_use = "the sink must be kept around to keep the servers running"]
 pub fn new_sink(
     open_browser: bool,
+    bind_ip: &str,
     web_port: WebViewerServerPort,
     ws_port: RerunServerPort,
 ) -> anyhow::Result<Box<dyn crate::sink::LogSink>> {
     Ok(Box::new(WebViewerSink::new(
         open_browser,
+        bind_ip,
         web_port,
         ws_port,
     )?))

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -29,9 +29,9 @@ impl WebViewerSink {
         let rerun_server = RerunServerHandle::new(rerun_rx, bind_ip.to_owned(), ws_port)?;
         let webviewer_server = WebViewerServerHandle::new(bind_ip, web_port)?;
 
-        let web_port = webviewer_server.port();
-        let server_url = rerun_server.server_url();
-        let viewer_url = format!("http://{bind_ip}:{web_port}?url={server_url}");
+        let http_web_viewer_url = webviewer_server.server_url();
+        let ws_server_url = rerun_server.server_url();
+        let viewer_url = format!("{http_web_viewer_url}?url={ws_server_url}");
 
         re_log::info!("Web server is running - view it at {viewer_url}");
         if open_browser {
@@ -62,12 +62,13 @@ pub async fn host_web_viewer(
     shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> anyhow::Result<()> {
     let web_server = re_web_viewer_server::WebViewerServer::new(&bind_ip, web_port)?;
-    let port = web_server.port();
+    let http_web_viewer_url = web_server.server_url();
     let web_server_handle = web_server.serve(shutdown_rx);
 
-    let viewer_url = format!("http://{bind_ip}:{port}?url={source_url}");
+    let viewer_url = format!("{http_web_viewer_url}?url={source_url}");
 
     re_log::info!("Web server is running - view it at {viewer_url}");
+
     if open_browser {
         webbrowser::open(&viewer_url).ok();
     }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1161,7 +1161,7 @@ fn version() -> String {
 fn get_app_url() -> String {
     #[cfg(feature = "web_viewer")]
     if let Some(hosted_assets) = &*global_web_viewer_server() {
-        return format!("http://localhost:{}", hosted_assets.port());
+        return hosted_assets.server_url();
     }
 
     let build_info = re_build_info::build_info!();

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -495,6 +495,7 @@ fn serve(
         recording.set_sink(
             rerun::web_viewer::new_sink(
                 open_browser,
+                "0.0.0.0",
                 web_port.map(WebViewerServerPort).unwrap_or_default(),
                 ws_port.map(RerunServerPort).unwrap_or_default(),
             )
@@ -1179,13 +1180,12 @@ fn start_web_viewer_server(port: u16) -> PyResult<()> {
 
         let _guard = enter_tokio_runtime();
         *web_handle = Some(
-            re_web_viewer_server::WebViewerServerHandle::new(WebViewerServerPort(port)).map_err(
-                |err| {
+            re_web_viewer_server::WebViewerServerHandle::new("0.0.0.0", WebViewerServerPort(port))
+                .map_err(|err| {
                     PyRuntimeError::new_err(format!(
                         "Failed to start web viewer server on port {port}: {err}",
                     ))
-                },
-            )?,
+                })?,
         );
 
         Ok(())


### PR DESCRIPTION
### What
Allow users to select the bind address (ip) to use with `--bind`

The default is still `0.0.0.0`, and still works (at least on my Mac).

I'm no network expert, so some of these names could probably be improved

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2159
