### PR TITLE
Added gcloud project name to `upload_image.py`

### DIFF
--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -47,7 +47,7 @@ def main() -> None:
     hash = content_hash(args.path)
     object_name = f"{hash}_{os.path.basename(args.path)}"
 
-    gcs = storage.Client()
+    gcs = storage.Client("rerun-open")
     bucket = gcs.bucket("rerun-static-img")
     destination = bucket.blob(object_name)
     destination.content_type, destination.content_encoding = mimetypes.guess_type(args.path)


### PR DESCRIPTION
### What

Somehow `upload_image.py` couldn't figure out the default project of my `gcloud` setup. This PR hard-codes the project name in the script.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] ~~I've included a screenshot or gif (if applicable)~~ 

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2381

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/47a7c7c/docs
Examples preview: https://rerun.io/preview/47a7c7c/examples
<!-- pr-link-docs:end -->
