### PR TITLE
Update `wasm-bindgen` to 0.2.86

### DIFF
--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Install wasm32 and wasm-bindgen-cli for building the web-viewer Wasm on windows
         if: inputs.platform == 'windows'
         shell: bash
-        run: rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.84
+        run: rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli --version 0.2.86
 
       # The last step of setup_web.sh, for Windows.
       # Since 'winget' is not available within the GitHub runner, we download the package directly:

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -72,7 +72,7 @@ jobs:
               runner="ubuntu-latest"
               target="x86_64-unknown-linux-gnu"
               run_tests="true"
-              container="{'image': 'rerunio/ci_docker:0.6'}"
+              container="{'image': 'rerunio/ci_docker:0.7'}"
               ;;
             windows)
               runner="windows-latest"

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable_build_web_demo.yml
+++ b/.github/workflows/reusable_build_web_demo.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -106,7 +106,7 @@ jobs:
     name: Rust lints (fmt, check, cranky, tests, doc)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
     steps:
       - name: Show context
         run: |
@@ -202,7 +202,7 @@ jobs:
     name: Check Rust web build (wasm32 + wasm-bindgen)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
     steps:
       - uses: actions/checkout@v3
 
@@ -281,7 +281,7 @@ jobs:
       - name: Check for too large files
         run: |
           ./scripts/check_large_files.sh
-      
+
       - name: Check Python example requirements
         run: |
           ./scripts/check_requirements.py
@@ -304,7 +304,7 @@ jobs:
     name: Cargo Deny ${{ matrix.platform }}
     runs-on: ubuntu-latest
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -97,7 +97,7 @@ jobs:
     name: Rust
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
     steps:
       - name: Show context
         run: |

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable_upload_wheels.yml
+++ b/.github/workflows/reusable_upload_wheels.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rerunio/ci_docker:0.6
+      image: rerunio/ci_docker:0.7
 
     permissions:
       contents: "read"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 [[package]]
 name = "ecolor"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.21.3"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "accesskit",
  "ahash 0.8.2",
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "bytemuck",
  "epaint",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.21.1"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "arboard",
  "egui",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "egui",
  "log",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1406,7 +1406,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "emath"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=ea71b7f#ea71b7f20b631c4d762dae4683e5fe89585f9212"
