### PR TITLE
scripts: add crash retriever script

### DIFF
--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Fetch user crashes from PostHog database, deduplicates them, and prefill issue reports for them.
 

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -1,0 +1,153 @@
+"""
+Fetch user crashes from PostHog database, deduplicates them, and prefill issue reports for them.
+
+Usage:
+```
+export POSTHOG_PERSONAL_API_KEY=<create_your_personal_api_key_in_posthog_ui>
+
+python scripts/fetch_crashes.py -v 0.5.0 -v 0.5.1 > crashes.md
+```
+
+Optionally, you can filter out data older than a given timestamp:
+```
+python scripts/fetch_crashes.py -v 0.5.0 -v 0.5.1 --after 2023-05-02T20:17:52 > crashes.md
+```
+
+See also:
+```
+python scripts/fetch_crashes.py --help
+```
+"""
+
+import argparse
+import json
+import os
+from collections import defaultdict
+
+import requests
+
+## CLI
+
+parser = argparse.ArgumentParser(description="Fetch user crashes from PostHog database")
+parser.add_argument(
+    "-v",
+    "--version",
+    action="append",
+    dest="versions",
+    metavar="VERSION",
+    help="Specify one or more Rerun version",
+    required=True,
+)
+parser.add_argument(
+    "-a",
+    "--after",
+    action="append",
+    dest="date_after_included",
+    metavar="TIMESTAMP",
+    help="Filter out data older than this ISO8061 timestamp",
+)
+args = parser.parse_args()
+
+## Set up query, auth, etc
+
+personal_api_key = os.environ.get("POSTHOG_PERSONAL_API_KEY")
+project_id = os.environ.get("POSTHOG_PROJECT_ID", "1954")
+
+url = f"https://eu.posthog.com/api/projects/{project_id}/events"
+properties = [
+    {"key": "email", "value": "is_not_set", "operator": "is_not_set", "type": "person"},
+    {"key": "rerun_version", "value": args.versions, "operator": "exact", "type": "event"},
+]
+
+## Fetch results
+
+
+# NOTE: For reference, here's the complete event payload:
+#
+# {
+#   "id": "01880cc1-10bd-0000-8338-2cc3ffed784b",
+#   "distinct_id": "7981eecd-f1b9-4446-8824-b854d5474787",
+#   "properties": {
+#     "llvm_version": "15.0.6",
+#     "target": "x86_64-pc-windows-msvc",
+#     "callstack": "<omitted>",
+#     "session_id": "f67f53b8-da72-4564-b849-05b048a5b6be",
+#     "git_hash": "968bf7355ef146c6fad3283835f2d87e7757abc6",
+#     "rerun_workspace": false,
+#     "file_line": "wgpu-0.15.1/src/backend/direct.rs:3024",
+#     "event_id": 1,
+#     "rerun_version": "0.5.1",
+#     "rust_version": "1.67.1 (d5a82bbd2 2023-02-07)",
+#     "debug": false,
+#     "build_date": "2023-05-02T21:24:20Z"
+#   },
+#   "event": "crash-panic",
+#   "timestamp": "2023-05-11T20:17:52.479000+00:00",
+#   "person": null,
+#   "elements": [],
+#   "elements_chain": ""
+# }
+
+
+results = []
+
+for event in ["crash-panic", "crash-signal"]:
+    params = {
+        "properties": json.dumps(properties),
+        "event": "crash-panic",
+        "orderBy": '["-timestamp"]',
+    }
+    if args.date_after_included:
+        params["after"] = args.date_after_included
+    headers = {"Authorization": f"Bearer {personal_api_key}"}
+
+    response = requests.get(url, headers=headers, params=params)
+
+    if response.status_code != 200:
+        print("Request failed with status code:", response.status_code)
+        exit(1)
+
+    results += response.json()["results"]
+
+## Deduplicate results and massage output
+
+backtraces = defaultdict(list)
+
+for res in results:
+    res["properties"]["timestamp"] = res["timestamp"]
+    res["properties"]["event"] = res["event"]
+    backtrace = res["properties"].pop("callstack").encode("utf-8").strip()
+    backtraces[backtrace].append(res.pop("properties"))
+
+backtraces = list(backtraces.items())
+backtraces.sort(key=(lambda x: len(x[1])), reverse=True)
+
+## Generate reports
+
+for backtrace, props in backtraces:
+    event = "panic" if props[0]["event"] == "crash-panic" else "signal"
+    file_line = props[0]["file_line"]
+
+    timestamps = sorted(list(set([prop["timestamp"] for prop in props])))
+    first_occurence = timestamps[0]
+    last_occurence = timestamps[-1]
+
+    targets = sorted(list(set([prop["target"] for prop in props])))
+    rust_versions = sorted(list(set([prop["rust_version"] for prop in props])))
+    rerun_versions = sorted(list(set([prop["rerun_version"] for prop in props])))
+
+
+    print(
+        f"## {len(props)} {event} crash(es) in `{file_line}`\n"
+        "\n"
+        f"- First occurence: {first_occurence}\n"
+        f"- Last occurence: {last_occurence}\n"
+        f"- Affected Rust versions: `{rust_versions}`\n"
+        f"- Affected Rerun versions: `{rerun_versions}`\n"
+        f"- Affected Targets: `{targets}`\n"
+        "\n"
+        "Backtrace:\n"
+        "```\n"
+        f'   {backtrace.decode("utf-8")}'
+        "```\n"
+    )

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -121,8 +121,10 @@ for res in results:
     backtrace = res["properties"].pop("callstack").encode("utf-8").strip()
     backtraces[backtrace].append(res.pop("properties"))
 
