### PR TITLE
In all our Python examples, show how to `pip install rerun-sdk`

### DIFF
--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -18,7 +18,7 @@ from typing import Callable
 
 import cv2
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def run_segmentation() -> None:

--- a/examples/python/arkitscenes/main.py
+++ b/examples/python/arkitscenes/main.py
@@ -9,7 +9,7 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import trimesh
 from download_dataset import AVAILABLE_RECORDINGS, ensure_recording_available
 from scipy.spatial.transform import Rotation as R

--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -3,7 +3,7 @@
 import argparse
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import rerun.experimental as rr_exp
 
 

--- a/examples/python/car/main.py
+++ b/examples/python/car/main.py
@@ -8,7 +8,7 @@ from typing import Iterator, Tuple
 import cv2
 import numpy as np
 import numpy.typing as npt
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def log_car_data() -> None:

--- a/examples/python/clock/main.py
+++ b/examples/python/clock/main.py
@@ -11,7 +11,7 @@ import math
 from typing import Final, Tuple
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 LENGTH_S: Final = 20.0
 LENGTH_M: Final = 10.0

--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -12,7 +12,7 @@ import cv2
 import numpy as np
 import numpy.typing as npt
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 from read_write_model import Camera, read_model
 from tqdm import tqdm
 

--- a/examples/python/deep_sdf/main.py
+++ b/examples/python/deep_sdf/main.py
@@ -37,7 +37,7 @@ from typing import Tuple, cast
 import mesh_to_sdf
 import numpy as np
 import numpy.typing as npt
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import trimesh
 from download_dataset import AVAILABLE_MESHES, ensure_mesh_downloaded
 from trimesh import Trimesh

--- a/examples/python/dicom/main.py
+++ b/examples/python/dicom/main.py
@@ -20,7 +20,7 @@ import numpy as np
 import numpy.typing as npt
 import pydicom as dicom
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
 DATASET_URL: Final = "https://storage.googleapis.com/rerun-example-datasets/dicom.zip"

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -9,7 +9,7 @@ The example from our Getting Started page.
 from math import tau
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 from rerun_demo.data import build_color_spiral
 from rerun_demo.util import bounce_lerp, interleave
 

--- a/examples/python/minimal/main.py
+++ b/examples/python/minimal/main.py
@@ -4,7 +4,7 @@
 
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 _, unknown = __import__("argparse").ArgumentParser().parse_known_args()
 [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]

--- a/examples/python/minimal_options/main.py
+++ b/examples/python/minimal_options/main.py
@@ -6,7 +6,7 @@
 import argparse
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
 rr.script_add_args(parser)

--- a/examples/python/mp_pose/main.py
+++ b/examples/python/mp_pose/main.py
@@ -13,7 +13,7 @@ import mediapipe as mp
 import numpy as np
 import numpy.typing as npt
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
 DATASET_DIR: Final = EXAMPLE_DIR / "dataset" / "pose_movement"

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -7,7 +7,7 @@ import multiprocessing
 import os
 import threading
 
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def task(title: str) -> None:

--- a/examples/python/multithreading/main.py
+++ b/examples/python/multithreading/main.py
@@ -8,7 +8,7 @@ import threading
 
 import numpy as np
 import numpy.typing as npt
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def rect_logger(path: str, color: npt.NDArray[np.float32]) -> None:

--- a/examples/python/notebook/blueprint.ipynb
+++ b/examples/python/notebook/blueprint.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import rerun as rr\n",
+    "import rerun as rr  # pip install rerun-sdk\n",
     "import rerun.experimental as rr_exp  # Note: blueprint support is still experimental"
    ]
   },

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -20,8 +20,7 @@
     "import math\n",
     "\n",
     "import numpy as np\n",
-    "\n",
-    "import rerun as rr\n",
+    "import rerun as rr  # pip install rerun-sdk\n",
     "\n",
     "rr.init(\"cube\")"
    ]

--- a/examples/python/nyud/main.py
+++ b/examples/python/nyud/main.py
@@ -16,7 +16,7 @@ import cv2
 import numpy as np
 import numpy.typing as npt
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 from tqdm import tqdm
 
 DEPTH_IMAGE_SCALING: Final = 1e4

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -18,7 +18,7 @@ from typing import Iterable, Iterator, List
 
 import numpy as np
 import numpy.typing as npt
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 from download_dataset import (
     ANNOTATIONS_FILENAME,
     AVAILABLE_RECORDINGS,

--- a/examples/python/opencv_canny/main.py
+++ b/examples/python/opencv_canny/main.py
@@ -25,7 +25,7 @@ import argparse
 from typing import Optional
 
 import cv2
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def run_canny(num_frames: Optional[int]) -> None:

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -15,7 +15,7 @@ import random
 from math import cos, sin, tau
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def clamp(n, smallest, largest):  # type: ignore[no-untyped-def]

--- a/examples/python/raw_mesh/main.py
+++ b/examples/python/raw_mesh/main.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Optional, cast
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import trimesh
 from download_dataset import AVAILABLE_MESHES, ensure_mesh_downloaded
 

--- a/examples/python/ros/main.py
+++ b/examples/python/ros/main.py
@@ -14,7 +14,7 @@ import argparse
 import sys
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 try:
     import cv_bridge

--- a/examples/python/ros/rerun_urdf.py
+++ b/examples/python/ros/rerun_urdf.py
@@ -4,7 +4,7 @@ from typing import Optional, cast
 from urllib.parse import urlparse
 
 import numpy as np
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import trimesh
 from ament_index_python.packages import get_package_share_directory
 from std_msgs.msg import String

--- a/examples/python/segment_anything/main.py
+++ b/examples/python/segment_anything/main.py
@@ -28,7 +28,7 @@ from urllib.parse import urlparse
 import cv2
 import numpy as np
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import torch
 import torchvision
 from cv2 import Mat

--- a/examples/python/stable_diffusion/huggingface_pipeline.py
+++ b/examples/python/stable_diffusion/huggingface_pipeline.py
@@ -56,7 +56,7 @@ from transformers import (
     DPTForDepthEstimation,
 )
 
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 logger.addHandler(rr.log.text.LoggingHandler("logs"))

--- a/examples/python/stable_diffusion/main.py
+++ b/examples/python/stable_diffusion/main.py
@@ -14,7 +14,7 @@ if platform.system() == "Darwin":
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 import torch
 from huggingface_pipeline import StableDiffusionDepth2ImgPipeline
 from PIL import Image

--- a/examples/python/text_logging/main.py
+++ b/examples/python/text_logging/main.py
@@ -13,7 +13,7 @@ Run:
 import argparse
 import logging
 
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 
 
 def setup_logging() -> None:

--- a/examples/python/tracking_hf_opencv/main.py
+++ b/examples/python/tracking_hf_opencv/main.py
@@ -12,7 +12,7 @@ import cv2 as cv
 import numpy as np
 import numpy.typing as npt
 import requests
-import rerun as rr
+import rerun as rr  # pip install rerun-sdk
 from PIL import Image
 
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))


### PR DESCRIPTION
### What
Changed all our examples from

```py
import rerun as rr
```

to

```py
import rerun as rr  # pip install rerun-sdk
```

A lot of people only look at examples, and we want to make sure they don't fall into the trap of `pip install rerun`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2221
