### PR TITLE
Things broken on main

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -16,3 +16,10 @@ teh = "teh" # part of @teh-cmc
 
 # American English:
 grey = "gray"
+
+[default]
+# Work around for typos inside of 8-character hashes. These show up inside of ipynb.
+# e.g. "f4e1caf9" -> `caf` should be `calf`
+# Specifically limit ourselves to exactly 8 chars in a quoted strong.
+# Just don't spell "defaced" wrong.
+extend-ignore-re = ["\"[a-f0-9]{8}\""]

--- a/crates/re_components/src/coordinates.rs
+++ b/crates/re_components/src/coordinates.rs
@@ -448,7 +448,7 @@ impl Handedness {
 
 #[cfg(feature = "glam")]
 #[test]
-fn view_coordinatess() {
+fn view_coordinates() {
     use glam::{vec3, Mat3};
 
     {

--- a/crates/re_renderer/shader/outlines/jumpflooding_init.wgsl
+++ b/crates/re_renderer/shader/outlines/jumpflooding_init.wgsl
@@ -21,7 +21,7 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
     var edge_pos_a_and_b = Vec4(0.0);
     var num_edges_a_and_b = Vec2(0.0);
 
-    // A lot of this code is repetetive, but wgsl/naga doesn't know yet how to do static indexing from unrolled loops.
+    // A lot of this code is repetitive, but wgsl/naga doesn't know yet how to do static indexing from unrolled loops.
 
     // Sample closest neighbors top/bottom/left/right
     { // right

--- a/crates/re_renderer/shader/outlines/jumpflooding_init_msaa.wgsl
+++ b/crates/re_renderer/shader/outlines/jumpflooding_init_msaa.wgsl
@@ -69,7 +69,7 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
         edge_pos_a_and_b += edge.xxyy * 0.5;
     }
 
-    // A lot of this code is repetetive, but wgsl/naga doesn't know yet how to do static indexing from unrolled loops.
+    // A lot of this code is repetitive, but wgsl/naga doesn't know yet how to do static indexing from unrolled loops.
 
     // Sample closest neighbors top/bottom/left/right
     { // right

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "re_tuid"
 authors.workspace = true
-description = "128-bit Time-based Unique IDentifier"
+description = "128-bit Time-based Unique Identifier"
 edition.workspace = true
 homepage.workspace = true
 include.workspace = true

--- a/crates/re_tuid/README.md
+++ b/crates/re_tuid/README.md
@@ -1,4 +1,4 @@
-# TUID: Time-based Unique IDentifier
+# TUID: Time-based Unique Identifier
 
 Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools as _;
 use web_time::Instant;
 
 use re_arrow_store::{DataStoreConfig, DataStoreStats};
@@ -1107,6 +1106,7 @@ fn save_database_to_file(
     path: std::path::PathBuf,
     time_selection: Option<(re_data_store::Timeline, re_log_types::TimeRangeF)>,
 ) -> anyhow::Result<impl FnOnce() -> anyhow::Result<std::path::PathBuf>> {
+    use itertools::Itertools as _;
     use re_arrow_store::TimeRange;
 
     re_tracing::profile_scope!("dump_messages");


### PR DESCRIPTION
Looks like [https://github.com/crate-c](https://github.com/crate-ci/typos/releases/tag/v1.15.0) came out at some point and broke spellcheck.

Not sure how the itertools thing snuck through.

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/a1103e5/docs
Examples preview: https://rerun.io/preview/a1103e5/examples
<!-- pr-link-docs:end -->
