### PR TITLE
New workflow for creating release artifacts

### DIFF
--- a/.github/workflows/manual_build_release.yml
+++ b/.github/workflows/manual_build_release.yml
@@ -1,0 +1,123 @@
+name: Build all artifacts for Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      RELEASE_VERSION:
+        description: 'Release Version Number (Must match Cargo.toml)'
+        type: string
+        required: true
+
+jobs:
+
+  build-linux:
+    name: 'Linux: Build/Test Wheels'
+    uses: ./.github/workflows/reusable_build_and_test_wheels.yml
+    with:
+      CONCURRENCY: manual-wheels-linux-prerelease
+      PLATFORM: linux
+      WHEEL_ARTIFACT_NAME: linux-wheel
+      RRD_ARTIFACT_NAME: linux-rrd
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+    secrets: inherit
+
+  build-windows:
+    name: 'Windows: Build/Test Wheels'
+    uses: ./.github/workflows/reusable_build_and_test_wheels.yml
+    with:
+      CONCURRENCY: manual-wheels-windows-prerelease
+      PLATFORM: windows
+      WHEEL_ARTIFACT_NAME: windows-wheel
+      RRD_ARTIFACT_NAME: ''
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+    secrets: inherit
+
+  build-macos-arm:
+    name: 'Macos-Arm: Build/Test Wheels'
+    uses: ./.github/workflows/reusable_build_and_test_wheels.yml
+    with:
+      CONCURRENCY: manual-wheels-macos-arm-prerelease
+      PLATFORM: macos-arm
+      WHEEL_ARTIFACT_NAME: macos-arm-wheel
+      RRD_ARTIFACT_NAME: ''
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+    secrets: inherit
+
+  build-macos-intel:
+    name: 'Macos-Intel: Build/Test Wheels'
+    uses: ./.github/workflows/reusable_build_and_test_wheels.yml
+    with:
+      CONCURRENCY: manual-wheels-macos-intel-prerelease
+      PLATFORM: macos-intel
+      WHEEL_ARTIFACT_NAME: 'macos-intel-wheel'
+      RRD_ARTIFACT_NAME: ''
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+    secrets: inherit
+
+  upload-wheels-linux:
+    name: 'Linux: Upload Wheels'
+    needs: [build-linux]
+    uses: ./.github/workflows/reusable_upload_wheels.yml
+    with:
+      CONCURRENCY: manual-upload-wheels-linux-prerelease
+      WHEEL_ARTIFACT_NAME: linux-wheel
+      RRD_ARTIFACT_NAME: linux-rrd
+    secrets: inherit
+
+  upload-wheels-windows:
+    name: 'Windows: Upload Wheels'
+    needs: [build-linux, build-windows]
+    uses: ./.github/workflows/reusable_upload_wheels.yml
+    with:
+      CONCURRENCY: manual-upload-wheels-windows-prerelease
+      WHEEL_ARTIFACT_NAME: windows-wheel
+      RRD_ARTIFACT_NAME: linux-rrd
+    secrets: inherit
+
+  upload-wheels-macos-arm:
+    name: 'Macos-Arm: Upload Wheels'
+    needs: [build-linux, build-macos-arm]
+    uses: ./.github/workflows/reusable_upload_wheels.yml
+    with:
+      CONCURRENCY: manual-upload-wheels-macos-arm-prerelease
+      WHEEL_ARTIFACT_NAME: macos-arm-wheel
+      RRD_ARTIFACT_NAME: linux-rrd
+    secrets: inherit
+
+  upload-wheels-macos-intel:
+    name: 'Macos-Intel: Upload Wheels'
+    needs: [build-linux, build-macos-intel]
+    uses: ./.github/workflows/reusable_upload_wheels.yml
+    with:
+      CONCURRENCY: manual-upload-wheels-macos-intel-prerelease
+      WHEEL_ARTIFACT_NAME: macos-intel-wheel
+      RRD_ARTIFACT_NAME: linux-rrd
+    secrets: inherit
+
+  build-web:
+    name: 'Build Web'
+    uses: ./.github/workflows/reusable_build_web.yml
+    with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+    secrets: inherit
+
+  upload-web:
+    name: 'Upload Web'
+    needs: [build-linux, build-web]
+    uses: ./.github/workflows/reusable_upload_web.yml
+    with:
+      CONCURRENCY: manual-dispatch-${{ github.run_id}}
+      MARK_PRERELEASE_FOR_MAINLINE: false
+      MARK_TAGGED_VERSION: true
+      RRD_ARTIFACT_NAME: linux-rrd
+      RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+    secrets: inherit
+
+  generate-wheel-index:
+    name: 'Generate Pip Index'
+    needs: [upload-wheels-linux, upload-wheels-windows, upload-wheels-macos-arm, upload-wheels-macos-intel]
+    uses: ./.github/workflows/reusable_pip_index.yml
+    with:
+      CONCURRENCY: manual-index-wheels-prerelease
+    secrets: inherit


### PR DESCRIPTION
During release process we want to build wheels and web artifacts before we do the final tagging / pypi uploading.