### PR TITLE
Enforce `from __future__ import annotations` in Python files

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -24,12 +24,13 @@ The Summary should look like:
 * [Helpers](helpers.md)
 ```
 """
+from __future__ import annotations
 
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, List, Optional
+from typing import Final
 
 import griffe
 import mkdocs_gen_files
@@ -38,13 +39,13 @@ import mkdocs_gen_files
 @dataclass
 class Section:
     title: str
-    module_summary: Optional[str]
-    func_list: List[str]
+    module_summary: str | None
+    func_list: list[str]
 
 
 # This is the list of sections and functions that will be included in the index
 # for each of them.
-SECTION_TABLE: Final[List[Section]] = [
+SECTION_TABLE: Final[list[Section]] = [
     Section(
         title="Initialization",
         module_summary=None,

--- a/rerun_py/docs/gen_package_index.py
+++ b/rerun_py/docs/gen_package_index.py
@@ -30,6 +30,7 @@ Example virtual file:
 ```
 
 """
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -86,6 +86,9 @@ select = [
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"
 
+[tool.ruff.isort]
+required-imports = ["from __future__ import annotations"]
+
 [tool.maturin]
 # We use a python package from inside the rerun_sdk folder to avoid conflicting
 # with the other `rerun` pypi package. The rerun_sdk.pth adds this to the pythonpath

--- a/rerun_py/rerun/__init__.py
+++ b/rerun_py/rerun/__init__.py
@@ -11,6 +11,8 @@ When we encounter this file on import, we instead redirect to the
 real rerun module by adding it to the path and then, and then
 replacing our own module content with it.
 """
+from __future__ import annotations
+
 import pathlib
 import sys
 

--- a/rerun_py/rerun_demo/__init__.py
+++ b/rerun_py/rerun_demo/__init__.py
@@ -11,6 +11,8 @@ When we encounter this file on import, we instead redirect to the
 real rerun module by adding it to the path and then, and then
 replacing our own module content with it.
 """
+from __future__ import annotations
+
 import pathlib
 import sys
 

--- a/rerun_py/tests/unit/test_color_conversion.py
+++ b/rerun_py/tests/unit/test_color_conversion.py
@@ -1,4 +1,6 @@
 """Test for color_conversion module."""
+from __future__ import annotations
+
 import numpy as np
 from rerun.color_conversion import linear_to_gamma_u8_pixel, linear_to_gamma_u8_value
 

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 """Build `demo.rerun.io`."""
+from __future__ import annotations
 
 import argparse
 import http.server
@@ -10,7 +11,6 @@ import shutil
 import subprocess
 import threading
 from functools import partial
-from typing import List
 
 from jinja2 import Template
 
@@ -22,7 +22,7 @@ class Example:
         title: str,
         description: str,
         commit: str,
-        build_args: List[str],
+        build_args: list[str],
     ):
         self.path = os.path.join("examples/python", name, "main.py")
         self.name = name
@@ -56,7 +56,7 @@ class Example:
             return "script_add_args" in f.read()
 
 
-def copy_static_assets(examples: List[Example]) -> None:
+def copy_static_assets(examples: list[Example]) -> None:
     # copy root
     src = os.path.join(SCRIPT_PATH, "demo_assets/static")
     dst = BASE_PATH
@@ -80,7 +80,7 @@ def build_wasm() -> None:
     subprocess.run(["cargo", "r", "-p", "re_build_web_viewer", "--", "--release"])
 
 
-def copy_wasm(examples: List[Example]) -> None:
+def copy_wasm(examples: list[Example]) -> None:
     files = ["re_viewer_bg.wasm", "re_viewer.js"]
     for example in examples:
         for file in files:
@@ -90,7 +90,7 @@ def copy_wasm(examples: List[Example]) -> None:
             )
 
 
-def collect_examples() -> List[Example]:
+def collect_examples() -> list[Example]:
     commit = os.environ.get("COMMIT_HASH") or "main"
     logging.info(f"Commit hash: {commit}")
     examples = []
@@ -107,14 +107,14 @@ def collect_examples() -> List[Example]:
     return examples
 
 
-def save_examples_rrd(examples: List[Example]) -> None:
+def save_examples_rrd(examples: list[Example]) -> None:
     logging.info("\nSaving examples as .rrd")
 
     for example in examples:
         example.save()
 
 
-def render_examples(examples: List[Example]) -> None:
+def render_examples(examples: list[Example]) -> None:
     logging.info("\nRendering examples")
 
     template_path = os.path.join(SCRIPT_PATH, "demo_assets/templates/example.html")

--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import os
 from glob import glob

--- a/scripts/fetch_crashes.py
+++ b/scripts/fetch_crashes.py
@@ -22,6 +22,7 @@ python scripts/fetch_crashes.py --help
 ```
 
 """
