### PR TITLE
Expand CommandSender to support SystemCommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,6 +4557,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "bytemuck",
+ "crossbeam",
  "egui",
  "egui-wgpu",
  "glam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,7 +4477,6 @@ dependencies = [
 name = "re_ui"
 version = "0.7.0-alpha.0"
 dependencies = [
- "crossbeam",
  "eframe",
  "egui",
  "egui_extras",
@@ -4557,7 +4556,6 @@ dependencies = [
  "anyhow",
  "arboard",
  "bytemuck",
- "crossbeam",
  "egui",
  "egui-wgpu",
  "glam",

--- a/crates/re_time_panel/src/time_control_ui.rs
+++ b/crates/re_time_panel/src/time_control_ui.rs
@@ -213,7 +213,7 @@ impl TimeControlUi {
 }
 
 fn toggle_playback_text(egui_ctx: &egui::Context) -> String {
-    if let Some(shortcut) = re_ui::Command::PlaybackTogglePlayPause.kb_shortcut() {
+    if let Some(shortcut) = re_ui::UICommand::PlaybackTogglePlayPause.kb_shortcut() {
         format!(" Toggle with {}", egui_ctx.format_shortcut(&shortcut))
     } else {
         Default::default()

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -43,7 +43,6 @@ sublime_fuzzy = "0.7"
 eframe = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
-crossbeam.workspace = true
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }
 egui_tiles.workspace = true
 re_log.workspace = true

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -29,7 +29,6 @@ eframe = ["dep:eframe"]
 
 
 [dependencies]
-crossbeam.workspace = true
 egui_extras.workspace = true
 egui.workspace = true
 image = { workspace = true, default-features = false, features = ["png"] }
@@ -44,6 +43,7 @@ sublime_fuzzy = "0.7"
 eframe = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
+crossbeam.workspace = true
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }
 egui_tiles.workspace = true
 re_log.workspace = true

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -1,7 +1,7 @@
 use re_ui::{toasts, CommandPalette, UICommand, UICommandSender};
 
 /// Sender that queues up the execution of a command.
-pub struct CommandSender(crossbeam::channel::Sender<UICommand>);
+pub struct CommandSender(std::sync::mpsc::Sender<UICommand>);
 
 impl UICommandSender for CommandSender {
     /// Send a command to be executed.
@@ -12,7 +12,7 @@ impl UICommandSender for CommandSender {
 }
 
 /// Receiver for the [`CommandSender`]
-pub struct CommandReceiver(crossbeam::channel::Receiver<UICommand>);
+pub struct CommandReceiver(std::sync::mpsc::Receiver<UICommand>);
 
 impl CommandReceiver {
     /// Receive a command to be executed if any is queued.
@@ -25,7 +25,7 @@ impl CommandReceiver {
 
 /// Creates a new command channel.
 fn command_channel() -> (CommandSender, CommandReceiver) {
-    let (sender, receiver) = crossbeam::channel::unbounded();
+    let (sender, receiver) = std::sync::mpsc::channel();
     (CommandSender(sender), CommandReceiver(receiver))
 }
 

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -1,32 +1,8 @@
 use egui::{Key, KeyboardShortcut, Modifiers};
 
-/// Sender that queues up the execution of a command.
-pub struct CommandSender(crossbeam::channel::Sender<Command>);
-
-impl CommandSender {
-    /// Send a command to be executed.
-    pub fn send(&self, command: Command) {
-        // The only way this can fail is if the receiver has been dropped.
-        self.0.send(command).ok();
-    }
-}
-
-/// Receiver for the [`CommandSender`]
-pub struct CommandReceiver(crossbeam::channel::Receiver<Command>);
-
-impl CommandReceiver {
-    /// Receive a command to be executed if any is queued.
-    pub fn recv(&self) -> Option<Command> {
-        // The only way this can fail (other than being empty)
-        // is if the sender has been dropped.
-        self.0.try_recv().ok()
-    }
-}
-
-/// Creates a new command channel.
-pub fn command_channel() -> (CommandSender, CommandReceiver) {
-    let (sender, receiver) = crossbeam::channel::unbounded();
-    (CommandSender(sender), CommandReceiver(receiver))
+/// Interface for sending [`UICommand`] messages.
+pub trait UICommandSender {
+    fn send_ui(&self, command: UICommand);
 }
 
 /// All the commands we support.
@@ -35,7 +11,7 @@ pub fn command_channel() -> (CommandSender, CommandReceiver) {
 /// some have keyboard shortcuts,
 /// and all are visible in the [`crate::CommandPalette`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, strum_macros::EnumIter)]
-pub enum Command {
+pub enum UICommand {
     // Listed in the order they show up in the command palette by default!
     #[cfg(not(target_arch = "wasm32"))]
     Open,
@@ -82,7 +58,7 @@ pub enum Command {
     ScreenshotWholeApp,
 }
 
-impl Command {
+impl UICommand {
     pub fn text(self) -> &'static str {
         self.text_and_tooltip().0
     }
@@ -94,76 +70,76 @@ impl Command {
     pub fn text_and_tooltip(self) -> (&'static str, &'static str) {
         match self {
             #[cfg(not(target_arch = "wasm32"))]
-            Command::Save => ("Save…", "Save all data to a Rerun data file (.rrd)"),
+            UICommand::Save => ("Save…", "Save all data to a Rerun data file (.rrd)"),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::SaveSelection => (
+            UICommand::SaveSelection => (
                 "Save loop selection…",
                 "Save data for the current loop selection to a Rerun data file (.rrd)",
             ),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::Open => ("Open…", "Open a Rerun Data File (.rrd)"),
+            UICommand::Open => ("Open…", "Open a Rerun Data File (.rrd)"),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::Quit => ("Quit", "Close the Rerun Viewer"),
+            UICommand::Quit => ("Quit", "Close the Rerun Viewer"),
 
-            Command::ResetViewer => (
+            UICommand::ResetViewer => (
                 "Reset viewer",
                 "Reset the viewer to how it looked the first time you ran it",
             ),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::OpenProfiler => (
+            UICommand::OpenProfiler => (
                 "Open profiler",
                 "Starts a profiler, showing what makes the viewer run slow",
             ),
 
-            Command::ToggleMemoryPanel => (
+            UICommand::ToggleMemoryPanel => (
                 "Toggle memory panel",
                 "Investigate what is using up RAM in Rerun Viewer",
             ),
-            Command::ToggleBlueprintPanel => ("Toggle blueprint panel", "Toggle the left panel"),
-            Command::ToggleSelectionPanel => ("Toggle selection panel", "Toggle the right panel"),
-            Command::ToggleTimePanel => ("Toggle time panel", "Toggle the bottom time panel"),
+            UICommand::ToggleBlueprintPanel => ("Toggle blueprint panel", "Toggle the left panel"),
+            UICommand::ToggleSelectionPanel => ("Toggle selection panel", "Toggle the right panel"),
+            UICommand::ToggleTimePanel => ("Toggle time panel", "Toggle the bottom time panel"),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::ToggleFullscreen => (
+            UICommand::ToggleFullscreen => (
                 "Toggle fullscreen",
                 "Toggle between windowed and fullscreen viewer",
             ),
             #[cfg(not(target_arch = "wasm32"))]
-            Command::ZoomIn => ("Zoom In", "Increases the ui scaling factor"),
+            UICommand::ZoomIn => ("Zoom In", "Increases the ui scaling factor"),
             #[cfg(not(target_arch = "wasm32"))]
-            Command::ZoomOut => ("Zoom Out", "Decreases the ui scaling factor"),
+            UICommand::ZoomOut => ("Zoom Out", "Decreases the ui scaling factor"),
             #[cfg(not(target_arch = "wasm32"))]
-            Command::ZoomReset => (
+            UICommand::ZoomReset => (
                 "Reset Zoom",
                 "Resets ui scaling factor to the OS provided default",
             ),
 
-            Command::SelectionPrevious => ("Previous selection", "Go to previous selection"),
-            Command::SelectionNext => ("Next selection", "Go to next selection"),
-            Command::ToggleCommandPalette => {
+            UICommand::SelectionPrevious => ("Previous selection", "Go to previous selection"),
+            UICommand::SelectionNext => ("Next selection", "Go to next selection"),
+            UICommand::ToggleCommandPalette => {
                 ("Command palette…", "Toggle the command palette window")
             }
 
-            Command::PlaybackTogglePlayPause => {
+            UICommand::PlaybackTogglePlayPause => {
                 ("Toggle play/pause", "Either play or pause the time")
             }
-            Command::PlaybackFollow => ("Follow", "Follow on from end of timeline"),
-            Command::PlaybackStepBack => (
+            UICommand::PlaybackFollow => ("Follow", "Follow on from end of timeline"),
+            UICommand::PlaybackStepBack => (
                 "Step time back",
                 "Move the time marker back to the previous point in time with any data",
             ),
-            Command::PlaybackStepForward => (
+            UICommand::PlaybackStepForward => (
                 "Step time forward",
                 "Move the time marker to the next point in time with any data",
             ),
-            Command::PlaybackRestart => ("Restart", "Restart from beginning of timeline"),
+            UICommand::PlaybackRestart => ("Restart", "Restart from beginning of timeline"),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::ScreenshotWholeApp => (
+            UICommand::ScreenshotWholeApp => (
                 "Screenshot",
                 "Copy screenshot of the whole app to clipboard",
             ),
@@ -190,52 +166,52 @@ impl Command {
 
         match self {
             #[cfg(not(target_arch = "wasm32"))]
-            Command::Save => Some(cmd(Key::S)),
+            UICommand::Save => Some(cmd(Key::S)),
             #[cfg(not(target_arch = "wasm32"))]
-            Command::SaveSelection => Some(cmd_shift(Key::S)),
+            UICommand::SaveSelection => Some(cmd_shift(Key::S)),
             #[cfg(not(target_arch = "wasm32"))]
-            Command::Open => Some(cmd(Key::O)),
+            UICommand::Open => Some(cmd(Key::O)),
 
             #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
-            Command::Quit => Some(KeyboardShortcut::new(Modifiers::ALT, Key::F4)),
+            UICommand::Quit => Some(KeyboardShortcut::new(Modifiers::ALT, Key::F4)),
 
             #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-            Command::Quit => Some(cmd(Key::Q)),
+            UICommand::Quit => Some(cmd(Key::Q)),
 
-            Command::ResetViewer => Some(ctrl_shift(Key::R)),
+            UICommand::ResetViewer => Some(ctrl_shift(Key::R)),
             #[cfg(not(target_arch = "wasm32"))]
-            Command::OpenProfiler => Some(ctrl_shift(Key::P)),
-            Command::ToggleMemoryPanel => Some(ctrl_shift(Key::M)),
-            Command::ToggleBlueprintPanel => Some(ctrl_shift(Key::B)),
-            Command::ToggleSelectionPanel => Some(ctrl_shift(Key::S)),
-            Command::ToggleTimePanel => Some(ctrl_shift(Key::T)),
-
-            #[cfg(not(target_arch = "wasm32"))]
-            Command::ToggleFullscreen => Some(key(Key::F11)),
-            #[cfg(not(target_arch = "wasm32"))]
-            Command::ZoomIn => Some(egui::gui_zoom::kb_shortcuts::ZOOM_IN),
-            #[cfg(not(target_arch = "wasm32"))]
-            Command::ZoomOut => Some(egui::gui_zoom::kb_shortcuts::ZOOM_OUT),
-            #[cfg(not(target_arch = "wasm32"))]
-            Command::ZoomReset => Some(egui::gui_zoom::kb_shortcuts::ZOOM_RESET),
-
-            Command::SelectionPrevious => Some(ctrl_shift(Key::ArrowLeft)),
-            Command::SelectionNext => Some(ctrl_shift(Key::ArrowRight)),
-            Command::ToggleCommandPalette => Some(cmd(Key::P)),
-
-            Command::PlaybackTogglePlayPause => Some(key(Key::Space)),
-            Command::PlaybackFollow => Some(cmd(Key::ArrowRight)),
-            Command::PlaybackStepBack => Some(key(Key::ArrowLeft)),
-            Command::PlaybackStepForward => Some(key(Key::ArrowRight)),
-            Command::PlaybackRestart => Some(cmd(Key::ArrowLeft)),
+            UICommand::OpenProfiler => Some(ctrl_shift(Key::P)),
+            UICommand::ToggleMemoryPanel => Some(ctrl_shift(Key::M)),
+            UICommand::ToggleBlueprintPanel => Some(ctrl_shift(Key::B)),
+            UICommand::ToggleSelectionPanel => Some(ctrl_shift(Key::S)),
+            UICommand::ToggleTimePanel => Some(ctrl_shift(Key::T)),
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::ScreenshotWholeApp => None,
+            UICommand::ToggleFullscreen => Some(key(Key::F11)),
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::ZoomIn => Some(egui::gui_zoom::kb_shortcuts::ZOOM_IN),
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::ZoomOut => Some(egui::gui_zoom::kb_shortcuts::ZOOM_OUT),
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::ZoomReset => Some(egui::gui_zoom::kb_shortcuts::ZOOM_RESET),
+
+            UICommand::SelectionPrevious => Some(ctrl_shift(Key::ArrowLeft)),
+            UICommand::SelectionNext => Some(ctrl_shift(Key::ArrowRight)),
+            UICommand::ToggleCommandPalette => Some(cmd(Key::P)),
+
+            UICommand::PlaybackTogglePlayPause => Some(key(Key::Space)),
+            UICommand::PlaybackFollow => Some(cmd(Key::ArrowRight)),
+            UICommand::PlaybackStepBack => Some(key(Key::ArrowLeft)),
+            UICommand::PlaybackStepForward => Some(key(Key::ArrowRight)),
+            UICommand::PlaybackRestart => Some(cmd(Key::ArrowLeft)),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::ScreenshotWholeApp => None,
         }
     }
 
     #[must_use = "Returns the Command that was triggered by some keyboard shortcut"]
-    pub fn listen_for_kb_shortcut(egui_ctx: &egui::Context) -> Option<Command> {
+    pub fn listen_for_kb_shortcut(egui_ctx: &egui::Context) -> Option<UICommand> {
         use strum::IntoEnumIterator as _;
 
         let anything_has_focus = egui_ctx.memory(|mem| mem.focus().is_some());
@@ -244,7 +220,7 @@ impl Command {
         }
 
         egui_ctx.input_mut(|input| {
-            for command in Command::iter() {
+            for command in UICommand::iter() {
                 if let Some(kb_shortcut) = command.kb_shortcut() {
                     if input.consume_shortcut(&kb_shortcut) {
                         return Some(command);
@@ -261,12 +237,12 @@ impl Command {
     pub fn menu_button_ui(
         self,
         ui: &mut egui::Ui,
-        command_sender: &CommandSender,
+        command_sender: &impl UICommandSender,
     ) -> egui::Response {
         let button = self.menu_button(ui.ctx());
         let response = ui.add(button).on_hover_text(self.tooltip());
         if response.clicked() {
-            command_sender.send(self);
+            command_sender.send_ui(self);
             ui.close_menu();
         }
         response

--- a/crates/re_ui/src/command_palette.rs
+++ b/crates/re_ui/src/command_palette.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use egui::{Align2, Key, NumExt as _};
 
-use crate::Command;
+use crate::UICommand;
 
 #[derive(Default)]
 pub struct CommandPalette {
@@ -18,7 +18,7 @@ impl CommandPalette {
 
     /// Show the command palette, if it is visible.
     #[must_use = "Returns the command that was selected"]
-    pub fn show(&mut self, egui_ctx: &egui::Context) -> Option<Command> {
+    pub fn show(&mut self, egui_ctx: &egui::Context) -> Option<UICommand> {
         self.visible &= !egui_ctx.input_mut(|i| i.consume_key(Default::default(), Key::Escape));
         if !self.visible {
             self.query.clear();
@@ -39,7 +39,7 @@ impl CommandPalette {
     }
 
     #[must_use = "Returns the command that was selected"]
-    fn window_content_ui(&mut self, ui: &mut egui::Ui) -> Option<Command> {
+    fn window_content_ui(&mut self, ui: &mut egui::Ui) -> Option<UICommand> {
         // Check _before_ we add the `TextEdit`, so it doesn't steal it.
         let enter_pressed = ui.input_mut(|i| i.consume_key(Default::default(), Key::Enter));
 
@@ -75,7 +75,7 @@ impl CommandPalette {
         ui: &mut egui::Ui,
         enter_pressed: bool,
         mut scroll_to_selected_alternative: bool,
-    ) -> Option<Command> {
+    ) -> Option<UICommand> {
         scroll_to_selected_alternative |= ui.input(|i| i.key_pressed(Key::ArrowUp));
         scroll_to_selected_alternative |= ui.input(|i| i.key_pressed(Key::ArrowDown));
 
@@ -172,7 +172,7 @@ impl CommandPalette {
 }
 
 struct FuzzyMatch {
-    command: Command,
+    command: UICommand,
     score: isize,
     fuzzy_match: Option<sublime_fuzzy::Match>,
 }
@@ -181,7 +181,7 @@ fn commands_that_match(query: &str) -> Vec<FuzzyMatch> {
     use strum::IntoEnumIterator as _;
 
     if query.is_empty() {
-        Command::iter()
+        UICommand::iter()
             .map(|command| FuzzyMatch {
                 command,
                 score: 0,
@@ -189,7 +189,7 @@ fn commands_that_match(query: &str) -> Vec<FuzzyMatch> {
             })
             .collect()
     } else {
-        let mut matches: Vec<_> = Command::iter()
+        let mut matches: Vec<_> = UICommand::iter()
             .filter_map(|command| {
                 let target_text = command.text();
                 sublime_fuzzy::best_match(query, target_text).map(|fuzzy_match| FuzzyMatch {

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -10,7 +10,7 @@ mod static_image_cache;
 pub mod toasts;
 mod toggle_switch;
 
-pub use command::{command_channel, Command, CommandReceiver, CommandSender};
+pub use command::{UICommand, UICommandSender};
 pub use command_palette::CommandPalette;
 pub use design_tokens::DesignTokens;
 pub use icons::Icon;

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -287,7 +287,7 @@ impl App {
         cmd: UICommand,
         blueprint: &mut Blueprint,
         store_hub: &mut StoreHub,
-        frame: &mut eframe::Frame,
+        _frame: &mut eframe::Frame,
         egui_ctx: &egui::Context,
     ) {
         let is_narrow_screen = egui_ctx.screen_rect().width() < 600.0; // responsive ui for mobiles etc
@@ -313,7 +313,7 @@ impl App {
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Quit => {
-                frame.close();
+                _frame.close();
             }
 
             UICommand::ResetViewer => {
@@ -350,7 +350,7 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ToggleFullscreen => {
-                frame.set_fullscreen(!frame.info().window_info.fullscreen);
+                _frame.set_fullscreen(!_frame.info().window_info.fullscreen);
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ZoomIn => {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -540,6 +540,7 @@ impl App {
                                 &self.component_ui_registry,
                                 &self.space_view_class_registry,
                                 &self.rx,
+                                &self.command_sender,
                             );
 
                             render_ctx.before_submit();

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -4,8 +4,8 @@ use re_data_store::StoreDb;
 use re_log_types::{LogMsg, StoreId, TimeRangeF};
 use re_smart_channel::Receiver;
 use re_viewer_context::{
-    AppOptions, Caches, ComponentUiRegistry, PlayState, RecordingConfig, SpaceViewClassRegistry,
-    StoreContext, ViewerContext,
+    AppOptions, Caches, CommandSender, ComponentUiRegistry, PlayState, RecordingConfig,
+    SpaceViewClassRegistry, StoreContext, ViewerContext,
 };
 use re_viewport::ViewportState;
 
@@ -79,6 +79,7 @@ impl AppState {
         component_ui_registry: &ComponentUiRegistry,
         space_view_class_registry: &SpaceViewClassRegistry,
         rx: &Receiver<LogMsg>,
+        command_sender: &CommandSender,
     ) {
         re_tracing::profile_function!();
 
@@ -108,6 +109,7 @@ impl AppState {
             rec_cfg,
             re_ui,
             render_ctx,
+            command_sender,
         };
 
         time_panel.show_panel(&mut ctx, ui, blueprint.time_panel_expanded);

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -2,8 +2,8 @@
 
 use egui::NumExt as _;
 
-use re_ui::Command;
-use re_viewer_context::{AppOptions, StoreContext};
+use re_ui::UICommand;
+use re_viewer_context::{AppOptions, StoreContext, SystemCommand, SystemCommandSender};
 
 use crate::App;
 
@@ -29,13 +29,13 @@ pub fn rerun_menu_button_ui(
 
         ui.add_space(spacing);
 
-        Command::ToggleCommandPalette.menu_button_ui(ui, &app.command_sender);
+        UICommand::ToggleCommandPalette.menu_button_ui(ui, &app.command_sender);
 
         ui.add_space(spacing);
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            Command::Open.menu_button_ui(ui, &app.command_sender);
+            UICommand::Open.menu_button_ui(ui, &app.command_sender);
 
             save_buttons_ui(ui, store_context, app);
 
@@ -45,24 +45,24 @@ pub fn rerun_menu_button_ui(
             let zoom_factor = app.app_options().zoom_factor;
             ui.weak(format!("Zoom {:.0}%", zoom_factor * 100.0))
                 .on_hover_text("The zoom factor applied on top of the OS scaling factor.");
-            Command::ZoomIn.menu_button_ui(ui, &app.command_sender);
-            Command::ZoomOut.menu_button_ui(ui, &app.command_sender);
+            UICommand::ZoomIn.menu_button_ui(ui, &app.command_sender);
+            UICommand::ZoomOut.menu_button_ui(ui, &app.command_sender);
             ui.add_enabled_ui(zoom_factor != 1.0, |ui| {
-                Command::ZoomReset.menu_button_ui(ui, &app.command_sender)
+                UICommand::ZoomReset.menu_button_ui(ui, &app.command_sender)
             });
 
-            Command::ToggleFullscreen.menu_button_ui(ui, &app.command_sender);
+            UICommand::ToggleFullscreen.menu_button_ui(ui, &app.command_sender);
 
             ui.add_space(spacing);
         }
 
         {
-            Command::ResetViewer.menu_button_ui(ui, &app.command_sender);
+            UICommand::ResetViewer.menu_button_ui(ui, &app.command_sender);
 
             #[cfg(not(target_arch = "wasm32"))]
-            Command::OpenProfiler.menu_button_ui(ui, &app.command_sender);
+            UICommand::OpenProfiler.menu_button_ui(ui, &app.command_sender);
 
-            Command::ToggleMemoryPanel.menu_button_ui(ui, &app.command_sender);
+            UICommand::ToggleMemoryPanel.menu_button_ui(ui, &app.command_sender);
         }
 
         ui.add_space(spacing);
@@ -86,7 +86,7 @@ pub fn rerun_menu_button_ui(
         #[cfg(not(target_arch = "wasm32"))]
         {
             ui.add_space(spacing);
-            Command::Quit.menu_button_ui(ui, &app.command_sender);
+            UICommand::Quit.menu_button_ui(ui, &app.command_sender);
         }
     });
 }
@@ -132,7 +132,7 @@ fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
     ui.hyperlink_to("www.rerun.io", "https://www.rerun.io/");
 }
 
-fn recordings_menu(ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>, app: &mut App) {
+fn recordings_menu(ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>, app: &App) {
     let store_dbs = store_context.map_or(vec![], |ctx| ctx.alternate_recordings.clone());
 
     if store_dbs.is_empty() {
@@ -159,8 +159,8 @@ fn recordings_menu(ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>, 
             .radio(active_recording == Some(store_db.store_id()), info)
             .clicked()
         {
-            // TODO(jleibs): This is gross but necessary to avoid a deadlock
-            app.requested_recording_id = Some(store_db.store_id().clone());
+            app.command_sender
+                .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
         }
     }
 }
@@ -201,10 +201,12 @@ fn options_menu_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame, options: &mut 
 // TODO(emilk): support saving data on web
 #[cfg(not(target_arch = "wasm32"))]
 fn save_buttons_ui(ui: &mut egui::Ui, store_view: Option<&StoreContext<'_>>, app: &mut App) {
+    use re_ui::UICommandSender;
+
     let file_save_in_progress = app.background_tasks.is_file_save_in_progress();
 
-    let save_button = Command::Save.menu_button(ui.ctx());
-    let save_selection_button = Command::SaveSelection.menu_button(ui.ctx());
+    let save_button = UICommand::Save.menu_button(ui.ctx());
+    let save_selection_button = UICommand::SaveSelection.menu_button(ui.ctx());
 
     if file_save_in_progress {
         ui.add_enabled_ui(false, |ui| {
@@ -228,7 +230,7 @@ fn save_buttons_ui(ui: &mut egui::Ui, store_view: Option<&StoreContext<'_>>, app
                 .clicked()
             {
                 ui.close_menu();
-                app.command_sender.send(Command::Save);
+                app.command_sender.send_ui(UICommand::Save);
             }
 
             // We need to know the loop selection _before_ we can even display the
@@ -245,7 +247,7 @@ fn save_buttons_ui(ui: &mut egui::Ui, store_view: Option<&StoreContext<'_>>, app
                 .clicked()
             {
                 ui.close_menu();
-                app.command_sender.send(Command::SaveSelection);
+                app.command_sender.send_ui(UICommand::SaveSelection);
             }
         });
     }

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -1,5 +1,5 @@
 use egui::RichText;
-use re_ui::Command;
+use re_ui::UICommand;
 use re_viewer_context::{Item, ItemCollection, SelectionHistory};
 
 use crate::ui::Blueprint;
@@ -49,7 +49,7 @@ impl SelectionHistoryUi {
                 {}\n\
                 \n\
                 Right-click for more.",
-                    Command::SelectionPrevious.format_shortcut_tooltip_suffix(ui.ctx()),
+                    UICommand::SelectionPrevious.format_shortcut_tooltip_suffix(ui.ctx()),
                     item_collection_to_string(blueprint, &previous.selection),
                 ));
 
@@ -93,7 +93,7 @@ impl SelectionHistoryUi {
                 {}\n\
                 \n\
                 Right-click for more.",
-                    Command::SelectionNext.format_shortcut_tooltip_suffix(ui.ctx()),
+                    UICommand::SelectionNext.format_shortcut_tooltip_suffix(ui.ctx()),
                     item_collection_to_string(blueprint, &next.selection),
                 ));
 

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -1,6 +1,6 @@
 use re_format::format_number;
 use re_renderer::WgpuResourcePoolStatistics;
-use re_ui::Command;
+use re_ui::{UICommand, UICommandSender};
 use re_viewer_context::StoreContext;
 
 use crate::{ui::Blueprint, App};
@@ -95,11 +95,11 @@ fn top_bar_ui(
             )
             .on_hover_text(format!(
                 "Toggle Selection View{}",
-                Command::ToggleSelectionPanel.format_shortcut_tooltip_suffix(ui.ctx())
+                UICommand::ToggleSelectionPanel.format_shortcut_tooltip_suffix(ui.ctx())
             ))
             .clicked()
         {
-            app.command_sender.send(Command::ToggleSelectionPanel);
+            app.command_sender.send_ui(UICommand::ToggleSelectionPanel);
         }
 
         let mut time_panel_expanded = blueprint.time_panel_expanded;
@@ -112,11 +112,11 @@ fn top_bar_ui(
             )
             .on_hover_text(format!(
                 "Toggle Timeline View{}",
-                Command::ToggleTimePanel.format_shortcut_tooltip_suffix(ui.ctx())
+                UICommand::ToggleTimePanel.format_shortcut_tooltip_suffix(ui.ctx())
             ))
             .clicked()
         {
-            app.command_sender.send(Command::ToggleTimePanel);
+            app.command_sender.send_ui(UICommand::ToggleTimePanel);
         }
 
         let mut blueprint_panel_expanded = blueprint.blueprint_panel_expanded;
@@ -129,11 +129,11 @@ fn top_bar_ui(
             )
             .on_hover_text(format!(
                 "Toggle Blueprint View{}",
-                Command::ToggleBlueprintPanel.format_shortcut_tooltip_suffix(ui.ctx())
+                UICommand::ToggleBlueprintPanel.format_shortcut_tooltip_suffix(ui.ctx())
             ))
             .clicked()
         {
-            app.command_sender.send(Command::ToggleBlueprintPanel);
+            app.command_sender.send_ui(UICommand::ToggleBlueprintPanel);
         }
 
         if cfg!(debug_assertions) && app.app_options().show_metrics {

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -30,6 +30,7 @@ re_ui.workspace = true
 ahash.workspace = true
 anyhow.workspace = true
 bytemuck.workspace = true
+crossbeam.workspace = true
 egui-wgpu.workspace = true
 egui.workspace = true
 glam.workspace = true

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -30,7 +30,6 @@ re_ui.workspace = true
 ahash.workspace = true
 anyhow.workspace = true
 bytemuck.workspace = true
-crossbeam.workspace = true
 egui-wgpu.workspace = true
 egui.workspace = true
 glam.workspace = true

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -23,10 +23,10 @@ pub enum Command {
 }
 
 /// Sender that queues up the execution of a command.
-pub struct CommandSender(crossbeam::channel::Sender<Command>);
+pub struct CommandSender(std::sync::mpsc::Sender<Command>);
 
 /// Receiver for the [`CommandSender`]
-pub struct CommandReceiver(crossbeam::channel::Receiver<Command>);
+pub struct CommandReceiver(std::sync::mpsc::Receiver<Command>);
 
 impl CommandReceiver {
     /// Receive a command to be executed if any is queued.
@@ -39,7 +39,7 @@ impl CommandReceiver {
 
 /// Creates a new command channel.
 pub fn command_channel() -> (CommandSender, CommandReceiver) {
-    let (sender, receiver) = crossbeam::channel::unbounded();
+    let (sender, receiver) = std::sync::mpsc::channel();
     (CommandSender(sender), CommandReceiver(receiver))
 }
 

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -45,18 +45,18 @@ pub fn command_channel() -> (CommandSender, CommandReceiver) {
 
 // ----------------------------------------------------------------------------
 
-impl UICommandSender for CommandSender {
-    /// Send a command to be executed.
-    fn send_ui(&self, command: UICommand) {
-        // The only way this can fail is if the receiver has been dropped.
-        self.0.send(Command::UICommand(command)).ok();
-    }
-}
-
 impl SystemCommandSender for CommandSender {
     /// Send a command to be executed.
     fn send_system(&self, command: SystemCommand) {
         // The only way this can fail is if the receiver has been dropped.
         self.0.send(Command::SystemCommand(command)).ok();
+    }
+}
+
+impl UICommandSender for CommandSender {
+    /// Send a command to be executed.
+    fn send_ui(&self, command: UICommand) {
+        // The only way this can fail is if the receiver has been dropped.
+        self.0.send(Command::UICommand(command)).ok();
     }
 }

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -1,0 +1,62 @@
+use re_log_types::StoreId;
+use re_ui::{UICommand, UICommandSender};
+
+// ----------------------------------------------------------------------------
+
+/// Commands used by internal system components
+// TODO(jleibs): Is there a better crate for this?
+pub enum SystemCommand {
+    SetRecordingId(StoreId),
+}
+
+/// Interface for sending [`SystemCommand`] messages.
+pub trait SystemCommandSender {
+    fn send_system(&self, command: SystemCommand);
+}
+
+// ----------------------------------------------------------------------------
+
+/// Generic Command
+pub enum Command {
+    SystemCommand(SystemCommand),
+    UICommand(UICommand),
+}
+
+/// Sender that queues up the execution of a command.
+pub struct CommandSender(crossbeam::channel::Sender<Command>);
+
+/// Receiver for the [`CommandSender`]
+pub struct CommandReceiver(crossbeam::channel::Receiver<Command>);
+
+impl CommandReceiver {
+    /// Receive a command to be executed if any is queued.
+    pub fn recv(&self) -> Option<Command> {
+        // The only way this can fail (other than being empty)
+        // is if the sender has been dropped.
+        self.0.try_recv().ok()
+    }
+}
+
+/// Creates a new command channel.
+pub fn command_channel() -> (CommandSender, CommandReceiver) {
+    let (sender, receiver) = crossbeam::channel::unbounded();
+    (CommandSender(sender), CommandReceiver(receiver))
+}
+
+// ----------------------------------------------------------------------------
+
+impl UICommandSender for CommandSender {
+    /// Send a command to be executed.
+    fn send_ui(&self, command: UICommand) {
+        // The only way this can fail is if the receiver has been dropped.
+        self.0.send(Command::UICommand(command)).ok();
+    }
+}
+
+impl SystemCommandSender for CommandSender {
+    /// Send a command to be executed.
+    fn send_system(&self, command: SystemCommand) {
+        // The only way this can fail is if the receiver has been dropped.
+        self.0.send(Command::SystemCommand(command)).ok();
+    }
+}

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -5,6 +5,7 @@
 mod annotations;
 mod app_options;
 mod caches;
+mod command_sender;
 mod component_ui_registry;
 mod item;
 mod selection_history;
@@ -24,6 +25,9 @@ use std::hash::BuildHasher;
 pub use annotations::{AnnotationMap, Annotations, ResolvedAnnotationInfo, MISSING_ANNOTATIONS};
 pub use app_options::AppOptions;
 pub use caches::{Cache, Caches};
+pub use command_sender::{
+    command_channel, Command, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,
+};
 pub use component_ui_registry::{ComponentUiRegistry, UiVerbosity};
 pub use item::{Item, ItemCollection};
 pub use selection_history::SelectionHistory;

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -1,7 +1,7 @@
 use re_data_store::store_db::StoreDb;
 
 use crate::{
-    AppOptions, Caches, ComponentUiRegistry, Item, ItemCollection, SelectionState,
+    AppOptions, Caches, CommandSender, ComponentUiRegistry, Item, ItemCollection, SelectionState,
     SpaceViewClassRegistry, StoreContext, TimeControl,
 };
 
@@ -36,6 +36,9 @@ pub struct ViewerContext<'a> {
 
     /// The global `re_renderer` context, holds on to all GPU resources.
     pub render_ctx: &'a mut re_renderer::RenderContext,
+
+    /// Interface for sending commands back to the app
+    pub command_sender: &'a CommandSender,
 }
 
 impl<'a> ViewerContext<'a> {


### PR DESCRIPTION
Built on top of: https://github.com/rerun-io/rerun/pull/2330
Need to rebase after merging.

## Motivation
The new CommandSender introduced in https://github.com/rerun-io/rerun/pull/2339 was limited to only supporting Commands from `re_ui`, which has a very limited set of dependencies. We needed a similar pattern for commands carrying additional data outside the context of the command palette.

## Overview
 - Rename `Commmand` -> `UICommand`
 - Introduce `SystemCommand`
 - Introduce a new `Command` as a union of `UICommand` and `SystemCommand`
 - Introduce new traits for sending the respective types.
 - Moves the implementation of the `CommanSender` to `re_viewer_context` so we can access it from more places.
 - Switches the business for setting recording id to use the new `SystemCommand` interfaces.
 - Adds `CommandSender` to `ViewerContext` so we can use it from the Blueprint panel in the future.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2344

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/af3f5f8/docs
Examples preview: https://rerun.io/preview/af3f5f8/examples
<!-- pr-link-docs:end -->
