### PR TITLE
Remove weird-looking argument parsing in examples

### DIFF
--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -429,8 +429,7 @@ def main() -> None:
     )
 
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     if not args.split_recordings:
         rec = rr.script_setup(args, "api_demo")

--- a/examples/python/arkitscenes/main.py
+++ b/examples/python/arkitscenes/main.py
@@ -439,8 +439,7 @@ def main() -> None:
         help="Include the high resolution camera and depth images",
     )
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "arkitscenes")
     recording_path = ensure_recording_available(args.video_id, args.include_highres)

--- a/examples/python/car/main.py
+++ b/examples/python/car/main.py
@@ -256,8 +256,7 @@ def generate_car_data(num_frames: int) -> Iterator[SampleFrame]:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "car")
     log_car_data()

--- a/examples/python/clock/main.py
+++ b/examples/python/clock/main.py
@@ -70,8 +70,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--steps", type=int, default=10_000, help="The number of time steps to log")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "clock")
     log_clock(args.steps)

--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -181,8 +181,7 @@ def main() -> None:
     )
     parser.add_argument("--resize", action="store", help="Target resolution to resize images")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     if args.resize:
         args.resize = tuple(int(x) for x in args.resize.split("x"))

--- a/examples/python/deep_sdf/main.py
+++ b/examples/python/deep_sdf/main.py
@@ -202,8 +202,7 @@ def main() -> None:
         help="Path to a mesh to analyze. If set, overrides the `--mesh` argument.",
     )
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "deep_sdf")
 

