### PR TITLE
Add Quarternion xyzw argument to ros_node example

### DIFF
--- a/examples/python/ros_node/main.py
+++ b/examples/python/ros_node/main.py
@@ -160,7 +160,7 @@ class TurtleSubscriber(Node):  # type: ignore[misc]
             t = tf.transform.translation
             q = tf.transform.rotation
             rr.log_transform3d(
-                path, rr.TranslationRotationScale3D([t.x, t.y, t.z], rr.Quaternion([q.x, q.y, q.z, q.w]))
+                path, rr.TranslationRotationScale3D([t.x, t.y, t.z], rr.Quaternion(xyzw=[q.x, q.y, q.z, q.w]))
             )
         except TransformException as ex:
             print(f"Failed to get transform: {ex}")


### PR DESCRIPTION
### What
Needed from the transform refactor.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2451

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/c9dee22/docs
Examples preview: https://rerun.io/preview/c9dee22/examples
<!-- pr-link-docs:end -->
