### PR TITLE
Update web examples

### DIFF
--- a/examples/python/tracking_hf_opencv/main.py
+++ b/examples/python/tracking_hf_opencv/main.py
@@ -85,7 +85,7 @@ class Detector:
         _, _, scaled_height, scaled_width = inputs["pixel_values"].shape
         scaled_size = (scaled_width, scaled_height)
         rgb_scaled = cv2.resize(rgb, scaled_size)
-        rr.log_image("image_scaled/rgb", rgb_scaled, jpeg_quality=95)
+        rr.log_image("image_scaled/rgb", rgb_scaled, jpeg_quality=85)
 
         logging.debug("Pass image to detection network")
         outputs = self.model(**inputs)

--- a/examples/python/tracking_hf_opencv/main.py
+++ b/examples/python/tracking_hf_opencv/main.py
@@ -333,14 +333,15 @@ def track_objects(video_path: str) -> None:
             break
 
         rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-        rr.log_image("image/rgb", rgb, jpeg_quality=95)
+        rr.log_image("image/rgb", rgb, jpeg_quality=85)
 
         if not trackers or frame_idx % 40 == 0:
             detections = detector.detect_objects_to_track(rgb=rgb, frame_idx=frame_idx)
             trackers = update_trackers_with_detections(trackers, detections, label_strs, bgr)
 
         else:
