### PR TITLE
Fixed a bunch of missing renames

### DIFF
--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -278,9 +278,9 @@ jobs:
         id: dataset
         uses: actions/cache@v3
         with:
-          path: examples/python/colmap/dataset/
+          path: examples/python/structure_from_motion/dataset/
           # TODO(jleibs): Derive this key from the invocation below
-          key: colmap-dataset-colmap-fiat-v1
+          key: structure-from-motion-dataset-structure-from-motion-fiat-v1
 
       - name: Generate Embedded RRD file
         if: needs.set-config.outputs.RUN_TESTS == 'true'
@@ -289,7 +289,7 @@ jobs:
         run: |
           mkdir rrd
           pip install -r examples/python/structure_from_motion/requirements.txt
-          python3 examples/python/structure_from_motion/main.py --dataset colmap_fiat --resize 800x600 --save rrd/colmap_fiat.rrd
+          python3 examples/python/structure_from_motion/main.py --dataset structure_from_motion_fiat --resize 800x600 --save rrd/structure_from_motion_fiat.rrd
 
       # All platforms are currently creating the same rrd file, upload one of them
       - name: Save RRD artifact

--- a/.github/workflows/reusable_upload_wheels.yml
+++ b/.github/workflows/reusable_upload_wheels.yml
@@ -78,7 +78,7 @@ jobs:
         # If you change the line below you should almost definitely change the `key:` line
         # in 'Cache RRD dataset'reusable_build_and_test.yml
         run: |
-          cp rrd/colmap_fiat.rrd unpack-dist/${{ steps.get_folder_name.outputs.PKG_FOLDER }}/rerun_sdk/rerun_demo/colmap_fiat.rrd
+          cp rrd/structure_from_motion_fiat.rrd unpack-dist/${{ steps.get_folder_name.outputs.PKG_FOLDER }}/rerun_sdk/rerun_demo/structure_from_motion_fiat.rrd
 
       - name: Repack the wheel
         shell: bash

--- a/crates/rerun-cli/README.md
+++ b/crates/rerun-cli/README.md
@@ -31,5 +31,5 @@ Run `rerun --help` for more.
 
 ### Running a web viewer
 ```sh
-rerun --web-viewer ../nyud.rrd
+rerun --web-viewer path/to/file.rrd
 ```

--- a/crates/rerun/README.md
+++ b/crates/rerun/README.md
@@ -59,5 +59,5 @@ Run `rerun --help` for more.
 The web viewer is an experimental feature, but you can try it out with:
 
 ```sh
-rerun --web-viewer ../nyud.rrd
+rerun --web-viewer path/to/file.rrd
 ```

--- a/docs/content/getting-started/viewer-walkthrough.md
+++ b/docs/content/getting-started/viewer-walkthrough.md
@@ -37,7 +37,7 @@ If you have already followed the Python Quickstart you may have used `rerun_demo
 
 This time, we will pass an additional flag:
 ```bash
-$ python -m rerun_demo --colmap
+$ python -m rerun_demo --structure-from-motion
 ```
 
 *Note: If this is your first time launching Rerun you will see a notification about the Rerun anonymous data usage
@@ -46,7 +46,7 @@ like.*
 
 In your terminal you should see an output along the lines of:
 ```
-2023-02-13T05:16:06.835424Z  INFO rerun::run: Loading "/home/rerun/venv/lib/python3.10/site-packages/rerun_sdk/rerun_demo/colmap.rrd"…
+2023-02-13T05:16:06.835424Z  INFO rerun::run: Loading "/home/rerun/venv/lib/python3.10/site-packages/rerun_sdk/rerun_demo/structure_from_motion_fiat.rrd"…
 ```
 
 And a window that looks like this will appear:

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,8 @@ The important part is that each example has a `README.md` file. This file contai
 ```
 ---
 title: Text Logging
-python: https://github.com/rerun-io/rerun/tree/latest/examples/python/tracking_hf_opencv/main.py
+python: https://github.com/rerun-io/rerun/tree/latest/examples/python/detect_and_track_objects/main.py
+tags: [2D, huggingface, object-detection, object-tracking, opencv]
 ---
 
 ...

--- a/examples/python/live_camera_edge_detection/main.py
+++ b/examples/python/live_camera_edge_detection/main.py
@@ -13,7 +13,7 @@ rerun --memory-limit 4GB
 
 And then connect using:
 ```
-python examples/python/opencv_canny/main.py --connect
+python examples/python/live_camera_edge_detection/main.py --connect
 ```
 
 """
@@ -89,7 +89,7 @@ rerun --memory-limit 4GB
 
 And then connect using:
 ```
-python examples/python/opencv_canny/main.py --connect
+python examples/python/live_camera_edge_detection/main.py --connect
 ```
 ################################################################################
         """

