### PR TITLE
Add instructions on how to fix weird gsutil crash

### DIFF
--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -4,4 +4,5 @@
 -r ../rerun_py/requirements-doc.txt
 -r ../rerun_py/requirements-lint.txt
 
+cryptography==38.0.4 # for scripts/upload_image.py
 google-cloud-storage==2.9.0 # for scripts/upload_image.py

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -9,6 +9,15 @@ Requires the following packages:
 Before running, you have to authenticate via the Google Cloud CLI:
 - Install it (https://cloud.google.com/storage/docs/gsutil_install)
 - Set up credentials (https://cloud.google.com/storage/docs/gsutil_install#authenticate)
+
+If you get this error:
+
+    File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/asymmetric/utils.py", line 6, in <module>
+        from cryptography.hazmat.bindings._rust import asn1
+    pyo3_runtime.PanicException: Python API call failed
+
+Then run `python3 -m pip install cryptography==38.0.4`
+(https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769)
 """
 
 import argparse

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -12,7 +12,7 @@ Before running, you have to authenticate via the Google Cloud CLI:
 
 If you get this error:
 
-    File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/asymmetric/utils.py", line 6, in <module>
+    File "…/site-packages/cryptography/hazmat/primitives/asymmetric/utils.py", line 6, in <module>
         from cryptography.hazmat.bindings._rust import asn1
     pyo3_runtime.PanicException: Python API call failed
 


### PR DESCRIPTION
### What
I had problems running our image uploader script (https://github.com/rerun-io/rerun/pull/2164) due to `gsutil` refusing to work on my machine, however I installed it:

```
❯  gsutil --help
ImportError: dlopen(/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/_cffi_backend.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '_ffi_prep_closure'
thread '<unnamed>' panicked at 'Python API call failed', /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.15.2/src/err/mod.rs:582:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "/Users/emilk/Downloads/google-cloud-sdk/bin/bootstrapping/gsutil.py", line 16, in <module>
    import bootstrapping
  File "/Users/emilk/Downloads/google-cloud-sdk/bin/bootstrapping/bootstrapping.py", line 50, in <module>
    from googlecloudsdk.core.credentials import store as c_store
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/googlecloudsdk/core/credentials/store.py", line 34, in <module>
    from google.auth import external_account as google_auth_external_account
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/external_account.py", line 42, in <module>
    from google.auth import impersonated_credentials
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/impersonated_credentials.py", line 39, in <module>
    from google.auth import jwt
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/jwt.py", line 57, in <module>
    from google.auth import _service_account_info
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/_service_account_info.py", line 22, in <module>
    from google.auth import crypt
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/crypt/__init__.py", line 43, in <module>
    from google.auth.crypt import rsa
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/crypt/rsa.py", line 20, in <module>
    from google.auth.crypt import _cryptography_rsa
  File "/Users/emilk/Downloads/google-cloud-sdk/lib/third_party/google/auth/crypt/_cryptography_rsa.py", line 25, in <module>
    from cryptography.hazmat.primitives import serialization
  File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/serialization/__init__.py", line 16, in <module>
    from cryptography.hazmat.primitives.serialization.base import (
  File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/serialization/base.py", line 9, in <module>
    from cryptography.hazmat.primitives.asymmetric.types import (
  File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/asymmetric/types.py", line 8, in <module>
    from cryptography.hazmat.primitives.asymmetric import (
  File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/asymmetric/dsa.py", line 10, in <module>
    from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
  File "/Users/emilk/.pyenv/versions/3.8.12/lib/python3.8/site-packages/cryptography/hazmat/primitives/asymmetric/utils.py", line 6, in <module>
    from cryptography.hazmat.bindings._rust import asn1
pyo3_runtime.PanicException: Python API call failed
```

After a lot of googling [I found the fix](https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769): `python3 -m pip install cryptography==38.0.4`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2278
