### PR TITLE
Add command to screenshot the application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,6 +4358,7 @@ dependencies = [
  "anyhow",
  "arrow2",
  "arrow2_convert",
+ "bytemuck",
  "cfg-if",
  "cocoa",
  "eframe",

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -713,7 +713,6 @@ fn save_image(tensor: &re_components::Tensor, dynamic_image: &image::DynamicImag
                 .save_file()
             {
                 match dynamic_image.save(&path) {
-                    // TODO(emilk): show a popup instead of logging result
                     Ok(()) => {
                         re_log::info!("Image saved to {path:?}");
                     }

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -238,7 +238,7 @@ impl ExampleApp {
         };
         let top_bar_style = self
             .re_ui
-            .top_bar_style(native_pixels_per_point, fullscreen);
+            .top_bar_style(native_pixels_per_point, fullscreen, false);
 
         egui::TopBottomPanel::top("top_bar")
             .frame(self.re_ui.top_panel_frame())

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -47,6 +47,10 @@ pub enum Command {
     PlaybackStepBack,
     PlaybackStepForward,
     PlaybackRestart,
+
+    // Dev-tools:
+    #[cfg(not(target_arch = "wasm32"))]
+    ScreenshotWholeApp,
 }
 
 impl Command {
@@ -128,6 +132,12 @@ impl Command {
                 "Move the time marker to the next point in time with any data",
             ),
             Command::PlaybackRestart => ("Restart", "Restart from beginning of timeline"),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ScreenshotWholeApp => (
+                "Screenshot",
+                "Copy screenshot of the whole app to clipboard",
+            ),
         }
     }
 
@@ -189,6 +199,9 @@ impl Command {
             Command::PlaybackStepBack => Some(key(Key::ArrowLeft)),
             Command::PlaybackStepForward => Some(key(Key::ArrowRight)),
             Command::PlaybackRestart => Some(cmd(Key::ArrowLeft)),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ScreenshotWholeApp => None,
         }
     }
 

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -236,6 +236,7 @@ impl ReUi {
         &self,
         native_pixels_per_point: Option<f32>,
         fullscreen: bool,
+        style_like_web: bool,
     ) -> TopBarStyle {
         let gui_zoom = if let Some(native_pixels_per_point) = native_pixels_per_point {
             native_pixels_per_point / self.egui_ctx.pixels_per_point()
@@ -245,7 +246,7 @@ impl ReUi {
 
         // On Mac, we share the same space as the native red/yellow/green close/minimize/maximize buttons.
         // This means we need to make room for them.
-        let make_room_for_window_buttons = {
+        let make_room_for_window_buttons = !style_like_web && {
             #[cfg(target_os = "macos")]
             {
                 crate::FULLSIZE_CONTENT && !fullscreen

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -69,6 +69,7 @@ ahash.workspace = true
 anyhow.workspace = true
 arrow2.workspace = true
 arrow2_convert.workspace = true
+bytemuck.workspace = true
 cfg-if.workspace = true
 eframe = { workspace = true, default-features = false, features = [
   "default_fonts",

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -389,6 +389,11 @@ impl App {
             Command::PlaybackRestart => {
                 self.run_time_control_command(TimeControlCommand::Restart);
             }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            Command::ScreenshotWholeApp => {
+                _frame.request_screenshot();
+            }
         }
     }
 
@@ -700,6 +705,15 @@ impl eframe::App for App {
             // create this same blueprint in `load_or_create_blueprint`, but we couldn't
             // keep it around for borrow-checker reasons.
             re_log::warn_once!("Blueprint unexpectedly missing from store.");
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn post_rendering(&mut self, _window_size: [u32; 2], frame: &eframe::Frame) {
+        if let Some(screenshot) = frame.screenshot() {
+            re_viewer_context::Clipboard::with(|cb| {
+                cb.set_image(screenshot.size, bytemuck::cast_slice(&screenshot.pixels));
+            });
         }
     }
 }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -548,7 +548,11 @@ impl eframe::App for App {
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        {
+        if self.screenshotter.is_screenshotting() {
+            // Set a standard screenshot resolution (for our docs and examples).
+            frame.set_window_size(egui::Vec2::new(800.0, 600.0));
+            egui_ctx.set_pixels_per_point(2.0);
+        } else {
             // Ensure zoom factor is sane and in 10% steps at all times before applying it.
             {
                 let mut zoom_factor = self.state.app_options.zoom_factor;

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -50,7 +50,7 @@ pub struct StartupOptions {
     /// Take a screenshot of the app and quit.
     /// We use this to generate screenshots of our exmples.
     #[cfg(not(target_arch = "wasm32"))]
-    pub screenshot_to_path_then_quite: Option<std::path::PathBuf>,
+    pub screenshot_to_path_then_quit: Option<std::path::PathBuf>,
 }
 
 impl Default for StartupOptions {
@@ -59,7 +59,7 @@ impl Default for StartupOptions {
             memory_limit: re_memory::MemoryLimit::default(),
             persist_state: true,
             #[cfg(not(target_arch = "wasm32"))]
-            screenshot_to_path_then_quite: None,
+            screenshot_to_path_then_quit: None,
         }
     }
 }
@@ -168,7 +168,7 @@ impl App {
         let mut screenshotter = crate::screenshotter::Screenshotter::default();
 
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(screenshot_path) = startup_options.screenshot_to_path_then_quite.clone() {
+        if let Some(screenshot_path) = startup_options.screenshot_to_path_then_quit.clone() {
             screenshotter.screenshot_to_path_then_quit(screenshot_path);
         }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -49,6 +49,7 @@ pub struct StartupOptions {
 
     /// Take a screenshot of the app and quit.
     /// We use this to generate screenshots of our exmples.
+    #[cfg(not(target_arch = "wasm32"))]
     pub screenshot_to_path_then_quite: Option<std::path::PathBuf>,
 }
 
@@ -57,6 +58,7 @@ impl Default for StartupOptions {
         Self {
             memory_limit: re_memory::MemoryLimit::default(),
             persist_state: true,
+            #[cfg(not(target_arch = "wasm32"))]
             screenshot_to_path_then_quite: None,
         }
     }
@@ -162,6 +164,7 @@ impl App {
             );
         }
 
+        #[allow(unused_mut, clippy::needless_update)] // false positive on web
         let mut screenshotter = crate::screenshotter::Screenshotter::default();
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -552,7 +552,10 @@ impl eframe::App for App {
             frame.set_window_size(resolution_in_points.into());
         }
 
-        self.screenshotter.update(egui_ctx, frame);
+        if self.screenshotter.update(egui_ctx, frame).quit {
+            frame.close();
+            return;
+        }
 
         if self.startup_options.memory_limit.limit.is_none() {
             // we only warn about high memory usage if the user hasn't specified a limit

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -548,10 +548,12 @@ impl eframe::App for App {
     fn update(&mut self, egui_ctx: &egui::Context, frame: &mut eframe::Frame) {
         let frame_start = Instant::now();
 
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(resolution_in_points) = self.startup_options.resolution_in_points.take() {
             frame.set_window_size(resolution_in_points.into());
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         if self.screenshotter.update(egui_ctx, frame).quit {
             frame.close();
             return;

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -689,7 +689,10 @@ impl eframe::App for App {
         }
 
         self.handle_dropping_files(egui_ctx);
-        self.toasts.show(egui_ctx);
+
+        if !self.screenshotter.is_screenshotting() {
+            self.toasts.show(egui_ctx);
+        }
 
         if let Some(cmd) = self.cmd_palette.show(egui_ctx) {
             self.pending_commands.push(cmd);

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -9,6 +9,7 @@ pub mod env_vars;
 #[cfg(not(target_arch = "wasm32"))]
 mod profiler;
 mod remote_viewer_app;
+mod screenshotter;
 mod ui;
 mod viewer_analytics;
 

--- a/crates/re_viewer/src/remote_viewer_app.rs
+++ b/crates/re_viewer/src/remote_viewer_app.rs
@@ -75,7 +75,7 @@ impl RemoteViewerApp {
                 let app = crate::App::from_receiver(
                     self.build_info,
                     &self.app_env,
-                    self.startup_options,
+                    self.startup_options.clone(),
                     self.re_ui.clone(),
                     storage,
                     rx,

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -1,5 +1,5 @@
-//! Screenshotting not implemented on web yet because
-//! we haven't implemented "copy image to clipbaord".
+//! Screenshotting not implemented on web yet because we
+//! haven't implemented "copy image to clipboard" there.
 
 /// Helper for screenshotting the entire app
 #[derive(Default)]

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -24,6 +24,9 @@ impl Screenshotter {
     }
 
     /// If true, temporarily re-style the UI to make it suitable for capture!
+    ///
+    /// We do the re-styling to create consistent screenshots across platforms.
+    /// In particular, we style the UI to look like the web viewer.
     pub fn is_screenshotting(&self) -> bool {
         self.countdown.is_some()
     }

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -19,9 +19,17 @@ pub struct ScreenshotterOutput {
 #[cfg(not(target_arch = "wasm32"))]
 impl Screenshotter {
     /// Used for generating screenshots in dev builds.
+    ///
+    /// Should only be called at startup.
     pub fn screenshot_to_path_then_quit(&mut self, path: std::path::PathBuf) {
+        assert!(self.countdown.is_none(), "screenshotter misused");
         self.request_screenshot();
         self.target_path = Some(path);
+    }
+
+    pub fn request_screenshot(&mut self) {
+        // Give app time to change the style, and then wait for animations to finish:
+        self.countdown = Some(10);
     }
 
     /// Call once per frame
@@ -49,11 +57,6 @@ impl Screenshotter {
     /// In particular, we style the UI to look like the web viewer.
     pub fn is_screenshotting(&self) -> bool {
         self.countdown.is_some()
-    }
-
-    pub fn request_screenshot(&mut self) {
-        // Give app time to change the style, and then wait for animations to finish:
-        self.countdown = Some(3);
     }
 
     pub fn save(&mut self, image: &egui::ColorImage) {

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -10,6 +10,7 @@ pub struct Screenshotter {
     quit: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub struct ScreenshotterOutput {
     /// If true, the screenshotter was told at startup to quit after its donw.
@@ -92,9 +93,6 @@ pub struct Screenshotter {}
 
 #[cfg(target_arch = "wasm32")]
 impl Screenshotter {
-    #[allow(clippy::unused_self)]
-    pub fn update(&mut self, _egui_ctx: &egui::Context, _frame: &mut eframe::Frame) {}
-
     #[allow(clippy::unused_self)]
     pub fn is_screenshotting(&self) -> bool {
         false

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -1,0 +1,52 @@
+//! Screenshotting not implemented on web yet because
+//! we haven't implemented "copy image to clipbaord".
+
+/// Helper for screenshotting the entire app
+#[derive(Default)]
+pub struct Screenshotter {
+    #[cfg(not(target_arch = "wasm32"))]
+    countdown: Option<usize>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Screenshotter {
+    /// Call once per frame
+    pub fn update(&mut self, egui_ctx: &egui::Context, frame: &mut eframe::Frame) {
+        if let Some(countdown) = &mut self.countdown {
+            if *countdown == 0 {
+                frame.request_screenshot();
+            } else {
+                *countdown -= 1;
+            }
+
+            egui_ctx.request_repaint(); // Make sure we keep counting down
+        }
+    }
+
+    /// If true, temporarily re-style the UI to make it suitable for capture!
+    pub fn is_screenshotting(&self) -> bool {
+        self.countdown.is_some()
+    }
+
+    pub fn request_screenshot(&mut self) {
+        self.countdown = Some(1);
+    }
+
+    pub fn save(&mut self, image: &egui::ColorImage) {
+        self.countdown = None;
+        re_viewer_context::Clipboard::with(|cb| {
+            cb.set_image(image.size, bytemuck::cast_slice(&image.pixels));
+        });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Screenshotter {
+    #[allow(clippy::unused_self)]
+    pub fn update(&mut self, _egui_ctx: &egui::Context, _frame: &mut eframe::Frame) {}
+
+    #[allow(clippy::unused_self)]
+    pub fn is_screenshotting(&self) -> bool {
+        false
+    }
+}

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -41,7 +41,8 @@ impl Screenshotter {
     }
 
     pub fn request_screenshot(&mut self) {
-        self.countdown = Some(1);
+        // give app time to set window size, and then wait for animations to finish etc:
+        self.countdown = Some(10);
     }
 
     pub fn save(&mut self, image: &egui::ColorImage) {

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -6,10 +6,19 @@
 pub struct Screenshotter {
     #[cfg(not(target_arch = "wasm32"))]
     countdown: Option<usize>,
+
+    #[cfg(not(target_arch = "wasm32"))]
+    target_path: Option<std::path::PathBuf>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Screenshotter {
+    /// Used for generating screenshots in dev builds.
+    pub fn screenshot_to_path_then_quit(&mut self, path: std::path::PathBuf) {
+        self.request_screenshot();
+        self.target_path = Some(path);
+    }
+
     /// Call once per frame
     pub fn update(&mut self, egui_ctx: &egui::Context, frame: &mut eframe::Frame) {
         if let Some(countdown) = &mut self.countdown {
@@ -37,9 +46,26 @@ impl Screenshotter {
 
     pub fn save(&mut self, image: &egui::ColorImage) {
         self.countdown = None;
-        re_viewer_context::Clipboard::with(|cb| {
-            cb.set_image(image.size, bytemuck::cast_slice(&image.pixels));
-        });
+        if let Some(path) = self.target_path.take() {
+            let w = image.width() as _;
+            let h = image.height() as _;
+            let image =
+                image::RgbaImage::from_raw(w, h, bytemuck::pod_collect_to_vec(&image.pixels))
+                    .expect("Failed to create image");
+            match image.save(&path) {
+                Ok(()) => {
+                    re_log::info!("Screenshot saved to {path:?}");
+                    std::process::exit(0); // Close nicely
+                }
+                Err(err) => {
+                    panic!("Failed saving screenshot to {path:?}: {err}");
+                }
+            }
+        } else {
+            re_viewer_context::Clipboard::with(|cb| {
+                cb.set_image(image.size, bytemuck::cast_slice(&image.pixels));
+            });
+        }
     }
 }
 

--- a/crates/re_viewer/src/screenshotter.rs
+++ b/crates/re_viewer/src/screenshotter.rs
@@ -41,8 +41,8 @@ impl Screenshotter {
     }
 
     pub fn request_screenshot(&mut self) {
-        // give app time to set window size, and then wait for animations to finish etc:
-        self.countdown = Some(10);
+        // Give app time to change the style, and then wait for animations to finish:
+        self.countdown = Some(3);
     }
 
     pub fn save(&mut self, image: &egui::ColorImage) {

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -43,6 +43,10 @@ struct Args {
     #[command(subcommand)]
     commands: Option<Commands>,
 
+    /// What bind address IP to use.
+    #[clap(long, default_value = "0.0.0.0")]
+    bind: String,
+
     /// Set a maximum input latency, e.g. "200ms" or "10s".
     ///
     /// If we go over this, we start dropping packets.
@@ -86,6 +90,11 @@ struct Args {
     #[clap(long)]
     save: Option<String>,
 
+    /// Take a screenshot of the app and quit.
+    /// We use this to generate screenshots of our exmples.
+    #[clap(long)]
+    screenshot_to: Option<std::path::PathBuf>,
+
     /// Exit with a non-zero exit code if any warning or error is logged. Useful for tests.
     #[clap(long)]
     strict: bool,
@@ -114,10 +123,6 @@ struct Args {
     /// Requires Rerun to have been compiled with the 'web_viewer' feature.
     #[clap(long)]
     web_viewer: bool,
-
-    /// What bind address IP to use.
-    #[clap(long, default_value = "0.0.0.0")]
-    bind: String,
 
     /// What port do we listen to for hosting the web viewer over HTTP.
     /// A port of 0 will pick a random port.
@@ -308,6 +313,7 @@ async fn run_impl(
                 .unwrap_or_else(|err| panic!("Bad --memory-limit: {err}"))
         }),
         persist_state: args.persist_state,
+        screenshot_to_path_then_quite: args.screenshot_to.clone(),
     };
 
     // Where do we get the data from?

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -313,7 +313,7 @@ async fn run_impl(
                 .unwrap_or_else(|err| panic!("Bad --memory-limit: {err}"))
         }),
         persist_state: args.persist_state,
-        screenshot_to_path_then_quite: args.screenshot_to.clone(),
+        screenshot_to_path_then_quit: args.screenshot_to.clone(),
     };
 
     // Where do we get the data from?

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -520,6 +520,7 @@ async fn run_impl(
     }
 }
 
+#[cfg(feature = "native_viewer")]
 fn parse_size(size: &str) -> anyhow::Result<[f32; 2]> {
     fn parse_size_inner(size: &str) -> Option<[f32; 2]> {
         let (w, h) = size.split_once('x')?;

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Start pruning the data once we reach this much memory allocated
             limit: Some(12_000_000_000),
         },
-        persist_state: true,
+        ..Default::default()
     };
 
     // This is used for analytics, if the `analytics` feature is on in `Cargo.toml`


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2117
Closes https://github.com/rerun-io/rerun/issues/482

### What
Cmd-P for command palette, then select "Screenshot" command. Rerun will re-style itself for Web for a frame, screenshot that, and then copy it to the clipboard. I only implemented this for the native viewer.

You can set the resolution at startup with `--window-size`. All screenshots are captured at 2x pixels-per-point, i.e. pretending that you are on a high-dpi screen, wether you are or not.

You can also trigger this from the command line:

```
❯ cargo rerun ../fiat.rrd --screenshot-to fiat.png
    Finished dev [optimized + debuginfo] target(s) in 0.46s
     Running `target/debug/rerun ../fiat.rrd --screenshot-to fiat.png --window-size 1024x768`
[2023-05-31T16:11:21Z INFO  rerun::run] Loading "../fiat.rrd"…
[2023-05-31T16:11:22Z INFO  re_viewer::screenshotter] Screenshot saved to "fiat.png"
```

We can use this to generate screenshots for our examples.

### Result:

![fiat](https://github.com/rerun-io/rerun/assets/1148717/98cc125e-6cb5-4d84-81ff-062f54c7fb97)



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2293

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/11b16c5/docs
<!-- pr-link-docs:end -->
