### PR TITLE
Objectron Rust example: install protoc for the user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "glam",
  "prost",
  "prost-build",
+ "protoc-prebuilt",
  "rerun",
 ]
 
@@ -3633,6 +3634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protoc-prebuilt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37aee930fb53074ec083bf049aa6133bb1a93cce8fc39f83e07f36a0937304dd"
+dependencies = [
+ "ureq",
+ "zip",
 ]
 
 [[package]]

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -21,3 +21,4 @@ prost = "0.11"
 
 [build-dependencies]
 prost-build = "0.11"
+protoc-prebuilt = "0.2"

--- a/examples/rust/objectron/build.rs
+++ b/examples/rust/objectron/build.rs
@@ -11,6 +11,15 @@ fn main() -> Result<(), std::io::Error> {
         return Ok(());
     }
 
+    match protoc_prebuilt::init("22.0") {
+        Ok((protoc_bin, _)) => {
+            std::env::set_var("PROTOC", protoc_bin);
+        }
+        Err(err) => {
+            eprintln!("Failed to install protoc: {err} - falling back to system 'protoc'");
+        }
+    }
+
     prost_build::compile_protos(
         &[
             "proto/a_r_capture_metadata.proto",


### PR DESCRIPTION
### What
Users need the protobuffer compiler `ptooc` installed to run the objectron example. There is a crate for that!

https://github.com/sergeiivankov/protoc-prebuilt

(and it has a very responsive maintainer: https://github.com/sergeiivankov/protoc-prebuilt/issues/1)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2280