+
 def count_uniques(backtrace):
     return len(set([prop["user_id"] for prop in backtrace[1]]))
+
 
 backtraces = list(backtraces.items())
 backtraces.sort(key=count_uniques, reverse=True)

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -148,6 +148,6 @@ for backtrace, props in backtraces:
         "\n"
         "Backtrace:\n"
         "```\n"
-        f'   {backtrace.decode("utf-8")}'
+        f'   {backtrace.decode("utf-8")}\n'
         "```\n"
     )

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -130,8 +130,8 @@ for backtrace, props in backtraces:
     file_line = props[0]["file_line"]
 
     timestamps = sorted(list(set([prop["timestamp"] for prop in props])))
-    first_occurence = timestamps[0]
-    last_occurence = timestamps[-1]
+    first_occurrence = timestamps[0]
+    last_occurrence = timestamps[-1]
 
     targets = sorted(list(set([prop["target"] for prop in props])))
     rust_versions = sorted(list(set([prop["rust_version"] for prop in props])))
@@ -140,8 +140,8 @@ for backtrace, props in backtraces:
     print(
         f"## {len(props)} {event} crash(es) in `{file_line}`\n"
         "\n"
-        f"- First occurence: {first_occurence}\n"
-        f"- Last occurence: {last_occurence}\n"
+        f"- First occurrence: {first_occurrence}\n"
+        f"- Last occurrence: {last_occurrence}\n"
         f"- Affected Rust versions: `{rust_versions}`\n"
         f"- Affected Rerun versions: `{rerun_versions}`\n"
         f"- Affected Targets: `{targets}`\n"

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -121,7 +121,8 @@ for res in results:
     backtrace = res["properties"].pop("callstack").encode("utf-8").strip()
     backtraces[backtrace].append(res.pop("properties"))
 
-count_uniques = lambda backtrace: len(set([prop["user_id"] for prop in backtrace[1]]))
+def count_uniques(backtrace):
+    return len(set([prop["user_id"] for prop in backtrace[1]]))
 
 backtraces = list(backtraces.items())
 backtraces.sort(key=count_uniques, reverse=True)

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -13,7 +13,8 @@ Optionally, you can filter out data older than a given timestamp:
 python scripts/fetch_crashes.py -v 0.5.0 -v 0.5.1 --after 2023-05-02T20:17:52 > crashes.md
 ```
 
-See also:
+See Also
+--------
 ```
 python scripts/fetch_crashes.py --help
 ```
@@ -135,7 +136,6 @@ for backtrace, props in backtraces:
     targets = sorted(list(set([prop["target"] for prop in props])))
     rust_versions = sorted(list(set([prop["rust_version"] for prop in props])))
     rerun_versions = sorted(list(set([prop["rerun_version"] for prop in props])))
-
 
     print(
         f"## {len(props)} {event} crash(es) in `{file_line}`\n"

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -95,7 +95,7 @@ results = []
 for event in ["crash-panic", "crash-signal"]:
     params = {
         "properties": json.dumps(properties),
-        "event": "crash-panic",
+        "event": event,
         "orderBy": '["-timestamp"]',
     }
     if args.date_after_included:
@@ -134,7 +134,9 @@ backtraces.sort(key=count_uniques, reverse=True)
 for backtrace, props in backtraces:
     n = count_uniques((backtrace, props))
     event = "panic" if props[0]["event"] == "crash-panic" else "signal"
-    file_line = props[0]["file_line"]
+    file_line = props[0].get("file_line")
+    signal = props[0].get("signal")
+    title = file_line if file_line is not None else signal
 
     timestamps = sorted(list(set([prop["timestamp"] for prop in props])))
     first_occurrence = timestamps[0]
@@ -145,10 +147,10 @@ for backtrace, props in backtraces:
     rerun_versions = sorted(list(set([prop["rerun_version"] for prop in props])))
 
     print(
-        f"## {n} {event} crash(es) in `{file_line}`\n"
+        f"## {n} {event} crash(es) in `{title}`\n"
         "\n"
-        f"- First occurrence: {first_occurrence}\n"
-        f"- Last occurrence: {last_occurrence}\n"
+        f"- First occurrence: `{first_occurrence}`\n"
+        f"- Last occurrence: `{last_occurrence}`\n"
         f"- Affected Rust versions: `{rust_versions}`\n"
         f"- Affected Rerun versions: `{rerun_versions}`\n"
         f"- Affected Targets: `{targets}`\n"

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -149,7 +149,7 @@ for backtrace, props in backtraces:
     rerun_versions = sorted(list(set([prop["rerun_version"] for prop in props])))
 
     print(
-        f"## {n} {event} crash(es) in `{title}`\n"
+        f"## {n} distinct user(s) affected by {event} crash @ `{title}`\n"
         "\n"
         f"- First occurrence: `{first_occurrence}`\n"
         f"- Last occurrence: `{last_occurrence}`\n"


### PR DESCRIPTION
Fetch user crashes from PostHog database, deduplicates them, and prefill issue reports for them.

Usage:
```
export POSTHOG_PERSONAL_API_KEY=<create_your_personal_api_key_in_posthog_ui>

python scripts/fetch_crashes.py -v 0.5.0 -v 0.5.1 > crashes.md
```

Optionally, you can filter out data older than a given timestamp:
```
python scripts/fetch_crashes.py -v 0.5.0 -v 0.5.1 --after 2023-05-02T20:17:52 > crashes.md
```

See also:
```
python scripts/fetch_crashes.py --help
```

---

# Live demo

```
$ python scripts/fetch_crashes.py -v 0.5.0 -v 0.5.1 --after 2023-05-14
```

## 2 distinct user(s) affected by panic crash @ `winit-0.28.1/src/platform_impl/linux/mod.rs:757`

- First occurrence: `2023-05-15T21:20:44.358000+00:00`
- Last occurrence: `2023-05-19T15:42:51.622000+00:00`
- Affected Rust versions: `['1.67.1 (d5a82bbd2 2023-02-07)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   6: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   7: winit::platform_impl::platform::EventLoop<T>::new
   8: std::thread::local::LocalKey<T>::with
   9: eframe::native::run::wgpu_integration::run_wgpu
```

## 1 distinct user(s) affected by panic crash @ `wgpu-0.15.1/src/backend/direct.rs:316`

- First occurrence: `2023-05-15T14:43:58.362000+00:00`
- Last occurrence: `2023-05-20T13:22:17.682000+00:00`
- Affected Rust versions: `['1.67.1 (d5a82bbd2 2023-02-07)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   6: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   7: wgpu::backend::direct::Context::handle_error_fatal
```

## 1 distinct user(s) affected by panic crash @ `winit-0.28.1/src/platform_impl/linux/wayland/window/mod.rs:327`

- First occurrence: `2023-05-19T09:39:05.464000+00:00`
- Last occurrence: `2023-05-20T05:50:40.112000+00:00`
- Affected Rust versions: `['1.67.1 (d5a82bbd2 2023-02-07)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   6: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   7: core::panicking::panic
             at core/src/panicking.rs:111:5
   8: winit::platform_impl::platform::wayland::window::Window::new::{{closure}}
```

## 1 distinct user(s) affected by panic crash @ `arrow2-0.16.0/src/array/growable/binary.rs:73`

- First occurrence: `2023-05-20T05:19:00.353000+00:00`
- Last occurrence: `2023-05-20T05:19:00.353000+00:00`
- Affected Rust versions: `['1.67.1 (d5a82bbd2 2023-02-07)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   6: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   7: core::result::unwrap_failed
             at core/src/result.rs:1791:5
   8: <arrow2::array::growable::binary::GrowableBinary<O> as arrow2::array::growable::Growable>::extend
   9: <arrow2::array::growable::union::GrowableUnion as arrow2::array::growable::Growable>::extend
  10: <arrow2::array::growable::structure::GrowableStruct as arrow2::array::growable::Growable>::extend
  11: arrow2::compute::concatenate::concatenate
  12: re_log_types::data_table::DataTable::serialize_data_column
  13: re_log_types::data_table::DataTable::serialize
  14: <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::try_fold
  15: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
  16: re_viewer::app::save
  17: <re_viewer::app::App as eframe::epi::App>::update
  18: eframe::native::epi_integration::EpiIntegration::update
  19: <eframe::native::run::wgpu_integration::WgpuWinitApp as eframe::native::run::WinitApp>::paint
  20: eframe::native::run::run_and_return::{{closure}}
  21: winit::platform_impl::platform::x11::EventLoop<T>::run_return::single_iteration
  22: winit::platform_impl::platform::x11::EventLoop<T>::run_return
  23: eframe::native::run::run_and_return
  24: std::thread::local::LocalKey<T>::with
  25: eframe::native::run::wgpu_integration::run_wgpu
```

## 1 distinct user(s) affected by panic crash @ `wgpu-0.15.1/src/backend/direct.rs:316`

- First occurrence: `2023-05-18T23:35:28.850000+00:00`
- Last occurrence: `2023-05-20T02:27:01.859000+00:00`
- Affected Rust versions: `['1.68.2 (9eb3afe9e 2023-03-27)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   6: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   7: wgpu::backend::direct::Context::handle_error_fatal
   8: <wgpu::backend::direct::Context as wgpu::context::Context>::device_poll
   9: <T as wgpu::context::DynContext>::device_poll
  10: wgpu::Device::poll
  11: re_renderer::context::RenderContext::begin_frame
  12: core::ops::function::FnOnce::call_once{{vtable.shim}}
  13: core::ops::function::FnOnce::call_once{{vtable.shim}}
  14: egui::containers::frame::Frame::show_dyn
  15: egui::containers::panel::CentralPanel::show_inside_dyn
  16: egui::containers::panel::CentralPanel::show_dyn
  17: <re_viewer::app::App as eframe::epi::App>::update
  18: egui::context::Context::run
  19: eframe::native::epi_integration::EpiIntegration::update
  20: <eframe::native::run::wgpu_integration::WgpuWinitApp as eframe::native::run::WinitApp>::paint
  21: eframe::native::run::run_and_return::{{closure}}
  22: winit::platform_impl::platform::x11::EventLoop<T>::run_return::single_iteration
  23: winit::platform_impl::platform::x11::EventLoop<T>::run_return
  24: eframe::native::run::run_and_return
  25: std::thread::local::LocalKey<T>::with
  26: eframe::native::run::wgpu_integration::run_wgpu
  27: eframe::run_native
```

## 1 distinct user(s) affected by panic crash @ `winit-0.28.6/src/platform_impl/linux/mod.rs:757`

- First occurrence: `2023-05-15T12:50:30.691000+00:00`
- Last occurrence: `2023-05-15T12:50:30.691000+00:00`
- Affected Rust versions: `['1.68.2 (9eb3afe9e 2023-03-27)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   6: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   7: winit::platform_impl::platform::EventLoop<T>::new
   8: std::thread::local::LocalKey<T>::with
   9: eframe::native::run::wgpu_integration::run_wgpu
  10: eframe::run_native
```

## 1 distinct user(s) affected by signal crash @ `SIGABRT`

- First occurrence: `2023-05-15T13:46:46.504000+00:00`
- Last occurrence: `2023-05-15T13:46:46.504000+00:00`
- Affected Rust versions: `['1.68.2 (9eb3afe9e 2023-03-27)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   1: rerun::crash_handler::install_signal_handler::signal_handler
   2: <unknown>
   3: __libc_signal_restore_set
             at nptl-signals.h:80
      __GI_raise
             at raise.c:48
   4: __GI_abort
             at abort.c:79
   5: std::sys::unix::abort_internal
             at std/src/sys/unix/mod.rs:350:14
   6: std::panicking::rust_panic_with_hook
             at std/src/panicking.rs:673:9
   7: std::panicking::begin_panic_handler::{{closure}}
             at std/src/panicking.rs:579:13
   8: std::sys_common::backtrace::__rust_end_short_backtrace
             at std/src/sys_common/backtrace.rs:137:18
   9: rust_begin_unwind
             at std/src/panicking.rs:575:5
  10: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
  11: std::io::stdio::print_to
             at std/src/io/stdio.rs:1008:9
      std::io::stdio::_eprint
             at std/src/io/stdio.rs:1085:5
  12: rerun::crash_handler::install_panic_hook::{{closure}}
  13: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at alloc/src/boxed.rs:2002:9
      std::panicking::rust_panic_with_hook
             at std/src/panicking.rs:692:13
  14: std::panicking::begin_panic_handler::{{closure}}
             at std/src/panicking.rs:579:13
  15: std::sys_common::backtrace::__rust_end_short_backtrace
             at std/src/sys_common/backtrace.rs:137:18
  16: rust_begin_unwind
             at std/src/panicking.rs:575:5
  17: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
  18: std::io::stdio::print_to
             at std/src/io/stdio.rs:1008:9
      std::io::stdio::_eprint
             at std/src/io/stdio.rs:1085:5
  19: rerun::crash_handler::install_panic_hook::{{closure}}
  20: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at alloc/src/boxed.rs:2002:9
      std::panicking::rust_panic_with_hook
             at std/src/panicking.rs:692:13
  21: std::panicking::begin_panic_handler::{{closure}}
             at std/src/panicking.rs:579:13
  22: std::sys_common::backtrace::__rust_end_short_backtrace
             at std/src/sys_common/backtrace.rs:137:18
  23: rust_begin_unwind
             at std/src/panicking.rs:575:5
  24: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
  25: core::result::unwrap_failed
             at core/src/result.rs:1790:5
  26: rerun::run::run_impl::{{closure}}::{{closure}}::{{closure}}
  27: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  28: tokio::runtime::task::core::Core<T,S>::poll
  29: tokio::runtime::task::harness::Harness<T,S>::poll
  30: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  31: tokio::runtime::scheduler::multi_thread::worker::Context::run
  32: tokio::macros::scoped_tls::ScopedKey<T>::set
  33: tokio::runtime::scheduler::multi_thread::worker::run
  34: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  35: tokio::runtime::task::core::Core<T,S>::poll
  36: tokio::runtime::task::harness::Harness<T,S>::poll
  37: tokio::runtime::blocking::pool::Inner::run
```

## 1 distinct user(s) affected by signal crash @ `SIGABRT`

- First occurrence: `2023-05-14T16:47:35.588000+00:00`
- Last occurrence: `2023-05-14T16:47:35.588000+00:00`
- Affected Rust versions: `['1.67.1 (d5a82bbd2 2023-02-07)']`
- Affected Rerun versions: `['0.5.1']`
- Affected Targets: `['x86_64-unknown-linux-gnu']`

Backtrace:
```
   1: rerun::crash_handler::install_signal_handler::signal_handler
   2: <unknown>
   3: __libc_signal_restore_set
             at internal-signals.h:86:3
      __GI_raise
             at raise.c:48:3
   4: __GI_abort
             at abort.c:79:7
   5: std::sys::unix::abort_internal
             at std/src/sys/unix/mod.rs:347:14
   6: std::panicking::rust_panic_with_hook
             at std/src/panicking.rs:673:9
   7: std::panicking::begin_panic_handler::{{closure}}
             at std/src/panicking.rs:579:13
   8: std::sys_common::backtrace::__rust_end_short_backtrace
             at std/src/sys_common/backtrace.rs:137:18
   9: rust_begin_unwind
             at std/src/panicking.rs:575:5
  10: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
  11: std::io::stdio::print_to
             at std/src/io/stdio.rs:1009:9
      std::io::stdio::_eprint
             at std/src/io/stdio.rs:1086:5
  12: rerun::crash_handler::install_panic_hook::{{closure}}
  13: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at alloc/src/boxed.rs:2032:9
      std::panicking::rust_panic_with_hook
             at std/src/panicking.rs:692:13
  14: std::panicking::begin_panic_handler::{{closure}}
             at std/src/panicking.rs:579:13
  15: std::sys_common::backtrace::__rust_end_short_backtrace
             at std/src/sys_common/backtrace.rs:137:18
  16: rust_begin_unwind
             at std/src/panicking.rs:575:5
  17: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
  18: std::io::stdio::print_to
             at std/src/io/stdio.rs:1009:9
      std::io::stdio::_eprint
             at std/src/io/stdio.rs:1086:5
  19: rerun::crash_handler::install_panic_hook::{{closure}}
  20: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at alloc/src/boxed.rs:2032:9
      std::panicking::rust_panic_with_hook
             at std/src/panicking.rs:692:13
  21: std::panicking::begin_panic_handler::{{closure}}
             at std/src/panicking.rs:579:13
  22: std::sys_common::backtrace::__rust_end_short_backtrace
             at std/src/sys_common/backtrace.rs:137:18
  23: rust_begin_unwind
             at std/src/panicking.rs:575:5
  24: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
  25: core::result::unwrap_failed
             at core/src/result.rs:1791:5
  26: rerun::run::run_impl::{{closure}}::{{closure}}::{{closure}}
  27: tokio::runtime::task::core::Core<T,S>::poll
```


---

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2168
