### PR TITLE
Fix tracking_hf example: put scaled thing under its own root entity

### DIFF
--- a/examples/python/tracking_hf_opencv/main.py
+++ b/examples/python/tracking_hf_opencv/main.py
@@ -85,8 +85,7 @@ class Detector:
         _, _, scaled_height, scaled_width = inputs["pixel_values"].shape
         scaled_size = (scaled_width, scaled_height)
         rgb_scaled = cv.resize(rgb, scaled_size)
-        rr.log_image("image/scaled/rgb", rgb_scaled)
-        rr.log_disconnected_space("image/scaled")  # Note: Haven't implemented 2D transforms yet.
+        rr.log_image("image_scaled/rgb", rgb_scaled)
 
         logging.debug("Pass image to detection network")
         outputs = self.model(**inputs)
@@ -99,7 +98,7 @@ class Detector:
         )[0]
 
         mask = segmentation_mask.detach().cpu().numpy().astype(np.uint8)
-        rr.log_segmentation_image("image/scaled/segmentation", mask)
+        rr.log_segmentation_image("image_scaled/segmentation", mask)
 
         boxes = detections["boxes"].detach().cpu().numpy()
         class_ids = detections["labels"].detach().cpu().numpy()
@@ -130,7 +129,7 @@ class Detector:
         thing_boxes = boxes[things_np, :]
         thing_class_ids = class_ids_np[things_np]
         rr.log_rects(
-            "image/scaled/detections/things",
+            "image_scaled/detections/things",
             thing_boxes,
             rect_format=rr.log.rects.RectFormat.XYXY,
             class_ids=thing_class_ids,
@@ -139,7 +138,7 @@ class Detector:
         background_boxes = boxes[~things_np, :]
         background_class_ids = class_ids[~things_np]
         rr.log_rects(
-            "image/scaled/detections/background",
+            "image_scaled/detections/background",
             background_boxes,
             rect_format=rr.log.rects.RectFormat.XYXY,
             class_ids=background_class_ids,


### PR DESCRIPTION
### What
Before:
![image](https://github.com/rerun-io/rerun/assets/1148717/5308685e-9a70-43aa-85ca-fc7d7bc2e00a)

After:
![image](https://github.com/rerun-io/rerun/assets/1148717/398857ef-3d08-4ef9-8018-cb79ae4ee4bf)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2419

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/501a2c6/docs
Examples preview: https://rerun.io/preview/501a2c6/examples
<!-- pr-link-docs:end -->
