### PR TITLE
Add `jpeg_quality` parameter to `log_image`, requiring `cv2`

### DIFF
--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -94,7 +94,7 @@ impl PerTensorState {
         ctx.re_ui
             .selection_grid(ui, "tensor_selection_ui")
             .show(ui, |ui| {
-                tensor_summary_ui_grid_contents(ctx.re_ui, ui, tensor, &tensor_stats);
+                tensor_summary_ui_grid_contents(ctx.re_ui, ui, tensor, tensor, &tensor_stats);
                 self.texture_settings.ui(ctx.re_ui, ui);
                 self.color_mapping.ui(ctx.render_ctx, ctx.re_ui, ui);
             });

--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -160,9 +160,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         if resize:
             img = cv2.imread(str(image_file))
             img = cv2.resize(img, resize)
-            jpeg_quality = [int(cv2.IMWRITE_JPEG_QUALITY), 75]
-            _, encimg = cv2.imencode(".jpg", img, jpeg_quality)
-            rr.log_image_file("camera/image", img_bytes=encimg)
+            rr.log_image("camera/image", img, jpeg_quality=75)
         else:
             rr.log_image_file("camera/image", img_path=dataset_path / "images" / image.name)
 


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2175

### What
You can now do `log_image("image", image, jpeg_quality=75)` to compress your logged images so they take up less space on disk and in RAM.  This requires the `opencv-python` (`cv2`) package to be installed.

I also updated the UI so you can actually tell whether or not a tensor was compressed.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
