### PR TITLE
Fix unstable order/flickering of "shown in" space view list on selection

### DIFF
--- a/crates/re_viewer/src/ui/blueprint_load.rs
+++ b/crates/re_viewer/src/ui/blueprint_load.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use ahash::HashMap;
 
 use re_data_store::{query_timeless_single, EntityPath};
@@ -111,7 +113,7 @@ fn load_viewport(
         .map(|(k, v)| (*k, v.clone()))
         .collect();
 
-    let known_space_views: HashMap<_, _> = space_views
+    let known_space_views: BTreeMap<_, _> = space_views
         .into_iter()
         .filter(|(k, _)| viewport_layout.space_view_keys.contains(k))
         .collect();

--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -51,7 +51,7 @@ pub(crate) fn tree_from_space_views(
     ctx: &mut ViewerContext<'_>,
     viewport_size: egui::Vec2,
     visible: &std::collections::BTreeSet<SpaceViewId>,
-    space_views: &HashMap<SpaceViewId, SpaceViewBlueprint>,
+    space_views: &BTreeMap<SpaceViewId, SpaceViewBlueprint>,
     space_view_states: &HashMap<SpaceViewId, SpaceViewState>,
 ) -> egui_tiles::Tree<SpaceViewId> {
     let mut space_make_infos = space_views

--- a/crates/re_viewport/src/space_view_highlights.rs
+++ b/crates/re_viewport/src/space_view_highlights.rs
@@ -1,4 +1,5 @@
-use ahash::HashMap;
+use std::collections::BTreeMap;
+
 use egui::NumExt;
 use nohash_hasher::IntMap;
 
@@ -14,7 +15,7 @@ use crate::SpaceViewBlueprint;
 pub fn highlights_for_space_view(
     selection_state: &SelectionState,
     space_view_id: SpaceViewId,
-    space_views: &HashMap<SpaceViewId, SpaceViewBlueprint>,
+    space_views: &BTreeMap<SpaceViewId, SpaceViewBlueprint>,
 ) -> SpaceViewHighlights {
     re_tracing::profile_function!();
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains all space views.
 
+use std::collections::BTreeMap;
+
 use ahash::HashMap;
 use itertools::Itertools as _;
 
@@ -32,7 +34,9 @@ pub type VisibilitySet = std::collections::BTreeSet<SpaceViewId>;
 #[serde(default)]
 pub struct Viewport {
     /// Where the space views are stored.
-    pub space_views: HashMap<SpaceViewId, SpaceViewBlueprint>,
+    ///
+    /// Not a hashmap in order to preserve the order of the space views.
+    pub space_views: BTreeMap<SpaceViewId, SpaceViewBlueprint>,
 
     /// Which views are visible.
     pub visible: VisibilitySet,
@@ -677,7 +681,7 @@ fn visibility_button_ui(
 struct TabViewer<'a, 'b> {
     viewport_state: &'a mut ViewportState,
     ctx: &'a mut ViewerContext<'b>,
-    space_views: &'a mut HashMap<SpaceViewId, SpaceViewBlueprint>,
+    space_views: &'a mut BTreeMap<SpaceViewId, SpaceViewBlueprint>,
     maximized: &'a mut Option<SpaceViewId>,
 }
 


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

List of space views is now a BTreeMap, not a HashMap
Fixes #2193
* #2193

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)


<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