--- a/examples/python/dicom/main.py
+++ b/examples/python/dicom/main.py
@@ -75,8 +75,7 @@ def ensure_dataset_downloaded() -> Iterable[Path]:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
     rr.script_setup(args, "dicom")
     dicom_files = ensure_dataset_downloaded()
     read_and_log_dicom_dataset(dicom_files)

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -6,6 +6,7 @@ The example from our Getting Started page.
 """
 from __future__ import annotations
 
+import sys
 from math import tau
 
 import numpy as np
@@ -13,8 +14,8 @@ import rerun as rr  # pip install rerun-sdk
 from rerun_demo.data import build_color_spiral
 from rerun_demo.util import bounce_lerp, interleave
 
-_, unknown = __import__("argparse").ArgumentParser().parse_known_args()
-[__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+# sanity-check since all other example scripts take arguments:
+assert len(sys.argv) == 1, f"{sys.argv[0]} does not take any arguments"
 
 rr.init("DNA Abacus")
 

--- a/examples/python/minimal/main.py
+++ b/examples/python/minimal/main.py
@@ -2,11 +2,13 @@
 """Demonstrates the most barebone usage of the Rerun SDK."""
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
 
-_, unknown = __import__("argparse").ArgumentParser().parse_known_args()
-[__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+# sanity-check since all other example scripts take arguments:
+assert len(sys.argv) == 1, f"{sys.argv[0]} does not take any arguments"
 
 rr.init("minimal", spawn=True)
 

--- a/examples/python/minimal_options/main.py
+++ b/examples/python/minimal_options/main.py
@@ -9,8 +9,7 @@ import rerun as rr  # pip install rerun-sdk
 
 parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
 rr.script_add_args(parser)
-args, unknown = parser.parse_known_args()
-[__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+args = parser.parse_args()
 
 rr.script_setup(args, "minimal_options")
 

--- a/examples/python/mp_pose/main.py
+++ b/examples/python/mp_pose/main.py
@@ -148,8 +148,7 @@ def main() -> None:
     parser.add_argument("--no-segment", action="store_true", help="Don't run person segmentation.")
     rr.script_add_args(parser)
 
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
     rr.script_setup(args, "mp_pose")
 
     video_path = args.video_path  # type: str

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -30,8 +30,7 @@ def task(child_index: int) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Test multi-process logging to the same Rerun server")
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    parser.parse_args()
 
     rr.init("multiprocessing")
     rr.spawn(connect=False)  # this is the viewer that each child process will connect to

--- a/examples/python/multithreading/main.py
+++ b/examples/python/multithreading/main.py
@@ -22,8 +22,7 @@ def rect_logger(path: str, color: npt.NDArray[np.float32]) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "multithreading")
 

--- a/examples/python/nyud/main.py
+++ b/examples/python/nyud/main.py
@@ -155,8 +155,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--subset-idx", type=int, default=0, help="The index of the subset of the recording to use.")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "nyud")
     recording_path = ensure_recording_downloaded(args.recording)

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -277,8 +277,7 @@ def main() -> None:
     )
 
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "objectron")
 

--- a/examples/python/opencv_canny/main.py
+++ b/examples/python/opencv_canny/main.py
@@ -73,8 +73,7 @@ def main() -> None:
     parser.add_argument("--num-frames", type=int, default=None, help="The number of frames to log")
 
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "opencv_canny")
 

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -84,8 +84,7 @@ def main() -> None:
         description="demonstrates how to integrate python's native `logging` with the Rerun SDK"
     )
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "plot")
 

--- a/examples/python/raw_mesh/main.py
+++ b/examples/python/raw_mesh/main.py
@@ -85,8 +85,7 @@ def main() -> None:
         help="Path to a scene to analyze. If set, overrides the `--scene` argument.",
     )
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "raw_mesh")
 

--- a/examples/python/segment_anything/main.py
+++ b/examples/python/segment_anything/main.py
@@ -181,8 +181,7 @@ def main() -> None:
     parser.add_argument("images", metavar="N", type=str, nargs="*", help="A list of images to process.")
 
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "segment_anything")
     logging.getLogger().addHandler(rr.LoggingHandler("logs"))

--- a/examples/python/stable_diffusion/main.py
+++ b/examples/python/stable_diffusion/main.py
@@ -110,8 +110,7 @@ expense of slower inference. This parameter will be modulated by `strength`.
     )
 
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "Depth Guided Stable Diffusion")
 

--- a/examples/python/text_logging/main.py
+++ b/examples/python/text_logging/main.py
@@ -73,8 +73,7 @@ def main() -> None:
     )
     parser.add_argument("--repeat", type=int, default=1, help="How many times do we want to run the log function?")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "text_logging")
 

--- a/examples/python/tracking_hf_opencv/main.py
+++ b/examples/python/tracking_hf_opencv/main.py
@@ -395,8 +395,7 @@ def main() -> None:
     parser.add_argument("--dataset_dir", type=Path, default=DATASET_DIR, help="Directory to save example videos to.")
     parser.add_argument("--video_path", type=str, default="", help="Full path to video to run on. Overrides `--video`.")
     rr.script_add_args(parser)
-    args, unknown = parser.parse_known_args()
-    [__import__("logging").warning(f"unknown arg: {arg}") for arg in unknown]
+    args = parser.parse_args()
 
     rr.script_setup(args, "tracking_hf_opencv")
 

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -39,15 +39,15 @@ class Example:
 
         logging.info(f"Running {in_path}, outputting to {out_dir}")
         os.makedirs(out_dir, exist_ok=True)
+
+        args = [
+            "python3",
+            in_path,
+            f"--save={out_dir}/data.rrd",
+        ]
+
         subprocess.run(
-            [
-                "python3",
-                in_path,
-                "--num-frames=30",
-                "--steps=200",
-                f"--save={out_dir}/data.rrd",
-            ]
-            + self.build_args,
+            args + self.build_args,
             check=True,
         )
 
@@ -100,7 +100,7 @@ def collect_examples() -> list[Example]:
             title=EXAMPLES[name]["title"],
             description=EXAMPLES[name]["description"],
             commit=commit,
-            build_args=EXAMPLES[name]["build_args"].split(" "),
+            build_args=EXAMPLES[name]["build_args"],
         )
         if example.supports_save():
             examples.append(example)
@@ -155,9 +155,7 @@ def main() -> None:
     )
     parser.add_argument("--skip-wasm-build", action="store_true", help="Skip the web viewer Wasm build")
 
-    args, unknown = parser.parse_known_args()
-    for arg in unknown:
-        logging.warning(f"unknown arg: {arg}")
+    args = parser.parse_args()
 
     if not args.skip_wasm_build:
         build_wasm()
@@ -192,21 +190,21 @@ EXAMPLES = {
         This is a swiss-army-knife example showing the usage of most of the Rerun SDK APIs.
         The data logged is static and meaningless.
         """,
