### PR TITLE
Added support for creating multi-resolution stacks with upload_image.py

### DIFF
--- a/examples/python/clock/README.md
+++ b/examples/python/clock/README.md
@@ -4,12 +4,13 @@ python: https://github.com/rerun-io/rerun/tree/latest/examples/python/clock/main
 ---
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/a1444b545986deca79302d538cd6b1a14b28314c_clock_480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/625e869c4d2d810dc6af70764894d3da5b2f3d25_clock_768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/874671091ec526047b8a8cd9b8046937cd978149_clock_1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/54807699ba1fe11df7ac34df70c34913197b1518_clock_1200w.png">
-  <img src="https://static.rerun.io/7eed6a7fe104aa0d277ffa7e571044de699b3b6a_clock_full.png" alt="screenshot of the clock example">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/30a2659cb4f9b6ac39c808c3312a3f89b71d040c_clock_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/acfb95102e353d67d0525e3a3d40fbe7f0ed638f_clock_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/7b1b0435cd8de9318c301036853d5c0d190b155f_clock_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/51938f84bdb0df1baa1d72e09f2a1daac6e66d1c_clock_1200w.png">
+  <img src="https://static.rerun.io/4040806d866f246eda1a1434f3a1ab083764eb56_clock_full.png" alt="screenshot of the clock example">
 </picture>
+
 
 An example visualizing an analog clock with hour, minute and seconds hands using Rerun Arrow3D primitives.
 

--- a/examples/python/clock/README.md
+++ b/examples/python/clock/README.md
@@ -3,7 +3,13 @@ title: Clock
 python: https://github.com/rerun-io/rerun/tree/latest/examples/python/clock/main.py
 ---
 
