### PR TITLE
Replace `image` crate jpeg decoder with zune-jpeg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,8 @@ dependencies = [
  "similar-asserts",
  "thiserror",
  "uuid",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -6731,6 +6733,25 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ca36c2e02af0d8d7ee977542bfe33ed1c516be73d3c1faa4420af46e96ceee"
+dependencies = [
+ "bitflags 2.3.1",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2848e8f4f29dbdcc79910ab3abdff22bb0bacef8556f2a983b5ca950d8b4991e"
+dependencies = [
+ "log",
+ "zune-core",
 ]
 
 [[package]]

--- a/crates/re_components/Cargo.toml
+++ b/crates/re_components/Cargo.toml
@@ -30,7 +30,7 @@ ecolor = ["dep:ecolor"]
 glam = ["dep:glam"]
 
 ## Integration with the [`image`](https://crates.io/crates/image/) crate.
-image = ["dep:ecolor", "dep:image"]
+image = ["dep:ecolor", "dep:image", "dep:zune-core", "dep:zune-jpeg"]
 
 ## Enable (de)serialization using serde.
 serde = ["dep:serde", "half/serde", "re_log_types/serde"]
@@ -62,11 +62,11 @@ uuid = { version = "1.1", features = ["serde", "v4", "js"] }
 # Optional dependencies:
 ecolor = { workspace = true, optional = true }
 glam = { workspace = true, optional = true }
-image = { workspace = true, optional = true, default-features = false, features = [
-  "jpeg",
-] }
+image = { workspace = true, optional = true, default-features = false }
 rand = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
+zune-core = { version = "0.2", optional = true }
+zune-jpeg = { version = "0.3", optional = true }
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/re_components/Cargo.toml
+++ b/crates/re_components/Cargo.toml
@@ -29,7 +29,7 @@ ecolor = ["dep:ecolor"]
 ## Add support for some math operations using [`glam`](https://crates.io/crates/glam/).
 glam = ["dep:glam"]
 
-## Integration with the [`image`](https://crates.io/crates/image/) crate.
+## Integration with the [`image`](https://crates.io/crates/image/) crate, plus JPEG support..
 image = ["dep:ecolor", "dep:image", "dep:zune-core", "dep:zune-jpeg"]
 
 ## Enable (de)serialization using serde.

--- a/crates/re_components/src/tensor.rs
+++ b/crates/re_components/src/tensor.rs
@@ -1246,7 +1246,14 @@ impl DecodedTensor {
             });
         }
 
