### PR TITLE
Remove long dead code python unit test

### DIFF
--- a/rerun_py/tests/unit/api_tests.py
+++ b/rerun_py/tests/unit/api_tests.py
@@ -1,8 +1,0 @@
-import rerun as rr
-from rerun.log.text import LogLevel
-
-
-def test_text() -> None:
-    rr.log_text_entry("path", "text", level=None)
-    rr.log_text_entry("path", "text", level=LogLevel.INFO)
-    rr.log_text_entry("path", None, level=LogLevel.INFO)  # type: ignore[arg-type]


### PR DESCRIPTION
Cleaning up before I add a bunch of my own stuff in there.

This was never run to begin with, `pytest` ignores files that don't start with `test_`.