### PR TITLE
Use forked `mkdocs-redirects`

### DIFF
--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -3,7 +3,7 @@ mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-material
 mkdocs-material-extensions
-https://github.com/rerun-io/mkdocs-redirects/archive/v1.3.1.zip # forked mkdocs-redirects with https://github.com/rerun-io/mkdocs-redirects/commit/d367a0847928438b66f73508e49852be1190409b
+git+https://github.com/rerun-io/mkdocs-redirects.git@v1.3.1 # forked mkdocs-redirects with https://github.com/rerun-io/mkdocs-redirects/commit/d367a0847928438b66f73508e49852be1190409b
 mkdocstrings
 mkdocstrings-python
 mike

--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -3,7 +3,7 @@ mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-material
 mkdocs-material-extensions
-mkdocs-redirects
+https://github.com/rerun-io/mkdocs-redirects/archive/v1.3.1.zip # forked mkdocs-redirects
 mkdocstrings
 mkdocstrings-python
 mike

--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -3,7 +3,7 @@ mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-material
 mkdocs-material-extensions
-https://github.com/rerun-io/mkdocs-redirects/archive/v1.3.1.zip # forked mkdocs-redirects
+https://github.com/rerun-io/mkdocs-redirects/archive/v1.3.1.zip # forked mkdocs-redirects with https://github.com/rerun-io/mkdocs-redirects/commit/d367a0847928438b66f73508e49852be1190409b
 mkdocstrings
 mkdocstrings-python
 mike


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Fix for https://github.com/rerun-io/rerun/issues/2222 (round 2)

[Related commit](https://github.com/rerun-io/mkdocs-redirects/commit/d367a0847928438b66f73508e49852be1190409b) - it's just removing the `noindex` line from the redirect `index.html` template. I have yet to confirm if this actually has the intended effect, but it's the only `noindex` anywhere in the entire docs site, and that's what google search console was complaining about. If this works, I'll make a PR upstream with the fix.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2404

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/6383747/docs
Examples preview: https://rerun.io/preview/6383747/examples
<!-- pr-link-docs:end -->