-![clock example>](https://static.rerun.io/f8003ba9954ae2236127b9623bc3d49ae1dc4af5_clock1.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/a1444b545986deca79302d538cd6b1a14b28314c_clock_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/625e869c4d2d810dc6af70764894d3da5b2f3d25_clock_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/874671091ec526047b8a8cd9b8046937cd978149_clock_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/54807699ba1fe11df7ac34df70c34913197b1518_clock_1200w.png">
+  <img src="https://static.rerun.io/7eed6a7fe104aa0d277ffa7e571044de699b3b6a_clock_full.png" alt="screenshot of the clock example">
+</picture>
 
 An example visualizing an analog clock with hour, minute and seconds hands using Rerun Arrow3D primitives.
 

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -7,3 +7,4 @@
 cryptography==38.0.4 # for scripts/upload_image.py
 google-cloud-storage==2.9.0 # for scripts/upload_image.py
 PyGithub==1.58.2 # for scripts/generate_pr_summary.py and scripts/pr_link_docs_preview.py
+Pillow # for scripts/upload_image.py

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -19,42 +19,149 @@ If you get this error:
 Then run `python3 -m pip install cryptography==38.0.4`
 (https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769)
 """
+
+# TODO:
+#  - pngcrush everything?
+#  - document how to use this script
+
 from __future__ import annotations
 
 import argparse
 import hashlib
+import logging
 import mimetypes
-import os
+from io import BytesIO
+from pathlib import Path
+from typing import BinaryIO
 
+import PIL
+import PIL.Image
 from google.cloud import storage
+from PIL.Image import Image, Resampling
+
+SIZES = [
+    480,
+    768,
+    1024,
+    1200,
+]
 
 
-def content_hash(path: str) -> str:
+class Uploader:
+    def __init__(self):
+        gcs = storage.Client("rerun-open")
+        self.bucket = gcs.bucket("rerun-static-img")
+
+    def upload_file(self, path: Path) -> str:
+        path = path.resolve()
+        digest = content_hash(path)
+
+        object_name = f"{digest}_{path.name}"
+        content_type, content_encoding = mimetypes.guess_type(path)
+        with open(path, "rb") as f:
+            self.upload_data(f, object_name, content_type, content_encoding)
+
+        return object_name
+
+    def upload_stack(self, image_path: Path) -> str:
+        """Create a multi-resolution stack and upload it."""
+
+        image = PIL.Image.open(image_path)
+        image_format = image.format
+        file_ext = image_path.suffix
+        content_type, _ = mimetypes.guess_type(image_path)
+
+        logging.info(f"Base image width: {image.width}px")
+
+        # build image stack
+        image_stack: list[tuple[str, int | None, Image]] = []
+        for width in SIZES:
+            if image.width > width:
+                logging.info(f"Resizing to: {width}px")
+                new_image = image.resize(
+                    size=(width, int(width * image.height / image.width)), resample=Resampling.LANCZOS
+                )
+
+                image_stack.append((f"{image_path.stem}_{width}w", width, new_image))
+
+        image_stack.append((f"{image_path.stem}_full", None, image))
+
+        html_str = "<picture>\n"
+
+        # upload images
+        for name, width, image in image_stack:
+            with BytesIO() as buffer:
+                image.save(buffer, image_format)
+                buffer.seek(0)
+                digest = content_hash(buffer)
+                buffer.seek(0)
+
+                object_name = f"{digest}_{name}{file_ext}"
+                logging.info(f"Uploading image: {object_name} (size: {buffer.getbuffer().nbytes} bytes)")
+                self.upload_data(buffer, object_name, content_type, None)
+
+                if width is not None:
+                    html_str += (
+                        f'  <source media="(min-width: {width}px)" srcset="https://static.rerun.io/{object_name}">\n'
+                    )
+                else:
+                    html_str += f'  <img src="https://static.rerun.io/{object_name}" alt="">\n'
+
+        html_str += "</picture>"
+        return html_str
+
+    def upload_data(
+        self, data: BinaryIO, name: str, content_type: str | None = None, content_encoding: str | None = None
+    ):
+        """Low-level upload of data."""
+
+        logging.debug(f"Uploading {name} (type: {content_type}, encoding: {content_encoding})")
+        destination = self.bucket.blob(name)
+        destination.content_type = content_type
+        destination.content_encoding = content_encoding
+        destination.upload_from_file(data)
+
+
+def content_hash(data: Path | BinaryIO) -> str:
     h = hashlib.sha1()
     b = bytearray(128 * 1024)
     mv = memoryview(b)
-    with open(path, "rb", buffering=0) as f:
+
+    def update(f: BinaryIO) -> None:
         while n := f.readinto(mv):
             h.update(mv[:n])
+
+    if isinstance(data, Path):
+        with open(data, "rb", buffering=0) as f:
+            update(f)
+    else:
+        update(data)
+
     return h.hexdigest()
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Upload an image.")
-    parser.add_argument("path", type=str, help="Path to the image.")
+    parser.add_argument("path", type=Path, help="Path to the image.")
+    parser.add_argument(
+        "--single", action="store_true", help="Upload a single image instead of creating a multi-resolution stack."
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
     args = parser.parse_args()
 
-    hash = content_hash(args.path)
-    object_name = f"{hash}_{os.path.basename(args.path)}"
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
 
-    gcs = storage.Client("rerun-open")
-    bucket = gcs.bucket("rerun-static-img")
-    destination = bucket.blob(object_name)
-    destination.content_type, destination.content_encoding = mimetypes.guess_type(args.path)
-    with open(args.path, "rb") as f:
-        destination.upload_from_file(f)
+    uploader = Uploader()
 
-    print(f"https://static.rerun.io/{object_name}")
+    if args.single:
+        object_name = uploader.upload_file(args.path)
+        print(f"https://static.rerun.io/{object_name}")
+    else:
+        html_str = uploader.upload_stack(args.path)
+        print("\n" + html_str)
 
 
 if __name__ == "__main__":

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -41,7 +41,6 @@ import tempfile
 from io import BytesIO
 from pathlib import Path
 
-
 import PIL
 import PIL.Image
 import PIL.ImageGrab
@@ -63,7 +62,8 @@ class Uploader:
         self.run_pngcrush = pngcrush
 
     def upload_file(self, path: Path) -> str:
-        """Upload a single file to Google Cloud.
+        """
+        Upload a single file to Google Cloud.
 
         Parameters
         ----------
@@ -88,7 +88,8 @@ class Uploader:
         return object_name
 
     def upload_stack_from_file(self, image_path: Path, name: str | None = None) -> str:
-        """Upload an image stack from a file.
+        """
+        Upload an image stack from a file.
 
         Parameters
         ----------
@@ -114,7 +115,8 @@ class Uploader:
         )
 
     def upload_stack_from_clipboard(self, name: str) -> str:
-        """Upload an image stack from the clipboard.
+        """
+        Upload an image stack from the clipboard.
 
         Parameters
         ----------
@@ -144,7 +146,8 @@ class Uploader:
         file_ext: str = ".png",
         content_type: str = "image/png",
     ) -> str:
-        """Create a multi-resolution stack and upload it.
+        """
+        Create a multi-resolution stack and upload it.
 
         Parameters
         ----------
@@ -204,7 +207,8 @@ class Uploader:
         return html_str
 
     def upload_data(self, data: bytes, name: str, content_type: str | None = None, content_encoding: str | None = None):
-        """Low-level upload of data.
+        """
+        Low-level upload of data.
 
         Parameters
         ----------
@@ -231,7 +235,8 @@ class Uploader:
 
 
 def run_pngcrush(data: bytes) -> bytes:
-    """Run pngcrush on some data.
+    """
+    Run pngcrush on some data.
 
     Parameters
     ----------

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -20,10 +20,6 @@ Then run `python3 -m pip install cryptography==38.0.4`
 (https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769)
 """
 
-# TODO:
-#  - pngcrush everything?
-#  - document how to use this script
-
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
### What

Create and upload multi-resolution stacks with `upload_image.py`

Clock example screenshot updated as an example of the result obtained.

Relates to #2273

TODO:
- [x] pngcrush stuff?
- [x] docs
- [x] test with jpg as well

### Usage

```sh
$ just upload --help
python3 "scripts/upload_image.py" --help
usage: upload_image.py [-h] [--single] [--name NAME] [--skip-pngcrush] [--debug] [path]

Upload an image.

positional arguments:
  path             File path to the image. If not provided, use the clipboard's content.

options:
  -h, --help       show this help message and exit
  --single         Upload a single image instead of creating a multi-resolution stack.
  --name NAME      Image name (required when uploading from clipboard).
  --skip-pngcrush  Skip PNGCrush.
  --debug          Enable debug logging.
```

### Example output


```
INFO:root:Base image width: 2348px
INFO:root:Resizing to: 480px
INFO:root:Resizing to: 768px
INFO:root:Resizing to: 1024px
INFO:root:Resizing to: 1200px
INFO:root:pngcrush reduced size from 76341 to 71599 bytes
INFO:root:Uploading 30a2659cb4f9b6ac39c808c3312a3f89b71d040c_clock_480w.png (size: 71599, type: image/png, encoding: None)
INFO:root:pngcrush reduced size from 145632 to 134514 bytes
INFO:root:Uploading acfb95102e353d67d0525e3a3d40fbe7f0ed638f_clock_768w.png (size: 134514, type: image/png, encoding: None)
INFO:root:pngcrush reduced size from 208771 to 188959 bytes
INFO:root:Uploading 7b1b0435cd8de9318c301036853d5c0d190b155f_clock_1024w.png (size: 188959, type: image/png, encoding: None)
INFO:root:pngcrush reduced size from 254562 to 231188 bytes
INFO:root:Uploading 51938f84bdb0df1baa1d72e09f2a1daac6e66d1c_clock_1200w.png (size: 231188, type: image/png, encoding: None)
INFO:root:pngcrush reduced size from 293024 to 265268 bytes
INFO:root:Uploading 4040806d866f246eda1a1434f3a1ab083764eb56_clock_full.png (size: 265268, type: image/png, encoding: None)

<picture>
  <source media="(max-width: 480px)" srcset="https://static.rerun.io/30a2659cb4f9b6ac39c808c3312a3f89b71d040c_clock_480w.png">
  <source media="(max-width: 768px)" srcset="https://static.rerun.io/acfb95102e353d67d0525e3a3d40fbe7f0ed638f_clock_768w.png">
  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/7b1b0435cd8de9318c301036853d5c0d190b155f_clock_1024w.png">
  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/51938f84bdb0df1baa1d72e09f2a1daac6e66d1c_clock_1200w.png">
  <img src="https://static.rerun.io/4040806d866f246eda1a1434f3a1ab083764eb56_clock_full.png" alt="">
</picture>
```



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2411

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/479fa5f/docs
Examples preview: https://rerun.io/preview/479fa5f/examples
<!-- pr-link-docs:end -->
