### PR TITLE
Install rerun-sdk with --no-index

### DIFF
--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -39,16 +39,27 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
-      - name: Download Wheel
+      - name: Download Wheel Artifact
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.WHEEL_ARTIFACT_NAME }}
-          path: wheel
+          path: wheel_artifact
 
-      - name: Install built wheel
+      - name: Install wheel dependencies
+        # First we install the dependencies manually so we can use `--no-index` when installing the wheel.
+        # This needs to be a separate step for some reason or the following step fails
+        # TODO(jleibs): pull these deps from pyproject.toml
         shell: bash
         run: |
-          pip install --find-links wheel rerun-sdk
+          pip install deprecated numpy>=1.23 pillow>=9.5.0 pyarrow==10.0.1 pytest==7.1.2
+
+      - name: Install downloaded wheel_artifact
+        # Now install the wheel using a specific version and --no-index to guarantee we get the version from
+        # the pre-dist folder. Note we don't use --force-reinstall here because --no-index means it wouldn't
+        # find the dependencies to reinstall them.
+        shell: bash
+        run: |
+          pip install rerun-sdk --no-index --find-links wheel_artifact
 
       - name: Install Deps
         shell: bash


### PR DESCRIPTION
I noticed that https://build.rerun.io/commit/e15ebb5/notebooks/cube.html was running with the 0.6 rerun-sdk, not the newly built version.

### What

Use the same trick we use elsewhere to install rerun-sdk using --no-index so we get the right version.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2434

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/1ba3e6a/docs
Examples preview: https://rerun.io/preview/1ba3e6a/examples
<!-- pr-link-docs:end -->