+source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.2",
@@ -5441,7 +5441,7 @@ dependencies = [
  "leb128",
  "log",
  "walrus-macro",
- "wasmparser 0.77.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5474,9 +5474,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5484,24 +5484,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4780c659b883a19ddb7ced365db19f7f45cd182d832ee14de2b7ef52e88a9f"
+checksum = "8315d6503415e5d44ff64f1ba34aefd8264c561df17e0f1c8eb8c96bde79c45e"
 dependencies = [
  "anyhow",
  "base64 0.9.3",
@@ -5517,16 +5517,13 @@ dependencies = [
  "wasm-bindgen-threads-xform",
  "wasm-bindgen-wasm-conventions",
  "wasm-bindgen-wasm-interpreter",
- "wit-text",
- "wit-validator",
- "wit-walrus",
 ]
 
 [[package]]
 name = "wasm-bindgen-externref-xform"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d154c3843bf3b635b602ad41b56f505f8f1a25f8a0133fca4bbd0918d74efdc"
+checksum = "4522bf3be16c6274c87a5a2c5d2a62efa80253b025f8e813f9682d0d6a8a8fca"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5546,9 +5543,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5556,22 +5553,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-multi-value-xform"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00a577fbd4be358ef8095432189b5c2e6b6e71f5081797c2032572f77d65d26"
+checksum = "113256596776ebb4b243512d3711e73d5475eaeff373e1ae65427c66e5aa2073"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5579,15 +5576,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-bindgen-threads-xform"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa93941bae037b7b4fac4ecfc132294b828036c5990a806d0e6fd9284297d94"
+checksum = "89106aaf83a2b80464fc8f60a074a4575135b73a491e174f35bbeae6ff0d7ec6"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5596,9 +5593,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-wasm-conventions"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f5de325048d945c90600fdf66b13521f3340d85971287775c36aa99c04466b"
+checksum = "84e5ad27a7930400994cb40823d3d4a7ef235fac52d0c75ebd61fa40eba994a8"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5606,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-wasm-interpreter"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f695df44962e3a107436282232a2daa185b8453c16be8ddfb637cd2601f31128"
+checksum = "e69500063b7b20f3e9422d78c2b381dd192c7c4ebaef34d205332877cd78e0d3"
 dependencies = [
  "anyhow",
  "log",
@@ -5633,24 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
-
-[[package]]
-name = "wasmparser"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
-
-[[package]]
-name = "wast"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1844f66a2bc8526d71690104c0e78a8e59ffa1597b7245769d174ebb91deb5"
-dependencies = [
- "leb128",
-]
 
 [[package]]
 name = "wayland-client"
@@ -6073,70 +6055,6 @@ dependencies = [
  "web-sys",
  "windows-sys 0.45.0",
  "x11-dl",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5fd97866f4b9c8e1ed57bcf9446f3d0d8ba37e2dd01c3c612c046c053b06f7"
-dependencies = [
- "anyhow",
- "leb128",
- "wit-schema-version",
-]
-
-[[package]]
-name = "wit-schema-version"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfee4a6a4716eefa0682e7a3b836152e894a3e4f34a9d6c2c3e1c94429bfe36a"
-
-[[package]]
-name = "wit-text"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33358e95c77d660f1c7c07f4a93c2bd89768965e844e3c50730bb4b42658df5f"
-dependencies = [
- "anyhow",
- "wast",
- "wit-writer",
-]
-
-[[package]]
-name = "wit-validator"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c11d93d925420e7872b226c4161849c32be38385ccab026b88df99d8ddc6ba6"
-dependencies = [
- "anyhow",
- "wasmparser 0.59.0",
- "wit-parser",
- "wit-schema-version",
-]
-
-[[package]]
-name = "wit-walrus"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad559e3e4c6404b2a6a675d44129d62a3836e3b951b90112fa1c5feb852757cd"
-dependencies = [
- "anyhow",
- "id-arena",
- "walrus",
- "wit-parser",
- "wit-schema-version",
- "wit-writer",
-]
-
-[[package]]
-name = "wit-writer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ad01ba5e9cbcff799a0689e56a153776ea694cec777f605938cb9880d41a09"
-dependencies = [
- "leb128",
- "wit-schema-version",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,13 +127,13 @@ debug = true
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
 # TODO(andreas/emilk): Update to a stable egui version
-# wgpu 0.16 support, device configuration dependent on adapter, and some additions to help egui_tiles, egui::Modifiers::contains, better error reporting for web
-ecolor = { git = "https://github.com/emilk/egui", rev = "ea71b7f" }
-eframe = { git = "https://github.com/emilk/egui", rev = "ea71b7f" }
-egui = { git = "https://github.com/emilk/egui", rev = "ea71b7f" }
-egui-wgpu = { git = "https://github.com/emilk/egui", rev = "ea71b7f" }
-egui_extras = { git = "https://github.com/emilk/egui", rev = "ea71b7f" }
-emath = { git = "https://github.com/emilk/egui", rev = "ea71b7f" }
+# wgpu 0.16 support, device configuration dependent on adapter, some additions to help egui_tiles, egui::Modifiers::contains, better error reporting for web, wasm-bindgen update
+ecolor = { git = "https://github.com/emilk/egui", rev = "856afc8" }
+eframe = { git = "https://github.com/emilk/egui", rev = "856afc8" }
+egui = { git = "https://github.com/emilk/egui", rev = "856afc8" }
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "856afc8" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "856afc8" }
+emath = { git = "https://github.com/emilk/egui", rev = "856afc8" }
 
 # TODO(andreas): Either work around this issue in wgpu-egui (never discard command buffers) or wait for wgpu patch release.
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -74,6 +74,5 @@ RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_11
 ENV CACHE_KEY=rerun_docker_v0.7
 
 # See: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
-# Note: this uses global and a more-specific path than '*' at recommended in that comment
-# this appears to have been needed due to a git version upgrade to 2.30.
-RUN git config --global --add safe.directory '/__w/rerun/rerun'
+RUN git config --system --add safe.directory '*'
+

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -74,5 +74,6 @@ RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_11
 ENV CACHE_KEY=rerun_docker_v0.7
 
 # See: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
-RUN git config --system --add safe.directory '*'
-
+# Note: this uses global and a more-specific path than '*' at recommended in that comment
+# this appears to have been needed due to a git version upgrade to 2.30.
+RUN git config --global --add safe.directory '/__w/rerun/rerun'

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -66,7 +66,9 @@ ADD rerun_py/requirements-build.txt requirements-build.txt
 RUN pip install -r requirements-build.txt
 
 # Install tools from setup_web.sh
-RUN cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.git --rev 13283975ddf48c2d90758095e235b28d381c5762
+ADD scripts/setup_web.sh setup_web.sh
+# Installing binaryen is going to cause this script to fail, but that's ok -- we install it manually
+RUN ./setup_web.sh || true
 # Note: We need a more modern binaryen than ships on ubuntu-20.4, so we pull it from github
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz | tar xzk --strip-components 1
 

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 LABEL maintainer="opensource@rerun.io"
 # Remember to update the version in publish.sh
 # TODO(jleibs) use this version in the publish.sh script and below in the CACHE_KEY
-LABEL version="0.6"
+LABEL version="0.7"
 LABEL description="Docker image used for the CI of https://github.com/rerun-io/rerun"
 
 # Install the ubuntu package dependencies
@@ -71,7 +71,7 @@ RUN cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindge
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz | tar xzk --strip-components 1
 
 # Increment this to invalidate cache
-ENV CACHE_KEY=rerun_docker_v0.6
+ENV CACHE_KEY=rerun_docker_v0.7
 
 # See: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
 RUN git config --system --add safe.directory '*'

--- a/ci_docker/publish.sh
+++ b/ci_docker/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
-VERSION=0.6 # Bump on each new version. Remember to update the version in the Dockerfile too.
+VERSION=0.7 # Bump on each new version. Remember to update the version in the Dockerfile too.
 
 # The build needs to run from top of repo to access the requirements.txt
 cd `git rev-parse --show-toplevel`

--- a/crates/re_build_build_info/src/lib.rs
+++ b/crates/re_build_build_info/src/lib.rs
@@ -83,7 +83,10 @@ pub fn export_env_vars() {
 
 fn rerun_if_changed(path: &str) {
     // Make sure the file exists, otherwise we'll be rebuilding all the time.
-    assert!(std::path::Path::new(path).exists(), "Failed to find {path}");
+    assert!(
+        std::path::Path::new(path).exists(),
+        "Failed to find {path:?}"
+    );
     println!("cargo:rerun-if-changed={path}");
 }
 
@@ -96,6 +99,14 @@ fn run_command(cmd: &str, args: &[&str]) -> anyhow::Result<String> {
         .args(args)
         .output()
         .with_context(|| format!("running '{cmd}'"))?;
+
+    assert!(
+        output.status.success(),
+        "Failed to run '{cmd} {args:?}':\n{}\n{}\n",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
     Ok(String::from_utf8(output.stdout)?.trim().to_owned())
 }
 

--- a/crates/re_build_build_info/src/lib.rs
+++ b/crates/re_build_build_info/src/lib.rs
@@ -83,10 +83,7 @@ pub fn export_env_vars() {
 
 fn rerun_if_changed(path: &str) {
     // Make sure the file exists, otherwise we'll be rebuilding all the time.
-    assert!(
-        std::path::Path::new(path).exists(),
-        "Failed to find {path:?}"
-    );
+    assert!(std::path::Path::new(path).exists(), "Failed to find {path}");
     println!("cargo:rerun-if-changed={path}");
 }
 
@@ -99,14 +96,6 @@ fn run_command(cmd: &str, args: &[&str]) -> anyhow::Result<String> {
         .args(args)
         .output()
         .with_context(|| format!("running '{cmd}'"))?;
-
-    assert!(
-        output.status.success(),
-        "Failed to run '{cmd} {args:?}':\n{}\n{}\n",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-
     Ok(String::from_utf8(output.stdout)?.trim().to_owned())
 }
 

--- a/crates/re_log/Cargo.toml
+++ b/crates/re_log/Cargo.toml
@@ -31,4 +31,4 @@ env_logger = "0.10"
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
-wasm-bindgen = "=0.2.84"
+wasm-bindgen = "0.2.86"

--- a/crates/re_memory/Cargo.toml
+++ b/crates/re_memory/Cargo.toml
@@ -37,4 +37,4 @@ sysinfo = { version = "0.28.3", default-features = false }
 
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "=0.2.84"
+wasm-bindgen = "0.2.86"

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -12,10 +12,7 @@ set -x
 rustup target add wasm32-unknown-unknown
 
 # For generating JS bindings:
-# cargo install wasm-bindgen-cli --version 0.2.84
-# We use our own patched version containing this critical fix: https://github.com/rustwasm/wasm-bindgen/pull/3310
-# See https://github.com/rerun-io/wasm-bindgen/commits/0.2.84-patch
-cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.git --rev 13283975ddf48c2d90758095e235b28d381c5762
+cargo install wasm-bindgen-cli --version 0.2.86
 
 # For local tests with `start_server.sh`:
 # cargo install basic-http-server

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -18,6 +18,9 @@ cargo install wasm-bindgen-cli --version 0.2.86
 # cargo install basic-http-server
 
 # binaryen gives us wasm-opt, for optimizing the an .wasm file for speed and size
+# If you add to this list, please consult the ci_docker/Dockerfile and make sure the
+# package actually installs properly. binaryen isn't supported on ubuntu 20.04 so we have
+# to install it manually there.
 packagesNeeded='binaryen'
 if [ -x "$(command -v brew)" ];      then brew install $packagesNeeded
 elif [ -x "$(command -v port)" ];    then sudo port install $packagesNeeded


### PR DESCRIPTION
### What
Update `wasm-bindgen` to 0.2.86

This release contains the fix for 2GiB memory usage, meaning we no longer need to use a forked version of wasm-bindgen-cli

Does not fix https://github.com/rerun-io/rerun/issues/2152

Tested in Firefo, Chromium, and Safari

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2161
