### PR TITLE
Fix setup scripts for Mac M1/MacPort configuration

### DIFF
--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -9,7 +9,7 @@ set -x
 ./scripts/setup.sh
 
 cargo install cargo-cranky # Uses lints defined in Cranky.toml. See https://github.com/ericseppanen/cargo-cranky
-cargo install cargo-deny # https://github.com/EmbarkStudios/cargo-deny
+cargo install --locked cargo-deny # https://github.com/EmbarkStudios/cargo-deny
 cargo install just # Just a command runner
 cargo install taplo-cli --locked # toml formatter/linter/lsp
 cargo install typos-cli

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -23,6 +23,7 @@ cargo install wasm-bindgen-cli --git https://github.com/rerun-io/wasm-bindgen.gi
 # binaryen gives us wasm-opt, for optimizing the an .wasm file for speed and size
 packagesNeeded='binaryen'
 if [ -x "$(command -v brew)" ];      then brew install $packagesNeeded
+elif [ -x "$(command -v port)" ];    then sudo port install $packagesNeeded
 elif [ -x "$(command -v apt-get)" ]; then sudo apt-get -y install $packagesNeeded
 elif [ -x "$(command -v dnf)" ];     then sudo dnf install $packagesNeeded
 elif [ -x "$(command -v zypper)" ];  then sudo zypper install $packagesNeeded


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

This PR includes two minor changes needed to for the `setup_dev.sh` script to complete on my M1 machine with [MacPorts](https://www.macports.org):

1) Add MacPorts in the list of supported package managers.
2) Add `--locked` flag when installing `cargo-deny`

Without `--locked`, I would get the following error:

```
 = note: Undefined symbols for architecture arm64:
            "_iconv", referenced from:
                _git_fs_path_iconv in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
               (maybe you meant: _git_fs_path_iconv_clear, _git_fs_path_iconv_init_precompose , _git_fs_path_iconv )
            "_iconv_close", referenced from:
                _git_fs_path_direach in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
                _git_fs_path_iconv_clear in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
                _git_fs_path_diriter_free in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
                _git_fs_path_dirload in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
            "_iconv_open", referenced from:
                _git_fs_path_direach in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
                _git_fs_path_iconv_init_precompose in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
                _git_fs_path_diriter_init in liblibgit2_sys-855562e07780fd1f.rlib(fs_path.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `cargo-deny` due to previous error
```

I haven't investigated why this is so, but the cargo-deny project always includes `--locked` in its installation instructions.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
