### PR TITLE
Introduce StoreHub and rename Recording->Store

### DIFF
--- a/crates/re_data_store/examples/memory_usage.rs
+++ b/crates/re_data_store/examples/memory_usage.rs
@@ -48,7 +48,7 @@ fn live_bytes() -> usize {
 
 // ----------------------------------------------------------------------------
 
-use re_log_types::{entity_path, DataRow, RecordingId, RowId, StoreKind};
+use re_log_types::{entity_path, DataRow, RowId, StoreId, StoreKind};
 
 fn main() {
     log_messages();
@@ -91,7 +91,7 @@ fn log_messages() {
 
     const NUM_POINTS: usize = 1_000;
 
-    let recording_id = RecordingId::random(StoreKind::Recording);
+    let store_id = StoreId::random(StoreKind::Recording);
     let timeline = Timeline::new_sequence("frame_nr");
     let mut time_point = TimePoint::default();
     time_point.insert(timeline, TimeInt::from(0));
@@ -118,7 +118,7 @@ fn log_messages() {
         );
         let table_bytes = live_bytes() - used_bytes_start;
         let log_msg = Box::new(LogMsg::ArrowMsg(
-            recording_id.clone(),
+            store_id.clone(),
             table.to_arrow_msg().unwrap(),
         ));
         let log_msg_bytes = live_bytes() - used_bytes_start;
@@ -143,10 +143,7 @@ fn log_messages() {
             .into_table(),
         );
         let table_bytes = live_bytes() - used_bytes_start;
-        let log_msg = Box::new(LogMsg::ArrowMsg(
-            recording_id,
-            table.to_arrow_msg().unwrap(),
-        ));
+        let log_msg = Box::new(LogMsg::ArrowMsg(store_id, table.to_arrow_msg().unwrap()));
         let log_msg_bytes = live_bytes() - used_bytes_start;
         println!("Arrow payload containing a Pos2 uses {table_bytes} bytes in RAM");
         let encoded = encode_log_msg(&log_msg);

--- a/crates/re_data_store/examples/memory_usage.rs
+++ b/crates/re_data_store/examples/memory_usage.rs
@@ -48,7 +48,7 @@ fn live_bytes() -> usize {
 
 // ----------------------------------------------------------------------------
 
-use re_log_types::{entity_path, DataRow, RecordingId, RecordingType, RowId};
+use re_log_types::{entity_path, DataRow, RecordingId, RowId, StoreKind};
 
 fn main() {
     log_messages();
@@ -91,7 +91,7 @@ fn log_messages() {
 
     const NUM_POINTS: usize = 1_000;
 
-    let recording_id = RecordingId::random(RecordingType::Data);
+    let recording_id = RecordingId::random(StoreKind::Recording);
     let timeline = Timeline::new_sequence("frame_nr");
     let mut time_point = TimePoint::default();
     time_point.insert(timeline, TimeInt::from(0));

--- a/crates/re_data_store/src/instance_path.rs
+++ b/crates/re_data_store/src/instance_path.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use re_log_types::{EntityPath, EntityPathHash, InstanceKey};
 
-use crate::log_db::EntityDb;
+use crate::store_db::EntityDb;
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -9,13 +9,13 @@ mod editable_auto_value;
 pub mod entity_properties;
 pub mod entity_tree;
 mod instance_path;
-pub mod log_db;
+pub mod store_db;
 mod util;
 
 pub use entity_properties::*;
 pub use entity_tree::*;
 pub use instance_path::*;
-pub use log_db::LogDb;
+pub use store_db::StoreDb;
 pub use util::*;
 
 #[cfg(feature = "serde")]

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -6,7 +6,7 @@ use re_arrow_store::{DataStoreConfig, TimeInt};
 use re_log_types::{
     ApplicationId, ArrowMsg, Component as _, ComponentPath, DataCell, DataRow, DataTable,
     EntityPath, EntityPathHash, EntityPathOpMsg, InstanceKey, LogMsg, PathOp, RecordingId,
-    RecordingInfo, RecordingType, RowId, SetRecordingInfo, TimePoint, Timeline,
+    RecordingInfo, RowId, SetRecordingInfo, StoreKind, TimePoint, Timeline,
 };
 
 use crate::{Error, TimesPerTimeline};
@@ -211,8 +211,8 @@ impl LogDb {
         self.recording_info().map(|ri| &ri.application_id)
     }
 
-    pub fn recording_type(&self) -> RecordingType {
-        self.recording_id.variant
+    pub fn store_kind(&self) -> StoreKind {
+        self.recording_id.kind
     }
 
     pub fn recording_id(&self) -> &RecordingId {

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -4,9 +4,9 @@ use nohash_hasher::IntMap;
 
 use re_arrow_store::{DataStoreConfig, TimeInt};
 use re_log_types::{
-    ArrowMsg, Component as _, ComponentPath, DataCell, DataRow, DataTable, EntityPath,
-    EntityPathHash, EntityPathOpMsg, InstanceKey, LogMsg, PathOp, RecordingId, RecordingInfo,
-    RecordingType, RowId, SetRecordingInfo, TimePoint, Timeline,
+    ApplicationId, ArrowMsg, Component as _, ComponentPath, DataCell, DataRow, DataTable,
+    EntityPath, EntityPathHash, EntityPathOpMsg, InstanceKey, LogMsg, PathOp, RecordingId,
+    RecordingInfo, RecordingType, RowId, SetRecordingInfo, TimePoint, Timeline,
 };
 
 use crate::{Error, TimesPerTimeline};
@@ -207,6 +207,10 @@ impl LogDb {
         self.recording_msg().map(|msg| &msg.info)
     }
 
+    pub fn app_id(&self) -> Option<&ApplicationId> {
+        self.recording_info().map(|ri| &ri.application_id)
+    }
+
     pub fn recording_type(&self) -> RecordingType {
         self.recording_id.variant
     }
@@ -238,6 +242,8 @@ impl LogDb {
 
     pub fn add(&mut self, msg: &LogMsg) -> Result<(), Error> {
         re_tracing::profile_function!();
+
+        debug_assert_eq!(msg.recording_id(), self.recording_id());
 
         match &msg {
             LogMsg::SetRecordingInfo(msg) => self.add_begin_recording_msg(msg),

--- a/crates/re_data_store/src/log_db.rs
+++ b/crates/re_data_store/src/log_db.rs
@@ -5,8 +5,8 @@ use nohash_hasher::IntMap;
 use re_arrow_store::{DataStoreConfig, TimeInt};
 use re_log_types::{
     ApplicationId, ArrowMsg, Component as _, ComponentPath, DataCell, DataRow, DataTable,
-    EntityPath, EntityPathHash, EntityPathOpMsg, InstanceKey, LogMsg, PathOp, RecordingInfo, RowId,
-    SetRecordingInfo, StoreId, StoreKind, TimePoint, Timeline,
+    EntityPath, EntityPathHash, EntityPathOpMsg, InstanceKey, LogMsg, PathOp, RowId, SetStoreInfo,
+    StoreId, StoreInfo, StoreKind, TimePoint, Timeline,
 };
 
 use crate::{Error, TimesPerTimeline};
@@ -181,8 +181,8 @@ pub struct LogDb {
     /// Set by whomever created this [`LogDb`].
     pub data_source: Option<re_smart_channel::SmartChannelSource>,
 
-    /// Comes in a special message, [`LogMsg::SetRecordingInfo`].
-    recording_msg: Option<SetRecordingInfo>,
+    /// Comes in a special message, [`LogMsg::SetStoreInfo`].
+    recording_msg: Option<SetStoreInfo>,
 
     /// Where we store the entities.
     pub entity_db: EntityDb,
@@ -199,16 +199,16 @@ impl LogDb {
         }
     }
 
-    pub fn recording_msg(&self) -> Option<&SetRecordingInfo> {
+    pub fn recording_msg(&self) -> Option<&SetStoreInfo> {
         self.recording_msg.as_ref()
     }
 
-    pub fn recording_info(&self) -> Option<&RecordingInfo> {
+    pub fn store_info(&self) -> Option<&StoreInfo> {
         self.recording_msg().map(|msg| &msg.info)
     }
 
     pub fn app_id(&self) -> Option<&ApplicationId> {
-        self.recording_info().map(|ri| &ri.application_id)
+        self.store_info().map(|ri| &ri.application_id)
     }
 
     pub fn store_kind(&self) -> StoreKind {
@@ -246,7 +246,7 @@ impl LogDb {
         debug_assert_eq!(msg.store_id(), self.store_id());
 
         match &msg {
-            LogMsg::SetRecordingInfo(msg) => self.add_begin_recording_msg(msg),
+            LogMsg::SetStoreInfo(msg) => self.add_begin_recording_msg(msg),
             LogMsg::EntityPathOpMsg(_, msg) => {
                 let EntityPathOpMsg {
                     row_id,
@@ -262,7 +262,7 @@ impl LogDb {
         Ok(())
     }
 
-    pub fn add_begin_recording_msg(&mut self, msg: &SetRecordingInfo) {
+    pub fn add_begin_recording_msg(&mut self, msg: &SetStoreInfo) {
         self.recording_msg = Some(msg.clone());
     }
 

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -171,14 +171,14 @@ impl EntityDb {
 // ----------------------------------------------------------------------------
 
 /// A in-memory database built from a stream of [`LogMsg`]es.
-pub struct LogDb {
+pub struct StoreDb {
     /// The [`StoreId`] for this log.
     store_id: StoreId,
 
     /// All [`EntityPathOpMsg`]s ever received.
     entity_op_msgs: BTreeMap<RowId, EntityPathOpMsg>,
 
-    /// Set by whomever created this [`LogDb`].
+    /// Set by whomever created this [`StoreDb`].
     pub data_source: Option<re_smart_channel::SmartChannelSource>,
 
     /// Comes in a special message, [`LogMsg::SetStoreInfo`].
@@ -188,7 +188,7 @@ pub struct LogDb {
     pub entity_db: EntityDb,
 }
 
-impl LogDb {
+impl StoreDb {
     pub fn new(store_id: StoreId) -> Self {
         Self {
             store_id,
@@ -266,7 +266,7 @@ impl LogDb {
         self.recording_msg = Some(msg.clone());
     }
 
-    /// Returns an iterator over all [`EntityPathOpMsg`]s that have been written to this `LogDb`.
+    /// Returns an iterator over all [`EntityPathOpMsg`]s that have been written to this `StoreDb`.
     pub fn iter_entity_op_msgs(&self) -> impl Iterator<Item = &EntityPathOpMsg> {
         self.entity_op_msgs.values()
     }

--- a/crates/re_data_store/src/util.rs
+++ b/crates/re_data_store/src/util.rs
@@ -3,7 +3,7 @@ use re_log_types::{
     DataRow, DeserializableComponent, EntityPath, RowId, SerializableComponent, TimePoint, Timeline,
 };
 
-use crate::LogDb;
+use crate::StoreDb;
 
 // ----------------------------------------------------------------------------
 
@@ -60,7 +60,7 @@ where
 
 /// Store a single value for a given [`re_log_types::Component`].
 pub fn store_one_component<C: SerializableComponent>(
-    log_db: &mut LogDb,
+    store_db: &mut StoreDb,
     entity_path: &EntityPath,
     timepoint: &TimePoint,
     component: C,
@@ -74,7 +74,7 @@ pub fn store_one_component<C: SerializableComponent>(
     );
     row.compute_all_size_bytes();
 
-    match log_db.entity_db.try_add_data_row(&row) {
+    match store_db.entity_db.try_add_data_row(&row) {
         Ok(()) => {}
         Err(err) => {
             re_log::warn_once!(

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -78,7 +78,7 @@ fn annotation_info(
     keypoint_id: &re_components::KeypointId,
 ) -> Option<re_components::AnnotationInfo> {
     let class_id = ctx
-        .log_db
+        .store_db
         .entity_db
         .data_store
         .query_latest_component::<ClassId>(entity_path, query)?;

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -11,7 +11,7 @@ impl DataUi for ComponentPath {
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         if let Some((_, component_data)) = re_query::get_component_with_instances(
             store,

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -17,7 +17,7 @@ impl DataUi for InstancePath {
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         let Some(mut components) = store.all_components(&query.timeline, &self.entity_path) else {
             ui.label(format!("No components in entity {}", self.entity_path));

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -1,4 +1,4 @@
-use re_log_types::{ArrowMsg, DataTable, EntityPathOpMsg, LogMsg, RecordingInfo, SetRecordingInfo};
+use re_log_types::{ArrowMsg, DataTable, EntityPathOpMsg, LogMsg, SetStoreInfo, StoreInfo};
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
@@ -13,14 +13,14 @@ impl DataUi for LogMsg {
         query: &re_arrow_store::LatestAtQuery,
     ) {
         match self {
-            LogMsg::SetRecordingInfo(msg) => msg.data_ui(ctx, ui, verbosity, query),
+            LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, verbosity, query),
             LogMsg::EntityPathOpMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
             LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
         }
     }
 }
 
-impl DataUi for SetRecordingInfo {
+impl DataUi for SetStoreInfo {
     fn data_ui(
         &self,
         _ctx: &mut ViewerContext<'_>,
@@ -28,9 +28,9 @@ impl DataUi for SetRecordingInfo {
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
     ) {
-        ui.code("SetRecordingInfo");
-        let SetRecordingInfo { row_id: _, info } = self;
-        let RecordingInfo {
+        ui.code("SetStoreInfo");
+        let SetStoreInfo { row_id: _, info } = self;
+        let StoreInfo {
             application_id,
             store_id,
             started,

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -32,7 +32,7 @@ impl DataUi for SetRecordingInfo {
         let SetRecordingInfo { row_id: _, info } = self;
         let RecordingInfo {
             application_id,
-            recording_id,
+            store_id,
             started,
             recording_source,
             is_official_example,
@@ -44,8 +44,8 @@ impl DataUi for SetRecordingInfo {
             ui.label(application_id.to_string());
             ui.end_row();
 
-            ui.monospace("recording_id:");
-            ui.label(format!("{recording_id:?}"));
+            ui.monospace("store_id:");
+            ui.label(format!("{store_id:?}"));
             ui.end_row();
 
             ui.monospace("started:");

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -36,7 +36,7 @@ impl DataUi for SetRecordingInfo {
             started,
             store_source,
             is_official_example,
-            store_kind: recording_type,
+            store_kind,
         } = info;
 
         egui::Grid::new("fields").num_columns(2).show(ui, |ui| {
@@ -60,8 +60,8 @@ impl DataUi for SetRecordingInfo {
             ui.label(format!("{is_official_example}"));
             ui.end_row();
 
-            ui.monospace("recording_type:");
-            ui.label(format!("{recording_type}"));
+            ui.monospace("store_kind:");
+            ui.label(format!("{store_kind}"));
             ui.end_row();
         });
     }

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -34,7 +34,7 @@ impl DataUi for SetRecordingInfo {
             application_id,
             store_id,
             started,
-            recording_source,
+            store_source,
             is_official_example,
             store_kind: recording_type,
         } = info;
@@ -52,8 +52,8 @@ impl DataUi for SetRecordingInfo {
             ui.label(started.format());
             ui.end_row();
 
-            ui.monospace("recording_source:");
-            ui.label(format!("{recording_source}"));
+            ui.monospace("store_source:");
+            ui.label(format!("{store_source}"));
             ui.end_row();
 
             ui.monospace("is_official_example:");

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -36,7 +36,7 @@ impl DataUi for SetRecordingInfo {
             started,
             recording_source,
             is_official_example,
-            recording_type,
+            store_kind: recording_type,
         } = info;
 
         egui::Grid::new("fields").num_columns(2).show(ui, |ui| {

--- a/crates/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -7,7 +7,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use re_components::datagen::{build_frame_nr, build_some_colors, build_some_point2d};
 
 use re_log_types::{
-    entity_path, DataRow, DataTable, Index, LogMsg, RecordingId, RecordingType, RowId, TableId,
+    entity_path, DataRow, DataTable, Index, LogMsg, RecordingId, RowId, StoreKind, TableId,
 };
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -83,7 +83,7 @@ fn mono_points_arrow(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random(RecordingType::Data);
+        let recording_id = RecordingId::random(StoreKind::Recording);
         let mut group = c.benchmark_group("mono_points_arrow");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -139,7 +139,7 @@ fn mono_points_arrow_batched(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random(RecordingType::Data);
+        let recording_id = RecordingId::random(StoreKind::Recording);
         let mut group = c.benchmark_group("mono_points_arrow_batched");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -196,7 +196,7 @@ fn batch_points_arrow(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random(RecordingType::Data);
+        let recording_id = RecordingId::random(StoreKind::Recording);
         let mut group = c.benchmark_group("batch_points_arrow");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {

--- a/crates/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -7,7 +7,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use re_components::datagen::{build_frame_nr, build_some_colors, build_some_point2d};
 
 use re_log_types::{
-    entity_path, DataRow, DataTable, Index, LogMsg, RecordingId, RowId, StoreKind, TableId,
+    entity_path, DataRow, DataTable, Index, LogMsg, RowId, StoreId, StoreKind, TableId,
 };
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -44,10 +44,10 @@ fn decode_log_msgs(mut bytes: &[u8]) -> Vec<LogMsg> {
     messages
 }
 
-fn generate_messages(recording_id: &RecordingId, tables: &[DataTable]) -> Vec<LogMsg> {
+fn generate_messages(store_id: &StoreId, tables: &[DataTable]) -> Vec<LogMsg> {
     tables
         .iter()
-        .map(|table| LogMsg::ArrowMsg(recording_id.clone(), table.to_arrow_msg().unwrap()))
+        .map(|table| LogMsg::ArrowMsg(store_id.clone(), table.to_arrow_msg().unwrap()))
         .collect()
 }
 
@@ -83,7 +83,7 @@ fn mono_points_arrow(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random(StoreKind::Recording);
+        let store_id = StoreId::random(StoreKind::Recording);
         let mut group = c.benchmark_group("mono_points_arrow");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -91,14 +91,14 @@ fn mono_points_arrow(c: &mut Criterion) {
         });
         let tables = generate_tables();
         group.bench_function("generate_messages", |b| {
-            b.iter(|| generate_messages(&recording_id, &tables));
+            b.iter(|| generate_messages(&store_id, &tables));
         });
-        let messages = generate_messages(&recording_id, &tables);
+        let messages = generate_messages(&store_id, &tables);
         group.bench_function("encode_log_msg", |b| {
             b.iter(|| encode_log_msgs(&messages));
         });
         group.bench_function("encode_total", |b| {
-            b.iter(|| encode_log_msgs(&generate_messages(&recording_id, &generate_tables())));
+            b.iter(|| encode_log_msgs(&generate_messages(&store_id, &generate_tables())));
         });
 
         let encoded = encode_log_msgs(&messages);
@@ -139,7 +139,7 @@ fn mono_points_arrow_batched(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random(StoreKind::Recording);
+        let store_id = StoreId::random(StoreKind::Recording);
         let mut group = c.benchmark_group("mono_points_arrow_batched");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -147,14 +147,14 @@ fn mono_points_arrow_batched(c: &mut Criterion) {
         });
         let tables = [generate_table()];
         group.bench_function("generate_messages", |b| {
-            b.iter(|| generate_messages(&recording_id, &tables));
+            b.iter(|| generate_messages(&store_id, &tables));
         });
-        let messages = generate_messages(&recording_id, &tables);
+        let messages = generate_messages(&store_id, &tables);
         group.bench_function("encode_log_msg", |b| {
             b.iter(|| encode_log_msgs(&messages));
         });
         group.bench_function("encode_total", |b| {
-            b.iter(|| encode_log_msgs(&generate_messages(&recording_id, &[generate_table()])));
+            b.iter(|| encode_log_msgs(&generate_messages(&store_id, &[generate_table()])));
         });
 
         let encoded = encode_log_msgs(&messages);
@@ -196,7 +196,7 @@ fn batch_points_arrow(c: &mut Criterion) {
     }
 
     {
-        let recording_id = RecordingId::random(StoreKind::Recording);
+        let store_id = StoreId::random(StoreKind::Recording);
         let mut group = c.benchmark_group("batch_points_arrow");
         group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
         group.bench_function("generate_message_bundles", |b| {
@@ -204,14 +204,14 @@ fn batch_points_arrow(c: &mut Criterion) {
         });
         let tables = generate_tables();
         group.bench_function("generate_messages", |b| {
-            b.iter(|| generate_messages(&recording_id, &tables));
+            b.iter(|| generate_messages(&store_id, &tables));
         });
-        let messages = generate_messages(&recording_id, &tables);
+        let messages = generate_messages(&store_id, &tables);
         group.bench_function("encode_log_msg", |b| {
             b.iter(|| encode_log_msgs(&messages));
         });
         group.bench_function("encode_total", |b| {
-            b.iter(|| encode_log_msgs(&generate_messages(&recording_id, &generate_tables())));
+            b.iter(|| encode_log_msgs(&generate_messages(&store_id, &generate_tables())));
         });
 
         let encoded = encode_log_msgs(&messages);

--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -162,13 +162,13 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 #[test]
 fn test_encode_decode() {
     use re_log_types::{
-        ApplicationId, LogMsg, RecordingInfo, RowId, SetRecordingInfo, StoreId, StoreKind,
-        StoreSource, Time,
+        ApplicationId, LogMsg, RowId, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource,
+        Time,
     };
 
-    let messages = vec![LogMsg::SetRecordingInfo(SetRecordingInfo {
+    let messages = vec![LogMsg::SetStoreInfo(SetStoreInfo {
         row_id: RowId::random(),
-        info: RecordingInfo {
+        info: StoreInfo {
             application_id: ApplicationId("test".to_owned()),
             store_id: StoreId::random(StoreKind::Recording),
             is_official_example: true,

--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -162,8 +162,8 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 #[test]
 fn test_encode_decode() {
     use re_log_types::{
-        ApplicationId, LogMsg, RecordingInfo, RecordingSource, RowId, SetRecordingInfo, StoreId,
-        StoreKind, Time,
+        ApplicationId, LogMsg, RecordingInfo, RowId, SetRecordingInfo, StoreId, StoreKind,
+        StoreSource, Time,
     };
 
     let messages = vec![LogMsg::SetRecordingInfo(SetRecordingInfo {
@@ -173,7 +173,7 @@ fn test_encode_decode() {
             store_id: StoreId::random(StoreKind::Recording),
             is_official_example: true,
             started: Time::now(),
-            recording_source: RecordingSource::RustSdk {
+            store_source: StoreSource::RustSdk {
                 rustc_version: String::new(),
                 llvm_version: String::new(),
             },

--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -162,22 +162,22 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 #[test]
 fn test_encode_decode() {
     use re_log_types::{
-        ApplicationId, LogMsg, RecordingId, RecordingInfo, RecordingSource, RecordingType, RowId,
-        SetRecordingInfo, Time,
+        ApplicationId, LogMsg, RecordingId, RecordingInfo, RecordingSource, RowId,
+        SetRecordingInfo, StoreKind, Time,
     };
 
     let messages = vec![LogMsg::SetRecordingInfo(SetRecordingInfo {
         row_id: RowId::random(),
         info: RecordingInfo {
             application_id: ApplicationId("test".to_owned()),
-            recording_id: RecordingId::random(RecordingType::Data),
+            recording_id: RecordingId::random(StoreKind::Recording),
             is_official_example: true,
             started: Time::now(),
             recording_source: RecordingSource::RustSdk {
                 rustc_version: String::new(),
                 llvm_version: String::new(),
             },
-            recording_type: re_log_types::RecordingType::Data,
+            store_kind: re_log_types::StoreKind::Recording,
         },
     })];
 

--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -162,15 +162,15 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 #[test]
 fn test_encode_decode() {
     use re_log_types::{
-        ApplicationId, LogMsg, RecordingId, RecordingInfo, RecordingSource, RowId,
-        SetRecordingInfo, StoreKind, Time,
+        ApplicationId, LogMsg, RecordingInfo, RecordingSource, RowId, SetRecordingInfo, StoreId,
+        StoreKind, Time,
     };
 
     let messages = vec![LogMsg::SetRecordingInfo(SetRecordingInfo {
         row_id: RowId::random(),
         info: RecordingInfo {
             application_id: ApplicationId("test".to_owned()),
-            recording_id: RecordingId::random(StoreKind::Recording),
+            store_id: StoreId::random(StoreKind::Recording),
             is_official_example: true,
             started: Time::now(),
             recording_source: RecordingSource::RustSdk {

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -159,9 +159,10 @@ impl StoreId {
 impl std::fmt::Display for StoreId {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { kind: variant, id } = self;
-        f.write_fmt(format_args!("{variant}:{id}"))?;
-        Ok(())
+        // `StoreKind` is not part of how we display the id,
+        // because that can easily lead to confusion and bugs
+        // when roundtripping to a string (e.g. via Python SDK).
+        self.id.fmt(f)
     }
 }
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -248,6 +248,7 @@ pub struct SetRecordingInfo {
     pub info: RecordingInfo,
 }
 
+/// Information about a recording or blueprint.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RecordingInfo {

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -85,30 +85,30 @@ macro_rules! impl_into_enum {
 
 // ----------------------------------------------------------------------------
 
-/// What type of `Recording` this is.
+/// What kind of Store this is.
 ///
-/// `Data` recordings contain user-data logged via `log_` API calls.
+/// `Recording` stores contain user-data logged via `log_` API calls.
 ///
-/// In the future, `Blueprint` recordings describe how that data is laid out
+/// In the future, `Blueprint` stores describe how that data is laid out
 /// in the viewer, though this is not currently supported.
 ///
-/// Both of these types can go over the same stream and be stored in the
+/// Both of these kinds can go over the same stream and be stored in the
 /// same datastore, but the viewer wants to treat them very differently.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum RecordingType {
+pub enum StoreKind {
     /// A recording of user-data.
-    Data,
+    Recording,
 
-    /// Not currently used: recording data associated with the blueprint state.
+    /// Data associated with the blueprint state.
     Blueprint,
 }
 
-impl std::fmt::Display for RecordingType {
+impl std::fmt::Display for StoreKind {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Data => "Data".fmt(f),
+            Self::Recording => "Recording".fmt(f),
             Self::Blueprint => "Blueprint".fmt(f),
         }
     }
@@ -118,31 +118,31 @@ impl std::fmt::Display for RecordingType {
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RecordingId {
-    pub variant: RecordingType,
+    pub kind: StoreKind,
     pub id: Arc<String>,
 }
 
 impl RecordingId {
     #[inline]
-    pub fn random(variant: RecordingType) -> Self {
+    pub fn random(kind: StoreKind) -> Self {
         Self {
-            variant,
+            kind,
             id: Arc::new(uuid::Uuid::new_v4().to_string()),
         }
     }
 
     #[inline]
-    pub fn from_uuid(variant: RecordingType, uuid: uuid::Uuid) -> Self {
+    pub fn from_uuid(kind: StoreKind, uuid: uuid::Uuid) -> Self {
         Self {
-            variant,
+            kind,
             id: Arc::new(uuid.to_string()),
         }
     }
 
     #[inline]
-    pub fn from_string(variant: RecordingType, str: String) -> Self {
+    pub fn from_string(kind: StoreKind, str: String) -> Self {
         Self {
-            variant,
+            kind,
             id: Arc::new(str),
         }
     }
@@ -156,7 +156,7 @@ impl RecordingId {
 impl std::fmt::Display for RecordingId {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { variant, id } = self;
+        let Self { kind: variant, id } = self;
         f.write_fmt(format_args!("{variant}:{id}"))?;
         Ok(())
     }
@@ -265,7 +265,7 @@ pub struct RecordingInfo {
 
     pub recording_source: RecordingSource,
 
-    pub recording_type: RecordingType,
+    pub store_kind: StoreKind,
 }
 
 impl RecordingInfo {

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -265,7 +265,7 @@ pub struct RecordingInfo {
     /// Should be an absolute time, i.e. relative to Unix Epoch.
     pub started: Time,
 
-    pub recording_source: RecordingSource,
+    pub store_source: StoreSource,
 
     pub store_kind: StoreKind,
 }
@@ -306,9 +306,10 @@ impl std::fmt::Display for PythonVersion {
     }
 }
 
+/// The source of a recording or blueprint.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum RecordingSource {
+pub enum StoreSource {
     Unknown,
 
     /// The official Rerun Python Logging SDK
@@ -324,7 +325,7 @@ pub enum RecordingSource {
     Other(String),
 }
 
-impl std::fmt::Display for RecordingSource {
+impl std::fmt::Display for StoreSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Unknown => "Unknown".fmt(f),

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -218,7 +218,7 @@ pub enum LogMsg {
     /// A new recording has begun.
     ///
     /// Should usually be the first message sent.
-    SetRecordingInfo(SetRecordingInfo),
+    SetStoreInfo(SetStoreInfo),
 
     /// Server-backed operation on an [`EntityPath`].
     EntityPathOpMsg(StoreId, EntityPathOpMsg),
@@ -230,28 +230,28 @@ pub enum LogMsg {
 impl LogMsg {
     pub fn store_id(&self) -> &StoreId {
         match self {
-            Self::SetRecordingInfo(msg) => &msg.info.store_id,
+            Self::SetStoreInfo(msg) => &msg.info.store_id,
             Self::EntityPathOpMsg(store_id, _) | Self::ArrowMsg(store_id, _) => store_id,
         }
     }
 }
 
-impl_into_enum!(SetRecordingInfo, LogMsg, SetRecordingInfo);
+impl_into_enum!(SetStoreInfo, LogMsg, SetStoreInfo);
 
 // ----------------------------------------------------------------------------
 
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct SetRecordingInfo {
+pub struct SetStoreInfo {
     pub row_id: RowId,
-    pub info: RecordingInfo,
+    pub info: StoreInfo,
 }
 
 /// Information about a recording or blueprint.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct RecordingInfo {
+pub struct StoreInfo {
     /// The user-chosen name of the application doing the logging.
     pub application_id: ApplicationId,
 
@@ -271,8 +271,8 @@ pub struct RecordingInfo {
     pub store_kind: StoreKind,
 }
 
-impl RecordingInfo {
-    /// Whether this `RecordingInfo` is the default used when a user is not explicitly
+impl StoreInfo {
+    /// Whether this `StoreInfo` is the default used when a user is not explicitly
     /// creating their own blueprint.
     pub fn is_app_default_blueprint(&self) -> bool {
         self.application_id.as_str() == self.store_id.as_str()

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -192,10 +192,10 @@ mod tests {
 
     #[test]
     fn fallbacks() {
-        fn check_recording_id(expected: &RecordingStream, got: Option<RecordingStream>) {
+        fn check_store_id(expected: &RecordingStream, got: Option<RecordingStream>) {
             assert_eq!(
-                expected.recording_info().unwrap().recording_id,
-                got.unwrap().recording_info().unwrap().recording_id
+                expected.recording_info().unwrap().store_id,
+                got.unwrap().recording_info().unwrap().store_id
             );
         }
 
@@ -205,11 +205,11 @@ mod tests {
 
         // nothing is set -- explicit wins
         let explicit = RecordingStreamBuilder::new("explicit").buffered().unwrap();
-        check_recording_id(
+        check_store_id(
             &explicit,
             RecordingStream::get(StoreKind::Recording, explicit.clone().into()),
         );
-        check_recording_id(
+        check_store_id(
             &explicit,
             RecordingStream::get(StoreKind::Blueprint, explicit.clone().into()),
         );
@@ -230,21 +230,21 @@ mod tests {
         );
 
         // globals are set, no explicit -- globals win
-        check_recording_id(
+        check_store_id(
             &global_data,
             RecordingStream::get(StoreKind::Recording, None),
         );
-        check_recording_id(
+        check_store_id(
             &global_blueprint,
             RecordingStream::get(StoreKind::Blueprint, None),
         );
 
         // overwrite globals with themselves -- we expect to get the same value back
-        check_recording_id(
+        check_store_id(
             &global_data,
             RecordingStream::set_global(StoreKind::Recording, Some(global_data.clone())),
         );
-        check_recording_id(
+        check_store_id(
             &global_blueprint,
             RecordingStream::set_global(StoreKind::Blueprint, Some(global_blueprint.clone())),
         );
@@ -255,11 +255,11 @@ mod tests {
                 let global_blueprint = global_blueprint.clone();
                 move || {
                     // globals are still set, no explicit -- globals still win
-                    check_recording_id(
+                    check_store_id(
                         &global_data,
                         RecordingStream::get(StoreKind::Recording, None),
                     );
-                    check_recording_id(
+                    check_store_id(
                         &global_blueprint,
                         RecordingStream::get(StoreKind::Blueprint, None),
                     );
@@ -283,21 +283,21 @@ mod tests {
                     .is_none());
 
                     // locals are set for this thread -- locals win
-                    check_recording_id(
+                    check_store_id(
                         &local_data,
                         RecordingStream::get(StoreKind::Recording, None),
                     );
-                    check_recording_id(
+                    check_store_id(
                         &local_blueprint,
                         RecordingStream::get(StoreKind::Blueprint, None),
                     );
 
                     // explicit still outsmarts everyone no matter what
-                    check_recording_id(
+                    check_store_id(
                         &explicit,
                         RecordingStream::get(StoreKind::Recording, explicit.clone().into()),
                     );
-                    check_recording_id(
+                    check_store_id(
                         &explicit,
                         RecordingStream::get(StoreKind::Blueprint, explicit.clone().into()),
                     );
@@ -308,11 +308,11 @@ mod tests {
             .unwrap();
 
         // locals should not exist in this thread -- global wins
-        check_recording_id(
+        check_store_id(
             &global_data,
             RecordingStream::get(StoreKind::Recording, None),
         );
-        check_recording_id(
+        check_store_id(
             &global_blueprint,
             RecordingStream::get(StoreKind::Blueprint, None),
         );
@@ -334,21 +334,21 @@ mod tests {
         )
         .is_none());
 
-        check_recording_id(
+        check_store_id(
             &global_data,
             RecordingStream::set_global(StoreKind::Recording, None),
         );
-        check_recording_id(
+        check_store_id(
             &global_blueprint,
             RecordingStream::set_global(StoreKind::Blueprint, None),
         );
 
         // locals still win
-        check_recording_id(
+        check_store_id(
             &local_data,
             RecordingStream::get(StoreKind::Recording, None),
         );
-        check_recording_id(
+        check_store_id(
             &local_blueprint,
             RecordingStream::get(StoreKind::Blueprint, None),
         );

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -52,7 +52,7 @@ impl RecordingStream {
             // NOTE: This is the one and only place where a warning about missing active recording
             // should be printed, don't stutter!
             re_log::warn_once!(
-                "There is no currently active {kind} recording available \
+                "There is no currently active {kind} stream available \
                 for the current thread ({:?}): have you called `set_global()` and/or \
                 `set_thread_local()` first?",
                 std::thread::current().id(),
@@ -79,7 +79,7 @@ impl RecordingStream {
             // NOTE: This is the one and only place where a warning about missing active recording
             // should be printed, don't stutter!
             re_log::debug_once!(
-                "There is no currently active {kind} recording available \
+                "There is no currently active {kind} stream available \
                 for the current thread ({:?}): have you called `set_global()` and/or \
                 `set_thread_local()` first?",
                 std::thread::current().id(),

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -194,8 +194,8 @@ mod tests {
     fn fallbacks() {
         fn check_store_id(expected: &RecordingStream, got: Option<RecordingStream>) {
             assert_eq!(
-                expected.recording_info().unwrap().store_id,
-                got.unwrap().recording_info().unwrap().store_id
+                expected.store_info().unwrap().store_id,
+                got.unwrap().store_info().unwrap().store_id
             );
         }
 

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
 
-use crate::{RecordingStream, RecordingType};
+use crate::{RecordingStream, StoreKind};
 
 // ---
 
@@ -42,20 +42,17 @@ impl RecordingStream {
     /// Returns `overrides` if it exists, otherwise returns the most appropriate active recording
     /// of the specified type (i.e. thread-local first, then global scope), if any.
     #[inline]
-    pub fn get(
-        which: RecordingType,
-        overrides: Option<RecordingStream>,
-    ) -> Option<RecordingStream> {
+    pub fn get(kind: StoreKind, overrides: Option<RecordingStream>) -> Option<RecordingStream> {
         let rec = overrides.or_else(|| {
-            Self::get_any(RecordingScope::ThreadLocal, which)
-                .or_else(|| Self::get_any(RecordingScope::Global, which))
+            Self::get_any(RecordingScope::ThreadLocal, kind)
+                .or_else(|| Self::get_any(RecordingScope::Global, kind))
         });
 
         if rec.is_none() {
             // NOTE: This is the one and only place where a warning about missing active recording
             // should be printed, don't stutter!
             re_log::warn_once!(
-                "There is no currently active {which} recording available \
+                "There is no currently active {kind} recording available \
                 for the current thread ({:?}): have you called `set_global()` and/or \
                 `set_thread_local()` first?",
                 std::thread::current().id(),
@@ -70,19 +67,19 @@ impl RecordingStream {
     #[inline]
     #[doc(hidden)]
     pub fn get_quiet(
-        which: RecordingType,
+        kind: StoreKind,
         overrides: Option<RecordingStream>,
     ) -> Option<RecordingStream> {
         let rec = overrides.or_else(|| {
-            Self::get_any(RecordingScope::ThreadLocal, which)
-                .or_else(|| Self::get_any(RecordingScope::Global, which))
+            Self::get_any(RecordingScope::ThreadLocal, kind)
+                .or_else(|| Self::get_any(RecordingScope::Global, kind))
         });
 
         if rec.is_none() {
             // NOTE: This is the one and only place where a warning about missing active recording
             // should be printed, don't stutter!
             re_log::debug_once!(
-                "There is no currently active {which} recording available \
+                "There is no currently active {kind} recording available \
                 for the current thread ({:?}): have you called `set_global()` and/or \
                 `set_thread_local()` first?",
                 std::thread::current().id(),
@@ -96,8 +93,8 @@ impl RecordingStream {
 
     /// Returns the currently active recording of the specified type in the global scope, if any.
     #[inline]
-    pub fn global(which: RecordingType) -> Option<RecordingStream> {
-        Self::get_any(RecordingScope::Global, which)
+    pub fn global(kind: StoreKind) -> Option<RecordingStream> {
+        Self::get_any(RecordingScope::Global, kind)
     }
 
     /// Replaces the currently active recording of the specified type in the global scope with
@@ -105,11 +102,8 @@ impl RecordingStream {
     ///
     /// Returns the previous one, if any.
     #[inline]
-    pub fn set_global(
-        which: RecordingType,
-        rec: Option<RecordingStream>,
-    ) -> Option<RecordingStream> {
-        Self::set_any(RecordingScope::Global, which, rec)
+    pub fn set_global(kind: StoreKind, rec: Option<RecordingStream>) -> Option<RecordingStream> {
+        Self::set_any(RecordingScope::Global, kind, rec)
     }
 
     // --- Thread local ---
@@ -117,25 +111,25 @@ impl RecordingStream {
     /// Returns the currently active recording of the specified type in the thread-local scope,
     /// if any.
     #[inline]
-    pub fn thread_local(which: RecordingType) -> Option<RecordingStream> {
-        Self::get_any(RecordingScope::ThreadLocal, which)
+    pub fn thread_local(kind: StoreKind) -> Option<RecordingStream> {
+        Self::get_any(RecordingScope::ThreadLocal, kind)
     }
 
     /// Replaces the currently active recording of the specified type in the thread-local scope
     /// with the specified one.
     #[inline]
     pub fn set_thread_local(
-        which: RecordingType,
+        kind: StoreKind,
         rec: Option<RecordingStream>,
     ) -> Option<RecordingStream> {
-        Self::set_any(RecordingScope::ThreadLocal, which, rec)
+        Self::set_any(RecordingScope::ThreadLocal, kind, rec)
     }
 
     // --- Internal helpers ---
 
-    fn get_any(scope: RecordingScope, which: RecordingType) -> Option<RecordingStream> {
-        match which {
-            RecordingType::Data => match scope {
+    fn get_any(scope: RecordingScope, kind: StoreKind) -> Option<RecordingStream> {
+        match kind {
+            StoreKind::Recording => match scope {
                 RecordingScope::Global => GLOBAL_DATA_RECORDING
                     .get_or_init(Default::default)
                     .read()
@@ -144,7 +138,7 @@ impl RecordingStream {
                     LOCAL_DATA_RECORDING.with(|rec| rec.borrow().clone())
                 }
             },
-            RecordingType::Blueprint => match scope {
+            StoreKind::Blueprint => match scope {
                 RecordingScope::Global => GLOBAL_BLUEPRINT_RECORDING
                     .get_or_init(Default::default)
                     .read()
@@ -158,11 +152,11 @@ impl RecordingStream {
 
     fn set_any(
         scope: RecordingScope,
-        which: RecordingType,
+        kind: StoreKind,
         rec: Option<RecordingStream>,
     ) -> Option<RecordingStream> {
-        match which {
-            RecordingType::Data => match scope {
+        match kind {
+            StoreKind::Recording => match scope {
                 RecordingScope::Global => std::mem::replace(
                     &mut *GLOBAL_DATA_RECORDING.get_or_init(Default::default).write(),
                     rec,
@@ -172,7 +166,7 @@ impl RecordingStream {
                     std::mem::replace(&mut *cell, rec)
                 }),
             },
-            RecordingType::Blueprint => match scope {
+            StoreKind::Blueprint => match scope {
                 RecordingScope::Global => std::mem::replace(
                     &mut *GLOBAL_BLUEPRINT_RECORDING
                         .get_or_init(Default::default)
@@ -206,54 +200,53 @@ mod tests {
         }
 
         // nothing is set
-        assert!(RecordingStream::get(RecordingType::Data, None).is_none());
-        assert!(RecordingStream::get(RecordingType::Blueprint, None).is_none());
+        assert!(RecordingStream::get(StoreKind::Recording, None).is_none());
+        assert!(RecordingStream::get(StoreKind::Blueprint, None).is_none());
 
         // nothing is set -- explicit wins
         let explicit = RecordingStreamBuilder::new("explicit").buffered().unwrap();
         check_recording_id(
             &explicit,
-            RecordingStream::get(RecordingType::Data, explicit.clone().into()),
+            RecordingStream::get(StoreKind::Recording, explicit.clone().into()),
         );
         check_recording_id(
             &explicit,
-            RecordingStream::get(RecordingType::Blueprint, explicit.clone().into()),
+            RecordingStream::get(StoreKind::Blueprint, explicit.clone().into()),
         );
 
         let global_data = RecordingStreamBuilder::new("global_data")
             .buffered()
             .unwrap();
         assert!(
-            RecordingStream::set_global(RecordingType::Data, Some(global_data.clone())).is_none()
+            RecordingStream::set_global(StoreKind::Recording, Some(global_data.clone())).is_none()
         );
 
         let global_blueprint = RecordingStreamBuilder::new("global_blueprint")
             .buffered()
             .unwrap();
-        assert!(RecordingStream::set_global(
-            RecordingType::Blueprint,
-            Some(global_blueprint.clone())
-        )
-        .is_none());
+        assert!(
+            RecordingStream::set_global(StoreKind::Blueprint, Some(global_blueprint.clone()))
+                .is_none()
+        );
 
         // globals are set, no explicit -- globals win
         check_recording_id(
             &global_data,
-            RecordingStream::get(RecordingType::Data, None),
+            RecordingStream::get(StoreKind::Recording, None),
         );
         check_recording_id(
             &global_blueprint,
-            RecordingStream::get(RecordingType::Blueprint, None),
+            RecordingStream::get(StoreKind::Blueprint, None),
         );
 
         // overwrite globals with themselves -- we expect to get the same value back
         check_recording_id(
             &global_data,
-            RecordingStream::set_global(RecordingType::Data, Some(global_data.clone())),
+            RecordingStream::set_global(StoreKind::Recording, Some(global_data.clone())),
         );
         check_recording_id(
             &global_blueprint,
-            RecordingStream::set_global(RecordingType::Blueprint, Some(global_blueprint.clone())),
+            RecordingStream::set_global(StoreKind::Blueprint, Some(global_blueprint.clone())),
         );
 
         std::thread::Builder::new()
@@ -264,18 +257,18 @@ mod tests {
                     // globals are still set, no explicit -- globals still win
                     check_recording_id(
                         &global_data,
-                        RecordingStream::get(RecordingType::Data, None),
+                        RecordingStream::get(StoreKind::Recording, None),
                     );
                     check_recording_id(
                         &global_blueprint,
-                        RecordingStream::get(RecordingType::Blueprint, None),
+                        RecordingStream::get(StoreKind::Blueprint, None),
                     );
 
                     let local_data = RecordingStreamBuilder::new("local_data")
                         .buffered()
                         .unwrap();
                     assert!(RecordingStream::set_thread_local(
-                        RecordingType::Data,
+                        StoreKind::Recording,
                         Some(local_data.clone())
                     )
                     .is_none());
@@ -284,7 +277,7 @@ mod tests {
                         .buffered()
                         .unwrap();
                     assert!(RecordingStream::set_thread_local(
-                        RecordingType::Blueprint,
+                        StoreKind::Blueprint,
                         Some(local_blueprint.clone())
                     )
                     .is_none());
@@ -292,21 +285,21 @@ mod tests {
                     // locals are set for this thread -- locals win
                     check_recording_id(
                         &local_data,
-                        RecordingStream::get(RecordingType::Data, None),
+                        RecordingStream::get(StoreKind::Recording, None),
                     );
                     check_recording_id(
                         &local_blueprint,
-                        RecordingStream::get(RecordingType::Blueprint, None),
+                        RecordingStream::get(StoreKind::Blueprint, None),
                     );
 
                     // explicit still outsmarts everyone no matter what
                     check_recording_id(
                         &explicit,
-                        RecordingStream::get(RecordingType::Data, explicit.clone().into()),
+                        RecordingStream::get(StoreKind::Recording, explicit.clone().into()),
                     );
                     check_recording_id(
                         &explicit,
-                        RecordingStream::get(RecordingType::Blueprint, explicit.clone().into()),
+                        RecordingStream::get(StoreKind::Blueprint, explicit.clone().into()),
                     );
                 }
             })
@@ -317,18 +310,18 @@ mod tests {
         // locals should not exist in this thread -- global wins
         check_recording_id(
             &global_data,
-            RecordingStream::get(RecordingType::Data, None),
+            RecordingStream::get(StoreKind::Recording, None),
         );
         check_recording_id(
             &global_blueprint,
-            RecordingStream::get(RecordingType::Blueprint, None),
+            RecordingStream::get(StoreKind::Blueprint, None),
         );
 
         let local_data = RecordingStreamBuilder::new("local_data")
             .buffered()
             .unwrap();
         assert!(
-            RecordingStream::set_thread_local(RecordingType::Data, Some(local_data.clone()))
+            RecordingStream::set_thread_local(StoreKind::Recording, Some(local_data.clone()))
                 .is_none()
         );
 
@@ -336,25 +329,28 @@ mod tests {
             .buffered()
             .unwrap();
         assert!(RecordingStream::set_thread_local(
-            RecordingType::Blueprint,
+            StoreKind::Blueprint,
             Some(local_blueprint.clone())
         )
         .is_none());
 
         check_recording_id(
             &global_data,
-            RecordingStream::set_global(RecordingType::Data, None),
+            RecordingStream::set_global(StoreKind::Recording, None),
         );
         check_recording_id(
             &global_blueprint,
-            RecordingStream::set_global(RecordingType::Blueprint, None),
+            RecordingStream::set_global(StoreKind::Blueprint, None),
         );
 
         // locals still win
-        check_recording_id(&local_data, RecordingStream::get(RecordingType::Data, None));
+        check_recording_id(
+            &local_data,
+            RecordingStream::get(StoreKind::Recording, None),
+        );
         check_recording_id(
             &local_blueprint,
-            RecordingStream::get(RecordingType::Blueprint, None),
+            RecordingStream::get(StoreKind::Blueprint, None),
         );
     }
 }

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -161,12 +161,12 @@ pub fn decide_logging_enabled(default_enabled: bool) -> bool {
 
 // ----------------------------------------------------------------------------
 
-/// Creates a new [`re_log_types::RecordingInfo`] which can be used with [`RecordingStream::new`].
+/// Creates a new [`re_log_types::StoreInfo`] which can be used with [`RecordingStream::new`].
 #[track_caller] // track_caller so that we can see if we are being called from an official example.
-pub fn new_recording_info(
+pub fn new_store_info(
     application_id: impl Into<re_log_types::ApplicationId>,
-) -> re_log_types::RecordingInfo {
-    re_log_types::RecordingInfo {
+) -> re_log_types::StoreInfo {
+    re_log_types::StoreInfo {
         application_id: application_id.into(),
         store_id: StoreId::random(StoreKind::Recording),
         is_official_example: called_from_official_rust_example(),

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -171,7 +171,7 @@ pub fn new_recording_info(
         store_id: StoreId::random(StoreKind::Recording),
         is_official_example: called_from_official_rust_example(),
         started: re_log_types::Time::now(),
-        recording_source: re_log_types::RecordingSource::RustSdk {
+        store_source: re_log_types::StoreSource::RustSdk {
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         },

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -23,8 +23,8 @@ pub use self::recording_stream::{RecordingStream, RecordingStreamBuilder};
 pub use re_sdk_comms::default_server_addr;
 
 pub use re_log_types::{
-    ApplicationId, Component, ComponentName, EntityPath, RecordingId, RecordingType,
-    SerializableComponent,
+    ApplicationId, Component, ComponentName, EntityPath, RecordingId, SerializableComponent,
+    StoreKind,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -169,14 +169,14 @@ pub fn new_recording_info(
 ) -> re_log_types::RecordingInfo {
     re_log_types::RecordingInfo {
         application_id: application_id.into(),
-        recording_id: RecordingId::random(RecordingType::Data),
+        recording_id: RecordingId::random(StoreKind::Recording),
         is_official_example: called_from_official_rust_example(),
         started: re_log_types::Time::now(),
         recording_source: re_log_types::RecordingSource::RustSdk {
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         },
-        recording_type: re_log_types::RecordingType::Data,
+        store_kind: re_log_types::StoreKind::Recording,
     }
 }
 

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -23,8 +23,7 @@ pub use self::recording_stream::{RecordingStream, RecordingStreamBuilder};
 pub use re_sdk_comms::default_server_addr;
 
 pub use re_log_types::{
-    ApplicationId, Component, ComponentName, EntityPath, RecordingId, SerializableComponent,
-    StoreKind,
+    ApplicationId, Component, ComponentName, EntityPath, SerializableComponent, StoreId, StoreKind,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -169,7 +168,7 @@ pub fn new_recording_info(
 ) -> re_log_types::RecordingInfo {
     re_log_types::RecordingInfo {
         application_id: application_id.into(),
-        recording_id: RecordingId::random(StoreKind::Recording),
+        store_id: StoreId::random(StoreKind::Recording),
         is_official_example: called_from_official_rust_example(),
         started: re_log_types::Time::now(),
         recording_source: re_log_types::RecordingSource::RustSdk {

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -1,4 +1,4 @@
-use re_log_types::{DataRow, DataTableError, InstanceKey, RecordingId, RowId};
+use re_log_types::{DataRow, DataTableError, InstanceKey, RowId, StoreId};
 
 use crate::{
     log::DataCell,
@@ -310,16 +310,13 @@ impl MsgSender {
     }
 
     /// Turns the current message into a single [`re_log_types::LogMsg`]
-    pub fn into_log_msg(
-        self,
-        recording_id: RecordingId,
-    ) -> Result<re_log_types::LogMsg, DataTableError> {
+    pub fn into_log_msg(self, store_id: StoreId) -> Result<re_log_types::LogMsg, DataTableError> {
         let data_table = re_log_types::DataTable::from_rows(
             re_log_types::TableId::random(),
             self.into_rows().into_iter().flatten(),
         );
         let arrow_msg = data_table.to_arrow_msg()?;
-        Ok(re_log_types::LogMsg::ArrowMsg(recording_id, arrow_msg))
+        Ok(re_log_types::LogMsg::ArrowMsg(store_id, arrow_msg))
     }
 
     fn into_rows(self) -> [Option<DataRow>; 2] {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -5,8 +5,8 @@ use crossbeam::channel::{Receiver, Sender};
 
 use re_log_types::{
     ApplicationId, DataRow, DataTable, DataTableBatcher, DataTableBatcherConfig,
-    DataTableBatcherError, LogMsg, RecordingId, RecordingInfo, RecordingSource, RecordingType,
-    Time, TimeInt, TimePoint, TimeType, Timeline, TimelineName,
+    DataTableBatcherError, LogMsg, RecordingId, RecordingInfo, RecordingSource, StoreKind, Time,
+    TimeInt, TimePoint, TimeType, Timeline, TimelineName,
 };
 
 use crate::sink::{LogSink, MemorySinkStorage};
@@ -45,7 +45,7 @@ pub type RecordingStreamResult<T> = Result<T, RecordingStreamError>;
 /// ```
 pub struct RecordingStreamBuilder {
     application_id: ApplicationId,
-    recording_type: RecordingType,
+    recording_type: StoreKind,
     recording_id: Option<RecordingId>,
     recording_source: Option<RecordingSource>,
 
@@ -76,7 +76,7 @@ impl RecordingStreamBuilder {
 
         Self {
             application_id,
-            recording_type: RecordingType::Data,
+            recording_type: StoreKind::Recording,
             recording_id: None,
             recording_source: None,
 
@@ -144,7 +144,7 @@ impl RecordingStreamBuilder {
 
     #[doc(hidden)]
     pub fn blueprint(mut self) -> Self {
-        self.recording_type = RecordingType::Blueprint;
+        self.recording_type = StoreKind::Blueprint;
         self
     }
 
@@ -277,7 +277,7 @@ impl RecordingStreamBuilder {
             is_official_example,
             started: Time::now(),
             recording_source,
-            recording_type,
+            store_kind: recording_type,
         };
 
         let batcher_config = batcher_config

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -111,9 +111,9 @@ impl RecordingStreamBuilder {
     /// Set the [`StoreId`] for this context.
     ///
     /// If you're logging from multiple processes and want all the messages to end up as the same
-    /// recording, you must make sure they all set the same [`StoreId`] using this function.
+    /// store, you must make sure they all set the same [`StoreId`] using this function.
     ///
-    /// Note that many recordings can share the same [`ApplicationId`], but they all have
+    /// Note that many stores can share the same [`ApplicationId`], but they all have
     /// unique [`StoreId`]s.
     ///
     /// The default is to use a random [`StoreId`].

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -45,7 +45,7 @@ pub type RecordingStreamResult<T> = Result<T, RecordingStreamError>;
 /// ```
 pub struct RecordingStreamBuilder {
     application_id: ApplicationId,
-    recording_type: StoreKind,
+    store_kind: StoreKind,
     store_id: Option<StoreId>,
     store_source: Option<StoreSource>,
 
@@ -76,7 +76,7 @@ impl RecordingStreamBuilder {
 
         Self {
             application_id,
-            recording_type: StoreKind::Recording,
+            store_kind: StoreKind::Recording,
             store_id: None,
             store_source: None,
 
@@ -144,7 +144,7 @@ impl RecordingStreamBuilder {
 
     #[doc(hidden)]
     pub fn blueprint(mut self) -> Self {
-        self.recording_type = StoreKind::Blueprint;
+        self.store_kind = StoreKind::Blueprint;
         self
     }
 
@@ -255,7 +255,7 @@ impl RecordingStreamBuilder {
     pub fn into_args(self) -> (bool, RecordingInfo, DataTableBatcherConfig) {
         let Self {
             application_id,
-            recording_type,
+            store_kind,
             store_id,
             store_source,
             default_enabled,
@@ -265,7 +265,7 @@ impl RecordingStreamBuilder {
         } = self;
 
         let enabled = enabled.unwrap_or_else(|| crate::decide_logging_enabled(default_enabled));
-        let store_id = store_id.unwrap_or(StoreId::random(recording_type));
+        let store_id = store_id.unwrap_or(StoreId::random(store_kind));
         let store_source = store_source.unwrap_or_else(|| StoreSource::RustSdk {
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
@@ -277,7 +277,7 @@ impl RecordingStreamBuilder {
             is_official_example,
             started: Time::now(),
             store_source,
-            store_kind: recording_type,
+            store_kind,
         };
 
         let batcher_config = batcher_config

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -5,8 +5,8 @@ use crossbeam::channel::{Receiver, Sender};
 
 use re_log_types::{
     ApplicationId, DataRow, DataTable, DataTableBatcher, DataTableBatcherConfig,
-    DataTableBatcherError, LogMsg, RecordingInfo, RecordingSource, StoreId, StoreKind, Time,
-    TimeInt, TimePoint, TimeType, Timeline, TimelineName,
+    DataTableBatcherError, LogMsg, RecordingInfo, StoreId, StoreKind, StoreSource, Time, TimeInt,
+    TimePoint, TimeType, Timeline, TimelineName,
 };
 
 use crate::sink::{LogSink, MemorySinkStorage};
@@ -47,7 +47,7 @@ pub struct RecordingStreamBuilder {
     application_id: ApplicationId,
     recording_type: StoreKind,
     store_id: Option<StoreId>,
-    recording_source: Option<RecordingSource>,
+    store_source: Option<StoreSource>,
 
     default_enabled: bool,
     enabled: Option<bool>,
@@ -78,7 +78,7 @@ impl RecordingStreamBuilder {
             application_id,
             recording_type: StoreKind::Recording,
             store_id: None,
-            recording_source: None,
+            store_source: None,
 
             default_enabled: true,
             enabled: None,
@@ -131,8 +131,8 @@ impl RecordingStreamBuilder {
     }
 
     #[doc(hidden)]
-    pub fn recording_source(mut self, recording_source: RecordingSource) -> Self {
-        self.recording_source = Some(recording_source);
+    pub fn store_source(mut self, store_source: StoreSource) -> Self {
+        self.store_source = Some(store_source);
         self
     }
 
@@ -257,7 +257,7 @@ impl RecordingStreamBuilder {
             application_id,
             recording_type,
             store_id,
-            recording_source,
+            store_source,
             default_enabled,
             enabled,
             batcher_config,
@@ -266,7 +266,7 @@ impl RecordingStreamBuilder {
 
         let enabled = enabled.unwrap_or_else(|| crate::decide_logging_enabled(default_enabled));
         let store_id = store_id.unwrap_or(StoreId::random(recording_type));
-        let recording_source = recording_source.unwrap_or_else(|| RecordingSource::RustSdk {
+        let store_source = store_source.unwrap_or_else(|| StoreSource::RustSdk {
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         });
@@ -276,7 +276,7 @@ impl RecordingStreamBuilder {
             store_id,
             is_official_example,
             started: Time::now(),
-            recording_source,
+            store_source,
             store_kind: recording_type,
         };
 

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -248,7 +248,7 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::SetRecordingInfo(_) | LogMsg::EntityPathOpMsg(_, _) => true,
+            LogMsg::SetStoreInfo(_) | LogMsg::EntityPathOpMsg(_, _) => true,
 
             LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }

--- a/crates/re_space_view_spatial/src/scene/mod.rs
+++ b/crates/re_space_view_spatial/src/scene/mod.rs
@@ -143,7 +143,7 @@ impl SceneSpatial {
             DefaultPoints,
         }
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         // Use a BTreeSet for entity hashes to get a stable order.
         let mut entities_per_draw_order = BTreeMap::<DrawOrder, BTreeSet<DrawOrderTarget>>::new();

--- a/crates/re_space_view_spatial/src/scene/scene_part/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/arrows3d.rs
@@ -102,7 +102,7 @@ impl ScenePart for Arrows3DPart {
             };
 
             match query_primary_with_history::<Arrow3D, 5>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/boxes2d.rs
@@ -117,7 +117,7 @@ impl ScenePart for Boxes2DPart {
             };
 
             match query_primary_with_history::<Rect2D, 6>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/boxes3d.rs
@@ -109,7 +109,7 @@ impl ScenePart for Boxes3DPart {
             let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
             match query_primary_with_history::<Box3D, 8>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/cameras.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/cameras.rs
@@ -190,13 +190,13 @@ impl ScenePart for CamerasPart {
     ) {
         re_tracing::profile_scope!("CamerasPart");
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
         for (ent_path, props) in query.iter_entities() {
             let query = re_arrow_store::LatestAtQuery::new(query.timeline, query.latest_at);
 
             if let Some(pinhole) = store.query_latest_component::<Pinhole>(ent_path, &query) {
                 let view_coordinates = determine_view_coordinates(
-                    &ctx.log_db.entity_db.data_store,
+                    &ctx.store_db.entity_db.data_store,
                     &ctx.rec_cfg.time_ctrl,
                     ent_path.clone(),
                 );

--- a/crates/re_space_view_spatial/src/scene/scene_part/images.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/images.rs
@@ -193,7 +193,7 @@ impl ImagesPart {
             if *properties.backproject_depth.get() && tensor.meaning == TensorDataMeaning::Depth {
                 let query = ctx.current_query();
                 let closet_pinhole = ctx
-                    .log_db
+                    .store_db
                     .entity_db
                     .data_store
                     .query_latest_component_at_closest_ancestor::<Pinhole>(ent_path, &query);
@@ -261,7 +261,7 @@ impl ImagesPart {
     ) -> Result<(), String> {
         re_tracing::profile_function!();
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
         let Some(intrinsics) = store.query_latest_component::<Pinhole>(
             pinhole_ent_path,
             &ctx.current_query(),
@@ -392,7 +392,7 @@ impl ScenePart for ImagesPart {
             };
 
             match query_primary_with_history::<Tensor, 4>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/lines2d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/lines2d.rs
@@ -87,7 +87,7 @@ impl ScenePart for Lines2DPart {
             let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
             match query_primary_with_history::<LineStrip2D, 4>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/lines3d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/lines3d.rs
@@ -86,7 +86,7 @@ impl ScenePart for Lines3DPart {
             let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
             match query_primary_with_history::<LineStrip3D, 4>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/meshes.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/meshes.rs
@@ -78,7 +78,7 @@ impl ScenePart for MeshPart {
             };
 
             match query_primary_with_history::<Mesh3D, 3>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/points2d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/points2d.rs
@@ -184,7 +184,7 @@ impl ScenePart for Points2DPart {
             let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
             match query_primary_with_history::<Point2D, 7>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/scene/scene_part/points3d.rs
+++ b/crates/re_space_view_spatial/src/scene/scene_part/points3d.rs
@@ -187,7 +187,7 @@ impl ScenePart for Points3DPart {
             let entity_highlight = highlights.entity_outline_mask(ent_path.hash());
 
             match query_primary_with_history::<Point3D, 7>(
-                &ctx.log_db.entity_db.data_store,
+                &ctx.store_db.entity_db.data_store,
                 &query.timeline,
                 &query.latest_at,
                 &props.visible_history,

--- a/crates/re_space_view_spatial/src/transform_cache.rs
+++ b/crates/re_space_view_spatial/src/transform_cache.rs
@@ -1,7 +1,7 @@
 use nohash_hasher::IntMap;
 use re_arrow_store::LatestAtQuery;
 use re_components::{DisconnectedSpace, Pinhole, Transform3D};
-use re_data_store::{log_db::EntityDb, EntityPath, EntityPropertyMap, EntityTree};
+use re_data_store::{store_db::EntityDb, EntityPath, EntityPropertyMap, EntityTree};
 use re_log_types::EntityPathHash;
 use re_viewer_context::TimeControl;
 

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -162,7 +162,7 @@ impl ViewSpatialState {
         query: &re_arrow_store::LatestAtQuery,
         entity_path: &EntityPath,
     ) {
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
         if store
             .query_latest_component::<Pinhole>(entity_path, query)
             .is_some()
@@ -191,7 +191,7 @@ impl ViewSpatialState {
         query: &re_arrow_store::LatestAtQuery,
         entity_path: &EntityPath,
     ) -> Option<()> {
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
         let tensor = store.query_latest_component::<Tensor>(entity_path, query)?;
 
         let mut properties = data_blueprint.data_blueprints_individual().get(entity_path);
@@ -389,7 +389,7 @@ impl ViewSpatialState {
         }
         self.scene_num_primitives = scene.primitives.num_primitives();
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
         match *self.nav_mode.get() {
             SpatialNavigationMode::ThreeD => {
                 let coordinates = store.query_latest_component(space, &ctx.current_query());
@@ -728,7 +728,7 @@ pub fn picking(
     // TODO(#1818): Depth at pointer only works for depth images so far.
     let mut depth_at_pointer = None;
     for hit in &picking_result.hits {
-        let Some(mut instance_path) = hit.instance_path_hash.resolve(&ctx.log_db.entity_db)
+        let Some(mut instance_path) = hit.instance_path_hash.resolve(&ctx.store_db.entity_db)
             else { continue; };
 
         let ent_properties = entity_properties.get(&instance_path.entity_path);
@@ -740,7 +740,7 @@ pub fn picking(
         let picked_image_with_coords = if hit.hit_type == PickingHitType::TexturedRect
             || *ent_properties.backproject_depth.get()
         {
-            let store = &ctx.log_db.entity_db.data_store;
+            let store = &ctx.store_db.entity_db.data_store;
             store
                 .query_latest_component::<Tensor>(&instance_path.entity_path, &ctx.current_query())
                 .and_then(|tensor| {

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -238,7 +238,7 @@ pub fn view_2d(
     // Save off the available_size since this is used for some of the layout updates later
     let available_size = ui.available_size();
 
-    let store = &ctx.log_db.entity_db.data_store;
+    let store = &ctx.store_db.entity_db.data_store;
 
     // Determine the canvas which determines the extent of the explorable scene coordinates,
     // and thus the size of the scroll area.

--- a/crates/re_space_view_text/src/scene_element.rs
+++ b/crates/re_space_view_text/src/scene_element.rs
@@ -42,7 +42,7 @@ impl SceneElementImpl for SceneText {
         query: &SceneQuery<'_>,
         state: &TextSpaceViewState,
     ) {
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         for entity_path in query.entity_paths {
             let ent_path = entity_path;

--- a/crates/re_space_view_text/src/space_view_class.rs
+++ b/crates/re_space_view_text/src/space_view_class.rs
@@ -201,7 +201,7 @@ impl ViewTextFilters {
             row_log_levels,
         } = self;
 
-        for timeline in ctx.log_db.timelines() {
+        for timeline in ctx.store_db.timelines() {
             col_timelines.entry(*timeline).or_insert(true);
         }
 
@@ -219,7 +219,7 @@ impl ViewTextFilters {
 
 fn get_time_point(ctx: &ViewerContext<'_>, entry: &TextEntry) -> Option<TimePoint> {
     if let Some(time_point) = ctx
-        .log_db
+        .store_db
         .entity_db
         .data_store
         .get_msg_metadata(&entry.row_id)

--- a/crates/re_space_view_text_box/src/scene_element.rs
+++ b/crates/re_space_view_text_box/src/scene_element.rs
@@ -29,7 +29,7 @@ impl SceneElement for SceneTextBox {
         query: &SceneQuery<'_>,
         _state: &dyn SpaceViewState,
     ) {
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         for (ent_path, props) in query.iter_entities() {
             if !props.visible {

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -155,7 +155,7 @@ impl TimePanel {
                 ui.horizontal(|ui| {
                     let re_ui = &ctx.re_ui;
                     let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
-                    let times_per_timeline = ctx.log_db.times_per_timeline();
+                    let times_per_timeline = ctx.store_db.times_per_timeline();
                     self.time_control_ui
                         .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
                     self.time_control_ui.playback_speed_ui(time_ctrl, ui);
@@ -165,7 +165,7 @@ impl TimePanel {
                     let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
                     self.time_control_ui.timeline_selector_ui(
                         time_ctrl,
-                        ctx.log_db.times_per_timeline(),
+                        ctx.store_db.times_per_timeline(),
                         ui,
                     );
                     collapsed_time_marker_and_time(ui, ctx);
@@ -175,7 +175,7 @@ impl TimePanel {
             // One row:
             let re_ui = &ctx.re_ui;
             let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
-            let times_per_timeline = ctx.log_db.times_per_timeline();
+            let times_per_timeline = ctx.store_db.times_per_timeline();
             self.time_control_ui
                 .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
             self.time_control_ui
@@ -275,7 +275,7 @@ impl TimePanel {
             full_y_range.clone(),
         );
         time_selection_ui::loop_selection_ui(
-            ctx.log_db,
+            ctx.store_db,
             &mut ctx.rec_cfg.time_ctrl,
             &self.time_ranges_ui,
             ui,
@@ -361,7 +361,7 @@ impl TimePanel {
                     ctx,
                     time_area_response,
                     time_area_painter,
-                    &ctx.log_db.entity_db.tree,
+                    &ctx.store_db.entity_db.tree,
                     ui,
                 );
             });
@@ -560,7 +560,7 @@ impl TimePanel {
                 ui.horizontal(|ui| {
                     let re_ui = &ctx.re_ui;
                     let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
-                    let times_per_timeline = ctx.log_db.times_per_timeline();
+                    let times_per_timeline = ctx.store_db.times_per_timeline();
                     self.time_control_ui
                         .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
                     self.time_control_ui.playback_speed_ui(time_ctrl, ui);
@@ -570,7 +570,7 @@ impl TimePanel {
                     let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
                     self.time_control_ui.timeline_selector_ui(
                         time_ctrl,
-                        ctx.log_db.times_per_timeline(),
+                        ctx.store_db.times_per_timeline(),
                         ui,
                     );
 
@@ -585,7 +585,7 @@ impl TimePanel {
             // One row:
             let re_ui = &ctx.re_ui;
             let time_ctrl = &mut ctx.rec_cfg.time_ctrl;
-            let times_per_timeline = ctx.log_db.times_per_timeline();
+            let times_per_timeline = ctx.store_db.times_per_timeline();
 
             self.time_control_ui
                 .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
@@ -685,15 +685,15 @@ fn help_button(ui: &mut egui::Ui) {
 ///
 /// This functions returns `true` iff the given time is safe to show.
 fn is_time_safe_to_show(
-    log_db: &re_data_store::LogDb,
+    store_db: &re_data_store::StoreDb,
     timeline: &re_arrow_store::Timeline,
     time: TimeReal,
 ) -> bool {
-    if log_db.num_timeless_messages() == 0 {
+    if store_db.num_timeless_messages() == 0 {
         return true; // no timeless messages, no problem
     }
 
-    if let Some(times) = log_db.entity_db.tree.prefix_times.get(timeline) {
+    if let Some(times) = store_db.entity_db.tree.prefix_times.get(timeline) {
         if let Some(first_time) = times.min_key() {
             let margin = match timeline.typ() {
                 re_arrow_store::TimeType::Time => TimeInt::from_seconds(10_000),
@@ -710,7 +710,7 @@ fn is_time_safe_to_show(
 fn current_time_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     if let Some(time_int) = ctx.rec_cfg.time_ctrl.time_int() {
         let timeline = ctx.rec_cfg.time_ctrl.timeline();
-        if is_time_safe_to_show(ctx.log_db, timeline, time_int.into()) {
+        if is_time_safe_to_show(ctx.store_db, timeline, time_int.into()) {
             let time_type = ctx.rec_cfg.time_ctrl.time_type();
             ui.monospace(time_type.format(time_int));
         }
@@ -727,7 +727,7 @@ fn initialize_time_ranges_ui(
     re_tracing::profile_function!();
 
     // If there's any timeless data, add the "beginning range" that contains timeless data.
-    let mut time_range = if ctx.log_db.num_timeless_messages() > 0 {
+    let mut time_range = if ctx.store_db.num_timeless_messages() > 0 {
         vec![TimeRange {
             min: TimeInt::BEGINNING,
             max: TimeInt::BEGINNING,
@@ -737,7 +737,7 @@ fn initialize_time_ranges_ui(
     };
 
     if let Some(times) = ctx
-        .log_db
+        .store_db
         .entity_db
         .tree
         .prefix_times

--- a/crates/re_time_panel/src/time_selection_ui.rs
+++ b/crates/re_time_panel/src/time_selection_ui.rs
@@ -1,13 +1,13 @@
 use egui::{CursorIcon, Id, NumExt as _, Rect};
 
-use re_data_store::LogDb;
+use re_data_store::StoreDb;
 use re_log_types::{Duration, TimeInt, TimeRangeF, TimeReal, TimeType};
 use re_viewer_context::{Looping, TimeControl};
 
 use super::{is_time_safe_to_show, time_ranges_ui::TimeRangesUi};
 
 pub fn loop_selection_ui(
-    log_db: &LogDb,
+    store_db: &StoreDb,
     time_ctrl: &mut TimeControl,
     time_ranges_ui: &TimeRangesUi,
     ui: &mut egui::Ui,
@@ -76,8 +76,8 @@ pub fn loop_selection_ui(
 
             if is_active
                 && !selected_range.is_empty()
-                && is_time_safe_to_show(log_db, &timeline, selected_range.min)
-                && is_time_safe_to_show(log_db, &timeline, selected_range.max)
+                && is_time_safe_to_show(store_db, &timeline, selected_range.min)
+                && is_time_safe_to_show(store_db, &timeline, selected_range.max)
             {
                 paint_range_text(time_ctrl, selected_range, ui, time_area_painter, rect);
             }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -93,7 +93,7 @@ pub struct App {
 
     rx: Receiver<LogMsg>,
 
-    /// Where the logs are stored.
+    /// Where the recordings and blueprints are stored.
     store_hub: crate::StoreHub,
 
     /// What is serialized

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -9,7 +9,7 @@ use web_time::Instant;
 use re_arrow_store::{DataStoreConfig, DataStoreStats};
 use re_data_store::log_db::LogDb;
 use re_format::format_number;
-use re_log_types::{ApplicationId, LogMsg, RecordingId, RecordingType};
+use re_log_types::{ApplicationId, LogMsg, RecordingId, StoreKind};
 use re_renderer::WgpuResourcePoolStatistics;
 use re_smart_channel::Receiver;
 use re_ui::{toasts, Command};
@@ -585,7 +585,7 @@ impl eframe::App for App {
             .get(&self.selected_app_id())
             .cloned()
             .unwrap_or_else(|| {
-                RecordingId::from_string(RecordingType::Blueprint, self.selected_app_id().0)
+                RecordingId::from_string(StoreKind::Blueprint, self.selected_app_id().0)
             });
 
         let store_config = self
@@ -878,13 +878,13 @@ impl App {
             let recording_id = msg.recording_id();
 
             let is_new_recording = if let LogMsg::SetRecordingInfo(msg) = &msg {
-                match msg.info.recording_id.variant {
-                    RecordingType::Data => {
+                match msg.info.recording_id.kind {
+                    StoreKind::Recording => {
                         re_log::debug!("Opening a new recording: {:?}", msg.info);
                         self.state.selected_rec_id = Some(recording_id.clone());
                     }
 
-                    RecordingType::Blueprint => {
+                    StoreKind::Blueprint => {
                         re_log::debug!("Opening a new blueprint: {:?}", msg.info);
                         self.state.selected_blueprint_by_app.insert(
                             msg.info.application_id.clone(),
@@ -1880,7 +1880,7 @@ fn blueprints_menu(ui: &mut egui::Ui, app: &mut App) {
     ui.style_mut().wrap = Some(false);
     for log_db in blueprint_dbs
         .iter()
-        .filter(|log| log.recording_type() == RecordingType::Blueprint)
+        .filter(|log| log.store_kind() == StoreKind::Blueprint)
     {
         let info = if let Some(rec_info) = log_db.recording_info() {
             if rec_info.is_app_default_blueprint() {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -2132,7 +2132,7 @@ fn load_file_path(path: &std::path::Path) -> Option<LogDbHub> {
         re_tracing::profile_function!();
         use anyhow::Context as _;
         let file = std::fs::File::open(path).context("Failed to open file")?;
-        LogDbHub::decode_rrd(file)
+        LogDbHub::from_rrd(file)
     }
 
     re_log::info!("Loading {path:?}…");
@@ -2161,7 +2161,7 @@ fn load_file_path(path: &std::path::Path) -> Option<LogDbHub> {
 
 #[must_use]
 fn load_file_contents(name: &str, read: impl std::io::Read) -> Option<LogDbHub> {
-    match LogDbHub::decode_rrd(read) {
+    match LogDbHub::from_rrd(read) {
         Ok(mut rrd) => {
             re_log::info!("Loaded {name:?}");
             for log_db in rrd.log_dbs_mut() {

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -6,11 +6,11 @@
 mod app;
 pub mod blueprint_components;
 pub mod env_vars;
-mod log_db_hub;
 #[cfg(not(target_arch = "wasm32"))]
 mod profiler;
 mod remote_viewer_app;
 mod screenshotter;
+mod store_hub;
 mod ui;
 mod viewer_analytics;
 
@@ -18,8 +18,8 @@ use re_log_types::PythonVersion;
 pub(crate) use ui::{memory_panel, selection_panel};
 
 pub use app::{App, StartupOptions};
-pub use log_db_hub::LogDbHub;
 pub use remote_viewer_app::RemoteViewerApp;
+pub use store_hub::StoreHub;
 
 pub mod external {
     pub use {eframe, egui};

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -83,18 +83,18 @@ pub enum AppEnvironment {
 }
 
 impl AppEnvironment {
-    pub fn from_recording_source(source: &re_log_types::RecordingSource) -> Self {
-        use re_log_types::RecordingSource;
+    pub fn from_store_source(source: &re_log_types::StoreSource) -> Self {
+        use re_log_types::StoreSource;
         match source {
-            RecordingSource::PythonSdk(python_version) => Self::PythonSdk(python_version.clone()),
-            RecordingSource::RustSdk {
+            StoreSource::PythonSdk(python_version) => Self::PythonSdk(python_version.clone()),
+            StoreSource::RustSdk {
                 rustc_version: rust_version,
                 llvm_version,
             } => Self::RustSdk {
                 rustc_version: rust_version.clone(),
                 llvm_version: llvm_version.clone(),
             },
-            RecordingSource::Unknown | RecordingSource::Other(_) => Self::RustSdk {
+            StoreSource::Unknown | StoreSource::Other(_) => Self::RustSdk {
                 rustc_version: "unknown".into(),
                 llvm_version: "unknown".into(),
             },

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -6,6 +6,7 @@
 mod app;
 pub mod blueprint_components;
 pub mod env_vars;
+mod log_db_hub;
 #[cfg(not(target_arch = "wasm32"))]
 mod profiler;
 mod remote_viewer_app;
@@ -17,6 +18,7 @@ use re_log_types::PythonVersion;
 pub(crate) use ui::{memory_panel, selection_panel};
 
 pub use app::{App, StartupOptions};
+pub use log_db_hub::LogDbHub;
 pub use remote_viewer_app::RemoteViewerApp;
 
 pub mod external {

--- a/crates/re_viewer/src/log_db_hub.rs
+++ b/crates/re_viewer/src/log_db_hub.rs
@@ -1,5 +1,5 @@
 use re_data_store::LogDb;
-use re_log_types::{RecordingId, RecordingType};
+use re_log_types::{RecordingId, StoreKind};
 
 /// Stores many [`LogDb`]s of recordings and blueprints.
 #[derive(Default)]
@@ -52,65 +52,65 @@ impl LogDbHub {
     // --
 
     pub fn contains_recording(&self, id: &RecordingId) -> bool {
-        debug_assert_eq!(id.variant, RecordingType::Data);
+        debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs.contains_key(id)
     }
 
     pub fn recording(&self, id: &RecordingId) -> Option<&LogDb> {
-        debug_assert_eq!(id.variant, RecordingType::Data);
+        debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs.get(id)
     }
 
     pub fn recording_mut(&mut self, id: &RecordingId) -> Option<&mut LogDb> {
-        debug_assert_eq!(id.variant, RecordingType::Data);
+        debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs.get_mut(id)
     }
 
     /// Creates one if it doesn't exist.
     pub fn recording_entry(&mut self, id: &RecordingId) -> &mut LogDb {
-        debug_assert_eq!(id.variant, RecordingType::Data);
+        debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs
             .entry(id.clone())
             .or_insert_with(|| LogDb::new(id.clone()))
     }
 
     pub fn insert_recording(&mut self, log_db: LogDb) {
-        debug_assert_eq!(log_db.recording_type(), RecordingType::Data);
+        debug_assert_eq!(log_db.store_kind(), StoreKind::Recording);
         self.log_dbs.insert(log_db.recording_id().clone(), log_db);
     }
 
     pub fn recordings(&self) -> impl Iterator<Item = &LogDb> {
         self.log_dbs
             .values()
-            .filter(|log| log.recording_type() == RecordingType::Data)
+            .filter(|log| log.store_kind() == StoreKind::Recording)
     }
 
     pub fn blueprints(&self) -> impl Iterator<Item = &LogDb> {
         self.log_dbs
             .values()
-            .filter(|log| log.recording_type() == RecordingType::Blueprint)
+            .filter(|log| log.store_kind() == StoreKind::Blueprint)
     }
 
     // --
 
     pub fn contains_blueprint(&self, id: &RecordingId) -> bool {
-        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        debug_assert_eq!(id.kind, StoreKind::Blueprint);
         self.log_dbs.contains_key(id)
     }
 
     pub fn blueprint(&self, id: &RecordingId) -> Option<&LogDb> {
-        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        debug_assert_eq!(id.kind, StoreKind::Blueprint);
         self.log_dbs.get(id)
     }
 
     pub fn blueprint_mut(&mut self, id: &RecordingId) -> Option<&mut LogDb> {
-        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        debug_assert_eq!(id.kind, StoreKind::Blueprint);
         self.log_dbs.get_mut(id)
     }
 
     /// Creates one if it doesn't exist.
     pub fn blueprint_entry(&mut self, id: &RecordingId) -> &mut LogDb {
-        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        debug_assert_eq!(id.kind, StoreKind::Blueprint);
 
         self.log_dbs.entry(id.clone()).or_insert_with(|| {
             // TODO(jleibs): If the blueprint doesn't exist this probably means we are
@@ -127,7 +127,7 @@ impl LogDbHub {
                     is_official_example: false,
                     started: re_log_types::Time::now(),
                     recording_source: re_log_types::RecordingSource::Other("viewer".to_owned()),
-                    recording_type: RecordingType::Blueprint,
+                    store_kind: StoreKind::Blueprint,
                 },
             });
 

--- a/crates/re_viewer/src/log_db_hub.rs
+++ b/crates/re_viewer/src/log_db_hub.rs
@@ -1,11 +1,11 @@
 use re_data_store::LogDb;
-use re_log_types::{RecordingId, StoreKind};
+use re_log_types::{StoreId, StoreKind};
 
 /// Stores many [`LogDb`]s of recordings and blueprints.
 #[derive(Default)]
 pub struct LogDbHub {
     // TODO(emilk): two separate maps per [`RecordingType`].
-    log_dbs: ahash::HashMap<RecordingId, LogDb>,
+    log_dbs: ahash::HashMap<StoreId, LogDb>,
 }
 
 impl LogDbHub {
@@ -20,14 +20,14 @@ impl LogDbHub {
 
         for msg in decoder {
             let msg = msg?;
-            slf.log_db_entry(msg.recording_id()).add(&msg)?;
+            slf.log_db_entry(msg.store_id()).add(&msg)?;
         }
         Ok(slf)
     }
 
     /// Returns either a recording or blueprint [`LogDb`].
     /// One is created if it doesn't already exist.
-    pub fn log_db_entry(&mut self, id: &RecordingId) -> &mut LogDb {
+    pub fn log_db_entry(&mut self, id: &StoreId) -> &mut LogDb {
         self.log_dbs
             .entry(id.clone())
             .or_insert_with(|| LogDb::new(id.clone()))
@@ -51,23 +51,23 @@ impl LogDbHub {
 
     // --
 
-    pub fn contains_recording(&self, id: &RecordingId) -> bool {
+    pub fn contains_recording(&self, id: &StoreId) -> bool {
         debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs.contains_key(id)
     }
 
-    pub fn recording(&self, id: &RecordingId) -> Option<&LogDb> {
+    pub fn recording(&self, id: &StoreId) -> Option<&LogDb> {
         debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs.get(id)
     }
 
-    pub fn recording_mut(&mut self, id: &RecordingId) -> Option<&mut LogDb> {
+    pub fn recording_mut(&mut self, id: &StoreId) -> Option<&mut LogDb> {
         debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs.get_mut(id)
     }
 
     /// Creates one if it doesn't exist.
-    pub fn recording_entry(&mut self, id: &RecordingId) -> &mut LogDb {
+    pub fn recording_entry(&mut self, id: &StoreId) -> &mut LogDb {
         debug_assert_eq!(id.kind, StoreKind::Recording);
         self.log_dbs
             .entry(id.clone())
@@ -76,7 +76,7 @@ impl LogDbHub {
 
     pub fn insert_recording(&mut self, log_db: LogDb) {
         debug_assert_eq!(log_db.store_kind(), StoreKind::Recording);
-        self.log_dbs.insert(log_db.recording_id().clone(), log_db);
+        self.log_dbs.insert(log_db.store_id().clone(), log_db);
     }
 
     pub fn recordings(&self) -> impl Iterator<Item = &LogDb> {
@@ -93,23 +93,23 @@ impl LogDbHub {
 
     // --
 
-    pub fn contains_blueprint(&self, id: &RecordingId) -> bool {
+    pub fn contains_blueprint(&self, id: &StoreId) -> bool {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
         self.log_dbs.contains_key(id)
     }
 
-    pub fn blueprint(&self, id: &RecordingId) -> Option<&LogDb> {
+    pub fn blueprint(&self, id: &StoreId) -> Option<&LogDb> {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
         self.log_dbs.get(id)
     }
 
-    pub fn blueprint_mut(&mut self, id: &RecordingId) -> Option<&mut LogDb> {
+    pub fn blueprint_mut(&mut self, id: &StoreId) -> Option<&mut LogDb> {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
         self.log_dbs.get_mut(id)
     }
 
     /// Creates one if it doesn't exist.
-    pub fn blueprint_entry(&mut self, id: &RecordingId) -> &mut LogDb {
+    pub fn blueprint_entry(&mut self, id: &StoreId) -> &mut LogDb {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
 
         self.log_dbs.entry(id.clone()).or_insert_with(|| {
@@ -123,7 +123,7 @@ impl LogDbHub {
                 row_id: re_log_types::RowId::random(),
                 info: re_log_types::RecordingInfo {
                     application_id: id.as_str().into(),
-                    recording_id: id.clone(),
+                    store_id: id.clone(),
                     is_official_example: false,
                     started: re_log_types::Time::now(),
                     recording_source: re_log_types::RecordingSource::Other("viewer".to_owned()),

--- a/crates/re_viewer/src/log_db_hub.rs
+++ b/crates/re_viewer/src/log_db_hub.rs
@@ -10,7 +10,7 @@ pub struct LogDbHub {
 
 impl LogDbHub {
     /// Decode an rrd stream.
-    /// It can theoreticaly contain multiple recordings, and blueprints.
+    /// It can theoretically contain multiple recordings, and blueprints.
     pub fn decode_rrd(read: impl std::io::Read) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 

--- a/crates/re_viewer/src/log_db_hub.rs
+++ b/crates/re_viewer/src/log_db_hub.rs
@@ -1,0 +1,119 @@
+use re_data_store::LogDb;
+use re_log_types::{RecordingId, RecordingType};
+
+/// Stores all [`LogDb`]s of recordings and blueprints.
+#[derive(Default)]
+pub struct LogDbHub {
+    // TODO(emilk): two separate maps per [`RecordingType`].
+    log_dbs: ahash::HashMap<RecordingId, LogDb>,
+}
+
+impl LogDbHub {
+    /// Returns either a recording or blueprint [`LogDb`].
+    /// One is created if it doesn't already exist.
+    pub fn log_db_entry(&mut self, id: &RecordingId) -> &mut LogDb {
+        self.log_dbs
+            .entry(id.clone())
+            .or_insert_with(|| LogDb::new(id.clone()))
+    }
+
+    // --
+
+    pub fn contains_recording(&self, id: &RecordingId) -> bool {
+        debug_assert_eq!(id.variant, RecordingType::Data);
+        self.log_dbs.contains_key(id)
+    }
+
+    pub fn recording(&self, id: &RecordingId) -> Option<&LogDb> {
+        debug_assert_eq!(id.variant, RecordingType::Data);
+        self.log_dbs.get(id)
+    }
+
+    pub fn recording_mut(&mut self, id: &RecordingId) -> Option<&mut LogDb> {
+        debug_assert_eq!(id.variant, RecordingType::Data);
+        self.log_dbs.get_mut(id)
+    }
+
+    /// Creates one if it doesn't exist.
+    pub fn recording_entry(&mut self, id: &RecordingId) -> &mut LogDb {
+        debug_assert_eq!(id.variant, RecordingType::Data);
+        self.log_dbs
+            .entry(id.clone())
+            .or_insert_with(|| LogDb::new(id.clone()))
+    }
+
+    pub fn insert_recording(&mut self, log_db: LogDb) {
+        debug_assert_eq!(log_db.recording_type(), RecordingType::Data);
+        self.log_dbs.insert(log_db.recording_id().clone(), log_db);
+    }
+
+    pub fn recordings(&self) -> impl Iterator<Item = &LogDb> {
+        self.log_dbs
+            .values()
+            .filter(|log| log.recording_type() == RecordingType::Data)
+    }
+
+    pub fn blueprints(&self) -> impl Iterator<Item = &LogDb> {
+        self.log_dbs
+            .values()
+            .filter(|log| log.recording_type() == RecordingType::Blueprint)
+    }
+
+    // --
+
+    pub fn contains_blueprint(&self, id: &RecordingId) -> bool {
+        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        self.log_dbs.contains_key(id)
+    }
+
+    pub fn blueprint(&self, id: &RecordingId) -> Option<&LogDb> {
+        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        self.log_dbs.get(id)
+    }
+
+    pub fn blueprint_mut(&mut self, id: &RecordingId) -> Option<&mut LogDb> {
+        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+        self.log_dbs.get_mut(id)
+    }
+
+    /// Creates one if it doesn't exist.
+    pub fn blueprint_entry(&mut self, id: &RecordingId) -> &mut LogDb {
+        debug_assert_eq!(id.variant, RecordingType::Blueprint);
+
+        self.log_dbs.entry(id.clone()).or_insert_with(|| {
+            // TODO(jleibs): If the blueprint doesn't exist this probably means we are
+            // initializing a new default-blueprint for the application in question.
+            // Make sure it's marked as a blueprint.
+
+            let mut blueprint_db = LogDb::new(id.clone());
+
+            blueprint_db.add_begin_recording_msg(&re_log_types::SetRecordingInfo {
+                row_id: re_log_types::RowId::random(),
+                info: re_log_types::RecordingInfo {
+                    application_id: id.as_str().into(),
+                    recording_id: id.clone(),
+                    is_official_example: false,
+                    started: re_log_types::Time::now(),
+                    recording_source: re_log_types::RecordingSource::Other("viewer".to_owned()),
+                    recording_type: RecordingType::Blueprint,
+                },
+            });
+
+            blueprint_db
+        })
+    }
+
+    // --
+
+    pub fn purge_empty(&mut self) {
+        self.log_dbs.retain(|_, log_db| !log_db.is_empty());
+    }
+
+    pub fn purge_fraction_of_ram(&mut self, fraction_to_purge: f32) {
+        re_tracing::profile_function!();
+
+        for log_db in self.log_dbs.values_mut() {
+            log_db.purge_fraction_of_ram(fraction_to_purge);
+        }
+    }
+}

--- a/crates/re_viewer/src/log_db_hub.rs
+++ b/crates/re_viewer/src/log_db_hub.rs
@@ -11,7 +11,7 @@ pub struct LogDbHub {
 impl LogDbHub {
     /// Decode an rrd stream.
     /// It can theoretically contain multiple recordings, and blueprints.
-    pub fn decode_rrd(read: impl std::io::Read) -> anyhow::Result<Self> {
+    pub fn from_rrd(read: impl std::io::Read) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 
         let decoder = re_log_encoding::decoder::Decoder::new(read)?;

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -1,11 +1,11 @@
-use re_data_store::LogDb;
+use re_data_store::StoreDb;
 use re_log_types::{StoreId, StoreKind};
 
-/// Stores many [`LogDb`]s of recordings and blueprints.
+/// Stores many [`StoreDb`]s of recordings and blueprints.
 #[derive(Default)]
 pub struct StoreHub {
     // TODO(emilk): two separate maps per [`StoreKind`].
-    log_dbs: ahash::HashMap<StoreId, LogDb>,
+    store_dbs: ahash::HashMap<StoreId, StoreDb>,
 }
 
 impl StoreHub {
@@ -20,32 +20,32 @@ impl StoreHub {
 
         for msg in decoder {
             let msg = msg?;
-            slf.log_db_entry(msg.store_id()).add(&msg)?;
+            slf.store_db_entry(msg.store_id()).add(&msg)?;
         }
         Ok(slf)
     }
 
-    /// Returns either a recording or blueprint [`LogDb`].
+    /// Returns either a recording or blueprint [`StoreDb`].
     /// One is created if it doesn't already exist.
-    pub fn log_db_entry(&mut self, id: &StoreId) -> &mut LogDb {
-        self.log_dbs
+    pub fn store_db_entry(&mut self, id: &StoreId) -> &mut StoreDb {
+        self.store_dbs
             .entry(id.clone())
-            .or_insert_with(|| LogDb::new(id.clone()))
+            .or_insert_with(|| StoreDb::new(id.clone()))
     }
 
-    /// All loaded [`LogDb`], both recordings and blueprints, in arbitrary order.
-    pub fn log_dbs(&self) -> impl Iterator<Item = &LogDb> {
-        self.log_dbs.values()
+    /// All loaded [`StoreDb`], both recordings and blueprints, in arbitrary order.
+    pub fn store_dbs(&self) -> impl Iterator<Item = &StoreDb> {
+        self.store_dbs.values()
     }
 
-    /// All loaded [`LogDb`], both recordings and blueprints, in arbitrary order.
-    pub fn log_dbs_mut(&mut self) -> impl Iterator<Item = &mut LogDb> {
-        self.log_dbs.values_mut()
+    /// All loaded [`StoreDb`], both recordings and blueprints, in arbitrary order.
+    pub fn store_dbs_mut(&mut self) -> impl Iterator<Item = &mut StoreDb> {
+        self.store_dbs.values_mut()
     }
 
     pub fn append(&mut self, mut other: Self) {
-        for (id, log_db) in other.log_dbs.drain() {
-            self.log_dbs.insert(id, log_db);
+        for (id, store_db) in other.store_dbs.drain() {
+            self.store_dbs.insert(id, store_db);
         }
     }
 
@@ -53,40 +53,40 @@ impl StoreHub {
 
     pub fn contains_recording(&self, id: &StoreId) -> bool {
         debug_assert_eq!(id.kind, StoreKind::Recording);
-        self.log_dbs.contains_key(id)
+        self.store_dbs.contains_key(id)
     }
 
-    pub fn recording(&self, id: &StoreId) -> Option<&LogDb> {
+    pub fn recording(&self, id: &StoreId) -> Option<&StoreDb> {
         debug_assert_eq!(id.kind, StoreKind::Recording);
-        self.log_dbs.get(id)
+        self.store_dbs.get(id)
     }
 
-    pub fn recording_mut(&mut self, id: &StoreId) -> Option<&mut LogDb> {
+    pub fn recording_mut(&mut self, id: &StoreId) -> Option<&mut StoreDb> {
         debug_assert_eq!(id.kind, StoreKind::Recording);
-        self.log_dbs.get_mut(id)
+        self.store_dbs.get_mut(id)
     }
 
     /// Creates one if it doesn't exist.
-    pub fn recording_entry(&mut self, id: &StoreId) -> &mut LogDb {
+    pub fn recording_entry(&mut self, id: &StoreId) -> &mut StoreDb {
         debug_assert_eq!(id.kind, StoreKind::Recording);
-        self.log_dbs
+        self.store_dbs
             .entry(id.clone())
-            .or_insert_with(|| LogDb::new(id.clone()))
+            .or_insert_with(|| StoreDb::new(id.clone()))
     }
 
-    pub fn insert_recording(&mut self, log_db: LogDb) {
-        debug_assert_eq!(log_db.store_kind(), StoreKind::Recording);
-        self.log_dbs.insert(log_db.store_id().clone(), log_db);
+    pub fn insert_recording(&mut self, store_db: StoreDb) {
+        debug_assert_eq!(store_db.store_kind(), StoreKind::Recording);
+        self.store_dbs.insert(store_db.store_id().clone(), store_db);
     }
 
-    pub fn recordings(&self) -> impl Iterator<Item = &LogDb> {
-        self.log_dbs
+    pub fn recordings(&self) -> impl Iterator<Item = &StoreDb> {
+        self.store_dbs
             .values()
             .filter(|log| log.store_kind() == StoreKind::Recording)
     }
 
-    pub fn blueprints(&self) -> impl Iterator<Item = &LogDb> {
-        self.log_dbs
+    pub fn blueprints(&self) -> impl Iterator<Item = &StoreDb> {
+        self.store_dbs
             .values()
             .filter(|log| log.store_kind() == StoreKind::Blueprint)
     }
@@ -95,29 +95,29 @@ impl StoreHub {
 
     pub fn contains_blueprint(&self, id: &StoreId) -> bool {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
-        self.log_dbs.contains_key(id)
+        self.store_dbs.contains_key(id)
     }
 
-    pub fn blueprint(&self, id: &StoreId) -> Option<&LogDb> {
+    pub fn blueprint(&self, id: &StoreId) -> Option<&StoreDb> {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
-        self.log_dbs.get(id)
+        self.store_dbs.get(id)
     }
 
-    pub fn blueprint_mut(&mut self, id: &StoreId) -> Option<&mut LogDb> {
+    pub fn blueprint_mut(&mut self, id: &StoreId) -> Option<&mut StoreDb> {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
-        self.log_dbs.get_mut(id)
+        self.store_dbs.get_mut(id)
     }
 
     /// Creates one if it doesn't exist.
-    pub fn blueprint_entry(&mut self, id: &StoreId) -> &mut LogDb {
+    pub fn blueprint_entry(&mut self, id: &StoreId) -> &mut StoreDb {
         debug_assert_eq!(id.kind, StoreKind::Blueprint);
 
-        self.log_dbs.entry(id.clone()).or_insert_with(|| {
+        self.store_dbs.entry(id.clone()).or_insert_with(|| {
             // TODO(jleibs): If the blueprint doesn't exist this probably means we are
             // initializing a new default-blueprint for the application in question.
             // Make sure it's marked as a blueprint.
 
-            let mut blueprint_db = LogDb::new(id.clone());
+            let mut blueprint_db = StoreDb::new(id.clone());
 
             blueprint_db.add_begin_recording_msg(&re_log_types::SetStoreInfo {
                 row_id: re_log_types::RowId::random(),
@@ -138,14 +138,14 @@ impl StoreHub {
     // --
 
     pub fn purge_empty(&mut self) {
-        self.log_dbs.retain(|_, log_db| !log_db.is_empty());
+        self.store_dbs.retain(|_, store_db| !store_db.is_empty());
     }
 
     pub fn purge_fraction_of_ram(&mut self, fraction_to_purge: f32) {
         re_tracing::profile_function!();
 
-        for log_db in self.log_dbs.values_mut() {
-            log_db.purge_fraction_of_ram(fraction_to_purge);
+        for store_db in self.store_dbs.values_mut() {
+            store_db.purge_fraction_of_ram(fraction_to_purge);
         }
     }
 }

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -119,9 +119,9 @@ impl StoreHub {
 
             let mut blueprint_db = LogDb::new(id.clone());
 
-            blueprint_db.add_begin_recording_msg(&re_log_types::SetRecordingInfo {
+            blueprint_db.add_begin_recording_msg(&re_log_types::SetStoreInfo {
                 row_id: re_log_types::RowId::random(),
-                info: re_log_types::RecordingInfo {
+                info: re_log_types::StoreInfo {
                     application_id: id.as_str().into(),
                     store_id: id.clone(),
                     is_official_example: false,

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -3,12 +3,12 @@ use re_log_types::{StoreId, StoreKind};
 
 /// Stores many [`LogDb`]s of recordings and blueprints.
 #[derive(Default)]
-pub struct LogDbHub {
+pub struct StoreHub {
     // TODO(emilk): two separate maps per [`RecordingType`].
     log_dbs: ahash::HashMap<StoreId, LogDb>,
 }
 
-impl LogDbHub {
+impl StoreHub {
     /// Decode an rrd stream.
     /// It can theoretically contain multiple recordings, and blueprints.
     pub fn from_rrd(read: impl std::io::Read) -> anyhow::Result<Self> {

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -4,7 +4,7 @@ use re_log_types::{StoreId, StoreKind};
 /// Stores many [`LogDb`]s of recordings and blueprints.
 #[derive(Default)]
 pub struct StoreHub {
-    // TODO(emilk): two separate maps per [`RecordingType`].
+    // TODO(emilk): two separate maps per [`StoreKind`].
     log_dbs: ahash::HashMap<StoreId, LogDb>,
 }
 

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -126,7 +126,7 @@ impl StoreHub {
                     store_id: id.clone(),
                     is_official_example: false,
                     started: re_log_types::Time::now(),
-                    recording_source: re_log_types::RecordingSource::Other("viewer".to_owned()),
+                    store_source: re_log_types::StoreSource::Other("viewer".to_owned()),
                     store_kind: StoreKind::Blueprint,
                 },
             });

--- a/crates/re_viewer/src/ui/blueprint.rs
+++ b/crates/re_viewer/src/ui/blueprint.rs
@@ -32,7 +32,7 @@ impl Blueprint {
     ) {
         re_tracing::profile_function!();
 
-        let spaces_info = SpaceInfoCollection::new(&ctx.log_db.entity_db);
+        let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
 
         self.viewport.on_frame_start(ctx, &spaces_info);
 

--- a/crates/re_viewer/src/ui/blueprint_load.rs
+++ b/crates/re_viewer/src/ui/blueprint_load.rs
@@ -82,7 +82,7 @@ fn load_viewport(
         // Only enable auto-space-views if this is the app-default blueprint
         AutoSpaceViews(
             blueprint_db
-                .recording_info()
+                .store_info()
                 .map_or(false, |ri| ri.is_app_default_blueprint()),
         )
     });

--- a/crates/re_viewer/src/ui/blueprint_load.rs
+++ b/crates/re_viewer/src/ui/blueprint_load.rs
@@ -14,7 +14,7 @@ use super::Blueprint;
 use crate::blueprint_components::panel::PanelState;
 
 impl Blueprint {
-    pub fn from_db(egui_ctx: &egui::Context, blueprint_db: &re_data_store::LogDb) -> Self {
+    pub fn from_db(egui_ctx: &egui::Context, blueprint_db: &re_data_store::StoreDb) -> Self {
         let mut ret = Self::new(egui_ctx);
 
         let space_views: HashMap<SpaceViewId, SpaceViewBlueprint> = if let Some(space_views) =
@@ -57,21 +57,21 @@ impl Blueprint {
     }
 }
 
-fn load_panel_state(path: &EntityPath, blueprint_db: &re_data_store::LogDb) -> Option<bool> {
+fn load_panel_state(path: &EntityPath, blueprint_db: &re_data_store::StoreDb) -> Option<bool> {
     query_timeless_single::<PanelState>(&blueprint_db.entity_db.data_store, path)
         .map(|p| p.expanded)
 }
 
 fn load_space_view(
     path: &EntityPath,
-    blueprint_db: &re_data_store::LogDb,
+    blueprint_db: &re_data_store::StoreDb,
 ) -> Option<SpaceViewBlueprint> {
     query_timeless_single::<SpaceViewComponent>(&blueprint_db.entity_db.data_store, path)
         .map(|c| c.space_view)
 }
 
 fn load_viewport(
-    blueprint_db: &re_data_store::LogDb,
+    blueprint_db: &re_data_store::StoreDb,
     space_views: HashMap<SpaceViewId, SpaceViewBlueprint>,
 ) -> Viewport {
     let auto_space_views = query_timeless_single::<AutoSpaceViews>(

--- a/crates/re_viewer/src/ui/blueprint_sync.rs
+++ b/crates/re_viewer/src/ui/blueprint_sync.rs
@@ -15,7 +15,11 @@ use crate::blueprint_components::panel::PanelState;
 
 // Resolving and applying updates
 impl Blueprint {
-    pub fn sync_changes_to_store(&self, snapshot: &Self, blueprint_db: &mut re_data_store::LogDb) {
+    pub fn sync_changes_to_store(
+        &self,
+        snapshot: &Self,
+        blueprint_db: &mut re_data_store::StoreDb,
+    ) {
         // Update the panel states
         sync_panel_expanded(
             blueprint_db,
@@ -55,7 +59,7 @@ impl Blueprint {
 }
 
 pub fn sync_panel_expanded(
-    blueprint_db: &mut re_data_store::LogDb,
+    blueprint_db: &mut re_data_store::StoreDb,
     panel_name: &str,
     expanded: bool,
     snapshot: bool,
@@ -72,7 +76,7 @@ pub fn sync_panel_expanded(
 }
 
 pub fn sync_space_view(
-    blueprint_db: &mut re_data_store::LogDb,
+    blueprint_db: &mut re_data_store::StoreDb,
     space_view: &SpaceViewBlueprint,
     snapshot: Option<&SpaceViewBlueprint>,
 ) {
@@ -94,7 +98,7 @@ pub fn sync_space_view(
     }
 }
 
-pub fn clear_space_view(blueprint_db: &mut re_data_store::LogDb, space_view_id: &SpaceViewId) {
+pub fn clear_space_view(blueprint_db: &mut re_data_store::StoreDb, space_view_id: &SpaceViewId) {
     let entity_path = EntityPath::from(format!(
         "{}/{}",
         SpaceViewComponent::SPACEVIEW_PREFIX,
@@ -119,7 +123,7 @@ pub fn clear_space_view(blueprint_db: &mut re_data_store::LogDb, space_view_id: 
 }
 
 pub fn sync_viewport(
-    blueprint_db: &mut re_data_store::LogDb,
+    blueprint_db: &mut re_data_store::StoreDb,
     viewport: &Viewport,
     snapshot: &Viewport,
 ) {

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -433,7 +433,7 @@ fn summarize_callstack(callstack: &str) -> String {
         ("App::receive_messages", "App::receive_messages"),
         ("w_store::store::ComponentBucket>::archive", "archive"),
         ("DataStore>::insert", "DataStore"),
-        ("LogDb", "LogDb"),
+        ("StoreDb", "StoreDb"),
         ("EntityDb", "EntityDb"),
         ("EntityTree", "EntityTree"),
         ("::LogMsg>::deserialize", "LogMsg"),

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -450,7 +450,7 @@ fn pinhole_props_ui(
     entity_props: &mut EntityProperties,
 ) {
     let query = ctx.current_query();
-    let store = &ctx.log_db.entity_db.data_store;
+    let store = &ctx.store_db.entity_db.data_store;
     if store
         .query_latest_component::<Pinhole>(entity_path, &query)
         .is_some()
@@ -482,13 +482,13 @@ fn depth_props_ui(
     re_tracing::profile_function!();
 
     let query = ctx.current_query();
-    let store = &ctx.log_db.entity_db.data_store;
+    let store = &ctx.store_db.entity_db.data_store;
     let tensor = store.query_latest_component::<Tensor>(entity_path, &query)?;
     if tensor.meaning != TensorDataMeaning::Depth {
         return Some(());
     }
     let pinhole_ent_path = ctx
-        .log_db
+        .store_db
         .entity_db
         .data_store
         .query_latest_component_at_closest_ancestor::<Pinhole>(entity_path, &query)?

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -133,28 +133,28 @@ impl ViewerAnalytics {
             return;
         }
 
-        if let Some(rec_info) = log_db.recording_info() {
+        if let Some(store_info) = log_db.store_info() {
             // We hash the application_id and recording_id unless this is an official example.
             // That's because we want to be able to track which are the popular examples,
             // but we don't want to collect actual application ids.
             self.register("application_id", {
-                let prop = Property::from(rec_info.application_id.0.clone());
-                if rec_info.is_official_example {
+                let prop = Property::from(store_info.application_id.0.clone());
+                if store_info.is_official_example {
                     prop
                 } else {
                     prop.hashed()
                 }
             });
             self.register("recording_id", {
-                let prop = Property::from(rec_info.store_id.to_string());
-                if rec_info.is_official_example {
+                let prop = Property::from(store_info.store_id.to_string());
+                if store_info.is_official_example {
                     prop
                 } else {
                     prop.hashed()
                 }
             });
 
-            let store_source = match &rec_info.store_source {
+            let store_source = match &store_info.store_source {
                 StoreSource::Unknown => "unknown".to_owned(),
                 StoreSource::PythonSdk(_version) => "python_sdk".to_owned(),
                 StoreSource::RustSdk { .. } => "rust_sdk".to_owned(),
@@ -169,20 +169,20 @@ impl ViewerAnalytics {
             if let StoreSource::RustSdk {
                 rustc_version: rust_version,
                 llvm_version,
-            } = &rec_info.store_source
+            } = &store_info.store_source
             {
                 self.register("rust_version", rust_version.to_string());
                 self.register("llvm_version", llvm_version.to_string());
                 self.deregister("python_version"); // can't be both!
             }
-            if let StoreSource::PythonSdk(version) = &rec_info.store_source {
+            if let StoreSource::PythonSdk(version) = &store_info.store_source {
                 self.register("python_version", version.to_string());
                 self.deregister("rust_version"); // can't be both!
                 self.deregister("llvm_version"); // can't be both!
             }
 
             self.register("store_source", store_source);
-            self.register("is_official_example", rec_info.is_official_example);
+            self.register("is_official_example", store_info.is_official_example);
         }
 
         if let Some(data_source) = &log_db.data_source {

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -13,7 +13,7 @@
 use re_analytics::{Analytics, Event, Property};
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "analytics"))]
-use re_log_types::RecordingSource;
+use re_log_types::StoreSource;
 
 pub struct ViewerAnalytics {
     // NOTE: Optional because it is possible to have the `analytics` feature flag enabled
@@ -154,11 +154,11 @@ impl ViewerAnalytics {
                 }
             });
 
-            let recording_source = match &rec_info.recording_source {
-                RecordingSource::Unknown => "unknown".to_owned(),
-                RecordingSource::PythonSdk(_version) => "python_sdk".to_owned(),
-                RecordingSource::RustSdk { .. } => "rust_sdk".to_owned(),
-                RecordingSource::Other(other) => other.clone(),
+            let store_source = match &rec_info.store_source {
+                StoreSource::Unknown => "unknown".to_owned(),
+                StoreSource::PythonSdk(_version) => "python_sdk".to_owned(),
+                StoreSource::RustSdk { .. } => "rust_sdk".to_owned(),
+                StoreSource::Other(other) => other.clone(),
             };
 
             // If we happen to know the Python or Rust version used on the _recording machine_,
@@ -166,22 +166,22 @@ impl ViewerAnalytics {
             //
             // The Python/Rust versions appearing in events always apply to the recording
             // environment, _not_ the environment in which the viewer is running!
-            if let RecordingSource::RustSdk {
+            if let StoreSource::RustSdk {
                 rustc_version: rust_version,
                 llvm_version,
-            } = &rec_info.recording_source
+            } = &rec_info.store_source
             {
                 self.register("rust_version", rust_version.to_string());
                 self.register("llvm_version", llvm_version.to_string());
                 self.deregister("python_version"); // can't be both!
             }
-            if let RecordingSource::PythonSdk(version) = &rec_info.recording_source {
+            if let StoreSource::PythonSdk(version) = &rec_info.store_source {
                 self.register("python_version", version.to_string());
                 self.deregister("rust_version"); // can't be both!
                 self.deregister("llvm_version"); // can't be both!
             }
 
-            self.register("recording_source", recording_source);
+            self.register("store_source", store_source);
             self.register("is_official_example", rec_info.is_official_example);
         }
 

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -128,12 +128,12 @@ impl ViewerAnalytics {
     }
 
     /// When we have loaded the start of a new recording.
-    pub fn on_open_recording(&mut self, log_db: &re_data_store::LogDb) {
-        if log_db.store_kind() != re_log_types::StoreKind::Recording {
+    pub fn on_open_recording(&mut self, store_db: &re_data_store::StoreDb) {
+        if store_db.store_kind() != re_log_types::StoreKind::Recording {
             return;
         }
 
-        if let Some(store_info) = log_db.store_info() {
+        if let Some(store_info) = store_db.store_info() {
             // We hash the application_id and recording_id unless this is an official example.
             // That's because we want to be able to track which are the popular examples,
             // but we don't want to collect actual application ids.
@@ -185,7 +185,7 @@ impl ViewerAnalytics {
             self.register("is_official_example", store_info.is_official_example);
         }
 
-        if let Some(data_source) = &log_db.data_source {
+        if let Some(data_source) = &store_db.data_source {
             let data_source = match data_source {
                 re_smart_channel::SmartChannelSource::Files { .. } => "file", // .rrd, .png, .glb, …
                 re_smart_channel::SmartChannelSource::RrdHttpStream { .. } => "http",
@@ -214,5 +214,5 @@ impl ViewerAnalytics {
     ) {
     }
     #[allow(clippy::unused_self)]
-    pub fn on_open_recording(&mut self, _log_db: &re_data_store::LogDb) {}
+    pub fn on_open_recording(&mut self, _store_db: &re_data_store::StoreDb) {}
 }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -129,6 +129,10 @@ impl ViewerAnalytics {
 
     /// When we have loaded the start of a new recording.
     pub fn on_open_recording(&mut self, log_db: &re_data_store::LogDb) {
+        if log_db.store_kind() != re_log_types::StoreKind::Recording {
+            return;
+        }
+
         if let Some(rec_info) = log_db.recording_info() {
             // We hash the application_id and recording_id unless this is an official example.
             // That's because we want to be able to track which are the popular examples,
@@ -142,7 +146,7 @@ impl ViewerAnalytics {
                 }
             });
             self.register("recording_id", {
-                let prop = Property::from(rec_info.recording_id.to_string());
+                let prop = Property::from(rec_info.store_id.to_string());
                 if rec_info.is_official_example {
                     prop
                 } else {

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -130,7 +130,7 @@ impl AnnotationMap {
 
         let mut visited = IntSet::<EntityPath>::default();
 
-        let data_store = &ctx.log_db.entity_db.data_store;
+        let data_store = &ctx.store_db.entity_db.data_store;
         let latest_at_query = LatestAtQuery::new(scene_query.timeline, scene_query.latest_at);
 
         // This logic is borrowed from `iter_ancestor_meta_field`, but using the arrow-store instead

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -1,4 +1,4 @@
-use re_data_store::log_db::LogDb;
+use re_data_store::store_db::StoreDb;
 
 use crate::{
     AppOptions, Caches, ComponentUiRegistry, Item, ItemCollection, SelectionState,
@@ -22,9 +22,9 @@ pub struct ViewerContext<'a> {
     pub space_view_class_registry: &'a SpaceViewClassRegistry,
 
     /// The current recording.
-    pub log_db: &'a LogDb,
+    pub store_db: &'a StoreDb,
 
-    /// UI config for the current recording (found in [`LogDb`]).
+    /// UI config for the current recording (found in [`StoreDb`]).
     pub rec_cfg: &'a mut RecordingConfig,
 
     /// The look and feel of the UI.
@@ -73,7 +73,7 @@ impl<'a> ViewerContext<'a> {
 
 // ----------------------------------------------------------------------------
 
-/// UI config for the current recording (found in [`LogDb`]).
+/// UI config for the current recording (found in [`StoreDb`]).
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct RecordingConfig {

--- a/crates/re_viewport/src/space_info.rs
+++ b/crates/re_viewport/src/space_info.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use re_arrow_store::{LatestAtQuery, TimeInt, Timeline};
 use re_components::{DisconnectedSpace, Pinhole, Transform3D};
-use re_data_store::{log_db::EntityDb, EntityPath, EntityTree};
+use re_data_store::{store_db::EntityDb, EntityPath, EntityTree};
 use re_space_view_spatial::UnreachableTransform;
 
 /// Transform connecting two space paths.

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -239,7 +239,7 @@ impl SpaceViewBlueprint {
 
                 ViewCategory::Spatial => {
                     let transforms = TransformCache::determine_transforms(
-                        &ctx.log_db.entity_db,
+                        &ctx.store_db.entity_db,
                         &ctx.rec_cfg.time_ctrl,
                         &self.space_path,
                         self.data_blueprint.data_blueprints_projected(),
@@ -288,14 +288,14 @@ impl SpaceViewBlueprint {
         &mut self,
         tree: &EntityTree,
         spaces_info: &SpaceInfoCollection,
-        log_db: &re_data_store::LogDb,
+        store_db: &re_data_store::StoreDb,
     ) {
         re_tracing::profile_function!();
 
         let mut entities = Vec::new();
         tree.visit_children_recursively(&mut |entity_path: &EntityPath| {
             let entity_categories =
-                categorize_entity_path(Timeline::log_time(), log_db, entity_path);
+                categorize_entity_path(Timeline::log_time(), store_db, entity_path);
 
             if entity_categories.contains(self.category)
                 && !self.data_blueprint.contains_entity(entity_path)

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -84,8 +84,8 @@ fn add_entities_ui(
     ui: &mut egui::Ui,
     space_view: &mut SpaceViewBlueprint,
 ) {
-    let spaces_info = SpaceInfoCollection::new(&ctx.log_db.entity_db);
-    let tree = &ctx.log_db.entity_db.tree;
+    let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
+    let tree = &ctx.store_db.entity_db.tree;
     let entities_add_info = create_entity_add_info(ctx, tree, space_view, &spaces_info);
 
     add_entities_tree_ui(
@@ -215,7 +215,7 @@ fn add_entities_line_ui(
                     |ui| {
                         let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::ADD);
                         if response.clicked() {
-                            space_view.add_entity_subtree(entity_tree, spaces_info, ctx.log_db);
+                            space_view.add_entity_subtree(entity_tree, spaces_info, ctx.store_db);
                         }
 
                         if add_info
@@ -307,7 +307,7 @@ fn create_entity_add_info(
     let mut meta_data: IntMap<EntityPath, EntityAddInfo> = IntMap::default();
 
     tree.visit_children_recursively(&mut |entity_path| {
-        let categories = categorize_entity_path(Timeline::log_time(), ctx.log_db, entity_path);
+        let categories = categorize_entity_path(Timeline::log_time(), ctx.store_db, entity_path);
         let can_add: CanAddToSpaceView = if categories.contains(space_view.category) {
             match spaces_info.is_reachable_by_transform(entity_path, &space_view.space_path) {
                 Ok(()) => CanAddToSpaceView::Compatible {

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -24,7 +24,7 @@ pub fn all_possible_space_views(
 
     // Everything with a SpaceInfo is a candidate (that is root + whenever there is a transform),
     // as well as all direct descendants of the root.
-    let root_children = &ctx.log_db.entity_db.tree.children;
+    let root_children = &ctx.store_db.entity_db.tree.children;
     let candidate_space_paths = spaces_info
         .iter()
         .map(|info| &info.path)
@@ -125,7 +125,7 @@ pub fn default_created_space_views(
     spaces_info: &SpaceInfoCollection,
 ) -> Vec<SpaceViewBlueprint> {
     let candidates = all_possible_space_views(ctx, spaces_info);
-    default_created_space_views_from_candidates(&ctx.log_db.entity_db.data_store, candidates)
+    default_created_space_views_from_candidates(&ctx.store_db.entity_db.data_store, candidates)
 }
 
 fn default_created_space_views_from_candidates(
@@ -301,8 +301,8 @@ pub fn default_queried_entities(
     re_tracing::profile_function!();
 
     let timeline = Timeline::log_time();
-    let log_db = &ctx.log_db;
-    let data_store = &log_db.entity_db.data_store;
+    let store_db = &ctx.store_db;
+    let data_store = &store_db.entity_db.data_store;
 
     let mut entities = Vec::new();
     let space_info = spaces_info.get_first_parent_with_info(space_path);
@@ -314,7 +314,8 @@ pub fn default_queried_entities(
                 .iter()
                 .filter(|entity_path| {
                     is_default_added_to_space_view(entity_path, space_path, data_store, timeline)
-                        && categorize_entity_path(timeline, log_db, entity_path).contains(category)
+                        && categorize_entity_path(timeline, store_db, entity_path)
+                            .contains(category)
                 })
                 .cloned(),
         );
@@ -332,8 +333,8 @@ fn default_queried_entities_by_category(
     re_tracing::profile_function!();
 
     let timeline = Timeline::log_time();
-    let log_db = &ctx.log_db;
-    let data_store = &log_db.entity_db.data_store;
+    let store_db = &ctx.store_db;
+    let data_store = &store_db.entity_db.data_store;
 
     let mut groups: BTreeMap<ViewCategory, Vec<EntityPath>> = BTreeMap::default();
     let space_info = space_info_collection.get_first_parent_with_info(space_path);
@@ -343,7 +344,7 @@ fn default_queried_entities_by_category(
         &mut |space_info| {
             for entity_path in &space_info.descendants_without_transform {
                 if is_default_added_to_space_view(entity_path, space_path, data_store, timeline) {
-                    for category in categorize_entity_path(timeline, log_db, entity_path) {
+                    for category in categorize_entity_path(timeline, store_db, entity_path) {
                         groups
                             .entry(category)
                             .or_default()

--- a/crates/re_viewport/src/view_bar_chart/scene.rs
+++ b/crates/re_viewport/src/view_bar_chart/scene.rs
@@ -21,7 +21,7 @@ impl SceneBarChart {
     fn load_tensors(&mut self, ctx: &mut ViewerContext<'_>, query: &SceneQuery<'_>) {
         re_tracing::profile_function!();
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         for (ent_path, props) in query.iter_entities() {
             if !props.visible {

--- a/crates/re_viewport/src/view_category.rs
+++ b/crates/re_viewport/src/view_category.rs
@@ -3,7 +3,7 @@ use re_components::{
     Arrow3D, Box3D, Component as _, LineStrip2D, LineStrip3D, Mesh3D, Pinhole, Point2D, Point3D,
     Rect2D, Scalar, Tensor, TextBox, TextEntry, Transform3D,
 };
-use re_data_store::{EntityPath, LogDb, Timeline};
+use re_data_store::{EntityPath, StoreDb, Timeline};
 
 #[derive(
     Debug, Default, PartialOrd, Ord, enumset::EnumSetType, serde::Deserialize, serde::Serialize,
@@ -64,14 +64,14 @@ pub type ViewCategorySet = enumset::EnumSet<ViewCategory>;
 
 pub fn categorize_entity_path(
     timeline: Timeline,
-    log_db: &LogDb,
+    store_db: &StoreDb,
     entity_path: &EntityPath,
 ) -> ViewCategorySet {
     re_tracing::profile_function!();
 
     let mut set = ViewCategorySet::default();
 
-    for component in log_db
+    for component in store_db
         .entity_db
         .data_store
         .all_components(&timeline, entity_path)
@@ -98,7 +98,7 @@ pub fn categorize_entity_path(
         } else if component == Tensor::name() {
             let timeline_query = LatestAtQuery::new(timeline, TimeInt::MAX);
 
-            let store = &log_db.entity_db.data_store;
+            let store = &store_db.entity_db.data_store;
             if let Some(tensor) =
                 store.query_latest_component::<Tensor>(entity_path, &timeline_query)
             {

--- a/crates/re_viewport/src/view_tensor/scene.rs
+++ b/crates/re_viewport/src/view_tensor/scene.rs
@@ -14,7 +14,7 @@ impl SceneTensor {
     pub(crate) fn load(&mut self, ctx: &mut ViewerContext<'_>, query: &SceneQuery<'_>) {
         re_tracing::profile_function!();
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
         for (ent_path, props) in query.iter_entities() {
             let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 

--- a/crates/re_viewport/src/view_time_series/scene.rs
+++ b/crates/re_viewport/src/view_time_series/scene.rs
@@ -73,7 +73,7 @@ impl SceneTimeSeries {
     fn load_scalars(&mut self, ctx: &mut ViewerContext<'_>, query: &SceneQuery<'_>) {
         re_tracing::profile_function!();
 
-        let store = &ctx.log_db.entity_db.data_store;
+        let store = &ctx.store_db.entity_db.data_store;
 
         for entity_path in query.entity_paths {
             let ent_path = entity_path;

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -95,7 +95,7 @@ impl RerunArgs {
         };
         let _tokio_runtime_guard = tokio_runtime_handle.enter();
 
-        let (rerun_enabled, recording_info, batcher_config) =
+        let (rerun_enabled, store_info, batcher_config) =
             crate::RecordingStreamBuilder::new(application_id)
                 .default_enabled(default_enabled)
                 .into_args();
@@ -123,12 +123,12 @@ impl RerunArgs {
 
             #[cfg(feature = "native_viewer")]
             RerunBehavior::Spawn => {
-                crate::native_viewer::spawn(recording_info, batcher_config, run)?;
+                crate::native_viewer::spawn(store_info, batcher_config, run)?;
                 return Ok(());
             }
         };
 
-        let rec_stream = RecordingStream::new(recording_info, batcher_config, sink)?;
+        let rec_stream = RecordingStream::new(store_info, batcher_config, sink)?;
         run(rec_stream.clone());
 
         // The user callback is done executing, it's a good opportunity to flush the pipeline

--- a/crates/rerun/src/native_viewer.rs
+++ b/crates/rerun/src/native_viewer.rs
@@ -1,5 +1,5 @@
 use re_log_types::LogMsg;
-use re_log_types::RecordingInfo;
+use re_log_types::StoreInfo;
 use re_sdk::RecordingStream;
 
 /// Starts a Rerun viewer on the current thread and migrates the given callback, along with
@@ -15,7 +15,7 @@ use re_sdk::RecordingStream;
 /// their UI runs on the main thread! ⚠️
 #[cfg(not(target_arch = "wasm32"))]
 pub fn spawn<F>(
-    recording_info: RecordingInfo,
+    store_info: StoreInfo,
     batcher_config: re_log_types::DataTableBatcherConfig,
     run: F,
 ) -> re_viewer::external::eframe::Result<()>
@@ -27,10 +27,10 @@ where
         re_smart_channel::SmartChannelSource::Sdk,
     );
     let sink = Box::new(NativeViewerSink(tx));
-    let app_env = re_viewer::AppEnvironment::from_store_source(&recording_info.store_source);
+    let app_env = re_viewer::AppEnvironment::from_store_source(&store_info.store_source);
 
     let rec_stream =
-        RecordingStream::new(recording_info, batcher_config, sink).expect("Failed to spawn thread");
+        RecordingStream::new(store_info, batcher_config, sink).expect("Failed to spawn thread");
 
     // NOTE: Forget the handle on purpose, leave that thread be.
     std::thread::Builder::new()

--- a/crates/rerun/src/native_viewer.rs
+++ b/crates/rerun/src/native_viewer.rs
@@ -27,8 +27,7 @@ where
         re_smart_channel::SmartChannelSource::Sdk,
     );
     let sink = Box::new(NativeViewerSink(tx));
-    let app_env =
-        re_viewer::AppEnvironment::from_recording_source(&recording_info.recording_source);
+    let app_env = re_viewer::AppEnvironment::from_store_source(&recording_info.store_source);
 
     let rec_stream =
         RecordingStream::new(recording_info, batcher_config, sink).expect("Failed to spawn thread");
@@ -67,7 +66,7 @@ pub fn show(msgs: Vec<LogMsg>) -> re_viewer::external::eframe::Result<()> {
         return Ok(());
     }
 
-    let recording_source = re_log_types::RecordingSource::RustSdk {
+    let store_source = re_log_types::StoreSource::RustSdk {
         rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
         llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
     };
@@ -75,7 +74,7 @@ pub fn show(msgs: Vec<LogMsg>) -> re_viewer::external::eframe::Result<()> {
     let startup_options = re_viewer::StartupOptions::default();
     re_viewer::run_native_viewer_with_messages(
         re_build_info::build_info!(),
-        re_viewer::AppEnvironment::from_recording_source(&recording_source),
+        re_viewer::AppEnvironment::from_store_source(&store_source),
         startup_options,
         msgs,
     )

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -450,7 +450,7 @@ async fn run_impl(
     // Now what do we do with the data?
 
     if args.test_receive {
-        assert_receive_into_log_db(&rx).map(|_db| ())
+        assert_receive_into_store_db(&rx).map(|_db| ())
     } else if let Some(rrd_path) = args.save {
         Ok(stream_to_rrd(&rx, &rrd_path.into())?)
     } else if args.web_viewer {
@@ -534,12 +534,12 @@ fn parse_size(size: &str) -> anyhow::Result<[f32; 2]> {
 }
 
 // NOTE: This is only used as part of end-to-end tests.
-fn assert_receive_into_log_db(rx: &Receiver<LogMsg>) -> anyhow::Result<re_data_store::LogDb> {
+fn assert_receive_into_store_db(rx: &Receiver<LogMsg>) -> anyhow::Result<re_data_store::StoreDb> {
     use re_smart_channel::RecvTimeoutError;
 
-    re_log::info!("Receiving messages into a LogDb…");
+    re_log::info!("Receiving messages into a StoreDb…");
 
-    let mut db: Option<re_data_store::LogDb> = None;
+    let mut db: Option<re_data_store::StoreDb> = None;
 
     let mut num_messages = 0;
 
@@ -553,7 +553,7 @@ fn assert_receive_into_log_db(rx: &Receiver<LogMsg>) -> anyhow::Result<re_data_s
                 match msg.payload {
                     SmartMessagePayload::Msg(msg) => {
                         let mut_db = db.get_or_insert_with(|| {
-                            re_data_store::LogDb::new(msg.store_id().clone())
+                            re_data_store::StoreDb::new(msg.store_id().clone())
                         });
 
                         mut_db.add(&msg)?;
@@ -568,7 +568,7 @@ fn assert_receive_into_log_db(rx: &Receiver<LogMsg>) -> anyhow::Result<re_data_s
                             re_log::info!("Successfully ingested {num_messages} messages.");
                             return Ok(db);
                         } else {
-                            anyhow::bail!("logdb never initialized");
+                            anyhow::bail!("StoreDb never initialized");
                         }
                     }
                 }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -350,9 +350,9 @@ async fn run_impl(
                             paths: vec![path.clone()],
                         },
                     );
-                    let recording_id =
-                        re_log_types::RecordingId::random(re_log_types::StoreKind::Recording);
-                    load_file_to_channel_at(recording_id, &path, tx)
+                    let store_id =
+                        re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
+                    load_file_to_channel_at(store_id, &path, tx)
                         .with_context(|| format!("{path:?}"))?;
                     rx
                 }
@@ -416,16 +416,15 @@ async fn run_impl(
                 },
             );
 
-            let recording_id =
-                re_log_types::RecordingId::random(re_log_types::StoreKind::Recording);
+            let store_id = re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
 
             // Load the files in parallel, and log errors.
             // Failing to log one out of many files is not a big deal.
             for path in paths {
                 let tx = tx.clone_as(re_smart_channel::SmartMessageSource::File(path.clone()));
-                let recording_id = recording_id.clone();
+                let store_id = store_id.clone();
                 rayon::spawn(move || {
-                    if let Err(err) = load_file_to_channel_at(recording_id, &path, tx) {
+                    if let Err(err) = load_file_to_channel_at(store_id, &path, tx) {
                         re_log::error!("Failed to load {path:?}: {err}");
                     }
                 });
@@ -554,7 +553,7 @@ fn assert_receive_into_log_db(rx: &Receiver<LogMsg>) -> anyhow::Result<re_data_s
                 match msg.payload {
                     SmartMessagePayload::Msg(msg) => {
                         let mut_db = db.get_or_insert_with(|| {
-                            re_data_store::LogDb::new(msg.recording_id().clone())
+                            re_data_store::LogDb::new(msg.store_id().clone())
                         });
 
                         mut_db.add(&msg)?;
@@ -773,7 +772,7 @@ fn native_viewer_connect_to_ws_url(
 
 #[allow(clippy::needless_pass_by_value)] // false positive on some feature flags
 fn load_file_to_channel_at(
-    recording_id: re_log_types::RecordingId,
+    store_id: re_log_types::StoreId,
     path: &std::path::Path,
     tx: re_smart_channel::Sender<LogMsg>,
 ) -> Result<(), anyhow::Error> {
@@ -792,7 +791,7 @@ fn load_file_to_channel_at(
     } else {
         #[cfg(feature = "sdk")]
         {
-            let log_msg = re_sdk::MsgSender::from_file_path(path)?.into_log_msg(recording_id)?;
+            let log_msg = re_sdk::MsgSender::from_file_path(path)?.into_log_msg(store_id)?;
             tx.send(log_msg).ok(); // .ok(): we may be running in a background thread, so who knows if the receiver is still open
             tx.quit(None).ok();
             Ok(())
@@ -800,7 +799,7 @@ fn load_file_to_channel_at(
 
         #[cfg(not(feature = "sdk"))]
         {
-            _ = recording_id;
+            _ = store_id;
             anyhow::bail!("Unsupported file extension: '{extension}' for path {path:?}. Try enabling the 'sdk' feature of 'rerun'.");
         }
     }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -351,7 +351,7 @@ async fn run_impl(
                         },
                     );
                     let recording_id =
-                        re_log_types::RecordingId::random(re_log_types::RecordingType::Data);
+                        re_log_types::RecordingId::random(re_log_types::StoreKind::Recording);
                     load_file_to_channel_at(recording_id, &path, tx)
                         .with_context(|| format!("{path:?}"))?;
                     rx
@@ -416,7 +416,8 @@ async fn run_impl(
                 },
             );
 
-            let recording_id = re_log_types::RecordingId::random(re_log_types::RecordingType::Data);
+            let recording_id =
+                re_log_types::RecordingId::random(re_log_types::StoreKind::Recording);
 
             // Load the files in parallel, and log errors.
             // Failing to log one out of many files is not a big deal.

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -44,7 +44,7 @@ def main() -> None:
     multiprocessing.set_start_method("spawn")
 
     for i in [1, 2, 3]:
-        p = multiprocessing.Process(target=task, args=(i, ))
+        p = multiprocessing.Process(target=task, args=(i,))
         p.start()
         p.join()
 

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -10,18 +10,22 @@ import threading
 import rerun as rr  # pip install rerun-sdk
 
 
-def task(title: str) -> None:
+def task(child_index: int) -> None:
     # All processes spawned with `multiprocessing` will automatically
     # be assigned the same default recording_id.
     # We just need to connect each process to the the rerun viewer:
     rr.init("multiprocessing")
     rr.connect()
 
+    title = f"task {child_index}"
     rr.log_text_entry(
         "log",
         text=f"Logging from pid={os.getpid()}, thread={threading.get_ident()} using the rerun recording id {rr.get_recording_id()}",  # noqa: E501 line too long
     )
-    rr.log_rect(title, [10, 20, 30, 40], label=title)
+    if child_index == 0:
+        rr.log_rect(title, [5, 5, 80, 80], label=title)
+    else:
+        rr.log_rect(title, [10 + child_index * 10, 20 + child_index * 5, 30, 40], label=title)
 
 
 def main() -> None:
@@ -30,18 +34,19 @@ def main() -> None:
     [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
 
     rr.init("multiprocessing")
-    rr.spawn(connect=False)  # this is the viewer that each process will connect to
+    rr.spawn(connect=False)  # this is the viewer that each child process will connect to
 
-    task("main_task")
+    task(0)
 
     # Using multiprocessing with "fork" results in a hang on shutdown so
     # always use "spawn"
     # TODO(https://github.com/rerun-io/rerun/issues/1921)
     multiprocessing.set_start_method("spawn")
 
-    p = multiprocessing.Process(target=task, args=("child_task",))
-    p.start()
-    p.join()
+    for i in [1, 2, 3]:
+        p = multiprocessing.Process(target=task, args=(i, ))
+        p.start()
+        p.join()
 
 
 if __name__ == "__main__":

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -15,8 +15,8 @@ use rerun::{
 const NUM_POINTS: usize = 100;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let recording_info = rerun::new_recording_info("DNA Abacus");
-    rerun::native_viewer::spawn(recording_info, Default::default(), |rec_stream| {
+    let store_info = rerun::new_store_info("DNA Abacus");
+    rerun::native_viewer::spawn(store_info, Default::default(), |rec_stream| {
         run(&rec_stream).unwrap();
     })?;
     Ok(())

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -112,8 +112,8 @@ impl MyApp {
 
 /// Show the content of the log database.
 fn log_db_ui(ui: &mut egui::Ui, log_db: &re_data_store::LogDb) {
-    if let Some(recording_info) = log_db.recording_info() {
-        ui.label(format!("Application ID: {}", recording_info.application_id));
+    if let Some(store_info) = log_db.store_info() {
+        ui.label(format!("Application ID: {}", store_info.application_id));
     }
 
     // There can be many timelines, but the `log_time` timeline is always there:

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -102,8 +102,8 @@ impl MyApp {
         });
         ui.separator();
 
-        if let Some(log_db) = self.rerun_app.log_db() {
-            log_db_ui(ui, log_db);
+        if let Some(store_db) = self.rerun_app.store_db() {
+            store_db_ui(ui, store_db);
         } else {
             ui.label("No log database loaded yet.");
         }
@@ -111,8 +111,8 @@ impl MyApp {
 }
 
 /// Show the content of the log database.
-fn log_db_ui(ui: &mut egui::Ui, log_db: &re_data_store::LogDb) {
-    if let Some(store_info) = log_db.store_info() {
+fn store_db_ui(ui: &mut egui::Ui, store_db: &re_data_store::StoreDb) {
+    if let Some(store_info) = store_db.store_info() {
         ui.label(format!("Application ID: {}", store_info.application_id));
     }
 
@@ -126,9 +126,9 @@ fn log_db_ui(ui: &mut egui::Ui, log_db: &re_data_store::LogDb) {
     egui::ScrollArea::vertical()
         .auto_shrink([false, true])
         .show(ui, |ui| {
-            for entity_path in log_db.entity_db.entity_paths() {
+            for entity_path in store_db.entity_db.entity_paths() {
                 ui.collapsing(entity_path.to_string(), |ui| {
-                    entity_ui(ui, log_db, timeline, entity_path);
+                    entity_ui(ui, store_db, timeline, entity_path);
                 });
             }
         });
@@ -136,12 +136,12 @@ fn log_db_ui(ui: &mut egui::Ui, log_db: &re_data_store::LogDb) {
 
 fn entity_ui(
     ui: &mut egui::Ui,
-    log_db: &re_data_store::LogDb,
+    store_db: &re_data_store::StoreDb,
     timeline: re_log_types::Timeline,
     entity_path: &re_log_types::EntityPath,
 ) {
     // Each entity can have many components (e.g. position, color, radius, …):
-    if let Some(mut components) = log_db
+    if let Some(mut components) = store_db
         .entity_db
         .data_store
         .all_components(&timeline, entity_path)
@@ -149,7 +149,7 @@ fn entity_ui(
         components.sort(); // Make the order predicatable
         for component in components {
             ui.collapsing(component.to_string(), |ui| {
-                component_ui(ui, log_db, timeline, entity_path, component);
+                component_ui(ui, store_db, timeline, entity_path, component);
             });
         }
     }
@@ -157,7 +157,7 @@ fn entity_ui(
 
 fn component_ui(
     ui: &mut egui::Ui,
-    log_db: &re_data_store::LogDb,
+    store_db: &re_data_store::StoreDb,
     timeline: re_log_types::Timeline,
     entity_path: &re_log_types::EntityPath,
     component_name: re_log_types::ComponentName,
@@ -167,7 +167,7 @@ fn component_ui(
     let query = re_arrow_store::LatestAtQuery::latest(timeline);
 
     if let Some((_, component)) = re_query::get_component_with_instances(
-        &log_db.entity_db.data_store,
+        &store_db.entity_db.data_store,
         &query,
         entity_path,
         component_name,

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -224,7 +224,7 @@ def init(
     if init_logging:
         new_recording(
             application_id,
-            recording_id,
+            recording_id=recording_id,
             make_default=True,
             make_thread_default=False,
             spawn=False,

--- a/rerun_py/rerun_sdk/rerun/log/experimental/blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/log/experimental/blueprint.py
@@ -35,12 +35,12 @@ def new_blueprint(
 
         The default blueprint_id is based on `multiprocessing.current_process().authkey`
         which means that all processes spawned with `multiprocessing`
-        will have the same default recording_id.
+        will have the same default blueprint_id.
 
         If you are not using `multiprocessing` and still want several different Python
         processes to log to the same Rerun instance (and be part of the same blueprint),
         you will need to manually assign them all the same blueprint_id.
-        Any random UUIDv4 will work, or copy the recording id for the parent process.
+        Any random UUIDv4 will work, or copy the blueprint_id for the parent process.
     make_default : bool
         If true (_not_ the default), the newly initialized blueprint will replace the current
         active one (if any) in the global scope.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -219,7 +219,7 @@ fn new_recording(
     let recording = RecordingStreamBuilder::new(application_id)
         .is_official_example(is_official_example)
         .store_id(recording_id.clone())
-        .recording_source(re_log_types::RecordingSource::PythonSdk(python_version(py)))
+        .store_source(re_log_types::StoreSource::PythonSdk(python_version(py)))
         .default_enabled(default_enabled)
         .buffered()
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
@@ -268,7 +268,7 @@ fn new_blueprint(
 
     let blueprint = RecordingStreamBuilder::new(application_id)
         .store_id(blueprint_id.clone())
-        .recording_source(re_log_types::RecordingSource::PythonSdk(python_version(py)))
+        .store_source(re_log_types::StoreSource::PythonSdk(python_version(py)))
         .default_enabled(default_enabled)
         .buffered()
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -320,14 +320,14 @@ impl std::ops::Deref for PyRecordingStream {
 #[pyfunction]
 fn get_application_id(recording: Option<&PyRecordingStream>) -> Option<String> {
     get_data_recording(recording)?
-        .recording_info()
+        .store_info()
         .map(|info| info.application_id.to_string())
 }
 
 #[pyfunction]
 fn get_recording_id(recording: Option<&PyRecordingStream>) -> Option<String> {
     get_data_recording(recording)?
-        .recording_info()
+        .store_info()
         .map(|info| info.store_id.to_string())
 }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -18,7 +18,7 @@ use re_viewport::{
     SpaceViewBlueprint, ViewCategory,
 };
 
-use re_log_types::{DataRow, RecordingType};
+use re_log_types::{DataRow, StoreKind};
 use rerun::{
     log::{PathOp, RowId},
     sink::MemorySinkStorage,
@@ -211,9 +211,9 @@ fn new_recording(
     });
 
     let recording_id = if let Some(recording_id) = recording_id {
-        RecordingId::from_string(RecordingType::Data, recording_id)
+        RecordingId::from_string(StoreKind::Recording, recording_id)
     } else {
-        default_recording_id(py, RecordingType::Data, &application_id)
+        default_recording_id(py, StoreKind::Recording, &application_id)
     };
 
     let recording = RecordingStreamBuilder::new(application_id)
@@ -261,9 +261,9 @@ fn new_blueprint(
     default_enabled: bool,
 ) -> PyResult<PyRecordingStream> {
     let blueprint_id = if let Some(blueprint_id) = blueprint_id {
-        RecordingId::from_string(RecordingType::Blueprint, blueprint_id)
+        RecordingId::from_string(StoreKind::Blueprint, blueprint_id)
     } else {
-        default_recording_id(py, RecordingType::Blueprint, &application_id)
+        default_recording_id(py, StoreKind::Blueprint, &application_id)
     };
 
     let blueprint = RecordingStreamBuilder::new(application_id)
@@ -336,7 +336,7 @@ fn get_recording_id(recording: Option<&PyRecordingStream>) -> Option<String> {
 #[pyfunction]
 fn get_data_recording(recording: Option<&PyRecordingStream>) -> Option<PyRecordingStream> {
     RecordingStream::get_quiet(
-        rerun::RecordingType::Data,
+        rerun::StoreKind::Recording,
         recording.map(|rec| rec.0.clone()),
     )
     .map(PyRecordingStream)
@@ -345,7 +345,7 @@ fn get_data_recording(recording: Option<&PyRecordingStream>) -> Option<PyRecordi
 /// Returns the currently active data recording in the global scope, if any.
 #[pyfunction]
 fn get_global_data_recording() -> Option<PyRecordingStream> {
-    RecordingStream::global(rerun::RecordingType::Data).map(PyRecordingStream)
+    RecordingStream::global(rerun::StoreKind::Recording).map(PyRecordingStream)
 }
 
 /// Replaces the currently active recording in the global scope with the specified one.
@@ -365,7 +365,7 @@ fn set_global_data_recording(
     // sorry.
     py.allow_threads(|| {
         RecordingStream::set_global(
-            rerun::RecordingType::Data,
+            rerun::StoreKind::Recording,
             recording.map(|rec| rec.0.clone()),
         )
         .map(PyRecordingStream)
@@ -375,7 +375,7 @@ fn set_global_data_recording(
 /// Returns the currently active data recording in the thread-local scope, if any.
 #[pyfunction]
 fn get_thread_local_data_recording() -> Option<PyRecordingStream> {
-    RecordingStream::thread_local(rerun::RecordingType::Data).map(PyRecordingStream)
+    RecordingStream::thread_local(rerun::StoreKind::Recording).map(PyRecordingStream)
 }
 
 /// Replaces the currently active recording in the thread-local scope with the specified one.
@@ -395,7 +395,7 @@ fn set_thread_local_data_recording(
     // sorry.
     py.allow_threads(|| {
         RecordingStream::set_thread_local(
-            rerun::RecordingType::Data,
+            rerun::StoreKind::Recording,
             recording.map(|rec| rec.0.clone()),
         )
         .map(PyRecordingStream)
@@ -407,7 +407,7 @@ fn set_thread_local_data_recording(
 #[pyfunction]
 fn get_blueprint_recording(overrides: Option<&PyRecordingStream>) -> Option<PyRecordingStream> {
     RecordingStream::get_quiet(
-        rerun::RecordingType::Blueprint,
+        rerun::StoreKind::Blueprint,
         overrides.map(|rec| rec.0.clone()),
     )
     .map(PyRecordingStream)
@@ -416,7 +416,7 @@ fn get_blueprint_recording(overrides: Option<&PyRecordingStream>) -> Option<PyRe
 /// Returns the currently active blueprint recording in the global scope, if any.
 #[pyfunction]
 fn get_global_blueprint_recording() -> Option<PyRecordingStream> {
-    RecordingStream::global(rerun::RecordingType::Blueprint).map(PyRecordingStream)
+    RecordingStream::global(rerun::StoreKind::Blueprint).map(PyRecordingStream)
 }
 
 /// Replaces the currently active recording in the global scope with the specified one.
@@ -436,7 +436,7 @@ fn set_global_blueprint_recording(
     // sorry.
     py.allow_threads(|| {
         RecordingStream::set_global(
-            rerun::RecordingType::Blueprint,
+            rerun::StoreKind::Blueprint,
             recording.map(|rec| rec.0.clone()),
         )
         .map(PyRecordingStream)
@@ -446,7 +446,7 @@ fn set_global_blueprint_recording(
 /// Returns the currently active blueprint recording in the thread-local scope, if any.
 #[pyfunction]
 fn get_thread_local_blueprint_recording() -> Option<PyRecordingStream> {
-    RecordingStream::thread_local(rerun::RecordingType::Blueprint).map(PyRecordingStream)
+    RecordingStream::thread_local(rerun::StoreKind::Blueprint).map(PyRecordingStream)
 }
 
 /// Replaces the currently active recording in the thread-local scope with the specified one.
@@ -466,7 +466,7 @@ fn set_thread_local_blueprint_recording(
     // sorry.
     py.allow_threads(|| {
         RecordingStream::set_thread_local(
-            rerun::RecordingType::Blueprint,
+            rerun::StoreKind::Blueprint,
             recording.map(|rec| rec.0.clone()),
         )
         .map(PyRecordingStream)
@@ -1326,11 +1326,7 @@ fn python_version(py: Python<'_>) -> re_log_types::PythonVersion {
     }
 }
 
-fn default_recording_id(
-    py: Python<'_>,
-    variant: RecordingType,
-    application_id: &str,
-) -> RecordingId {
+fn default_recording_id(py: Python<'_>, variant: StoreKind, application_id: &str) -> RecordingId {
     use rand::{Rng as _, SeedableRng as _};
     use std::hash::{Hash as _, Hasher as _};
 

--- a/tests/rust/test_image_memory/src/main.rs
+++ b/tests/rust/test_image_memory/src/main.rs
@@ -13,8 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         re_viewer::env_vars::RERUN_TRACK_ALLOCATIONS,
     );
 
-    let recording_info = rerun::new_recording_info("test_image_memory_rs");
-    rerun::native_viewer::spawn(recording_info, Default::default(), |rec_stream| {
+    let store_info = rerun::new_store_info("test_image_memory_rs");
+    rerun::native_viewer::spawn(store_info, Default::default(), |rec_stream| {
         log_images(&rec_stream).unwrap();
     })?;
     Ok(())


### PR DESCRIPTION
Tip: review commit-by-commit

### What
Break out a simple `StoreHub` from `App`. It is responsible for handling all loaded recordings and blueprints.

This PR also fixes a bug where we would before assume an `.rrd` file could only contain data from a single store, and assumed that store was a recording.

### Renames
A _Store_ is either a _Recording_ or a _Blueprint_. So now we have:

* `LogDb -> StoreDb`
* `RecordingId -> StoreId`
* `RecordingInfo -> StoreInfo` and `SetRecordingInfo -> SetStoreInfo`
* `RecordingSource -> StoreSource`
* `RecordingType -> StoreKind`


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2301

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/1f07303/docs
<!-- pr-link-docs:end -->
