### PR TITLE
Remove `native_viewer` from the default features of `rerun` crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,7 @@
 [alias]
+# `cargo rerun` is short a convenient shorthand
+rerun = "run --package rerun --features native_viewer --features server --"
+
 # To easily run examples on the web, see https://github.com/rukai/cargo-run-wasm.
 # Temporary solution while we wait for our own xtasks!
 run-wasm = "run --release --package run_wasm --"

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,9 @@ This is a guide to how to build Rerun.
 * Run `./scripts/setup_dev.sh`.
 * Make sure `cargo --version` prints `1.69.0` once you are done
 
+You should now be able run our Rust examples, e.g. with `cargo run -p dna`.
+
+You can type `cargo rerun` to compile and run the `rerun` binary with most features enabled, thanks to a shortcut in `.cargo/config.toml`.
 
 ### Apple-silicon Macs
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ rr.log_rect("car", bbox)
 ### Rerun Viewer binary
 Both the Python and Rust library can start the Rerun Viewer, but to stream log data over the network or load our `.rrd` data files you also need the `rerun` binary.
 
-It can be installed with `pip install rerun-sdk` or with `cargo install rerun`.
+It can be installed with `pip install rerun-sdk` or with `cargo install rerun --features binary`.
 
 You should now be able to run `rerun --help` in any terminal.
 

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -21,15 +21,13 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
 [features]
-default = [
-  "analytics",
-  "demo",
-  "glam",
-  "image",
-  "native_viewer",
-  "server",
-  "sdk",
-]
+default = ["library"]
+
+## Default features when using `rerun` as a binary. Everything included.
+binary = ["library", "native_viewer", "server", "web_viewer"]
+
+## Default features when using `rerun` as a logging library. Optimized for compilation speed.
+library = ["analytics", "demo", "glam", "image", "sdk", "server"]
 
 ## Enable telemetry using our analytics SDK.
 analytics = [
@@ -52,7 +50,7 @@ image = ["re_log_types/image", "re_sdk?/image"]
 ## This adds a lot of extra dependencies, so only enable this feature if you need it!
 native_viewer = ["dep:re_viewer"]
 
-## Support for running a HTTP server that listens to incoming log messages from a Rerun SDK.
+## Support for running a TCP server that listens to incoming log messages from a Rerun SDK.
 server = ["re_sdk_comms/server"]
 
 ## Embed the Rerun SDK and re-export all of its public symbols.

--- a/crates/rerun/README.md
+++ b/crates/rerun/README.md
@@ -46,7 +46,7 @@ You can add the `rerun` crate to your project with `cargo add rerun`.
 To get started, see [the examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust).
 
 ## Binary
-You can install the binary with `cargo install rerun`
+You can install the binary with `cargo install rerun --features binary`
 
 This can act either as a server, a viewer, or both, depending on which options you use when you start it.
 

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -5,7 +5,7 @@
 //! There is also a `rerun` binary.
 //! The binary is required in order to stream log data
 //! over the networks, and to open our `.rrd` data files.
-//! If you need it, install the `rerun` binary with `cargo install rerun`.
+//! If you need it, install the `rerun` binary with `cargo install rerun --features binary`.
 //!
 //! ## Feature flags
 #![doc = document_features::document_features!()]

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -94,7 +94,7 @@ impl crate::sink::LogSink for WebViewerSink {
 /// If the `open_browser` argument is `true`, your default browser
 /// will be opened with a connected web-viewer.
 ///
-/// If not, you can connect to this server using the `rerun` binary (`cargo install rerun`).
+/// If not, you can connect to this server using the `rerun` binary (`cargo install rerun --features binary`).
 ///
 /// NOTE: you can not connect one `Session` to another.
 ///

--- a/examples/rust/api_demo/Cargo.toml
+++ b/examples/rust/api_demo/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }
 
 itertools = "0.10"
 rand = "0.8"

--- a/examples/rust/minimal/Cargo.toml
+++ b/examples/rust/minimal/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun" }
+rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -8,7 +8,10 @@ publish = false
 
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "native_viewer",
+  "web_viewer",
+] }
 
 anyhow = "1.0"
 bytes = "1.3"


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1997

### What

Most of our users only use the `rerun` library as a logging library but are still paying the cost of compiling the native viewer.

With this PR, the `rerun` crate will not have the `native_viewer` (nor `web_viewer`) feature on by default. This halves the compilation time on my computer. It also reduces the chance of crate mismatch (we've had users complaining about us using an older `wgpu` than they, even though they only use `rerun` for logging).

The `native_viewer` feature is only for users using the `show` or `spawn` features, which will hopefully be removed soon anyway:
* https://github.com/rerun-io/rerun/issues/2109

To install the `rerun` binary with `native_viewer` and `web_viewer`, you now have to run `cargo install rerun --features binary`. This will be improved by:
* https://github.com/rerun-io/rerun/issues/2108

To make things nicer for us developers, I've added `cargo rerun` as a shorthand for compiling and running `rerun` with the `native_viewer` feature, but NOT the `web_viewer` feature.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2177