-        assert_eq!(pixels.len() as u64, w * h * depth, "Bug in JPEG decoder");
+        if pixels.len() as u64 != w * h * depth {
+            return Err(zune_jpeg::errors::DecodeErrors::Format(format!(
+                "Bug in zune-jpeg: Expected {w}x{h}x{depth}={} bytes, got {}",
+                w * h * depth,
+                pixels.len()
+            ))
+            .into());
+        }
 
         let tensor = Tensor {
             tensor_id: TensorId::random(),

--- a/crates/re_components/src/tensor.rs
+++ b/crates/re_components/src/tensor.rs
@@ -765,7 +765,7 @@ pub enum TensorImageLoadError {
     #[error(transparent)]
     Image(std::sync::Arc<image::ImageError>),
 
-    #[error("Expexted a HxW, HxWx1 or HxWx3 tensor, but got {0:?}")]
+    #[error("Expected a HxW, HxWx1 or HxWx3 tensor, but got {0:?}")]
     UnexpectedJpegShape(Vec<TensorDimension>),
 
     #[error("Unsupported color type: {0:?}. We support 8-bit, 16-bit, and f32 images, and RGB, RGBA, Luminance, and Luminance-Alpha.")]

--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -40,6 +40,12 @@ pub mod external {
     pub use log;
 }
 
+/// Never log anything less serious than a `ERROR` from these crates.
+const CRATES_AT_ERROR_LEVEL: [&str; 1] = [
+    // Waiting for https://github.com/etemesi254/zune-image/issues/131 to be released
+    "zune_jpeg",
+];
+
 /// Never log anything less serious than a `WARN` from these crates.
 const CRATES_AT_WARN_LEVEL: [&str; 3] = [
     // wgpu crates spam a lot on info level, which is really annoying
@@ -57,6 +63,13 @@ const CRATES_FORCED_TO_INFO: [&str; 4] = [
 
 /// Should we log this message given the filter?
 fn is_log_enabled(filter: log::LevelFilter, metadata: &log::Metadata<'_>) -> bool {
+    if CRATES_AT_ERROR_LEVEL
+        .iter()
+        .any(|crate_name| metadata.target().starts_with(crate_name))
+    {
+        return metadata.level() <= log::LevelFilter::Error;
+    }
+
     if CRATES_AT_WARN_LEVEL
         .iter()
         .any(|crate_name| metadata.target().starts_with(crate_name))

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -7,6 +7,11 @@
 fn log_filter() -> String {
     let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
 
+    for crate_name in crate::CRATES_AT_ERROR_LEVEL {
+        if !rust_log.contains(&format!("{crate_name}=")) {
+            rust_log += &format!(",{crate_name}=error");
+        }
+    }
     for crate_name in crate::CRATES_AT_WARN_LEVEL {
         if !rust_log.contains(&format!("{crate_name}=")) {
             rust_log += &format!(",{crate_name}=warn");

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -27,7 +27,7 @@ demo = []
 ## Add support for some math operations using [`glam`](https://crates.io/crates/glam/).
 glam = ["re_components/glam"]
 
-## Integration with the [`image`](https://crates.io/crates/image/) crate.
+## Integration with the [`image`](https://crates.io/crates/image/) crate, plus JPEG support..
 image = ["re_components/image"]
 
 

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -83,10 +83,7 @@ eframe = { workspace = true, default-features = false, features = [
 ] }
 egui.workspace = true
 egui-wgpu.workspace = true
-image = { workspace = true, default-features = false, features = [
-  "jpeg",
-  "png",
-] }
+image = { workspace = true, default-features = false, features = ["png"] }
 itertools = { workspace = true }
 poll-promise = "0.2"
 rfd.workspace = true

--- a/crates/re_viewport/Cargo.toml
+++ b/crates/re_viewport/Cargo.toml
@@ -40,10 +40,7 @@ egui_tiles.workspace = true
 egui.workspace = true
 enumset.workspace = true
 glam.workspace = true
-image = { workspace = true, default-features = false, features = [
-  "jpeg",
-  "png",
-] }
+image = { workspace = true, default-features = false, features = ["png"] }
 itertools.workspace = true
 nohash-hasher = "0.2"
 serde = "1.0"

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -37,7 +37,7 @@ demo = ["re_sdk?/demo"]
 ## Only relevant if feature `sdk` is enabled.
 glam = ["re_sdk?/glam"]
 
-## Integration with the [`image`](https://crates.io/crates/image/) crate.
+## Integration with the [`image`](https://crates.io/crates/image/) crate, plus JPEG support..
 image = ["re_sdk?/image"]
 
 ## Support spawning a native viewer.

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -56,10 +56,7 @@ re_viewport.workspace = true
 
 arrow2 = { workspace = true, features = ["io_ipc", "io_print"] }
 document-features = "0.2"
-image = { workspace = true, default-features = false, features = [
-  "jpeg",
-  "png",
-] }
+image = { workspace = true, default-features = false, features = ["png"] }
 itertools = { workspace = true }
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 numpy = { version = "0.19.0", features = ["half"] }


### PR DESCRIPTION
### Why
It is much faster.

On my Mac, it takes objectron JPEG decoding from 15 to 10 ms. On the web the difference is smaller: 35ms -> 29ms. See https://github.com/emilk/image-decode-bench for more.

It can also decode directly to RGBA, which means we don't need to spend cycles later padding RGB to RGBA. This takes the entire `objectron` demo `App::update` down from 21 ms to 14 ms.

Sadly, the `gltf` crate still use the `"jpeg"` feature of the `image` crate, so weneed to pay for the compilation and code bloat of two jpeg decoders. The `.wasm` of the web-viewer increases by 23kB (pre-compression) because of this PR.

This PR also adds support for monochrome JPEGs.

### Related
* https://github.com/image-rs/image/issues/1845
* https://github.com/image-rs/image/pull/1876

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2376

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/1aae8d4/docs
Examples preview: https://rerun.io/preview/1aae8d4/examples
<!-- pr-link-docs:end -->
