### PR TITLE
Objectron example: tell users to install protoc

### DIFF
--- a/examples/rust/objectron/README.md
+++ b/examples/rust/objectron/README.md
@@ -1,0 +1,7 @@
+Requires the Protobuf Compiler `protoc` to be installed:
+
+* Linux: `apt install -y protobuf-compiler`
+* Mac: `brew install protobuf`
+* Or visit <https://grpc.io/docs/protoc-installation/>
+
+It would be nice to use [`protoc_prebuilt`](https://crates.io/crates/protoc-prebuilt) here, but [it has a huge dependency tree](https://github.com/sergeiivankov/protoc-prebuilt/issues/1).


### PR DESCRIPTION
### What
I was going through @jprochazk's onboarding notes and noticed we have no system in place for installing `protoc` which is required by the `objectron` example.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2265
