### PR TITLE
`impl Copy for Arrow3D`.

### DIFF
--- a/crates/re_log_types/src/component_types/arrow.rs
+++ b/crates/re_log_types/src/component_types/arrow.rs
@@ -30,7 +30,7 @@ use crate::Component;
 ///     ])
 /// );
 /// ```
-#[derive(Clone, Debug, ArrowField, ArrowSerialize, ArrowDeserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, ArrowField, ArrowSerialize, ArrowDeserialize, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Arrow3D {
     pub origin: Vec3D,


### PR DESCRIPTION
### What

`Arrow3D` is a simple pair of vectors, so it should be `Copy` like vectors are. This will ease working with, for example, batches of arrows stored in arrays.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] ~~I've included a screenshot or gif (if applicable)~~

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}
