### PR TITLE
Fix blueprint sync by bringing back `store_one_component`

### DIFF
--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -10,11 +10,13 @@ pub mod entity_properties;
 pub mod entity_tree;
 mod instance_path;
 pub mod store_db;
+mod util;
 
 pub use entity_properties::*;
 pub use entity_tree::*;
 pub use instance_path::*;
 pub use store_db::StoreDb;
+pub use util::*;
 
 #[cfg(feature = "serde")]
 pub use editable_auto_value::EditableAutoValue;

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -77,7 +77,7 @@ impl EntityDb {
 
     // TODO(jleibs): If this shouldn't be public, chain together other setters
     // TODO(cmc): Updates of secondary datastructures should be the result of subscribing to the
-    // datastore's changelog and reacting to these changes apropriately. We shouldn't be creating
+    // datastore's changelog and reacting to these changes appropriately. We shouldn't be creating
     // many sources of truth.
     pub fn try_add_data_row(&mut self, row: &DataRow) -> Result<(), Error> {
         for (&timeline, &time_int) in row.timepoint().iter() {

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -76,6 +76,9 @@ impl EntityDb {
     }
 
     // TODO(jleibs): If this shouldn't be public, chain together other setters
+    // TODO(cmc): Updates of secondary datastructures should be the result of subscribing to the
+    // datastore's changelog and reacting to these changes apropriately. We shouldn't be creating
+    // many sources of truth.
     pub fn try_add_data_row(&mut self, row: &DataRow) -> Result<(), Error> {
         for (&timeline, &time_int) in row.timepoint().iter() {
             self.times_per_timeline.insert(timeline, time_int);

--- a/crates/re_data_store/src/util.rs
+++ b/crates/re_data_store/src/util.rs
@@ -1,0 +1,33 @@
+use re_log_types::{DataRow, EntityPath, RowId, SerializableComponent, TimePoint};
+
+use crate::StoreDb;
+
+// ----------------------------------------------------------------------------
+
+/// Store a single value for a given [`re_log_types::Component`].
+pub fn store_one_component<C: SerializableComponent>(
+    store_db: &mut StoreDb,
+    entity_path: &EntityPath,
+    timepoint: &TimePoint,
+    component: C,
+) {
+    let mut row = DataRow::from_cells1(
+        RowId::random(),
+        entity_path.clone(),
+        timepoint.clone(),
+        1,
+        [component].as_slice(),
+    );
+    row.compute_all_size_bytes();
+
+    match store_db.entity_db.try_add_data_row(&row) {
+        Ok(()) => {}
+        Err(err) => {
+            re_log::warn_once!(
+                "Failed to store component {}.{}: {err}",
+                entity_path,
+                C::name(),
+            );
+        }
+    }
+}

--- a/crates/re_data_store/src/util.rs
+++ b/crates/re_data_store/src/util.rs
@@ -5,6 +5,10 @@ use crate::StoreDb;
 // ----------------------------------------------------------------------------
 
 /// Store a single value for a given [`re_log_types::Component`].
+///
+/// BEWARE: This does more than just writing component data to the datastore, it actually updates
+/// several other datastructures in the process.
+/// This is _not_ equivalent to [`re_arrow_store::DataStore::insert_component`]!
 pub fn store_one_component<C: SerializableComponent>(
     store_db: &mut StoreDb,
     entity_path: &EntityPath,

--- a/crates/re_viewer/src/ui/blueprint_sync.rs
+++ b/crates/re_viewer/src/ui/blueprint_sync.rs
@@ -1,4 +1,5 @@
 use arrow2_convert::field::ArrowField;
+use re_data_store::store_one_component;
 use re_log_types::{Component, DataCell, DataRow, EntityPath, RowId, TimePoint};
 use re_viewer_context::SpaceViewId;
 use re_viewport::{
@@ -70,9 +71,7 @@ pub fn sync_panel_expanded(
 
         let component = PanelState { expanded };
 
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 }
 
@@ -95,9 +94,7 @@ pub fn sync_space_view(
             space_view: space_view.clone(),
         };
 
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 }
 
@@ -137,23 +134,17 @@ pub fn sync_viewport(
 
     if viewport.auto_space_views != snapshot.auto_space_views {
         let component = AutoSpaceViews(viewport.auto_space_views);
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 
     if viewport.visible != snapshot.visible {
         let component = SpaceViewVisibility(viewport.visible.clone());
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 
     if viewport.maximized != snapshot.maximized {
         let component = SpaceViewMaximized(viewport.maximized);
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 
     // Note: we can't just check `viewport.trees != snapshot.trees` because the
@@ -174,17 +165,13 @@ pub fn sync_viewport(
             has_been_user_edited: viewport.has_been_user_edited,
         };
 
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
 
         // TODO(jleibs): Sort out this causality mess
         // If we are saving a new layout, we also need to save the visibility-set because
         // it gets mutated on load but isn't guaranteed to be mutated on layout-change
         // which means it won't get saved.
         let component = SpaceViewVisibility(viewport.visible.clone());
-        blueprint_db
-            .store_mut()
-            .insert_component(&entity_path, &timepoint, component);
+        store_one_component(blueprint_db, &entity_path, &timepoint, component);
     }
 }


### PR DESCRIPTION
Turns out `store_one_component` is more than a datastore helper... it actually updates a whole bunch of secondary/derived datastructures at the same time.

At some point we should really start moving towards a reactive model where secondary indices merely subscribe to the changelog of a single source of truth and react appropriately.

Supersedes #2395 