### PR TITLE
Premultiply the alpha on the GPU

### DIFF
--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -26,15 +26,7 @@ impl framework::Example for Render2D {
         let rerun_logo =
             image::load_from_memory(include_bytes!("../../re_ui/data/logo_dark_mode.png")).unwrap();
 
-        let mut image_data = rerun_logo.as_rgba8().unwrap().to_vec();
-
-        // Premultiply alpha.
-        for color in image_data.chunks_exact_mut(4) {
-            color.clone_from_slice(
-                &ecolor::Color32::from_rgba_unmultiplied(color[0], color[1], color[2], color[3])
-                    .to_array(),
-            );
-        }
+        let image_data = rerun_logo.as_rgba8().unwrap().to_vec();
 
         let rerun_logo_texture = re_ctx
             .texture_manager_2d
@@ -229,7 +221,7 @@ impl framework::Example for Render2D {
                     top_left_corner_position: glam::vec3(500.0, 120.0, -0.05),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    colormapped_texture: ColormappedTexture::from_unorm_srgba(
+                    colormapped_texture: ColormappedTexture::from_unorm_rgba(
                         self.rerun_logo_texture.clone(),
                     ),
                     options: RectangleOptions {
@@ -247,7 +239,7 @@ impl framework::Example for Render2D {
                     ),
                     extent_u: self.rerun_logo_texture_width as f32 * image_scale * glam::Vec3::X,
                     extent_v: self.rerun_logo_texture_height as f32 * image_scale * glam::Vec3::Y,
-                    colormapped_texture: ColormappedTexture::from_unorm_srgba(
+                    colormapped_texture: ColormappedTexture::from_unorm_rgba(
                         self.rerun_logo_texture.clone(),
                     ),
                     options: RectangleOptions {

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -315,7 +315,7 @@ impl framework::Example for RenderDepthClouds {
                     .transform_point3(glam::Vec3::new(1.0, 1.0, 0.0)),
                 extent_u: world_from_model.transform_vector3(-glam::Vec3::X),
                 extent_v: world_from_model.transform_vector3(-glam::Vec3::Y),
-                colormapped_texture: ColormappedTexture::from_unorm_srgba(albedo.texture.clone()),
+                colormapped_texture: ColormappedTexture::from_unorm_rgba(albedo.texture.clone()),
                 options: RectangleOptions {
                     texture_filter_magnification: re_renderer::renderer::TextureFilterMag::Nearest,
                     texture_filter_minification: re_renderer::renderer::TextureFilterMin::Linear,

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -3,10 +3,9 @@
 // Keep in sync with mirror in rectangle.rs
 
 // Which texture to read from?
-const SAMPLE_TYPE_FLOAT_FILTER   = 1u;
-const SAMPLE_TYPE_FLOAT_NOFILTER = 2u;
-const SAMPLE_TYPE_SINT_NOFILTER  = 3u;
-const SAMPLE_TYPE_UINT_NOFILTER  = 4u;
+const SAMPLE_TYPE_FLOAT = 1u;
+const SAMPLE_TYPE_SINT  = 2u;
+const SAMPLE_TYPE_UINT  = 3u;
 
 // How do we do colormapping?
 const COLOR_MAPPER_OFF      = 1u;
@@ -51,6 +50,9 @@ struct UniformBuffer {
 
     minification_filter: u32,
     magnification_filter: u32,
+
+    /// Boolean: decode 0-1 sRGB gamma to linear space before filtering?
+    decode_srgb: u32,
 };
 
 @group(1) @binding(0)

--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -14,29 +14,41 @@ fn tex_filter(pixel_coord: Vec2) -> u32 {
     }
 }
 
+fn mul_alpha(rgba_arg: Vec4) -> Vec4 {
+    // TODO(emilk): is this order correct?
+
+    var rgba = rgba_arg;
+
+    if rect_info.decode_srgb != 0u {
+        rgba = linear_from_srgba(rgba);
+    }
+
+    // Premultiply alpha:
+    rgba = vec4(rgba.xyz * rgba.a, rgba.a);
+
+    return rgba;
+}
+
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     // Sample the main texture:
     var sampled_value: Vec4;
-    if rect_info.sample_type == SAMPLE_TYPE_FLOAT_FILTER {
-        // TODO(emilk): support mipmaps
-        sampled_value = textureSampleLevel(texture_float_filterable, texture_sampler, in.texcoord, 0.0);
-    } else if rect_info.sample_type == SAMPLE_TYPE_FLOAT_NOFILTER {
+    if rect_info.sample_type == SAMPLE_TYPE_FLOAT {
         let coord = in.texcoord * Vec2(textureDimensions(texture_float).xy);
         if tex_filter(coord) == FILTER_NEAREST {
             // nearest
-            sampled_value = textureLoad(texture_float, IVec2(coord + vec2(0.5)), 0);
+            sampled_value = mul_alpha(textureLoad(texture_float, IVec2(coord + vec2(0.5)), 0));
         } else {
             // bilinear
-            let v00 = textureLoad(texture_float, IVec2(coord) + IVec2(0, 0), 0);
-            let v01 = textureLoad(texture_float, IVec2(coord) + IVec2(0, 1), 0);
-            let v10 = textureLoad(texture_float, IVec2(coord) + IVec2(1, 0), 0);
-            let v11 = textureLoad(texture_float, IVec2(coord) + IVec2(1, 1), 0);
+            let v00 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(0, 0), 0));
+            let v01 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(0, 1), 0));
+            let v10 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(1, 0), 0));
+            let v11 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(1, 1), 0));
             let top = mix(v00, v10, fract(coord.x));
             let bottom = mix(v01, v11, fract(coord.x));
             sampled_value = mix(top, bottom, fract(coord.y));
         }
-    } else if rect_info.sample_type == SAMPLE_TYPE_SINT_NOFILTER {
+    } else if rect_info.sample_type == SAMPLE_TYPE_SINT {
         let coord = in.texcoord * Vec2(textureDimensions(texture_sint).xy);
         if tex_filter(coord) == FILTER_NEAREST {
             // nearest
@@ -51,7 +63,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
             let bottom = mix(v01, v11, fract(coord.x));
             sampled_value = mix(top, bottom, fract(coord.y));
         }
-    } else if rect_info.sample_type == SAMPLE_TYPE_UINT_NOFILTER {
+    } else if rect_info.sample_type == SAMPLE_TYPE_UINT {
         let coord = in.texcoord * Vec2(textureDimensions(texture_uint).xy);
         if tex_filter(coord) == FILTER_NEAREST {
             // nearest
@@ -75,7 +87,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
     var normalized_value: Vec4 = (sampled_value - range.x) / (range.y - range.x);
 
     // Apply gamma:
-    normalized_value = vec4(pow(normalized_value.rgb, vec3(rect_info.gamma)), normalized_value.a); // TODO(emilk): handle premultiplied alpha
+    normalized_value = vec4(pow(normalized_value.rgb, vec3(rect_info.gamma)), normalized_value.a);
 
     // Apply colormap, if any:
     var texture_color: Vec4;

--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -64,6 +64,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
             sampled_value = mix(top, bottom, fract(coord.y));
         }
     } else if rect_info.sample_type == SAMPLE_TYPE_UINT {
+        // TODO(emilk): support premultiplying alpha on this path. Requires knowing the alpha range (255, 65535, …).
         let coord = in.texcoord * Vec2(textureDimensions(texture_uint).xy);
         if tex_filter(coord) == FILTER_NEAREST {
             // nearest

--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -14,11 +14,10 @@ fn tex_filter(pixel_coord: Vec2) -> u32 {
     }
 }
 
-fn mul_alpha(rgba_arg: Vec4) -> Vec4 {
-    // TODO(emilk): is this order correct?
-
+fn decode_color(rgba_arg: Vec4) -> Vec4 {
     var rgba = rgba_arg;
 
+    // Convert to linear space:
     if rect_info.decode_srgb != 0u {
         rgba = linear_from_srgba(rgba);
     }
@@ -37,13 +36,13 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
         let coord = in.texcoord * Vec2(textureDimensions(texture_float).xy);
         if tex_filter(coord) == FILTER_NEAREST {
             // nearest
-            sampled_value = mul_alpha(textureLoad(texture_float, IVec2(coord + vec2(0.5)), 0));
+            sampled_value = decode_color(textureLoad(texture_float, IVec2(coord + vec2(0.5)), 0));
         } else {
             // bilinear
-            let v00 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(0, 0), 0));
-            let v01 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(0, 1), 0));
-            let v10 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(1, 0), 0));
-            let v11 = mul_alpha(textureLoad(texture_float, IVec2(coord) + IVec2(1, 1), 0));
+            let v00 = decode_color(textureLoad(texture_float, IVec2(coord) + IVec2(0, 0), 0));
+            let v01 = decode_color(textureLoad(texture_float, IVec2(coord) + IVec2(0, 1), 0));
+            let v10 = decode_color(textureLoad(texture_float, IVec2(coord) + IVec2(1, 0), 0));
+            let v11 = decode_color(textureLoad(texture_float, IVec2(coord) + IVec2(1, 1), 0));
             let top = mix(v00, v10, fract(coord.x));
             let bottom = mix(v01, v11, fract(coord.x));
             sampled_value = mix(top, bottom, fract(coord.y));

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -55,7 +55,7 @@ pub struct ColormappedTexture {
 
     /// Decode 0-1 sRGB gamma values to linear space before filtering?
     ///
-    /// Only applies to [`TextureFormat::Rgba8Unorm`] and float textures.
+    /// Only applies to [`wgpu::TextureFormat::Rgba8Unorm`] and float textures.
     pub decode_srgb: bool,
 
     /// Min/max range of the values in the texture.

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -93,7 +93,7 @@ pub enum ColorMapper {
 }
 
 impl ColormappedTexture {
-    /// Assumes a separate alpha.
+    /// Assumes a separate/unmultiplied alpha.
     pub fn from_unorm_rgba(texture: GpuTexture2D) -> Self {
         // If the texture is an sRGB texture, the GPU will decode it for us.
         let decode_srgb = !texture.format().is_srgb();

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -19,7 +19,6 @@ use crate::{
     draw_phases::{DrawPhase, OutlineMaskProcessor},
     include_shader_module,
     resource_managers::{GpuTexture2D, ResourceManagerError},
-    texture_info,
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
@@ -53,6 +52,11 @@ pub enum TextureFilterMin {
 #[derive(Clone)]
 pub struct ColormappedTexture {
     pub texture: GpuTexture2D,
+
+    /// Decode 0-1 sRGB gamma values to linear space before filtering?
+    ///
+    /// Only applies to [`TextureFormat::Rgba8Unorm`] and float textures.
+    pub decode_srgb: bool,
 
     /// Min/max range of the values in the texture.
     /// Used to normalize the input values (squash them to the 0-1 range).
@@ -89,9 +93,13 @@ pub enum ColorMapper {
 }
 
 impl ColormappedTexture {
-    pub fn from_unorm_srgba(texture: GpuTexture2D) -> Self {
+    /// Assumes a separate alpha.
+    pub fn from_unorm_rgba(texture: GpuTexture2D) -> Self {
+        // If the texture is an sRGB texture, the GPU will decode it for us.
+        let decode_srgb = !texture.format().is_srgb();
         Self {
             texture,
+            decode_srgb,
             range: [0.0, 1.0],
             gamma: 1.0,
             color_mapper: None,
@@ -166,6 +174,9 @@ pub enum RectangleError {
 
     #[error("Invalid color map texture format: {0:?}")]
     UnsupportedColormapTextureFormat(wgpu::TextureFormat),
+
+    #[error("decode_srgb set to true, but the texture was already sRGB aware")]
+    DoubleDecodingSrgbTexture,
 }
 
 mod gpu_data {
@@ -176,10 +187,9 @@ mod gpu_data {
     // Keep in sync with mirror in rectangle.wgsl
 
     // Which texture to read from?
-    const SAMPLE_TYPE_FLOAT_FILTER: u32 = 1;
-    const SAMPLE_TYPE_FLOAT_NOFILTER: u32 = 2;
-    const SAMPLE_TYPE_SINT_NOFILTER: u32 = 3;
-    const SAMPLE_TYPE_UINT_NOFILTER: u32 = 4;
+    const SAMPLE_TYPE_FLOAT: u32 = 1;
+    const SAMPLE_TYPE_SINT: u32 = 2;
+    const SAMPLE_TYPE_UINT: u32 = 3;
 
     // How do we do colormapping?
     const COLOR_MAPPER_OFF: u32 = 1;
@@ -213,15 +223,19 @@ mod gpu_data {
         minification_filter: u32,
         magnification_filter: u32,
 
-        _end_padding: [wgpu_buffer_types::PaddingRow; 16 - 6],
+        decode_srgb: u32,
+        _row_padding: [u32; 3],
+
+        _end_padding: [wgpu_buffer_types::PaddingRow; 16 - 7],
     }
 
     impl UniformBuffer {
-        pub fn from_textured_rect(
-            rectangle: &super::TexturedRect,
-            device_features: wgpu::Features,
-        ) -> Result<Self, RectangleError> {
+        pub fn from_textured_rect(rectangle: &super::TexturedRect) -> Result<Self, RectangleError> {
             let texture_format = rectangle.colormapped_texture.texture.format();
+
+            if texture_format.is_srgb() && rectangle.colormapped_texture.decode_srgb {
+                return Err(RectangleError::DoubleDecodingSrgbTexture);
+            }
 
             let TexturedRect {
                 top_left_corner_position,
@@ -233,6 +247,7 @@ mod gpu_data {
 
             let super::ColormappedTexture {
                 texture: _,
+                decode_srgb,
                 range,
                 gamma,
                 color_mapper,
@@ -247,15 +262,9 @@ mod gpu_data {
             } = options;
 
             let sample_type = match texture_format.sample_type(None) {
-                Some(wgpu::TextureSampleType::Float { .. }) => {
-                    if texture_info::is_float_filterable(texture_format, device_features) {
-                        SAMPLE_TYPE_FLOAT_FILTER
-                    } else {
-                        SAMPLE_TYPE_FLOAT_NOFILTER
-                    }
-                }
-                Some(wgpu::TextureSampleType::Sint) => SAMPLE_TYPE_SINT_NOFILTER,
-                Some(wgpu::TextureSampleType::Uint) => SAMPLE_TYPE_UINT_NOFILTER,
+                Some(wgpu::TextureSampleType::Float { .. }) => SAMPLE_TYPE_FLOAT,
+                Some(wgpu::TextureSampleType::Sint) => SAMPLE_TYPE_SINT,
+                Some(wgpu::TextureSampleType::Uint) => SAMPLE_TYPE_UINT,
                 _ => {
                     return Err(RectangleError::DepthTexturesNotSupported);
                 }
@@ -312,6 +321,8 @@ mod gpu_data {
                 gamma: *gamma,
                 minification_filter,
                 magnification_filter,
+                decode_srgb: *decode_srgb as _,
+                _row_padding: Default::default(),
                 _end_padding: Default::default(),
             })
         }
@@ -357,7 +368,7 @@ impl RectangleDrawData {
         // TODO(emilk): continue on error (skipping just that rectangle)?
         let uniform_buffers: Vec<_> = rectangles
             .iter()
-            .map(|rect| gpu_data::UniformBuffer::from_textured_rect(rect, ctx.device.features()))
+            .map(gpu_data::UniformBuffer::from_textured_rect)
             .try_collect()?;
 
         let uniform_buffer_bindings = create_and_fill_uniform_buffer_batch(
@@ -401,18 +412,13 @@ impl RectangleDrawData {
             }
 
             // We set up several texture sources, then instruct the shader to read from at most one of them.
-            let mut texture_float_filterable = ctx.texture_manager_2d.zeroed_texture_float().handle;
-            let mut texture_float_nofilter = ctx.texture_manager_2d.zeroed_texture_float().handle;
+            let mut texture_float = ctx.texture_manager_2d.zeroed_texture_float().handle;
             let mut texture_sint = ctx.texture_manager_2d.zeroed_texture_sint().handle;
             let mut texture_uint = ctx.texture_manager_2d.zeroed_texture_uint().handle;
 
             match texture_format.sample_type(None) {
                 Some(wgpu::TextureSampleType::Float { .. }) => {
-                    if texture_info::is_float_filterable(texture_format, ctx.device.features()) {
-                        texture_float_filterable = texture.handle;
-                    } else {
-                        texture_float_nofilter = texture.handle;
-                    }
+                    texture_float = texture.handle;
                 }
                 Some(wgpu::TextureSampleType::Sint) => {
                     texture_sint = texture.handle;
@@ -447,11 +453,10 @@ impl RectangleDrawData {
                         entries: smallvec![
                             uniform_buffer,
                             BindGroupEntry::Sampler(sampler),
-                            BindGroupEntry::DefaultTextureView(texture_float_nofilter),
+                            BindGroupEntry::DefaultTextureView(texture_float),
                             BindGroupEntry::DefaultTextureView(texture_sint),
                             BindGroupEntry::DefaultTextureView(texture_uint),
                             BindGroupEntry::DefaultTextureView(colormap_texture),
-                            BindGroupEntry::DefaultTextureView(texture_float_filterable),
                         ],
                         layout: rectangle_renderer.bind_group_layout,
                     },
@@ -545,17 +550,6 @@ impl Renderer for RectangleRenderer {
                     // colormap texture:
                     wgpu::BindGroupLayoutEntry {
                         binding: 5,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                    // float textures with filtering (e.g. Rgba8UnormSrgb):
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 6,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             sample_type: wgpu::TextureSampleType::Float { filterable: true },

--- a/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
+++ b/crates/re_viewer/src/ui/view_tensor/tensor_slice_to_gpu.rs
@@ -41,6 +41,7 @@ pub fn colormapped_texture(
 
     Ok(ColormappedTexture {
         texture,
+        decode_srgb: false,
         range,
         gamma: color_mapping.gamma,
         color_mapper: Some(re_renderer::renderer::ColorMapper::Function(

--- a/crates/re_viewer/src/ui/view_tensor/ui.rs
+++ b/crates/re_viewer/src/ui/view_tensor/ui.rs
@@ -342,6 +342,7 @@ fn paint_colormap_gradient(
 
     let colormapped_texture = re_renderer::renderer::ColormappedTexture {
         texture: horizontal_gradient,
+        decode_srgb: false,
         range: [0.0, 1.0],
         gamma: 1.0,
         color_mapper: Some(re_renderer::renderer::ColorMapper::Function(colormap)),

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -74,18 +74,12 @@ fn color_tensor_to_gpu(
             (1, TensorData::I8(buf)) => (cast_slice_to_cow(buf), TextureFormat::R8Snorm),
 
             // Special handling for sRGB(A) textures:
-            (3, TensorData::U8(buf)) => (
-                pad_and_cast(buf.as_slice(), 255),
-                TextureFormat::Rgba8UnormSrgb,
-            ),
-            (4, TensorData::U8(buf)) => (
-                // We pre-multiply on the CPU because we currently use hardware texture filtering
-                // in `rectangle_fs.wgsl`, and pre-multiplication needs to happen before filtering.
-                // If we switched our shader to always do software filtering we could do the pre-multiplication
-                // on the GPU instead, saving us some time here!
-                premultiply_alpha(buf.as_slice()).into(),
-                TextureFormat::Rgba8UnormSrgb,
-            ),
+            (3, TensorData::U8(buf)) => {
+                (pad_and_cast(buf.as_slice(), 255), TextureFormat::Rgba8Unorm)
+            }
+            (4, TensorData::U8(buf)) => {
+                (cast_slice_to_cow(buf.as_slice()), TextureFormat::Rgba8Unorm)
+            }
 
             _ => {
                 // Fallback to general case:
@@ -105,10 +99,12 @@ fn color_tensor_to_gpu(
 
     let texture_format = texture_handle.format();
 
+    let decode_srgb = texture_format == TextureFormat::Rgba8Unorm; // TODO(emilk): let the user specify this.
+
     // Special casing for normalized textures used above:
     let range = if matches!(
         texture_format,
-        TextureFormat::R8Unorm | TextureFormat::Rgba8UnormSrgb
+        TextureFormat::R8Unorm | TextureFormat::Rgba8Unorm
     ) {
         [0.0, 1.0]
     } else if texture_format == TextureFormat::R8Snorm {
@@ -126,6 +122,7 @@ fn color_tensor_to_gpu(
 
     Ok(ColormappedTexture {
         texture: texture_handle,
+        decode_srgb,
         range,
         gamma: 1.0,
         color_mapper,
@@ -181,7 +178,7 @@ fn class_id_tensor_to_gpu(
             Texture2DCreationDesc {
                 label: "class_id_colormap".into(),
                 data: data.into(),
-                format: TextureFormat::Rgba8UnormSrgb,
+                format: TextureFormat::Rgba8Unorm,
                 width: colormap_width as u32,
                 height: colormap_height as u32,
             }
@@ -195,6 +192,7 @@ fn class_id_tensor_to_gpu(
 
     Ok(ColormappedTexture {
         texture: main_texture_handle,
+        decode_srgb: true,
         range: [0.0, (colormap_width * colormap_height) as f32],
         gamma: 1.0,
         color_mapper: Some(ColorMapper::Texture(colormap_texture_handle)),
@@ -225,6 +223,7 @@ fn depth_tensor_to_gpu(
 
     Ok(ColormappedTexture {
         texture,
+        decode_srgb: false,
         range: [min as f32, max as f32],
         gamma: 1.0,
         color_mapper: Some(ColorMapper::Function(re_renderer::Colormap::Turbo)),
@@ -448,15 +447,6 @@ fn pad_and_narrow_and_cast<T: Copy + Pod>(
         .flat_map(|chunk| [narrow(chunk[0]), narrow(chunk[1]), narrow(chunk[2]), pad])
         .collect();
     pod_collect_to_vec(&floats).into()
-}
-
-fn premultiply_alpha(rgba: &[u8]) -> Vec<u8> {
-    crate::profile_function!();
-    rgba.chunks_exact(4)
-        .flat_map(|rgba| {
-            egui::Color32::from_rgba_unmultiplied(rgba[0], rgba[1], rgba[2], rgba[3]).to_array()
-        })
-        .collect()
 }
 
 // ----------------------------------------------------------------------------;


### PR DESCRIPTION
### What
Premultiplying on the GPU saves us A LOT of CPU time when loading e.g. a png. But texture filtering must happen AFTER premultiplying, which means we need to do texture filtering in software on the shader.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] Test on the Web

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2190
