### PR TITLE
Add `log_cleared` to the common index

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -123,6 +123,11 @@ SECTION_TABLE: Final[list[Section]] = [
         func_list=["log_text_entry"],
     ),
     Section(
+        title="Clearing Entities",
+        module_summary=None,
+        func_list=["log_cleared"],
+    ),
+    Section(
         title="Helpers",
         module_summary="script_helpers",
         func_list=["script_add_args", "script_setup", "script_teardown"],


### PR DESCRIPTION
### What
Help users discover the `log_cleared` API by adding it to the index.

Resolves:
 - https://github.com/rerun-io/rerun/issues/2348

TODO:
 - [ ] After merging, this change should be cherry-picked into `release-0.6` branch and documentation should be re-deployed.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
