### PR TITLE
Don't persist blueprints for unknown apps

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -115,13 +115,19 @@ impl App {
             );
         }
 
-        let state: AppState = if startup_options.persist_state {
+        let mut state: AppState = if startup_options.persist_state {
             storage
                 .and_then(|storage| eframe::get_value(storage, eframe::APP_KEY))
                 .unwrap_or_default()
         } else {
             AppState::default()
         };
+
+        // Forget the blueprint we used for some unknown app,
+        // so we don't reuse it for some unrelated unknown app.
+        // This is in particularly important for `rerun foo.png`
+        // followed by `rerun bar.png`, which both uses the unknow App ID.
+        state.blueprints.remove(&ApplicationId::unknown());
 
         let mut analytics = ViewerAnalytics::new();
         analytics.on_viewer_started(&build_info, app_env);

--- a/crates/re_viewer/src/ui/viewport.rs
+++ b/crates/re_viewer/src/ui/viewport.rs
@@ -770,7 +770,7 @@ fn space_view_ui(
 ) {
     let Some(latest_at) = ctx.rec_cfg.time_ctrl.time_int() else {
         ui.centered_and_justified(|ui| {
-            ui.label(ctx.re_ui.warning_text("No time selected"));
+            ui.weak("No time selected");
         });
         return
     };


### PR DESCRIPTION
### What
This improves the the `rerun foo.png` story by not persisting blueprint for data with unknown application ids. Previously you would see spaceviews from previous runs.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
