### PR TITLE
Clean up warnings printed when rr.init hasn't been called

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -419,7 +419,9 @@ def start_web_viewer_server(port: int = 0) -> None:
     """
 
     if not bindings.is_enabled():
-        logging.warning("Rerun is disabled - self_host_assets() call ignored")
+        logging.warning(
+            "Rerun is disabled - start_web_viewer_server() call ignored. . You must call rerun.init before starting the web viewer server."
+        )
         return
 
     bindings.start_web_viewer_server(port)

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -420,7 +420,8 @@ def start_web_viewer_server(port: int = 0) -> None:
 
     if not bindings.is_enabled():
         logging.warning(
-            "Rerun is disabled - start_web_viewer_server() call ignored. . You must call rerun.init before starting the web viewer server."
+            "Rerun is disabled - start_web_viewer_server() call ignored. You must call rerun.init before starting the"
+            + " web viewer server."
         )
         return
 

--- a/rerun_py/rerun_sdk/rerun/log/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log/log_decorator.py
@@ -32,7 +32,9 @@ def log_decorator(func: _TFunc) -> _TFunc:
         recording = RecordingStream.to_native(kwargs.get("recording"))
         if not bindings.is_enabled(recording):
             # NOTE: use `warnings` which handles runtime deduplication.
-            warnings.warn(f"Rerun is disabled - {func.__name__}() call ignored")
+            warnings.warn(
+                f"Rerun is disabled - {func.__name__}() call ignored. You must call rerun.init before using log APIs."
+            )
             return
 
         if rerun.strict_mode():

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -50,7 +50,7 @@ def save(path: str, recording: Optional[RecordingStream] = None) -> None:
     """
 
     if not bindings.is_enabled():
-        logging.warning("Rerun is disabled - save() call ignored")
+        logging.warning("Rerun is disabled - save() call ignored. You must call rerun.init before saving a recording.")
         return
 
     recording = RecordingStream.to_native(recording)

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -337,7 +337,7 @@ fn get_recording_id(recording: Option<&PyRecordingStream>) -> Option<String> {
 /// specified recording otherwise, if any.
 #[pyfunction]
 fn get_data_recording(recording: Option<&PyRecordingStream>) -> Option<PyRecordingStream> {
-    RecordingStream::get(
+    RecordingStream::get_quiet(
         rerun::RecordingType::Data,
         recording.map(|rec| rec.0.clone()),
     )
@@ -408,7 +408,7 @@ fn set_thread_local_data_recording(
 /// specified recording otherwise, if any.
 #[pyfunction]
 fn get_blueprint_recording(overrides: Option<&PyRecordingStream>) -> Option<PyRecordingStream> {
-    RecordingStream::get(
+    RecordingStream::get_quiet(
         rerun::RecordingType::Blueprint,
         overrides.map(|rec| rec.0.clone()),
     )


### PR DESCRIPTION
The recording handle work changed the behavior of some of our warnings when calling a log API without having called `rr.init`.

Before:
```
[2023-05-25T09:09:33Z WARN  re_sdk::global] There is no currently active Data recording available for the current thread (ThreadId(1)): have you called `set_global()` and/or `set_thread_local()` first?
WARNING:rerun:Rerun is disabled - log_text_box() call ignored
```

After:
```
WARNING:rerun:Rerun is disabled - log_text_box() call ignored. You must call rerun.init before using log APIs.
```

PR Build Summary: https://build.rerun.io/pr/2209
