### PR TITLE
Bound the channels on the SDK to apply back-pressure on slow ingest

### DIFF
--- a/crates/re_log_types/src/data_table_batcher.rs
+++ b/crates/re_log_types/src/data_table_batcher.rs
@@ -76,8 +76,8 @@ impl DataTableBatcherConfig {
         flush_tick: Duration::from_millis(50),
         flush_num_bytes: 1024 * 1024, // 1 MiB
         flush_num_rows: u64::MAX,
-        max_commands_in_flight: None,
-        max_tables_in_flight: None,
+        max_commands_in_flight: Some(1), // TODO(#2216)
+        max_tables_in_flight: Some(1),   // TODO(#2216)
     };
 
     /// Always flushes ASAP.
@@ -85,8 +85,8 @@ impl DataTableBatcherConfig {
         flush_tick: Duration::MAX,
         flush_num_bytes: 0,
         flush_num_rows: 0,
-        max_commands_in_flight: None,
-        max_tables_in_flight: None,
+        max_commands_in_flight: Some(1), // TODO(#2216)
+        max_tables_in_flight: Some(1),   // TODO(#2216)
     };
 
     /// Never flushes unless manually told to.
@@ -94,8 +94,8 @@ impl DataTableBatcherConfig {
         flush_tick: Duration::MAX,
         flush_num_bytes: u64::MAX,
         flush_num_rows: u64::MAX,
-        max_commands_in_flight: None,
-        max_tables_in_flight: None,
+        max_commands_in_flight: Some(1), // TODO(#2216)
+        max_tables_in_flight: Some(1),   // TODO(#2216)
     };
 
     /// Environment variable to configure [`Self::flush_tick`].

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -376,7 +376,7 @@ impl RecordingStreamInner {
             );
         }
 
-        let (cmds_tx, cmds_rx) = crossbeam::channel::unbounded();
+        let (cmds_tx, cmds_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
 
         let batcher_to_sink_handle = {
             const NAME: &str = "RecordingStream::batcher_to_sink";

--- a/crates/re_sdk_comms/src/buffered_client.rs
+++ b/crates/re_sdk_comms/src/buffered_client.rs
@@ -54,15 +54,13 @@ impl Client {
     pub fn new(addr: SocketAddr) -> Self {
         re_log::debug!("Connecting to remote {addr}…");
 
-        // TODO(emilk): keep track of how much memory is in each pipe
-        // and apply back-pressure to not use too much RAM.
-        let (msg_tx, msg_rx) = crossbeam::channel::unbounded();
-        let (msg_drop_tx, msg_drop_rx) = crossbeam::channel::unbounded();
-        let (packet_tx, packet_rx) = crossbeam::channel::unbounded();
-        let (flushed_tx, flushed_rx) = crossbeam::channel::unbounded();
-        let (encode_quit_tx, encode_quit_rx) = crossbeam::channel::unbounded();
-        let (send_quit_tx, send_quit_rx) = crossbeam::channel::unbounded();
-        let (drop_quit_tx, drop_quit_rx) = crossbeam::channel::unbounded();
+        let (msg_tx, msg_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
+        let (msg_drop_tx, msg_drop_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
+        let (packet_tx, packet_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
+        let (flushed_tx, flushed_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
+        let (encode_quit_tx, encode_quit_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
+        let (send_quit_tx, send_quit_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
+        let (drop_quit_tx, drop_quit_rx) = crossbeam::channel::bounded(1); // TODO(#2216)
 
         let encode_join = std::thread::Builder::new()
             .name("msg_encoder".into())


### PR DESCRIPTION
Mitigates https://github.com/rerun-io/rerun/issues/2216

There will always be situations where the user logs things faster than we can convert them to arrow and send them on the wire. In these cases we should offer the user a choice of buffering and back-pressure, but until we have that choice for the user we should always go with back-pressure

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2218
