### PR TITLE
Fix greyscale colormapping being not gamma-corrected

### DIFF
--- a/crates/re_renderer/shader/colormap.wgsl
+++ b/crates/re_renderer/shader/colormap.wgsl
@@ -15,7 +15,7 @@ const COLORMAP_VIRIDIS:   u32 = 6u;
 fn colormap_srgb(which: u32, t_unsaturated: f32) -> Vec3 {
     let t = saturate(t_unsaturated);
     if which == COLORMAP_GRAYSCALE {
-        return Vec3(t);
+        return srgb_from_linear(Vec3(t));
     } else if which == COLORMAP_INFERNO {
         return colormap_inferno_srgb(t);
     } else if which == COLORMAP_MAGMA {


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Fix `colormap_srgb` outputting linear greyscale map instead of srgb greyscale map.

Note how this method is documented as:
`/// Returns a gamma-space sRGB in 0-1 range.`
but then a few lines below outputted `Vec3(t)` directly, i.e. a linear scale.

This became visually apparent when you put a 3 channel image (no color map!) next to a single channel image (greyscale color map applied) next to each other.

Before:
<img width="402" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/65e0feaa-2443-483b-9b6f-424e6b22c0d7">

After:
<img width="411" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/da1ba05e-7343-4700-a218-c5bb240870cb">


(this is not what the sample usually looks like, I made both images take the value 128, they are different by default)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2456

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/1c35935/docs
Examples preview: https://rerun.io/preview/1c35935/examples
<!-- pr-link-docs:end -->
