### PR TITLE
Fix transforms not applied to connections from transform context

### DIFF
--- a/crates/re_space_view_spatial/src/scene/mod.rs
+++ b/crates/re_space_view_spatial/src/scene/mod.rs
@@ -84,7 +84,7 @@ pub fn preferred_navigation_mode(
 
 pub fn load_keypoint_connections(
     ent_context: &SpatialSceneEntityContext<'_>,
-    entity_path: &re_data_store::EntityPath,
+    ent_path: &re_data_store::EntityPath,
     keypoints: Keypoints,
 ) {
     if keypoints.is_empty() {
@@ -95,7 +95,8 @@ pub fn load_keypoint_connections(
     let mut line_builder = ent_context.shared_render_builders.lines();
     let mut line_batch = line_builder
         .batch("keypoint connections")
-        .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
+        .world_from_obj(ent_context.world_from_obj)
+        .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
     for ((class_id, _time), keypoints_in_class) in keypoints {
         let Some(class_description) = ent_context.annotations.context.class_map.get(&class_id) else {
@@ -111,7 +112,7 @@ pub fn load_keypoint_connections(
             let (Some(a), Some(b)) = (keypoints_in_class.get(a), keypoints_in_class.get(b)) else {
                 re_log::warn_once!(
                     "Keypoint connection from index {:?} to {:?} could not be resolved in object {:?}",
-                    a, b, entity_path
+                    a, b, ent_path
                 );
                 continue;
             };


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Applies to 2D & 3D connections between points.

Before:
<img width="488" alt="Screenshot 2023-06-13 at 10 47 08" src="https://github.com/rerun-io/rerun/assets/1220815/a78a96b0-7169-43c3-8bd9-a46512bb583a">

After:
<img width="395" alt="Screenshot 2023-06-13 at 10 46 11" src="https://github.com/rerun-io/rerun/assets/1220815/caf84de6-56ff-46e1-96c2-bf8e91ff3630">

Also briefly checkd that the other example with keypoints, mp_pose, also still works

Fixes #2402
* #2402

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2407

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/fe899e0/docs
Examples preview: https://rerun.io/preview/fe899e0/examples
<!-- pr-link-docs:end -->
