### PR TITLE
Fix BGR/RGB mixup in colmap demo

### DIFF
--- a/examples/python/colmap/main.py
+++ b/examples/python/colmap/main.py
@@ -158,9 +158,10 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         )
 
         if resize:
-            img = cv2.imread(str(image_file))
-            img = cv2.resize(img, resize)
-            rr.log_image("camera/image", img, jpeg_quality=75)
+            bgr = cv2.imread(str(image_file))
+            bgr = cv2.resize(bgr, resize)
+            rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+            rr.log_image("camera/image", rgb, jpeg_quality=75)
         else:
             rr.log_image_file("camera/image", img_path=dataset_path / "images" / image.name)
 


### PR DESCRIPTION
### What
Bug introduced in https://github.com/rerun-io/rerun/pull/2418

It's back to being red:
![image](https://github.com/rerun-io/rerun/assets/1148717/9ce4ab6b-a782-4b0d-9f75-2c905bf3313e)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2430

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/df06d4c/docs
Examples preview: https://rerun.io/preview/df06d4c/examples
<!-- pr-link-docs:end -->
