### PR TITLE
Fix texture clamping and color gradient selection being displayed incorrectly

### DIFF
--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -75,7 +75,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
                 clamp_to_edge_nearest_neighbor(coord, texture_dimensions), 0));
         } else {
             // bilinear
-            let sample_positions = clamp_to_edge_bilinear_samples(coord, Vec2(textureDimensions(texture_float).xy));
+            let sample_positions = clamp_to_edge_bilinear_samples(coord, texture_dimensions);
             let v00 = decode_color(textureLoad(texture_float, sample_positions[0], 0));
             let v01 = decode_color(textureLoad(texture_float, sample_positions[1], 0));
             let v10 = decode_color(textureLoad(texture_float, sample_positions[2], 0));
@@ -91,7 +91,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
                 clamp_to_edge_nearest_neighbor(coord, texture_dimensions), 0)));
         } else {
             // bilinear
-            let sample_positions = clamp_to_edge_bilinear_samples(coord, Vec2(textureDimensions(texture_float).xy));
+            let sample_positions = clamp_to_edge_bilinear_samples(coord, texture_dimensions);
             let v00 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[0], 0)));
             let v01 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[1], 0)));
             let v10 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[2], 0)));
@@ -107,7 +107,7 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
                 clamp_to_edge_nearest_neighbor(coord, texture_dimensions), 0)));
         } else {
             // bilinear
-            let sample_positions = clamp_to_edge_bilinear_samples(coord, Vec2(textureDimensions(texture_float).xy));
+            let sample_positions = clamp_to_edge_bilinear_samples(coord, texture_dimensions);
             let v00 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[0], 0)));
             let v01 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[1], 0)));
             let v10 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[2], 0)));


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Rectangle texture samples are now clamped to border

Before:
<img width="480" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/e6286fc8-c317-4717-b432-e4f73cbf5114">


After:
<img width="491" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/5171ef00-d409-48e0-856b-e66aca488ff1">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2394

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/79e93ca/docs
Examples preview: https://rerun.io/preview/79e93ca/examples
<!-- pr-link-docs:end -->