+from __future__ import annotations
 
 import argparse
 import json

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -5,12 +5,13 @@ Summarizes recent PRs based on their GitHub labels.
 
 The result can be copy-pasted into CHANGELOG.md, though it often needs some manual editing too.
 """
+from __future__ import annotations
 
 import multiprocessing
 import re
 import sys
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any
 
 import requests
 from git import Repo  # pip install GitPython
@@ -34,14 +35,14 @@ OFFICIAL_RERUN_DEVS = [
 class PrInfo:
     gh_user_name: str
     pr_title: str
-    labels: List[str]
+    labels: list[str]
 
 
 @dataclass
 class CommitInfo:
     hexsha: str
     title: str
-    pr_number: Optional[int]
+    pr_number: int | None
 
 
 def get_github_token() -> str:
@@ -66,7 +67,7 @@ def get_github_token() -> str:
 
 
 # Slow
-def fetch_pr_info_from_commit_info(commit_info: CommitInfo) -> Optional[PrInfo]:
+def fetch_pr_info_from_commit_info(commit_info: CommitInfo) -> PrInfo | None:
     if commit_info.pr_number is None:
         return None
     else:
@@ -74,7 +75,7 @@ def fetch_pr_info_from_commit_info(commit_info: CommitInfo) -> Optional[PrInfo]:
 
 
 # Slow
-def fetch_pr_info(pr_number: int) -> Optional[PrInfo]:
+def fetch_pr_info(pr_number: int) -> PrInfo | None:
     url = f"https://api.github.com/repos/{OWNER}/{REPO}/pulls/{pr_number}"
     gh_access_token = get_github_token()
     headers = {"Authorization": f"Token {gh_access_token}"}
@@ -99,7 +100,7 @@ def get_commit_info(commit: Any) -> CommitInfo:
         return CommitInfo(hexsha=commit.hexsha, title=commit.summary, pr_number=None)
 
 
-def print_section(title: str, items: List[str]) -> None:
+def print_section(title: str, items: list[str]) -> None:
     if 0 < len(items):
         print(f"#### {title}")
         for line in items:

--- a/scripts/generate_pr_summary.py
+++ b/scripts/generate_pr_summary.py
@@ -9,11 +9,12 @@ This is expected to be run by the `reusable_pr_summary.yml` GitHub workflow.
 Requires the following packages:
   pip install google-cloud-storage Jinja2 PyGithub # NOLINT
 """
+from __future__ import annotations
 
 import argparse
 import io
 import os
-from typing import Any, Dict
+from typing import Any
 
 from github import Github  # NOLINT
 from google.cloud import storage
