### PR TITLE
Flush the batches every 8ms instead of 50 ms

### DIFF
--- a/crates/re_log_types/src/data_table_batcher.rs
+++ b/crates/re_log_types/src/data_table_batcher.rs
@@ -73,8 +73,8 @@ impl Default for DataTableBatcherConfig {
 impl DataTableBatcherConfig {
     /// Default configuration, applicable to most use cases.
     pub const DEFAULT: Self = Self {
-        flush_tick: Duration::from_millis(50),
-        flush_num_bytes: 1024 * 1024, // 1 MiB
+        flush_tick: Duration::from_millis(8), // We want it fast enough for 60 Hz for real time camera feel
+        flush_num_bytes: 1024 * 1024,         // 1 MiB
         flush_num_rows: u64::MAX,
         max_commands_in_flight: None,
         max_tables_in_flight: None,


### PR DESCRIPTION
Gives us a much nicer realtime feel for the camera example.

Our example .rrd files don't grow by more than a few percent at worst, so I think this is well worth it to make rerun feel snappy.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2220