-            logging.debug("Running tracking update step for frame %d", frame_idx)
+            if frame_idx % 10 == 0:
+                logging.debug("Running tracking update step for frame %d", frame_idx)
             for tracker in trackers:
                 tracker.update(bgr)
             trackers = [tracker for tracker in trackers if tracker.is_tracking]

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -190,25 +190,10 @@ BASE_PATH = "web_demo"
 SCRIPT_PATH = os.path.dirname(os.path.relpath(__file__))
 # When adding examples, add their requirements to `requirements-web-demo.txt`
 EXAMPLES = {
-    "api_demo": {
-        "title": "API Demo",
+    "arkitscenes": {
+        "title": "ARKitScenes",
         "description": """
-        This is a swiss-army-knife example showing the usage of most of the Rerun SDK APIs.
-        The data logged is static and meaningless.
-        """,
-        "build_args": [],
-    },
-    "car": {
-        "title": "Car",
-        "description": """
-        A very simple 2D car is drawn using OpenCV, and a depth image is simulated and logged as a point cloud.
-        """,
-        "build_args": [],
-    },
-    "clock": {
-        "title": "Clock",
-        "description": """
-        An example visualizing an analog clock with hour, minute and seconds hands using Rerun Arrow3D primitives.
+        TODO
         """,
         "build_args": [],
     },
@@ -225,7 +210,7 @@ EXAMPLES = {
         and we use Rerun to visualize the individual camera frames, estimated camera poses,
         and resulting point clouds over time.
         """,
-        "build_args": ["--resize=800x600"],
+        "build_args": ["--dataset=colmap_fiat", "--resize=800x600"],
     },
     "dicom": {
         "title": "Dicom",
@@ -235,29 +220,38 @@ EXAMPLES = {
         """,
         "build_args": [],
     },
+    "dna": {
+        "title": "dna",
+        "description": """
+        TODO
+        """,
+        "build_args": [],
+    },
+    "minimal": {
+        "title": "minimal",
+        "description": """
+        TODO
+        """,
+        "build_args": [],
+    },
+    "mp_pose": {
+        "title": "mp_pose",
+        "description": """
+        TODO
+        """,
+        "build_args": [],
+    },
     "plots": {
-        "title": "Plots",
+        "title": "plots",
         "description": """
-        This example demonstrates how to log simple plots with the Rerun SDK.
-        Charts can be created from 1-dimensional tensors, or from time-varying scalars.
+        TODO
         """,
         "build_args": [],
     },
-    "raw_mesh": {
-        "title": "Raw Mesh",
+    "tracking_hf_opencv": {
+        "title": "tracking_hf_opencv",
         "description": """
-        This example demonstrates how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups")
-        and their transform hierarchy. Simple material properties are supported.
-        """,
-        "build_args": [],
-    },
-    "text_logging": {
-        "title": "Text Logging",
-        "description": """
-        This example demonstrates how to integrate python's native `logging` with the Rerun SDK.
-
-        Rerun is able to act as a Python logging handler, and can show all your Python log messages
-        in the viewer next to your other data.
+        TODO
         """,
         "build_args": [],
     },

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -105,8 +105,10 @@ def collect_examples() -> list[Example]:
             commit=commit,
             build_args=EXAMPLES[name]["build_args"],
         )
-        if example.supports_save():
-            examples.append(example)
+        assert example.supports_save(), f'Example "{name}" does not support saving'
+        examples.append(example)
+
+
     return examples
 
 
@@ -167,6 +169,7 @@ def main() -> None:
 
     shutil.rmtree(f"{BASE_PATH}/examples", ignore_errors=True)
     examples = collect_examples()
+    assert len(examples) > 0, "No examples found"
     save_examples_rrd(examples)
     render_examples(examples)
     copy_static_assets(examples)
@@ -217,20 +220,6 @@ EXAMPLES = {
         "description": """
         Example using a <a href="https://en.wikipedia.org/wiki/DICOM" target="_blank">DICOM</a> MRI scan.
         This demonstrates the flexible tensor slicing capabilities of the Rerun viewer.
-        """,
-        "build_args": [],
-    },
-    "dna": {
-        "title": "dna",
-        "description": """
-        TODO
-        """,
-        "build_args": [],
-    },
-    "minimal": {
-        "title": "minimal",
-        "description": """
-        TODO
         """,
         "build_args": [],
     },

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -165,6 +165,7 @@ def main() -> None:
     if not args.skip_wasm_build:
         build_wasm()
 
+    shutil.rmtree(f"{BASE_PATH}/examples", ignore_errors=True)
     examples = collect_examples()
     save_examples_rrd(examples)
     render_examples(examples)

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -194,14 +194,14 @@ SCRIPT_PATH = os.path.dirname(os.path.relpath(__file__))
 # When adding examples, add their requirements to `requirements-web-demo.txt`
 EXAMPLES = {
     "arkitscenes": {
-        "title": "ARKitScenes",
+        "title": "ARKit Scenes",
         "description": """
         TODO
         """,
         "build_args": [],
     },
     "colmap": {
-        "title": "COLMAP",
+        "title": "Structure From Motion",
         "description": """
         An example using Rerun to log and visualize the output of COLMAP's sparse reconstruction.
 
@@ -216,7 +216,7 @@ EXAMPLES = {
         "build_args": ["--dataset=colmap_fiat", "--resize=800x600"],
     },
     "dicom": {
-        "title": "Dicom",
+        "title": "Dicom MRI",
         "description": """
         Example using a <a href="https://en.wikipedia.org/wiki/DICOM" target="_blank">DICOM</a> MRI scan.
         This demonstrates the flexible tensor slicing capabilities of the Rerun viewer.
@@ -224,21 +224,21 @@ EXAMPLES = {
         "build_args": [],
     },
     "mp_pose": {
-        "title": "mp_pose",
+        "title": "Human Pose Tracking",
         "description": """
         TODO
         """,
         "build_args": [],
     },
     "plots": {
-        "title": "plots",
+        "title": "Plots",
         "description": """
         TODO
         """,
         "build_args": [],
     },
     "tracking_hf_opencv": {
-        "title": "tracking_hf_opencv",
+        "title": "Object Tracking and Segmentation",
         "description": """
         TODO
         """,

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -37,19 +37,22 @@ class Example:
         in_path = os.path.abspath(self.path)
         out_dir = f"{BASE_PATH}/examples/{self.name}"
 
-        logging.info(f"Running {in_path}, outputting to {out_dir}")
         os.makedirs(out_dir, exist_ok=True)
+        rrd_path = os.path.join(out_dir, "data.rrd")
+        logging.info(f"Running {self.name}, outputting to {rrd_path}")
 
         args = [
             "python3",
             in_path,
-            f"--save={out_dir}/data.rrd",
+            f"--save={rrd_path}",
         ]
 
         subprocess.run(
             args + self.build_args,
             check=True,
         )
+
+        print(f"{rrd_path}: {os.path.getsize(rrd_path) / 1e6:.1f} MB")
 
     def supports_save(self) -> bool:
         with open(self.path) as f:
@@ -108,14 +111,16 @@ def collect_examples() -> list[Example]:
 
 
 def save_examples_rrd(examples: list[Example]) -> None:
-    logging.info("\nSaving examples as .rrd")
+    logging.info("\nSaving examples as .rrd…")
 
+    print("")
     for example in examples:
         example.save()
+        print("")
 
 
 def render_examples(examples: list[Example]) -> None:
-    logging.info("\nRendering examples")
+    logging.info("Rendering examples")
 
     template_path = os.path.join(SCRIPT_PATH, "demo_assets/templates/example.html")
     with open(template_path) as f:

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -108,7 +108,6 @@ def collect_examples() -> list[Example]:
         assert example.supports_save(), f'Example "{name}" does not support saving'
         examples.append(example)
 
-
     return examples
 
 
@@ -196,7 +195,9 @@ EXAMPLES = {
     "arkitscenes": {
         "title": "ARKit Scenes",
         "description": """
-        TODO
+        Visualizes the <a href="https://github.com/apple/ARKitScenes/" target="_blank">ARKitScenes dataset</a>
+        using the Rerun SDK.
+        The dataset contains color+depth images, the reconstructed mesh and labeled bounding boxes around furniture.
         """,
         "build_args": [],
     },
@@ -226,21 +227,24 @@ EXAMPLES = {
     "mp_pose": {
         "title": "Human Pose Tracking",
         "description": """
-        TODO
+        Use the <a href="https://google.github.io/mediapipe/" target="_blank">MediaPipe</a> Pose
+        solution to detect and track a human pose in video.
         """,
         "build_args": [],
     },
     "plots": {
         "title": "Plots",
         "description": """
-        TODO
+        Simple example of plots and charts.
         """,
         "build_args": [],
     },
     "tracking_hf_opencv": {
         "title": "Object Tracking and Segmentation",
         "description": """
-        TODO
+        Applying simple object detection and segmentation on a video using the Huggingface `transformers` library.
+        Tracking across frames is performed using
+        <a href="https://arxiv.org/pdf/1611.08461.pdf" target="_blank">CSRT</a> from OpenCV.
         """,
         "build_args": [],
     },

--- a/scripts/requirements-web-demo.txt
+++ b/scripts/requirements-web-demo.txt
@@ -1,8 +1,6 @@
 -r ../examples/python/arkitscenes/requirements.txt
 -r ../examples/python/colmap/requirements.txt
 -r ../examples/python/dicom/requirements.txt
--r ../examples/python/dna/requirements.txt
--r ../examples/python/minimal/requirements.txt
 -r ../examples/python/mp_pose/requirements.txt
 -r ../examples/python/plots/requirements.txt
 -r ../examples/python/tracking_hf_opencv/requirements.txt

--- a/scripts/requirements-web-demo.txt
+++ b/scripts/requirements-web-demo.txt
@@ -1,9 +1,8 @@
--r ../examples/python/api_demo/requirements.txt
--r ../examples/python/car/requirements.txt
--r ../examples/python/clock/requirements.txt
+-r ../examples/python/arkitscenes/requirements.txt
 -r ../examples/python/colmap/requirements.txt
--r ../examples/python/deep_sdf/requirements.txt
 -r ../examples/python/dicom/requirements.txt
+-r ../examples/python/dna/requirements.txt
+-r ../examples/python/minimal/requirements.txt
+-r ../examples/python/mp_pose/requirements.txt
 -r ../examples/python/plots/requirements.txt
--r ../examples/python/raw_mesh/requirements.txt
--r ../examples/python/text_logging/requirements.txt
+-r ../examples/python/tracking_hf_opencv/requirements.txt


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2260

### What
I've updated the list of examples to use at demo.rerun.io.

Sizes are pretty good now with JPEG compression, and all of these will be streamed once we have  https://github.com/rerun-io/rerun/issues/2262 (except DICOM, which is just one big tensor)

```
arkitscenes:         42.7 MB
colmap:               7.6 MB
dicom:               67.7 MB
mp_pose:             58.2 MB
plots:                0.1 MB
tracking_hf_opencv:  58.2 MB
```

The CSS here could use some work though in a folllow-up PR:
![image](https://github.com/rerun-io/rerun/assets/1148717/0ac44586-6438-4976-b959-2e0f327b989f)

Some of the names here have been updated, following the lead of https://github.com/rerun-io/rerun/pull/2416

### How to test it
```
scripts/build_demo_app.py
(cd web_demo && basic-http-server -a 0.0.0.0:8080 .)
```

This will also require a manual deploy to `demo.rerun.io` at some point.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2420

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/07dd16b/docs
Examples preview: https://rerun.io/preview/07dd16b/examples
<!-- pr-link-docs:end -->
