### PR TITLE
lint: standardize formatting of let-else-return statements

### DIFF
--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -359,7 +359,7 @@ pub fn show_zoomed_image_region_area_outline(
 ) {
     use egui::{pos2, remap, Rect};
 
-    let Some([height, width, _]) = tensor.image_height_width_channels() else {return;};
+    let Some([height, width, _]) = tensor.image_height_width_channels() else { return; };
 
     let width = width as f32;
     let height = height as f32;

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -434,11 +434,11 @@ impl App {
     }
 
     fn run_time_control_command(&mut self, command: TimeControlCommand) {
-        let Some(rec_id) = &self.state.selected_rec_id else {return;};
-        let Some(rec_cfg) = self.state.recording_configs.get_mut(rec_id) else {return;};
+        let Some(rec_id) = &self.state.selected_rec_id else { return; };
+        let Some(rec_cfg) = self.state.recording_configs.get_mut(rec_id) else { return; };
         let time_ctrl = &mut rec_cfg.time_ctrl;
 
-        let Some(log_db) = self.log_dbs.get(rec_id) else { return };
+        let Some(log_db) = self.log_dbs.get(rec_id) else { return; };
         let times_per_timeline = log_db.times_per_timeline();
 
         match command {

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1171,7 +1171,7 @@ fn add_space_view(
     entity_paths: Vec<&str>,
     blueprint: Option<&PyRecordingStream>,
 ) {
-    let Some(blueprint) = get_blueprint_recording(blueprint) else { return };
+    let Some(blueprint) = get_blueprint_recording(blueprint) else { return; };
 
     let mut space_view = SpaceViewBlueprint::new(
         "Spatial".into(),
@@ -1213,7 +1213,7 @@ fn add_space_view(
 
 #[pyfunction]
 fn set_auto_space_views(enabled: bool, blueprint: Option<&PyRecordingStream>) {
-    let Some(blueprint) = get_blueprint_recording(blueprint) else { return };
+    let Some(blueprint) = get_blueprint_recording(blueprint) else { return; };
 
     // TODO(jleibs) timeless? Something else?
     let timepoint = time(true, &blueprint);


### PR DESCRIPTION
`cargo fmt` doesn't handle let-else statements, so let's try to keep a consistent style using a lint

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2297

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/c04c9b2/docs
<!-- pr-link-docs:end -->
