### PR TITLE
Fix class id resolving to wrong color for class-id tensors

### DIFF
--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -201,7 +201,7 @@ fn class_id_tensor_to_gpu(
     Ok(ColormappedTexture {
         texture: main_texture_handle,
         range: [0.0, (colormap_width * colormap_height) as f32],
-        decode_srgb: true,
+        decode_srgb: false, // Setting this to true would affect the class ids, not the color they resolve to.
         multiply_rgb_with_alpha: false, // already premultiplied!
         gamma: 1.0,
         color_mapper: Some(ColorMapper::Texture(colormap_texture_handle)),


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Accidentally applied srgb conversion on the classids themselves.

Before:
![image](https://github.com/rerun-io/rerun/assets/1220815/c6f8661f-be3b-4fd4-9a0e-a6e81ee5d976)


After:
![image](https://github.com/rerun-io/rerun/assets/1220815/d2ec5598-1c04-450e-952d-727bb7c86384)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
