### PR TITLE
Simpler SIGINT handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,6 +4343,7 @@ name = "rerun_py"
 version = "0.6.0-alpha.0"
 dependencies = [
  "arrow2",
+ "ctrlc",
  "document-features",
  "glam",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,7 +4199,6 @@ name = "re_web_viewer_server"
 version = "0.6.0-alpha.0"
 dependencies = [
  "clap 4.1.14",
- "ctrlc",
  "document-features",
  "futures-util",
  "hyper",
@@ -4297,7 +4296,6 @@ dependencies = [
  "anyhow",
  "backtrace",
  "clap 4.1.14",
- "ctrlc",
  "document-features",
  "itertools",
  "libc",

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -70,11 +70,7 @@ pub async fn serve(
     Ok(rx)
 }
 
-async fn listen_for_new_clients(
-    listener: TcpListener,
-    options: ServerOptions,
-    tx: Sender<LogMsg>,
-) {
+async fn listen_for_new_clients(listener: TcpListener, options: ServerOptions, tx: Sender<LogMsg>) {
     loop {
         match listener.accept().await {
             Ok((stream, _)) => {

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -34,15 +34,13 @@ impl Default for ServerOptions {
 /// # use re_sdk_comms::{serve, ServerOptions};
 /// #[tokio::main]
 /// async fn main() {
-///     let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
-///     let log_msg_rx = serve("0.0.0.0", 80, ServerOptions::default(), shutdown_rx).await.unwrap();
+///     let log_msg_rx = serve("0.0.0.0", 80, ServerOptions::default()).await.unwrap();
 /// }
 /// ```
 pub async fn serve(
     bind_ip: &str,
     port: u16,
     options: ServerOptions,
-    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> anyhow::Result<Receiver<LogMsg>> {
     let (tx, rx) = re_smart_channel::smart_channel(
         // NOTE: We don't know until we start actually accepting clients!
@@ -67,7 +65,7 @@ pub async fn serve(
         );
     }
 
-    tokio::spawn(listen_for_new_clients(listener, options, tx, shutdown_rx));
+    tokio::spawn(listen_for_new_clients(listener, options, tx));
 
     Ok(rx)
 }
@@ -76,16 +74,9 @@ async fn listen_for_new_clients(
     listener: TcpListener,
     options: ServerOptions,
     tx: Sender<LogMsg>,
-    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) {
     loop {
-        let incoming = tokio::select! {
-            res = listener.accept() => res,
-            _ = shutdown_rx.recv() => {
-                return;
-            }
-        };
-        match incoming {
+        match listener.accept().await {
             Ok((stream, _)) => {
                 let addr = stream.peer_addr().ok();
                 let tx = tx.clone_as(re_smart_channel::SmartMessageSource::TcpClient { addr });

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -75,9 +75,6 @@ pub struct App {
     /// What is serialized
     state: AppState,
 
-    /// Set to `true` on Ctrl-C.
-    shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
-
     /// Pending background tasks, using `poll_promise`.
     pending_promises: HashMap<String, Promise<Box<dyn Any + Send>>>,
 
@@ -108,7 +105,6 @@ impl App {
         re_ui: re_ui::ReUi,
         storage: Option<&dyn eframe::Storage>,
         rx: Receiver<LogMsg>,
-        shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
         let (logger, text_log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Info);
         if re_log::add_boxed_logger(Box::new(logger)).is_err() {
@@ -139,7 +135,6 @@ impl App {
             rx,
             log_dbs: Default::default(),
             state,
-            shutdown,
             pending_promises: Default::default(),
             toasts: toasts::Toasts::new(),
             memory_panel: Default::default(),
@@ -484,12 +479,6 @@ impl eframe::App for App {
         if self.startup_options.memory_limit.limit.is_none() {
             // we only warn about high memory usage if the user hasn't specified a limit
             self.ram_limit_warner.update();
-        }
-
-        if self.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
-            #[cfg(not(target_arch = "wasm32"))]
-            frame.close();
-            return;
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -94,7 +94,6 @@ pub fn run_native_viewer_with_messages(
             re_ui,
             cc.storage,
             rx,
-            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         ))
     }))
 }

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -79,7 +79,6 @@ impl RemoteViewerApp {
                     self.re_ui.clone(),
                     storage,
                     rx,
-                    std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 );
 
                 self.app = Some((connection, app));

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -98,7 +98,6 @@ impl WebHandle {
                                 re_ui,
                                 cc.storage,
                                 rx,
-                                std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
                             ))
                         }
                         EndpointCategory::WebEventListener => {
@@ -135,7 +134,6 @@ impl WebHandle {
                                 re_ui,
                                 cc.storage,
                                 rx,
-                                std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
                             ))
                         }
                         EndpointCategory::WebSocket(url) => {

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -46,7 +46,6 @@ analytics = ["dep:re_analytics"]
 [dependencies]
 re_log.workspace = true
 
-ctrlc.workspace = true
 document-features = "0.2"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -235,9 +235,7 @@ impl WebViewerServer {
         Ok(Self { server })
     }
 
-    pub async fn serve(
-        self,
-    ) -> Result<(), WebViewerServerError> {
+    pub async fn serve(self) -> Result<(), WebViewerServerError> {
         self.server
             .await
             .map_err(WebViewerServerError::ServeFailed)?;

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -221,10 +221,9 @@ impl WebViewerServer {
     /// ``` no_run
     /// # use re_web_viewer_server::{WebViewerServer, WebViewerServerPort, WebViewerServerError};
     /// # async fn example() -> Result<(), WebViewerServerError> {
-    /// let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
     /// let server = WebViewerServer::new("0.0.0.0", WebViewerServerPort::AUTO)?;
     /// let server_url = server.server_url();
-    /// server.serve(shutdown_rx).await?;
+    /// server.serve().await?;
     /// # Ok(()) }
     /// ```
     pub fn new(bind_ip: &str, port: WebViewerServerPort) -> Result<Self, WebViewerServerError> {

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -237,6 +237,15 @@ impl WebViewerServer {
 
     pub async fn serve(
         self,
+    ) -> Result<(), WebViewerServerError> {
+        self.server
+            .await
+            .map_err(WebViewerServerError::ServeFailed)?;
+        Ok(())
+    }
+
+    pub async fn serve_with_graceful_shutdown(
+        self,
         mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
     ) -> Result<(), WebViewerServerError> {
         self.server
@@ -286,7 +295,7 @@ impl WebViewerServerHandle {
 
         let local_addr = web_server.server.local_addr();
 
-        tokio::spawn(async move { web_server.serve(shutdown_rx).await });
+        tokio::spawn(async move { web_server.serve_with_graceful_shutdown(shutdown_rx).await });
 
         let slf = Self {
             local_addr,

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -29,14 +29,6 @@ async fn main() {
     use clap::Parser as _;
     let args = Args::parse();
 
-    // Shutdown server via Ctrl+C
-    let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
-    ctrlc::set_handler(move || {
-        re_log::debug!("Ctrl-C detected - Closing web server.");
-        shutdown_tx.send(()).unwrap();
-    })
-    .expect("Error setting Ctrl-C handler");
-
     let bind_ip = &args.bind;
     let server = re_web_viewer_server::WebViewerServer::new(
         bind_ip,
@@ -53,5 +45,5 @@ async fn main() {
         }
     }
 
-    server.serve(shutdown_rx).await.unwrap();
+    server.serve().await.unwrap();
 }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -51,10 +51,7 @@ impl RerunServer {
     }
 
     /// Accept new connections
-    pub async fn listen(
-        self,
-        rx: Receiver<LogMsg>,
-    ) -> Result<(), RerunServerError> {
+    pub async fn listen(self, rx: Receiver<LogMsg>) -> Result<(), RerunServerError> {
         let (_shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
         self.listen_with_graceful_shutdown(rx, shutdown_rx).await
     }
@@ -131,7 +128,11 @@ impl RerunServerHandle {
 
         let local_addr = ws_server.local_addr;
 
-        tokio::spawn(async move { ws_server.listen_with_graceful_shutdown(rerun_rx, shutdown_rx).await });
+        tokio::spawn(async move {
+            ws_server
+                .listen_with_graceful_shutdown(rerun_rx, shutdown_rx)
+                .await
+        });
 
         Ok(Self {
             local_addr,

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -92,7 +92,6 @@ webbrowser = { version = "0.8", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = "0.3"
 clap = { workspace = true, features = ["derive"] }
-ctrlc.workspace = true
 puffin.workspace = true
 rayon.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -138,8 +138,9 @@ impl RerunArgs {
         #[cfg(feature = "web_viewer")]
         if matches!(self.to_behavior(), Ok(RerunBehavior::Serve)) {
             // Sleep waiting for Ctrl-C:
-            tokio_runtime_handle
-                .block_on(async { tokio::time::sleep(std::time::Duration::from_secs(1_000_000_000)).await; });
+            tokio_runtime_handle.block_on(async {
+                tokio::time::sleep(std::time::Duration::from_secs(1_000_000_000)).await;
+            });
         }
 
         Ok(())

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -137,12 +137,9 @@ impl RerunArgs {
 
         #[cfg(feature = "web_viewer")]
         if matches!(self.to_behavior(), Ok(RerunBehavior::Serve)) {
-            use anyhow::Context as _;
-
-            let (mut shutdown_rx, _) = crate::run::setup_ctrl_c_handler();
-            return tokio_runtime_handle
-                .block_on(async { shutdown_rx.recv().await })
-                .context("Failed to wait for shutdown signal.");
+            // Sleep waiting for Ctrl-C:
+            tokio_runtime_handle
+                .block_on(async { tokio::time::sleep(std::time::Duration::from_secs(1_000_000_000)).await; });
         }
 
         Ok(())

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -139,7 +139,7 @@ impl RerunArgs {
         if matches!(self.to_behavior(), Ok(RerunBehavior::Serve)) {
             // Sleep waiting for Ctrl-C:
             tokio_runtime_handle.block_on(async {
-                tokio::time::sleep(std::time::Duration::from_secs(1_000_000_000)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(u64::MAX)).await;
             });
         }
 

--- a/crates/rerun/src/crash_handler.rs
+++ b/crates/rerun/src/crash_handler.rs
@@ -124,7 +124,6 @@ fn install_signal_handler(build_info: BuildInfo) {
             libc::SIGBUS,
             libc::SIGFPE,
             libc::SIGILL,
-            libc::SIGINT,
             libc::SIGSEGV,
             libc::SIGTERM,
         ] {

--- a/crates/rerun/src/native_viewer.rs
+++ b/crates/rerun/src/native_viewer.rs
@@ -52,7 +52,6 @@ where
             re_ui,
             cc.storage,
             rx,
-            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         ))
     }))
 }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -458,14 +458,11 @@ async fn run_impl(
                 );
             }
 
-            // Make it possible to gracefully shutdown the servers on ctrl-c.
-            let shutdown_ws_server = shutdown_rx.resubscribe();
-
             // This is the server which the web viewer will talk to:
             let ws_server =
                 re_ws_comms::RerunServer::new(args.bind.clone(), args.ws_server_port).await?;
             let ws_server_url = ws_server.server_url();
-            let ws_server_handle = tokio::spawn(ws_server.listen(rx, shutdown_ws_server));
+            let ws_server_handle = tokio::spawn(ws_server.listen(rx));
 
             // This is the server that serves the Wasm+HTML:
             let web_server_handle = tokio::spawn(host_web_viewer(

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -352,7 +352,6 @@ async fn run_impl(
                                 args.web_viewer_port,
                                 true,
                                 rerun_server_ws_url,
-                                shutdown_rx.resubscribe(),
                             );
                             // We return here because the running [`WebViewerServer`] is all we need.
                             // The page we open will be pointed at a websocket url hosted by a *different* server.
@@ -360,7 +359,7 @@ async fn run_impl(
                         }
                         #[cfg(not(feature = "web_viewer"))]
                         {
-                            _ = (rerun_server_ws_url, shutdown_rx);
+                            _ = rerun_server_ws_url;
                             panic!("Can't host web-viewer - rerun was not compiled with the 'web_viewer' feature");
                         }
                     } else {
@@ -461,7 +460,6 @@ async fn run_impl(
 
             // Make it possible to gracefully shutdown the servers on ctrl-c.
             let shutdown_ws_server = shutdown_rx.resubscribe();
-            let shutdown_web_viewer = shutdown_rx.resubscribe();
 
             // This is the server which the web viewer will talk to:
             let ws_server =
@@ -475,7 +473,6 @@ async fn run_impl(
                 args.web_viewer_port,
                 true,
                 ws_server_url,
-                shutdown_web_viewer,
             ));
 
             // Wait for both servers to shutdown.

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -421,12 +421,7 @@ async fn run_impl(
                 // `rerun.spawn()` doesn't need to log that a connection has been made
                 quiet: call_source.is_python(),
             };
-            re_sdk_comms::serve(
-                &args.bind,
-                args.port,
-                server_options,
-            )
-            .await?
+            re_sdk_comms::serve(&args.bind, args.port, server_options).await?
         }
 
         #[cfg(not(feature = "server"))]

--- a/crates/rerun/src/web_viewer.rs
+++ b/crates/rerun/src/web_viewer.rs
@@ -63,11 +63,10 @@ pub async fn host_web_viewer(
     web_port: WebViewerServerPort,
     open_browser: bool,
     source_url: String,
-    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> anyhow::Result<()> {
     let web_server = re_web_viewer_server::WebViewerServer::new(&bind_ip, web_port)?;
     let http_web_viewer_url = web_server.server_url();
-    let web_server_handle = web_server.serve(shutdown_rx);
+    let web_server_handle = web_server.serve();
 
     let viewer_url = format!("{http_web_viewer_url}?url={source_url}");
 

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -52,6 +52,7 @@ re_ws_comms = { workspace = true, optional = true }
 re_viewer = { workspace = true }
 
 arrow2 = { workspace = true, features = ["io_ipc", "io_print"] }
+ctrlc.workspace = true
 document-features = "0.2"
 glam.workspace = true
 image = { workspace = true, default-features = false, features = [

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -72,6 +72,15 @@ fn global_web_viewer_server(
 
 #[pyfunction]
 fn main(py: Python<'_>, argv: Vec<String>) -> PyResult<u8> {
+    // Python catches SIGINT and waints for us to release the GIL before shtting down.
+    // That's no good, so we need to catch SIGINT ourselves and shut down:
+    ctrlc::set_handler(move || {
+        eprintln!("Ctrl-C detected in rerun_py. Shutting down.");
+        #[allow(clippy::exit)]
+        std::process::exit(42);
+    })
+    .expect("Error setting Ctrl-C handler");
+
     let build_info = re_build_info::build_info!();
     let call_src = rerun::CallSource::Python(python_version(py));
     tokio::runtime::Builder::new_multi_thread()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -72,7 +72,7 @@ fn global_web_viewer_server(
 
 #[pyfunction]
 fn main(py: Python<'_>, argv: Vec<String>) -> PyResult<u8> {
-    // Python catches SIGINT and waints for us to release the GIL before shtting down.
+    // Python catches SIGINT and waits for us to release the GIL before shtting down.
     // That's no good, so we need to catch SIGINT ourselves and shut down:
     ctrlc::set_handler(move || {
         eprintln!("Ctrl-C detected in rerun_py. Shutting down.");


### PR DESCRIPTION
### What
`python -m rerun` needs to shutdown on SIGINT. Python catches SIGINT though, and waits for the GIL to shut down. But if the viewer is running, we never return to Python. So instead we install our own SIGINT handler in Rust and just call `std::process::exit` on SIGINT.

## Testing
Check that Ctrl-C works in all these situations:

* `cargo rerun`
   * [x] Linux
   * [x] Mac
   * [x] Windows
* `cargo rerun foo.rrd`
   * [x] Linux
   * [x] Mac
   * [x] Windows
 * `cargo run -p rerun-cli --features web_viewer -- --web-viewer`
   * [x] Linux
   * [x] Mac
   * [x] Windows
 * `cargo run -p api_demo -- --serve`
   * [x] Linux
   * [x] Mac
   * [x] Windows
* `just py-build && python -m rerun`
   * [x] Linux
   * [x] Mac
   * [x] Windows
 * `just py-build -F web_viewer && ./examples/python/api_demo/main.py --serve`
   * [x] Linux
   * [x] Mac
   * [x] Windows
 * `just py-build --features web_viewer && python -m rerun --web-viewer`
   * [x] Linux
   * [x] Mac
   * [x] Windows

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2198