--- a/examples/python/signed_distance_fields/main.py
+++ b/examples/python/signed_distance_fields/main.py
@@ -22,7 +22,7 @@ Using both traditional methods as well as the one described in the DeepSDF paper
 Run:
 ```sh
 # assuming your virtual env is up
-examples/python/deep_sdf/main.py
+examples/python/signed_distance_fields/main.py
 ```
 """
 from __future__ import annotations

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -175,7 +175,7 @@ def main() -> None:
         "--dataset",
         action="store",
         default="colmap_rusty_car",
-        choices=["colmap_rusty_car", "colmap_fiat"],
+        choices=["colmap_rusty_car", "structure_from_motion_fiat"],
         help="Which dataset to download",
     )
     parser.add_argument("--resize", action="store", help="Target resolution to resize images")

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -100,7 +100,7 @@ required-imports = ["from __future__ import annotations"]
 # with the other `rerun` pypi package. The rerun_sdk.pth adds this to the pythonpath
 # which then allows `import rerun` to work as expected.
 # See https://github.com/rerun-io/rerun/pull/1085 for more details
-include = ["rerun_sdk.pth", "rerun_sdk/rerun_demo/colmap_fiat.rrd"]
+include = ["rerun_sdk.pth", "rerun_sdk/rerun_demo/structure_from_motion_fiat.rrd"]
 locked = true
 python-packages = [
   "rerun_sdk/rerun",

--- a/rerun_py/rerun_sdk/rerun_demo/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_demo/__main__.py
@@ -26,7 +26,7 @@ def run_cube(args: argparse.Namespace):
     rr.script_teardown(args)
 
 
-def run_colmap(args):
+def run_structure_from_motion(args):
     from rerun import bindings, unregister_shutdown  # type: ignore[attr-defined]
 
     serve_opts = []
@@ -45,7 +45,7 @@ def run_colmap(args):
     # We don't need to call shutdown in this case. Rust should be handling everything
     unregister_shutdown()
 
-    rrd_file = pathlib.Path(__file__).parent.joinpath("colmap_fiat.rrd").resolve()
+    rrd_file = pathlib.Path(__file__).parent.joinpath("structure_from_motion_fiat.rrd").resolve()
     if not rrd_file.exists():
         print(f"No demo file found at {rrd_file}. Package was built without demo support", file=sys.stderr)
         exit(1)
@@ -67,7 +67,7 @@ def main() -> None:
     )
 
     group.add_argument(
-        "--colmap",
+        "--structure-from-motion",
         action="store_true",
         help="Run the COLMAP data demo",
     )
@@ -76,14 +76,14 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if not any([args.cube, args.colmap]):
+    if not any([args.cube, args.structure_from_motion]):
         args.cube = True
 
     if args.cube:
         run_cube(args)
 
-    elif args.colmap:
-        run_colmap(args)
+    elif args.structure_from_motion:
+        run_structure_from_motion(args)
 
 
 if __name__ == "__main__":

--- a/scripts/build_demo_app.py
+++ b/scripts/build_demo_app.py
@@ -214,7 +214,7 @@ EXAMPLES = {
         and we use Rerun to visualize the individual camera frames, estimated camera poses,
         and resulting point clouds over time.
         """,
-        "build_args": ["--dataset=colmap_fiat", "--resize=800x600"],
+        "build_args": ["--dataset=structure_from_motion_fiat", "--resize=800x600"],
     },
     "dicom_mri": {
         "title": "Dicom MRI",

--- a/scripts/demo_assets/static/index.html
+++ b/scripts/demo_assets/static/index.html
@@ -25,7 +25,7 @@
     ></script>
 
     <script>
-      window.location.href = "examples/colmap";
+      window.location.href = "examples/structure_from_motion";
     </script>
   </body>
 </html>

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -253,7 +253,7 @@
             // exa: 'https://app.rerun.io/version/v4.0.0/index.html' -> '/data/version/v4.0.0/'
             let data_path = '/data/' + window.location.pathname.replace(/index\.html$/, '') + '/';
 
-            const rrd_file = url_params.get('file') || 'colmap_fiat.rrd';
+            const rrd_file = url_params.get('file') || 'structure_from_motion_fiat.rrd';
 
             // Normalize the extra slashes from the url
             return (data_path + rrd_file).replace(/\/{2,}/g, '/');


### PR DESCRIPTION
### What

This PR fixes a bunch of places where renames from #2416 weren't applied.

⚠️ It touches various build-related places, due to the renaming of `colmap_fiat.rrd` into `structure_from_motion_fiat.rrd`, which is included in the SDK demo feature.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] ~~I've included a screenshot or gif (if applicable)~~ 

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
