### PR TITLE
Fix WebGL crash due to rectangle shader returning arrays

### DIFF
--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -46,16 +46,6 @@ fn clamp_to_edge_nearest_neighbor(coord: Vec2, texture_dimension: Vec2) -> IVec2
     return IVec2(clamp(floor(coord), Vec2(0.0), texture_dimension - Vec2(1.0)));
 }
 
-/// Takes a floating point texel coordinate and outputs the four integer texel coordinates that are used for bilinear filtering.
-/// All four samples are clamped to the texture edge.
-fn clamp_to_edge_bilinear_samples(coord: Vec2, texture_dimension: Vec2) -> array<IVec2, 4> {
-    let v00 = clamp_to_edge_nearest_neighbor(coord + vec2(-0.5, -0.5), texture_dimension);
-    let v01 = clamp_to_edge_nearest_neighbor(coord + vec2(-0.5,  0.5), texture_dimension);
-    let v10 = clamp_to_edge_nearest_neighbor(coord + vec2( 0.5, -0.5), texture_dimension);
-    let v11 = clamp_to_edge_nearest_neighbor(coord + vec2( 0.5,  0.5), texture_dimension);
-    return array<IVec2, 4>(IVec2(v00), IVec2(v01), IVec2(v10), IVec2(v11));
-}
-
 fn filter_bilinear(coord: Vec2, v00: Vec4, v01: Vec4, v10: Vec4, v11: Vec4) -> Vec4 {
     let top = mix(v00, v10, fract(coord.x - 0.5));
     let bottom = mix(v01, v11, fract(coord.x - 0.5));
@@ -75,11 +65,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
                 clamp_to_edge_nearest_neighbor(coord, texture_dimensions), 0));
         } else {
             // bilinear
-            let sample_positions = clamp_to_edge_bilinear_samples(coord, texture_dimensions);
-            let v00 = decode_color(textureLoad(texture_float, sample_positions[0], 0));
-            let v01 = decode_color(textureLoad(texture_float, sample_positions[1], 0));
-            let v10 = decode_color(textureLoad(texture_float, sample_positions[2], 0));
-            let v11 = decode_color(textureLoad(texture_float, sample_positions[3], 0));
+            let v00 = decode_color(textureLoad(texture_float, clamp_to_edge_nearest_neighbor(coord + vec2(-0.5, -0.5), texture_dimensions), 0));
+            let v01 = decode_color(textureLoad(texture_float, clamp_to_edge_nearest_neighbor(coord + vec2(-0.5,  0.5), texture_dimensions), 0));
+            let v10 = decode_color(textureLoad(texture_float, clamp_to_edge_nearest_neighbor(coord + vec2( 0.5, -0.5), texture_dimensions), 0));
+            let v11 = decode_color(textureLoad(texture_float, clamp_to_edge_nearest_neighbor(coord + vec2( 0.5,  0.5), texture_dimensions), 0));
             normalized_value = filter_bilinear(coord, v00, v01, v10, v11);
         }
     } else if rect_info.sample_type == SAMPLE_TYPE_SINT {
@@ -91,11 +80,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
                 clamp_to_edge_nearest_neighbor(coord, texture_dimensions), 0)));
         } else {
             // bilinear
-            let sample_positions = clamp_to_edge_bilinear_samples(coord, texture_dimensions);
-            let v00 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[0], 0)));
-            let v01 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[1], 0)));
-            let v10 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[2], 0)));
-            let v11 = decode_color(Vec4(textureLoad(texture_sint, sample_positions[3], 0)));
+            let v00 = decode_color(Vec4(textureLoad(texture_sint, clamp_to_edge_nearest_neighbor(coord + vec2(-0.5, -0.5), texture_dimensions), 0)));
+            let v01 = decode_color(Vec4(textureLoad(texture_sint, clamp_to_edge_nearest_neighbor(coord + vec2(-0.5,  0.5), texture_dimensions), 0)));
+            let v10 = decode_color(Vec4(textureLoad(texture_sint, clamp_to_edge_nearest_neighbor(coord + vec2( 0.5, -0.5), texture_dimensions), 0)));
+            let v11 = decode_color(Vec4(textureLoad(texture_sint, clamp_to_edge_nearest_neighbor(coord + vec2( 0.5,  0.5), texture_dimensions), 0)));
             normalized_value = filter_bilinear(coord, v00, v01, v10, v11);
         }
     } else if rect_info.sample_type == SAMPLE_TYPE_UINT {
@@ -107,11 +95,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
                 clamp_to_edge_nearest_neighbor(coord, texture_dimensions), 0)));
         } else {
             // bilinear
-            let sample_positions = clamp_to_edge_bilinear_samples(coord, texture_dimensions);
-            let v00 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[0], 0)));
-            let v01 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[1], 0)));
-            let v10 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[2], 0)));
-            let v11 = decode_color(Vec4(textureLoad(texture_uint, sample_positions[3], 0)));
+            let v00 = decode_color(Vec4(textureLoad(texture_uint, clamp_to_edge_nearest_neighbor(coord + vec2(-0.5, -0.5), texture_dimensions), 0)));
+            let v01 = decode_color(Vec4(textureLoad(texture_uint, clamp_to_edge_nearest_neighbor(coord + vec2(-0.5,  0.5), texture_dimensions), 0)));
+            let v10 = decode_color(Vec4(textureLoad(texture_uint, clamp_to_edge_nearest_neighbor(coord + vec2( 0.5, -0.5), texture_dimensions), 0)));
+            let v11 = decode_color(Vec4(textureLoad(texture_uint, clamp_to_edge_nearest_neighbor(coord + vec2( 0.5,  0.5), texture_dimensions), 0)));
             normalized_value = filter_bilinear(coord, v00, v01, v10, v11);
         }
     } else {


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Works around  https://github.com/gfx-rs/naga/issues/2380

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)


<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