@@ -40,7 +41,7 @@ def generate_pr_summary(github_token: str, github_repository: str, pr_number: in
         commit_short = commit[:7]
         print(f"Checking commit: {commit_short}...")
 
-        found: Dict[str, Any] = {}
+        found: dict[str, Any] = {}
 
         # Check if there is a hosted app for the current commit
         app_blob = viewer_bucket.blob(f"commit/{commit_short}/index.html")

--- a/scripts/generate_prerelease_pip_index.py
+++ b/scripts/generate_prerelease_pip_index.py
@@ -9,11 +9,12 @@ This is expected to be run by the `reusable_pip_index.yml` GitHub workflow.
 Requires the following packages:
   pip install google-cloud-storage Jinja2 PyGithub # NOLINT
 """
+from __future__ import annotations
 
 import argparse
 import io
 import os
-from typing import Any, Dict
+from typing import Any
 
 from google.cloud import storage
 from jinja2 import Template
@@ -30,7 +31,7 @@ def generate_pip_index(commit: str, upload: bool) -> None:
     commit_short = commit[:7]
     print(f"Checking commit: {commit_short}...")
 
-    found: Dict[str, Any] = {}
+    found: dict[str, Any] = {}
 
     # Get the wheel files for the commit
     wheel_blobs = list(wheels_bucket.list_blobs(prefix=f"commit/{commit_short}/wheels"))

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -5,12 +5,13 @@ Runs custom linting on our code.
 
 Adding "NOLINT" to any line makes the linter ignore that line.
 """
+from __future__ import annotations
 
 import argparse
 import os
 import re
 import sys
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 # -----------------------------------------------------------------------------
 
@@ -24,7 +25,7 @@ else_return = re.compile(r"else\s*{\s*return;?\s*};")
 explicit_quotes = re.compile(r'[^(]\\"\{\w*\}\\"')  # looks for: \"{foo}\"
 
 
-def lint_line(line: str) -> Optional[str]:
+def lint_line(line: str) -> str | None:
     if "NOLINT" in line:
         return None  # NOLINT ignores the linter
 
@@ -186,7 +187,7 @@ def is_missing_blank_line_between(prev_line: str, line: str) -> bool:
     return False
 
 
-def lint_vertical_spacing(lines_in: List[str]) -> Tuple[List[str], List[str]]:
+def lint_vertical_spacing(lines_in: list[str]) -> tuple[list[str], list[str]]:
     """Only for Rust files."""
     prev_line = None
 
@@ -286,7 +287,7 @@ def test_lint_vertical_spacing() -> None:
 re_workspace_dep = re.compile(r"workspace\s*=\s*(true|false)")
 
 
-def lint_workspace_deps(lines_in: List[str]) -> Tuple[List[str], List[str]]:
+def lint_workspace_deps(lines_in: list[str]) -> tuple[list[str], list[str]]:
     """Only for Cargo files."""
 
     errors = []

--- a/scripts/pr_link_docs.py
+++ b/scripts/pr_link_docs.py
@@ -8,6 +8,7 @@ This is expected to be run by the `reusable_pr_link_docs.yml` GitHub workflow.
 Requires the following packages:
   pip install PyGithub # NOLINT
 """
+from __future__ import annotations
 
 import argparse
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 """Run all examples."""
+from __future__ import annotations
 
 import argparse
 import os
@@ -9,10 +10,10 @@ import subprocess
 import time
 from glob import glob
 from types import TracebackType
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any
 
 
-def start_process(args: List[str], cwd: str, wait: bool) -> Any:
+def start_process(args: list[str], cwd: str, wait: bool) -> Any:
     process = subprocess.Popen(
         args,
         cwd=cwd,
@@ -28,7 +29,7 @@ def start_process(args: List[str], cwd: str, wait: bool) -> Any:
     return process
 
 
-def run_py_example(path: str, viewer_port: Optional[int] = None, wait: bool = True, save: Optional[str] = None) -> Any:
+def run_py_example(path: str, viewer_port: int | None = None, wait: bool = True, save: str | None = None) -> Any:
     args = ["python3", "main.py", "--num-frames=30", "--steps=200"]
     if save is not None:
         args += [f"--save={save}"]
@@ -56,7 +57,7 @@ def get_free_port() -> int:
         return int(s.getsockname()[1])
 
 
-def collect_examples(fast: bool) -> List[str]:
+def collect_examples(fast: bool) -> list[str]:
     if fast:
         # cherry picked
         return [
@@ -89,7 +90,7 @@ class Viewer:
     sdk_port: int  # where the logging SDK sends the log stream (where the server receives)
     web_viewer_port: int  # the HTTP port where we serve the web viewer
     ws_server_port: int  # the WebSocket port where we serve the log stream
-    process: Optional[Any]
+    process: Any | None
 
     def __init__(self, close: bool = False, web: bool = False):
         self.should_close = close
@@ -104,7 +105,7 @@ class Viewer:
             self.process.kill()
         self.process = None
 
-    def start(self) -> "Viewer":
+    def start(self) -> Viewer:
         print(f"\nStarting viewer on {'web ' if self.web else ''}port {self.sdk_port}")
         args = ["./target/debug/rerun", f"--port={self.sdk_port}"]
         if self.web:
@@ -118,15 +119,15 @@ class Viewer:
         time.sleep(1)
         return self
 
-    def __enter__(self) -> "Viewer":
+    def __enter__(self) -> Viewer:
         self.start()
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         self.close()
 
@@ -161,7 +162,7 @@ def run_viewer_build() -> None:
     assert returncode == 0, f"process exited with error code {returncode}"
 
 
-def run_web(examples: List[str], separate: bool) -> None:
+def run_web(examples: list[str], separate: bool) -> None:
     if not separate:
         with Viewer(close=True, web=True) as viewer:
             for path in examples:
@@ -169,7 +170,7 @@ def run_web(examples: List[str], separate: bool) -> None:
                 print_example_output(path, example)
         return
 
-    entries: List[Tuple[str, Any, Any]] = []
+    entries: list[tuple[str, Any, Any]] = []
     # start all examples in parallel
     for path in examples:
         # each example gets its own viewer
@@ -192,13 +193,13 @@ def run_web(examples: List[str], separate: bool) -> None:
         viewer.close()
 
 
-def run_save(examples: List[str]) -> None:
+def run_save(examples: list[str]) -> None:
     for path in examples:
         example = run_py_example(path, save="out.rrd")
         print_example_output(path, example)
 
 
-def run_load(examples: List[str], separate: bool, close: bool) -> None:
+def run_load(examples: list[str], separate: bool, close: bool) -> None:
     if not separate:
         # run all examples sequentially
         for path in examples:
@@ -207,7 +208,7 @@ def run_load(examples: List[str], separate: bool, close: bool) -> None:
             print_example_output(path, example)
         return
 
-    entries: List[Tuple[str, Any]] = []
+    entries: list[tuple[str, Any]] = []
     for path in examples:
         example = run_saved_example(path, wait=False)
         entries.append((path, example))
@@ -219,7 +220,7 @@ def run_load(examples: List[str], separate: bool, close: bool) -> None:
             example.kill()
 
 
-def run_native(examples: List[str], separate: bool, close: bool) -> None:
+def run_native(examples: list[str], separate: bool, close: bool) -> None:
     if not separate:
         # run all examples sequentially in a single viewer
         with Viewer(close) as viewer:
@@ -228,7 +229,7 @@ def run_native(examples: List[str], separate: bool, close: bool) -> None:
                 print_example_output(path, example)
         return
 
-    cleanup: List[Tuple[Any, Any]] = []
+    cleanup: list[tuple[Any, Any]] = []
     # start all examples in parallel
     for path in examples:
         # each example gets its own viewer

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -10,13 +10,13 @@ This is an end-to-end test for testing:
 * TCP connection
 * Data store ingestion
 """
+from __future__ import annotations
 
 import argparse
 import os
 import subprocess
 import sys
 import time
-from typing import List
 
 
 def main() -> None:
@@ -80,7 +80,7 @@ def main() -> None:
     print("All tests passed successfully!")
 
 
-def run_example(example: str, args: List[str]) -> None:
+def run_example(example: str, args: list[str]) -> None:
     port = 9752
 
     # sys.executable: the absolute path of the executable binary for the Python interpreter

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -19,6 +19,7 @@ If you get this error:
 Then run `python3 -m pip install cryptography==38.0.4`
 (https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769)
 """
+from __future__ import annotations
 
 import argparse
 import hashlib

--- a/scripts/verify_wheels.py
+++ b/scripts/verify_wheels.py
@@ -1,4 +1,6 @@
 """Script to confirm wheels have the expected version number."""
+from __future__ import annotations
+
 import argparse
 import sys
 from pathlib import Path

--- a/scripts/version_util.py
+++ b/scripts/version_util.py
@@ -10,6 +10,7 @@ This script accepts one argument:
     --bare_cargo_version Outputs the bare cargo version. This is helpful for setting an environment variable, such as:
     EXPECTED_VERSION=$(python3 scripts/version_util.py --bare_cargo_version)
 """
+from __future__ import annotations
 
 import re
 import subprocess


### PR DESCRIPTION
### What

Follow-up to #2361:

- Add a Ruff rule to check/add `from __future__ import annotations` everywhere.
- Normalise a bunch of python files (mainly scripts) that the previous PR missed.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2377

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/2c443d9/docs
Examples preview: https://rerun.io/preview/2c443d9/examples
<!-- pr-link-docs:end -->
