### PR TITLE
Reduce need for mutable App access, towards decoupling with the ViewerContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -4408,6 +4409,7 @@ dependencies = [
 name = "re_ui"
 version = "0.7.0-alpha.0"
 dependencies = [
+ "crossbeam",
  "eframe",
  "egui",
  "egui_extras",
@@ -4433,12 +4435,14 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cocoa",
+ "crossbeam",
  "eframe",
  "egui",
  "egui-wgpu",
  "image",
  "itertools",
  "objc",
+ "parking_lot 0.12.1",
  "poll-promise",
  "puffin",
  "puffin_http",

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1"
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 sublime_fuzzy = "0.7"
+crossbeam.workspace = true
 
 ## Optional dependencies:
 eframe = { workspace = true, optional = true, default-features = false }

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -1,4 +1,4 @@
-use re_ui::{toasts, Command, CommandPalette};
+use re_ui::{toasts, Command, CommandPalette, CommandReceiver, CommandSender};
 
 fn main() -> eframe::Result<()> {
     re_log::setup_native_logging();
@@ -49,7 +49,8 @@ pub struct ExampleApp {
     cmd_palette: CommandPalette,
 
     /// Commands to run at the end of the frame.
-    pending_commands: Vec<Command>,
+    pub command_sender: CommandSender,
+    command_receiver: CommandReceiver,
     latest_cmd: String,
 }
 
@@ -59,6 +60,8 @@ impl ExampleApp {
         re_log::add_boxed_logger(Box::new(logger)).unwrap();
 
         let tree = egui_tiles::Tree::new_tabs(vec![1, 2, 3]);
+
+        let (command_sender, command_receiver) = crossbeam::channel::unbounded();
 
         Self {
             re_ui,
@@ -74,7 +77,8 @@ impl ExampleApp {
             dummy_bool: true,
 
             cmd_palette: CommandPalette::default(),
-            pending_commands: Default::default(),
+            command_sender,
+            command_receiver,
             latest_cmd: Default::default(),
         }
     }
@@ -205,13 +209,13 @@ impl eframe::App for ExampleApp {
             });
 
         if let Some(cmd) = self.cmd_palette.show(egui_ctx) {
-            self.pending_commands.push(cmd);
+            self.command_sender.send(cmd).ok();
         }
         if let Some(cmd) = re_ui::Command::listen_for_kb_shortcut(egui_ctx) {
-            self.pending_commands.push(cmd);
+            self.command_sender.send(cmd).ok();
         }
 
-        for cmd in self.pending_commands.drain(..) {
+        while let Ok(cmd) = self.command_receiver.try_recv() {
             self.latest_cmd = cmd.text().to_owned();
 
             #[allow(clippy::single_match)]
@@ -248,7 +252,7 @@ impl ExampleApp {
                     ui.set_height(top_bar_style.height);
                     ui.add_space(top_bar_style.indent);
 
-                    ui.menu_button("File", |ui| file_menu(ui, &mut self.pending_commands));
+                    ui.menu_button("File", |ui| file_menu(ui, &self.command_sender));
 
                     self.top_bar_ui(ui, frame);
                 })
@@ -297,11 +301,11 @@ impl ExampleApp {
     }
 }
 
-fn file_menu(ui: &mut egui::Ui, pending_commands: &mut Vec<Command>) {
-    Command::Save.menu_button_ui(ui, pending_commands);
-    Command::SaveSelection.menu_button_ui(ui, pending_commands);
-    Command::Open.menu_button_ui(ui, pending_commands);
-    Command::Quit.menu_button_ui(ui, pending_commands);
+fn file_menu(ui: &mut egui::Ui, command_sender: &CommandSender) {
+    Command::Save.menu_button_ui(ui, command_sender);
+    Command::SaveSelection.menu_button_ui(ui, command_sender);
+    Command::Open.menu_button_ui(ui, command_sender);
+    Command::Quit.menu_button_ui(ui, command_sender);
 }
 
 fn selection_buttons(ui: &mut egui::Ui) {

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -1,5 +1,11 @@
 use egui::{Key, KeyboardShortcut, Modifiers};
 
+/// Sender that queues up the execution of a command.
+pub type CommandSender = crossbeam::channel::Sender<Command>;
+
+/// Receiver for the [`CommandSender`]
+pub type CommandReceiver = crossbeam::channel::Receiver<Command>;
+
 /// All the commands we support.
 ///
 /// Most are available in the GUI,
@@ -232,12 +238,12 @@ impl Command {
     pub fn menu_button_ui(
         self,
         ui: &mut egui::Ui,
-        pending_commands: &mut Vec<Command>,
+        command_sender: &CommandSender,
     ) -> egui::Response {
         let button = self.menu_button(ui.ctx());
         let response = ui.add(button).on_hover_text(self.tooltip());
         if response.clicked() {
-            pending_commands.push(self);
+            command_sender.send(self).ok();
             ui.close_menu();
         }
         response

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -10,7 +10,7 @@ mod static_image_cache;
 pub mod toasts;
 mod toggle_switch;
 
-pub use command::Command;
+pub use command::{Command, CommandReceiver, CommandSender};
 pub use command_palette::CommandPalette;
 pub use design_tokens::DesignTokens;
 pub use icons::Icon;

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -72,6 +72,7 @@ anyhow.workspace = true
 arrow2.workspace = true
 arrow2_convert.workspace = true
 bytemuck.workspace = true
+crossbeam.workspace = true
 cfg-if.workspace = true
 eframe = { workspace = true, default-features = false, features = [
   "default_fonts",
@@ -86,6 +87,7 @@ image = { workspace = true, default-features = false, features = [
   "png",
 ] }
 itertools = { workspace = true }
+parking_lot = { workspace = true, features = ["serde"] }
 poll-promise = "0.2"
 rfd.workspace = true
 serde = { version = "1", features = ["derive"] }

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -1,5 +1,5 @@
 /// Global options for the viewer.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct AppOptions {
     pub low_latency: f32,


### PR DESCRIPTION


<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

In hope to help out #2330, but doesn't nearly go far enough yet.

Interior mutability for App's pending commands, app options and selected recording & blueprint


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2333

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/e95997a/docs
Examples preview: https://rerun.io/preview/e95997a/examples
<!-- pr-link-docs:end -->
