### PR TITLE
Trying out https://github.com/gfx-rs/wgpu/pull/3780 directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5925,14 +5925,14 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 [[package]]
 name = "wgpu"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
+source = "git+https://github.com/rerun-io/wgpu?rev=6241c4f#6241c4f2ef7166923ffbfd825804b1cbaedd533d"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5948,7 +5948,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
+source = "git+https://github.com/rerun-io/wgpu?rev=6241c4f#6241c4f2ef7166923ffbfd825804b1cbaedd533d"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5956,7 +5956,7 @@ dependencies = [
  "codespan-reporting",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
@@ -5970,7 +5970,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
+source = "git+https://github.com/rerun-io/wgpu?rev=6241c4f#6241c4f2ef7166923ffbfd825804b1cbaedd533d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5994,7 +5994,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -6011,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.16.0"
-source = "git+https://github.com/rerun-io/wgpu?rev=de497aeda152a3515bac5eb4bf1b17f1757b9dac#de497aeda152a3515bac5eb4bf1b17f1757b9dac"
+source = "git+https://github.com/rerun-io/wgpu?rev=6241c4f#6241c4f2ef7166923ffbfd825804b1cbaedd533d"
 dependencies = [
  "bitflags 2.3.1",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,5 +128,5 @@ debug = true
 
 # TODO(andreas): Either work around this issue in wgpu-egui (never discard command buffers) or wait for wgpu patch release.
 # Fix for command buffer dropping crash https://github.com/gfx-rs/wgpu/pull/3726
-wgpu = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
-wgpu-core = { git = "https://github.com/rerun-io/wgpu", rev = "de497aeda152a3515bac5eb4bf1b17f1757b9dac" }
+wgpu = { git = "https://github.com/rerun-io/wgpu", rev = "6241c4f" }
+wgpu-core = { git = "https://github.com/rerun-io/wgpu", rev = "6241c4f" }


### PR DESCRIPTION
### What

<https://github.com/gfx-rs/wgpu/pull/3780>


Running this locally I get:

```
  > "wasm-bindgen" "/Users/emilk/code/rerun/rerun/target_wasm/wasm32-unknown-unknown/debug/re_viewer.wasm" "--out-dir" "/Users/emilk/code/rerun/rerun/web_viewer" "--out-name" "re_viewer_debug" "--no-modules" "--no-typescript" "--debug"
  error: cannot import from modules (`env`) with `--no-modules`
  thread 'main' panicked at 'Failed to run wasm-bindgen', crates/re_build_web_viewer/src/lib.rs:128:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I wonder if the CI gets the same

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
