### PR TITLE
Don't early-exit on non-pinhole transforms when looking up cameras

### DIFF
--- a/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
+++ b/crates/re_viewer/src/ui/view_spatial/scene/scene_part/cameras.rs
@@ -198,7 +198,7 @@ impl ScenePart for CamerasPart {
 
             if let Some(transform) = store.query_latest_component::<Transform>(ent_path, &query) {
                 let Transform::Pinhole(pinhole) = transform else {
-                        return;
+                        continue;
                     };
                 let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 


### PR DESCRIPTION
This was a real bug that we started hitting due to:
 - https://github.com/rerun-io/rerun/issues/2193

(one benefit of unstable traversal orders is it uncovers stuff like this).

Previously I assume we always got lucky due to something like the order being mostly deterministic as a function of insertion-order which was stable for objectron, but it seems likely a different insertion order could have broken this since if we ever hit a 3D transform *before* hitting the pinhole, we would never find the pinhole camera necessary to override the existence of the image in the heuristics.

Fixes:
 - https://github.com/rerun-io/rerun/issues/2176

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2194
