### PR TITLE
Fix test dependencies of re_arrow_store

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -33,7 +33,7 @@ core_benchmarks_only = []
 [dependencies]
 # Rerun dependencies:
 re_format.workspace = true
-re_log_types.workspace = true
+re_log_types = { workspace = true, features = ["arrow_datagen"] }
 re_log.workspace = true
 
 # External dependencies:
@@ -109,6 +109,10 @@ name = "range_components"
 path = "examples/range_components.rs"
 required-features = ["polars"]
 
+[[test]]
+name = "dump"
+path = "tests/dump.rs"
+required-features = ["polars"]
 
 [[bench]]
 name = "data_store"


### PR DESCRIPTION
Ran into issues when running `cargo test -p re_arrow_store` and  `cargo test` because of missing dependency specification

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
