### PR TITLE
Fix ARKit example

### DIFF
--- a/rerun_py/rerun_sdk/rerun/components/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/components/quaternion.py
@@ -22,6 +22,9 @@ class Quaternion:
     def __init__(self, *, xyzw: npt.ArrayLike):
         self.xyzw = xyzw
 
+    def __array__(self) -> npt.NDArray[np.float32]:
+        return np.asarray(self.xyzw, dtype=np.float32)
+
 
 class QuaternionArray(pa.ExtensionArray):  # type: ignore[misc]
     def from_numpy(array: npt.NDArray[np.float32]) -> QuaternionArray:


### PR DESCRIPTION
By implementing numpy's `__array__` protocol for our `Quaternion` component.

HOPE should hopefully make regressions of this nature a thing of the past :pray: 

Fixes #2349 