-        "build_args": "",
+        "build_args": [],
     },
     "car": {
         "title": "Car",
         "description": """
         A very simple 2D car is drawn using OpenCV, and a depth image is simulated and logged as a point cloud.
         """,
-        "build_args": "",
+        "build_args": [],
     },
     "clock": {
         "title": "Clock",
         "description": """
         An example visualizing an analog clock with hour, minute and seconds hands using Rerun Arrow3D primitives.
         """,
-        "build_args": "",
+        "build_args": [],
     },
     "colmap": {
         "title": "COLMAP",
@@ -221,7 +219,7 @@ EXAMPLES = {
         and we use Rerun to visualize the individual camera frames, estimated camera poses,
         and resulting point clouds over time.
         """,
-        "build_args": "--resize=800x600",
+        "build_args": ["--resize=800x600"],
     },
     "dicom": {
         "title": "Dicom",
@@ -229,7 +227,7 @@ EXAMPLES = {
         Example using a <a href="https://en.wikipedia.org/wiki/DICOM" target="_blank">DICOM</a> MRI scan.
         This demonstrates the flexible tensor slicing capabilities of the Rerun viewer.
         """,
-        "build_args": "",
+        "build_args": [],
     },
     "plots": {
         "title": "Plots",
@@ -237,7 +235,7 @@ EXAMPLES = {
         This example demonstrates how to log simple plots with the Rerun SDK.
         Charts can be created from 1-dimensional tensors, or from time-varying scalars.
         """,
-        "build_args": "",
+        "build_args": [],
     },
     "raw_mesh": {
         "title": "Raw Mesh",
@@ -245,7 +243,7 @@ EXAMPLES = {
         This example demonstrates how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups")
         and their transform hierarchy. Simple material properties are supported.
         """,
-        "build_args": "",
+        "build_args": [],
     },
     "text_logging": {
         "title": "Text Logging",
@@ -255,7 +253,7 @@ EXAMPLES = {
         Rerun is able to act as a Python logging handler, and can show all your Python log messages
         in the viewer next to your other data.
         """,
-        "build_args": "",
+        "build_args": [],
     },
 }
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -12,6 +12,11 @@ from glob import glob
 from types import TracebackType
 from typing import Any
 
+EXTRA_ARGS = {
+    "examples/python/clock": ["--steps=200"],  # Make it faster
+    "examples/python/opencv_canny": ["--num-frames=30"],  # Make sure it finishes
+}
+
 
 def start_process(args: list[str], cwd: str, wait: bool) -> Any:
     process = subprocess.Popen(
@@ -30,7 +35,11 @@ def start_process(args: list[str], cwd: str, wait: bool) -> Any:
 
 
 def run_py_example(path: str, viewer_port: int | None = None, wait: bool = True, save: str | None = None) -> Any:
-    args = ["python3", "main.py", "--num-frames=30", "--steps=200"]
+    args = ["python3", "main.py"]
+
+    if path in EXTRA_ARGS:
+        args += EXTRA_ARGS[path]
+
     if save is not None:
         args += [f"--save={save}"]
     if viewer_port is not None:


### PR DESCRIPTION
### What
Closes https://github.com/rerun-io/rerun/issues/2217

Remove weird-looking argument parsing in examples. We only added them in https://github.com/rerun-io/rerun/pull/1927 because of `run_all.py`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2398

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/26bc44f/docs
Examples preview: https://rerun.io/preview/26bc44f/examples
<!-- pr-link-docs:end -->
