### PR TITLE
Revert #2378, causing noninteractive 2D and 3D spaceviews

### DIFF
--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -10,11 +10,13 @@ pub mod entity_properties;
 pub mod entity_tree;
 mod instance_path;
 pub mod store_db;
+mod util;
 
 pub use entity_properties::*;
 pub use entity_tree::*;
 pub use instance_path::*;
 pub use store_db::StoreDb;
+pub use util::*;
 
 #[cfg(feature = "serde")]
 pub use editable_auto_value::EditableAutoValue;

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -211,16 +211,6 @@ impl StoreDb {
         self.store_info().map(|ri| &ri.application_id)
     }
 
-    #[inline]
-    pub fn store_mut(&mut self) -> &mut re_arrow_store::DataStore {
-        &mut self.entity_db.data_store
-    }
-
-    #[inline]
-    pub fn store(&self) -> &re_arrow_store::DataStore {
-        &self.entity_db.data_store
-    }
-
     pub fn store_kind(&self) -> StoreKind {
         self.store_id.kind
     }

--- a/crates/re_data_store/src/util.rs
+++ b/crates/re_data_store/src/util.rs
@@ -1,0 +1,87 @@
+use re_arrow_store::LatestAtQuery;
+use re_log_types::{
+    DataRow, DeserializableComponent, EntityPath, RowId, SerializableComponent, TimePoint, Timeline,
+};
+
+use crate::StoreDb;
+
+// ----------------------------------------------------------------------------
+
+/// Get the latest value for a given [`re_log_types::Component`].
+///
+/// This assumes that the row we get from the store only contains a single instance for this
+/// component; it will log a warning otherwise.
+///
+/// This should only be used for "mono-components" such as `Transform` and `Tensor`.
+pub fn query_latest_single<C: DeserializableComponent>(
+    data_store: &re_arrow_store::DataStore,
+    entity_path: &EntityPath,
+    query: &LatestAtQuery,
+) -> Option<C>
+where
+    for<'b> &'b C::ArrayType: IntoIterator,
+{
+    re_tracing::profile_function!();
+
+    // Although it would be nice to use the `re_query` helpers for this, we would need to move
+    // this out of re_data_store to avoid a circular dep. Since we don't need to do a join for
+    // single components this is easy enough.
+
+    let (_, cells) = data_store.latest_at(query, entity_path, C::name(), &[C::name()])?;
+    let cell = cells.get(0)?.as_ref()?;
+
+    let mut iter = cell.try_to_native::<C>().ok()?;
+
+    let component = iter.next();
+
+    if iter.next().is_some() {
+        re_log::warn_once!("Unexpected batch for {} at: {}", C::name(), entity_path);
+    }
+
+    component
+}
+
+/// Get the latest value for a given [`re_log_types::Component`] assuming it is timeless.
+///
+/// This assumes that the row we get from the store only contains a single instance for this
+/// component; it will log a warning otherwise.
+pub fn query_timeless_single<C: DeserializableComponent>(
+    data_store: &re_arrow_store::DataStore,
+    entity_path: &EntityPath,
+) -> Option<C>
+where
+    for<'b> &'b C::ArrayType: IntoIterator,
+{
+    let query = re_arrow_store::LatestAtQuery::latest(Timeline::default());
+    query_latest_single(data_store, entity_path, &query)
+}
+
+// ----------------------------------------------------------------------------
+
+/// Store a single value for a given [`re_log_types::Component`].
+pub fn store_one_component<C: SerializableComponent>(
+    store_db: &mut StoreDb,
+    entity_path: &EntityPath,
+    timepoint: &TimePoint,
+    component: C,
+) {
+    let mut row = DataRow::from_cells1(
+        RowId::random(),
+        entity_path.clone(),
+        timepoint.clone(),
+        1,
+        [component].as_slice(),
+    );
+    row.compute_all_size_bytes();
+
+    match store_db.entity_db.try_add_data_row(&row) {
+        Ok(()) => {}
+        Err(err) => {
+            re_log::warn_once!(
+                "Failed to store component {}.{}: {err}",
+                entity_path,
+                C::name(),
+            );
+        }
+    }
+}

--- a/crates/re_viewer/src/ui/blueprint_sync.rs
+++ b/crates/re_viewer/src/ui/blueprint_sync.rs
@@ -1,4 +1,5 @@
 use arrow2_convert::field::ArrowField;
+use re_data_store::store_one_component;
 use re_log_types::{Component, DataCell, DataRow, EntityPath, RowId, TimePoint};
 use re_viewer_context::SpaceViewId;
 use re_viewport::{
@@ -70,9 +71,7 @@ pub fn sync_panel_expanded(
 
         let component = PanelState { expanded };
 
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 }
 
@@ -95,9 +94,7 @@ pub fn sync_space_view(
             space_view: space_view.clone(),
         };
 
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 }
 
@@ -137,23 +134,17 @@ pub fn sync_viewport(
 
     if viewport.auto_space_views != snapshot.auto_space_views {
         let component = AutoSpaceViews(viewport.auto_space_views);
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 
     if viewport.visible != snapshot.visible {
         let component = SpaceViewVisibility(viewport.visible.clone());
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 
     if viewport.maximized != snapshot.maximized {
         let component = SpaceViewMaximized(viewport.maximized);
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 
     // Note: we can't just check `viewport.trees != snapshot.trees` because the
@@ -174,17 +165,13 @@ pub fn sync_viewport(
             has_been_user_edited: viewport.has_been_user_edited,
         };
 
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
 
         // TODO(jleibs): Sort out this causality mess
         // If we are saving a new layout, we also need to save the visibility-set because
         // it gets mutated on load but isn't guaranteed to be mutated on layout-change
         // which means it won't get saved.
         let component = SpaceViewVisibility(viewport.visible.clone());
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 }


### PR DESCRIPTION
### What
This reverts commit bdae196010411d608f8ff688dd862fcd57b80bb0.

PR #2378 caused all 2D and 3D spaceviews to become non-interactive, meaning you could not zoom or pan.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2395

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/6c6f215/docs
Examples preview: https://rerun.io/preview/6c6f215/examples
<!-- pr-link-docs:end -->
