### PR TITLE
Update egui and eframe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
  "objc",
  "percent-encoding",
  "pollster",
- "puffin 0.15.0",
+ "puffin",
  "raw-window-handle",
  "ron",
  "serde",
@@ -1320,7 +1320,7 @@ dependencies = [
  "bytemuck",
  "epaint",
  "log",
- "puffin 0.15.0",
+ "puffin",
  "thiserror",
  "type-map",
  "wgpu",
@@ -1336,7 +1336,7 @@ dependencies = [
  "egui",
  "instant",
  "log",
- "puffin 0.15.0",
+ "puffin",
  "raw-window-handle",
  "serde",
  "smithay-clipboard",
@@ -1365,7 +1365,7 @@ dependencies = [
  "glow",
  "log",
  "memoffset 0.6.5",
- "puffin 0.15.0",
+ "puffin",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -3484,41 +3484,31 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796a1b7d7d0ec984dde24615178cbd14dc697ea4cdcddfd1fee9a5f87135f9e8"
-dependencies = [
- "anyhow",
- "bincode",
- "byteorder",
- "once_cell",
- "parking_lot 0.12.1",
- "ruzstd",
- "serde",
- "zstd",
-]
-
-[[package]]
-name = "puffin"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f99b70359a44d98fceb167734e8cc19e232fe885a547f1b622e66d8099931b6"
 dependencies = [
+ "anyhow",
+ "bincode",
  "byteorder",
  "instant",
  "once_cell",
+ "parking_lot 0.12.1",
+ "ruzstd",
+ "serde",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]
 name = "puffin_http"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dae1a51a8887f161ae17809ec4159bb3fbc8be60d12947039fa063cf211f1b"
+checksum = "cfbab9321f576e78566ac0986da3992ba8c3714056a12c6e92f4b5f71865cff7"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
  "log",
- "puffin 0.14.0",
+ "puffin",
 ]
 
 [[package]]
@@ -3720,7 +3710,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "polars-core",
  "polars-ops",
- "puffin 0.14.0",
+ "puffin",
  "rand",
  "re_format",
  "re_log",
@@ -3761,7 +3751,7 @@ dependencies = [
  "itertools",
  "mimalloc",
  "nohash-hasher",
- "puffin 0.14.0",
+ "puffin",
  "rand",
  "re_arrow_store",
  "re_format",
@@ -3785,7 +3775,7 @@ dependencies = [
  "image",
  "itertools",
  "nohash-hasher",
- "puffin 0.14.0",
+ "puffin",
  "re_arrow_store",
  "re_data_store",
  "re_error",
@@ -3850,7 +3840,7 @@ dependencies = [
  "js-sys",
  "mimalloc",
  "parking_lot 0.12.1",
- "puffin 0.14.0",
+ "puffin",
  "re_build_info",
  "re_log",
  "re_log_types",
@@ -3863,7 +3853,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -3889,7 +3879,7 @@ dependencies = [
  "nohash-hasher",
  "num-derive",
  "num-traits",
- "puffin 0.14.0",
+ "puffin",
  "rand",
  "re_format",
  "re_log",
@@ -3937,7 +3927,7 @@ dependencies = [
  "itertools",
  "mimalloc",
  "polars-core",
- "puffin 0.14.0",
+ "puffin",
  "re_arrow_store",
  "re_data_store",
  "re_format",
@@ -3976,7 +3966,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pathdiff",
  "pollster",
- "puffin 0.14.0",
+ "puffin",
  "rand",
  "re_error",
  "re_log",
@@ -4125,7 +4115,7 @@ dependencies = [
  "nohash-hasher",
  "objc",
  "poll-promise",
- "puffin 0.14.0",
+ "puffin",
  "puffin_http",
  "re_analytics",
  "re_arrow_store",
@@ -4178,7 +4168,7 @@ dependencies = [
  "macaw",
  "ndarray",
  "nohash-hasher",
- "puffin 0.14.0",
+ "puffin",
  "re_arrow_store",
  "re_data_store",
  "re_log",
@@ -4302,7 +4292,7 @@ dependencies = [
  "libc",
  "mimalloc",
  "parking_lot 0.12.1",
- "puffin 0.14.0",
+ "puffin",
  "rayon",
  "re_analytics",
  "re_build_build_info",
@@ -4505,9 +4495,9 @@ checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ruzstd"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffae8df4aa221781b715c27bbed0fac16b6f1e2643efb7af8a24dfc78d444493"
+checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
 dependencies = [
  "byteorder",
  "thiserror",
@@ -6217,7 +6207,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+dependencies = [
+ "zstd-safe 6.0.5+zstd.1.5.4",
 ]
 
 [[package]]
@@ -6231,13 +6230,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd-sys"
-version = "2.0.3+zstd.1.5.2"
+name = "zstd-safe"
+version = "6.0.5+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
+checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,7 +3496,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "ruzstd",
  "serde",
- "zstd 0.12.3+zstd.1.5.2",
+ "zstd",
 ]
 
 [[package]]
@@ -3853,7 +3853,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "zstd 0.11.2+zstd.1.5.2",
+ "zstd",
 ]
 
 [[package]]
@@ -6203,30 +6203,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
- "zstd-safe 6.0.5+zstd.1.5.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "330223a1aecc308757b9926e9391c9b47f8ef2dbd8aea9df88312aea18c5e8d6"
 
 [[package]]
 name = "accesskit"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704d532b1cd3d912bb37499c55a81ac748cc1afa737eedd100ba441acdd47d38"
+checksum = "02c98a5d094590335462354da402d754fe2cb78f0e6ce5024611c28ed539c1de"
 dependencies = [
  "enumn",
  "serde",
@@ -1261,7 +1261,7 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 [[package]]
 name = "ecolor"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.21.3"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1285,7 +1285,7 @@ dependencies = [
  "objc",
  "percent-encoding",
  "pollster",
- "puffin",
+ "puffin 0.15.0",
  "raw-window-handle",
  "ron",
  "serde",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "accesskit",
  "ahash 0.8.2",
@@ -1315,12 +1315,12 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "bytemuck",
  "epaint",
  "log",
- "puffin",
+ "puffin 0.15.0",
  "thiserror",
  "type-map",
  "wgpu",
@@ -1330,13 +1330,13 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.21.1"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "arboard",
  "egui",
  "instant",
  "log",
- "puffin",
+ "puffin 0.15.0",
  "raw-window-handle",
  "serde",
  "smithay-clipboard",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "egui",
  "log",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1365,7 +1365,7 @@ dependencies = [
  "glow",
  "log",
  "memoffset 0.6.5",
- "puffin",
+ "puffin 0.15.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1406,7 +1406,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "emath"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.21.0"
-source = "git+https://github.com/emilk/egui?rev=856afc8#856afc8f7e7de77d5592ac657f9a07be1938ae7a"
+source = "git+https://github.com/emilk/egui?rev=bb252e2#bb252e2788a8db8fedd6e7dfc0700aad52f6aa70"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.2",
@@ -3499,6 +3499,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "puffin"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f99b70359a44d98fceb167734e8cc19e232fe885a547f1b622e66d8099931b6"
+dependencies = [
+ "byteorder",
+ "instant",
+ "once_cell",
+]
+
+[[package]]
 name = "puffin_http"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,7 +3518,7 @@ dependencies = [
  "anyhow",
  "crossbeam-channel",
  "log",
- "puffin",
+ "puffin 0.14.0",
 ]
 
 [[package]]
@@ -3709,7 +3720,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "polars-core",
  "polars-ops",
- "puffin",
+ "puffin 0.14.0",
  "rand",
  "re_format",
  "re_log",
@@ -3750,7 +3761,7 @@ dependencies = [
  "itertools",
  "mimalloc",
  "nohash-hasher",
- "puffin",
+ "puffin 0.14.0",
  "rand",
  "re_arrow_store",
  "re_format",
@@ -3774,7 +3785,7 @@ dependencies = [
  "image",
  "itertools",
  "nohash-hasher",
- "puffin",
+ "puffin 0.14.0",
  "re_arrow_store",
  "re_data_store",
  "re_error",
@@ -3839,7 +3850,7 @@ dependencies = [
  "js-sys",
  "mimalloc",
  "parking_lot 0.12.1",
- "puffin",
+ "puffin 0.14.0",
  "re_build_info",
  "re_log",
  "re_log_types",
@@ -3878,7 +3889,7 @@ dependencies = [
  "nohash-hasher",
  "num-derive",
  "num-traits",
- "puffin",
+ "puffin 0.14.0",
  "rand",
  "re_format",
  "re_log",
@@ -3926,7 +3937,7 @@ dependencies = [
  "itertools",
  "mimalloc",
  "polars-core",
- "puffin",
+ "puffin 0.14.0",
  "re_arrow_store",
  "re_data_store",
  "re_format",
@@ -3965,7 +3976,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pathdiff",
  "pollster",
- "puffin",
+ "puffin 0.14.0",
  "rand",
  "re_error",
  "re_log",
@@ -4114,7 +4125,7 @@ dependencies = [
  "nohash-hasher",
  "objc",
  "poll-promise",
- "puffin",
+ "puffin 0.14.0",
  "puffin_http",
  "re_analytics",
  "re_arrow_store",
@@ -4167,7 +4178,7 @@ dependencies = [
  "macaw",
  "ndarray",
  "nohash-hasher",
- "puffin",
+ "puffin 0.14.0",
  "re_arrow_store",
  "re_data_store",
  "re_log",
@@ -4291,7 +4302,7 @@ dependencies = [
  "libc",
  "mimalloc",
  "parking_lot 0.12.1",
- "puffin",
+ "puffin 0.14.0",
  "rayon",
  "re_analytics",
  "re_build_build_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,13 +127,13 @@ debug = true
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
 # TODO(andreas/emilk): Update to a stable egui version
-# wgpu 0.16 support, device configuration dependent on adapter, some additions to help egui_tiles, egui::Modifiers::contains, better error reporting for web, wasm-bindgen update
-ecolor = { git = "https://github.com/emilk/egui", rev = "856afc8" }
-eframe = { git = "https://github.com/emilk/egui", rev = "856afc8" }
-egui = { git = "https://github.com/emilk/egui", rev = "856afc8" }
-egui-wgpu = { git = "https://github.com/emilk/egui", rev = "856afc8" }
-egui_extras = { git = "https://github.com/emilk/egui", rev = "856afc8" }
-emath = { git = "https://github.com/emilk/egui", rev = "856afc8" }
+# wgpu 0.16 support, device configuration dependent on adapter, some additions to help egui_tiles, egui::Modifiers::contains, better error reporting for web, wasm-bindgen update, `NativeOptions::app_id`
+ecolor = { git = "https://github.com/emilk/egui", rev = "bb252e2" }
+eframe = { git = "https://github.com/emilk/egui", rev = "bb252e2" }
+egui = { git = "https://github.com/emilk/egui", rev = "bb252e2" }
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "bb252e2" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "bb252e2" }
+emath = { git = "https://github.com/emilk/egui", rev = "bb252e2" }
 
 # TODO(andreas): Either work around this issue in wgpu-egui (never discard command buffers) or wait for wgpu patch release.
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ parking_lot = "0.12"
 polars-core = "0.29"
 polars-lazy = "0.29"
 polars-ops = "0.29"
-puffin = "0.14"
+puffin = "0.15"
 rayon = "1.7"
 rfd = { version = "0.11.3", default_features = false, features = [
   "xdg-portal",

--- a/crates/re_log_encoding/Cargo.toml
+++ b/crates/re_log_encoding/Cargo.toml
@@ -46,7 +46,7 @@ rmp-serde = { version = "1", optional = true }
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 puffin.workspace = true
-zstd = { version = "0.11.0", optional = true } # native only
+zstd = { version = "0.12.0", optional = true } # native only
 
 # Web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -4,6 +4,8 @@ fn main() -> eframe::Result<()> {
     re_log::setup_native_logging();
 
     let native_options = eframe::NativeOptions {
+        app_id: Some("re_ui_example".to_owned()),
+
         initial_window_size: Some([1200.0, 800.0].into()),
         follow_system_theme: false,
         default_theme: eframe::Theme::Dark,

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -110,7 +110,7 @@ wgpu.workspace = true
 
 # native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-puffin_http = "0.11"
+puffin_http = "0.12"
 puffin.workspace = true
 
 [target.'cfg(any(target_os = "macos"))'.dependencies]

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -113,9 +113,6 @@ impl AppEnvironment {
 
 // ---------------------------------------------------------------------------
 
-#[allow(dead_code)]
-const APPLICATION_NAME: &str = "Rerun Viewer";
-
 pub(crate) fn wgpu_options() -> egui_wgpu::WgpuConfiguration {
     egui_wgpu::WgpuConfiguration {
             // When running wgpu on native debug builds, we want some extra control over how

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -6,7 +6,7 @@ type AppCreator =
 // NOTE: the name of this function is hard-coded in `crates/rerun/src/crash_handler.rs`!
 pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
     let native_options = eframe::NativeOptions {
-        // Controls where on disk the app state is presisted.
+        // Controls where on disk the app state is persisted.
         app_id: Some("rerun".to_owned()),
 
         initial_window_size: Some([1600.0, 1200.0].into()),

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -1,13 +1,14 @@
 use re_log_types::LogMsg;
 
-use crate::APPLICATION_NAME;
-
 type AppCreator =
     Box<dyn FnOnce(&eframe::CreationContext<'_>, re_ui::ReUi) -> Box<dyn eframe::App>>;
 
 // NOTE: the name of this function is hard-coded in `crates/rerun/src/crash_handler.rs`!
 pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
     let native_options = eframe::NativeOptions {
+        // Controls where on disk the app state is presisted.
+        app_id: Some("rerun".to_owned()),
+
         initial_window_size: Some([1600.0, 1200.0].into()),
         min_window_size: Some([320.0, 450.0].into()), // Should be high enough to fit the rerun menu
 
@@ -32,8 +33,9 @@ pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
         ..Default::default()
     };
 
+    let window_title = "Rerun Viewer";
     eframe::run_native(
-        APPLICATION_NAME,
+        window_title,
         native_options,
         Box::new(move |cc| {
             let re_ui = crate::customize_eframe(cc);

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -66,9 +66,12 @@ struct Args {
     /// Whether the Rerun Viewer should persist the state of the viewer to disk.
     ///
     /// When persisted, the state will be stored at the following locations:
-    /// - Linux: /home/UserName/.local/share/rerunviewer
-    /// - macOS: /Users/UserName/Library/Application Support/rerunviewer
-    /// - Windows: C:\Users\UserName\AppData\Roaming\rerunviewer
+    ///
+    /// - Linux: /home/UserName/.local/share/rerun
+    ///
+    /// - macOS: /Users/UserName/Library/Application Support/rerun
+    ///
+    /// - Windows: C:\Users\UserName\AppData\Roaming\rerun
     #[clap(long, default_value_t = true)]
     persist_state: bool,
 


### PR DESCRIPTION
### What
This updates egui and eframe to latest `master` to test it against Rerun ahead of the next release.

One new feature is `app_id`, which controls where the app state is persisted. It also controls the `.desktop` files on Wayland: https://github.com/emilk/egui/pull/3007

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2184
