### PR TITLE
Update all documentation screenshots to optimised multi-resolution stacks

### DIFF
--- a/docs/content/concepts/annotation-context.md
+++ b/docs/content/concepts/annotation-context.md
@@ -14,7 +14,13 @@ This is particularly useful for visualizing the output of classifications algori
 (as demonstrated by the [Detect and Track Objects](https://github.com/rerun-io/rerun/tree/main/examples/python/detect_and_track_objects) example),
 but can be used more generally for any kind of reoccurring categorization within a Rerun recording.
 
-![class_ids](https://static.rerun.io/5508e3fd5b2fdc020eda0bd545ccb97d26a01303_classids.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/bb5f5e06931b4924ce3c0243d8285eee558e8f21_classids_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/43c5455dd453e8a3668f0426c3d8961d22a5471e_classids_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/c445af268f7700536bec97bd54134cfe5a48304e_classids_1024w.png">
+  <img src="https://static.rerun.io/7f881338f1970161f52a00f1ddd01d4dcccf8a46_classids_full.png" alt="viewer screenshot showing various tracked objects and their class ids">
+</picture>
+
 
 
 ### Keypoints & Keypoint Connections
@@ -32,7 +38,10 @@ Just as with labels & colors this allows you to use the same connection informat
 
 Keypoints are currently only applicable to 2D and 3D points.
 
-![keypoints](https://static.rerun.io/a8be4dff9cf1d2793d5a5f0d5c4bb058d1430ea8_keypoints.png)
+<picture>
+  <img src="https://static.rerun.io/98b627503df82a6e04c01133dcf6395b040cbd53_keypoints_full.png" alt="keypoint shown on a 3d skeleton">
+</picture>
+
 
 
 ### Logging an Annotation Context
@@ -65,4 +74,9 @@ you can explicitly determine the color of each class.
 * Python: [`log_segmentation_image`](https://ref.rerun.io/docs/python/latest/common/images/#rerun.log_segmentation_image)
 * Rust: Log a [`Tensor`](https://docs.rs/rerun/latest/rerun/components/struct.Tensor.html) with [`TensorDataMeaning::ClassId`](https://docs.rs/rerun/latest/rerun/components/enum.TensorDataMeaning.html#variant.ClassId)
 
-![segmentation image](https://static.rerun.io/7c47738b791a7faaad8f0221a78c027300d407fc_segmentation_image.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/b1da782a05e2f7c0048f4bddf9ea29fef7c80b4e_segmentation_image_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/f63cb085ee392f38e6431ab7e8c79aecb1b4e6e1_segmentation_image_768w.png">
+  <img src="https://static.rerun.io/716eeff1a99f51a6e77fca85c4e7dccf76b77c69_segmentation_image_full.png" alt="screenshot of a segmentation image">
+</picture>
+

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -53,7 +53,16 @@ Now you can run your application just as you would any other python script:
 ```
 
 And with that, we're ready to start sending out data:
-![logging data - waiting for data](https://static.rerun.io/4f83e588d7ca4ba6d09390d6d445f63bb4a73b4e_logging_data2_waiting.png)
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/b509f0c8ba4a46ed8ffd68bea4ade384525a41a1_logging_data2_waiting_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/89b4674ee51f3f5365bad2347bc3f7319ff8de0f_logging_data2_waiting_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/349e38deb9307100471b66becd6fab5d09dae80f_logging_data2_waiting_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/4820da379135db095f0d160550245114e6257400_logging_data2_waiting_1200w.png">
+  <img src="https://static.rerun.io/a45b879f74828ff22d0767c7892bffb17a0ac25f_logging_data2_waiting_full.png" alt="screenshot of the waiting screen">
+</picture>
+
+
 
 By default, the SDK will start a viewer in another process and automatically pipe the data through.
 There are other means of sending data to a viewer as we'll see at the end of this section, but for now this default will work great as we experiment.
@@ -92,7 +101,14 @@ rr.log_points("dna/structure/right", points2, colors=colors2, radii=0.08)
 Run your script once again and you should now see this scene in the viewer.
 Note that if the viewer was still running, Rerun will simply connect to this existing session and replace the data with this new [_recording_](../concepts/apps-and-recordings.md).
 
-![logging data - first points](https://static.rerun.io/46140c891a60026b3ef9fb0c34fcf63e23199ec7_logging_data3_first_points.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/5305cec597b9957036291198402d5afbbcce218e_logging_data3_first_points_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/5fa88ed6192920f6162b7080928aa538ae2025dd_logging_data3_first_points_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/9a87ed7e20b72902c6506a87fda3d62f716eed88_logging_data3_first_points_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/b32a40031e47a4aa3b1669bef53048765c1b7b10_logging_data3_first_points_1200w.png">
+  <img src="https://static.rerun.io/0e0fada083d59cf14ad20ed0ee50ef88a9550d82_logging_data3_first_points_full.png" alt="screenshot after logging the first points">
+</picture>
+
 
 _This is a good time to make yourself familiar with the viewer: try interacting with the scene and exploring the different menus._
 _Checkout the [Viewer Walkthrough](viewer-walkthrough.md) and [viewer reference](../reference/viewer/overview.md) for a complete tour of the viewer's capabilities._
@@ -152,7 +168,14 @@ rr.log_points("dna/structure/scaffolding/beads", beads, radii=0.06, colors=np.re
 Once again, although we are getting fancier and fancier with our [`numpy` incantations](https://ref.rerun.io/docs/python/latest/package/rerun_demo/util/#rerun_demo.util.bounce_lerp),
 there is nothing new here: it's all about building out `numpy` arrays and feeding them to the Rerun API.
 
-![logging data - beads](https://static.rerun.io/60c3c762448f68da3f5fdd7927a6e65e11f5385f_logging_data5_beads.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/5ad83403acc560dac2bd85211419482c60019783_logging_data5_beads_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/cdec3af724a3ceff147c1c6fd6cc9dbc51a2204d_logging_data5_beads_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cb272220c85e3376c75fd6da7f18462b920e172a_logging_data5_beads_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/de68973ad6420112eba8b91217d9f4713d5d9a02_logging_data5_beads_1200w.png">
+  <img src="https://static.rerun.io/7825d736cb8b7dab27f27aa7611c4bac24f23433_logging_data5_beads_full.png" alt="screenshot after logging beads">
+</picture>
+
 
 ## Animating the beads
 
@@ -162,7 +185,14 @@ Up until this point, we've completely set aside one of the core concepts of Reru
 
 Even so, if you look at your [Timeline View](../reference/viewer/timeline.md) right now, you'll notice that Rerun has kept track of time on your behalf anyways by memorizing when each log call occurred.
 
-![logging data - timeline closeup](https://static.rerun.io/f6dbc83f555597e2bfe946e8228301da82ad4611_logging_data6_timeline.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/720e5ba4d1881f88e1f0dd3342c52f3b472b70c6_logging_data6_timeline_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/96bdee91b139b19023524bc6954798005a24f298_logging_data6_timeline_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/c824ea981c457ee11c03b10645245b51e75de428_logging_data6_timeline_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/d8dcfc5d19865d0c50f43d377fbbcad027d44bf3_logging_data6_timeline_1200w.png">
+  <img src="https://static.rerun.io/37fbc6fcbe8e89b2267057e3eae2e56b8d9ddf42_logging_data6_timeline_full.png" alt="screenshot of the beads with the timeline">
+</picture>
+
 
 Unfortunately, the logging time isn't particularly helpful to us in this case: we can't have our beads animate depending on the logging time, else they would move at different speeds depending on the performance of the logging process!
 For that, we need to introduce our own custom timeline that uses a deterministic clock which we control.
@@ -189,7 +219,14 @@ A call to [`set_time_seconds`](https://ref.rerun.io/docs/python/latest/common/ti
 
 ⚠️  If you run this code as is, the result will be.. surprising: the beads are animating as expected, but everything we've logged until that point is gone! ⚠️
 
-![logging data - wat](https://static.rerun.io/a396c8aae1cbd717a3f35472594f789e4829b1ae_logging_data7_wat.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/af29a2c3ed2c7a829cd91c2ad11d38f4418b9b23_logging_data7_wat_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/a46e9b2e7cc03366712fc0d3e3bc5bcb1efb406c_logging_data7_wat_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/398fb5f7164b6ccf010e4af8b5c761818bf015a1_logging_data7_wat_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/263d82b50e184ecb4d83350a1ef8b89b5a4d7b5f_logging_data7_wat_1200w.png">
+  <img src="https://static.rerun.io/74239084e9e45d2a0187b5e5e944063e3c8df5fa_logging_data7_wat_full.png" alt="screenshot of the surprising situation">
+</picture>
+
 
 Enter...
 
@@ -202,7 +239,14 @@ rr.spawn()
 rr.set_time_seconds("stable_time", 0)
 ```
 
-![logging data - latest at](https://static.rerun.io/0182b4795ca2fed2f2097cfa5f5271115dee0aaf_logging_data8_latest_at.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/6c6918d4e1c33dc321d15e8746753ed2b1ca2037_logging_data8_latest_at_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/73755db0243987f750f620c34d2b5f67e47c6ab4_logging_data8_latest_at_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/72d2625d37ed6b149a4f5c016768d300c36a9bee_logging_data8_latest_at_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/a9559392295bc0bfc75da81badae2ae053f707e7_logging_data8_latest_at_1200w.png">
+  <img src="https://static.rerun.io/0a7c2f339aaff03c3ccf82d5686f3af2c19a00a7_logging_data8_latest_at_full.png" alt="screenshot after using latest at">
+</picture>
+
 
 This fix actually introduces yet another very important concept in Rerun: "latest at" semantics.
 Notice how entities `"dna/structure/left"` & `"dna/structure/right"` have only ever been logged at time zero, and yet they are still visible when querying times far beyond that point.

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -23,7 +23,15 @@ $ python3 -m rerun_demo
 
 If everything is installed and working correctly, you should end up with a window like below.
 Try looping the recording to see the fun animation.
-![Colored Cube](https://static.rerun.io/bb8a27a4a41d226ceca6cf805f7f16fe24224cfe_quickstart0_cube.png)
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/6e767ee4d13d9f4ccb887750302ea3934678672f_quickstart0_cube_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/4544950fee5574bbd0fdbd511c2fbbdcf2ca99c9_quickstart0_cube_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/f1ae7def70ced930795b09a8d84973c3f3859ec4_quickstart0_cube_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/14181fab1e3fde320e84727c3804cbc5259b4b93_quickstart0_cube_1200w.png">
+  <img src="https://static.rerun.io/770ffcd66ebc020bb0ff00ec123e19f1fcb0a3a4_quickstart0_cube_full.png" alt="colored cube">
+</picture>
+
 
 *Note: If this is your first time launching Rerun you will see a notification in the terminal about the Rerun anonymous
 data usage policy. Rerun collects anonymous usage data to help improve the project, though you may choose to opt out if you
@@ -70,7 +78,14 @@ rr.log_points("my_points", positions=positions, colors=colors, radii=0.5)
 When you run this script you will again be greeted with the [Rerun Viewer](../reference/viewer/overview.md), this time
 only showing a simple line of red points.
 
-![Simple Line](https://static.rerun.io/945dcc1c89e0bd8598116f3bd4f12c22834604a8_quickstart1_line.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/a4633eac537a4383a62db88d54c8b9e7260fdd95_quickstart1_line_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/5950b31e3698641b79803cbe61d5160502537bff_quickstart1_line_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/e274fd2baa46d89365e2e31ee6a2158e00c4ca07_quickstart1_line_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/3d0915cfdc86b25ed486693f80f65076e43d57fa_quickstart1_line_1200w.png">
+  <img src="https://static.rerun.io/37d42194bc99cbb805e3ca53eba11c2896616893_quickstart1_line_full.png" alt="simple line">
+</picture>
+
 
 The [rr.log_points](https://ref.rerun.io/docs/python/latest/common/spatial_primitives/#rerun.log_points) function can
 take any Nx2 or Nx3 numpy array as a collection of positions.
@@ -94,7 +109,13 @@ colors = np.vstack([c.reshape(-1) for c in col_grid]).astype(np.uint8).T
 rr.log_points("my_points", positions=positions, colors=colors, radii=0.5)
 ```
 
-![Simple Cube](https://static.rerun.io/48482e9dc110e0b95c1cf310eab3ccdba6d8880f_quickstart2_simple_cube.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/a624fdd8cd99414f12bb9e05b27d52720a48bd10_quickstart2_simple_cube_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/eee0373668bb90fd6b66c3687012833a136dc969_quickstart2_simple_cube_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/81da909eb3e44058ac6c67071e2b57490ba6e0ed_quickstart2_simple_cube_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/6eb065269db26ff92292c0d4360cd5affc197410_quickstart2_simple_cube_1200w.png">
+  <img src="https://static.rerun.io/56b44aef7d6875c222219dcff2bc3a3d470c8891_quickstart2_simple_cube_full.png" alt="">
+</picture>
 
 ## What's next
 

--- a/docs/content/getting-started/rust.md
+++ b/docs/content/getting-started/rust.md
@@ -54,7 +54,15 @@ cargo run
 ```
 
 Once everything finishes compiling, you will see the points in the Rerun Viewer:
-![intro users - result](https://static.rerun.io/d9124a2aea32a8f76536c78289bf488ea6261c4d_intro_users1_result.png)
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/64200b0042929ec0a686de6ee154488447a80540_intro_users1_result_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/2d8bbd8fe7da242f73ea269fdaa1c830552cff7d_intro_users1_result_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/429ce634ff41a5350167eff9dea51477c9225772_intro_users1_result_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/c18c538b4e1a577cb0f89e87ef5853c03d5eb2d2_intro_users1_result_1200w.png">
+  <img src="https://static.rerun.io/40dca5343e79c4a214fdac277dc601c3da8fb491_intro_users1_result_full.png" alt="Rust getting started result">
+</picture>
+
 
 ## Using the viewer
 Try out the following to interact with the viewer:

--- a/docs/content/getting-started/viewer-walkthrough.md
+++ b/docs/content/getting-started/viewer-walkthrough.md
@@ -14,7 +14,13 @@ be comfortable with the following topics:
 
 Here is a preview of the dataset that we will be working with:
 
-![Preview](https://static.rerun.io/187c2379476cfb91f23b58dc9253688ef357c029_viewer_walkthrough0_preview.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/74a37346b0a1f47a8dc6d57d2dbc01ee6afb3960_viewer_walkthrough0_preview_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/1d645a8fd2eb8f874bbbad3be084c96fe0c9bd39_viewer_walkthrough0_preview_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/6708f38efc707557d4ce15b5e67dddd7782d5051_viewer_walkthrough0_preview_1024w.png">
+  <img src="https://static.rerun.io/d63e6774d94ff403d51355bacdfee9a3e7751dcf_viewer_walkthrough0_preview_full.png" alt="viewer walkthrough dataset preview screenshot">
+</picture>
+
 
 The demo uses the output of the [COLMAP](https://colmap.github.io/) structure-from-motion pipeline on a small dataset.
 Familiarity with structure-from-motion algorithms is not a prerequisite for following the guide. All you need to know is
@@ -51,7 +57,14 @@ In your terminal you should see an output along the lines of:
 
 And a window that looks like this will appear:
 
-![First Launch](https://static.rerun.io/11b19a8c38f49f1b4fd22cf8b67b427b28794ec7_viewer_walkthrough1_first_launch.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/e3ed0032e35937f22ab473a63f9a44dbe9fcc519_viewer_walkthrough1_first_launch_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/3b0bff307be3711c4bcf1fa1e54a1808ddccafe6_viewer_walkthrough1_first_launch_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/bcf6a979f66df8d5435b958ee3286b80604b161e_viewer_walkthrough1_first_launch_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/4d7d0e9933abb124253ae9455933ba40fcb72fb4_viewer_walkthrough1_first_launch_1200w.png">
+  <img src="https://static.rerun.io/793d828d867a8d341cd3ec35bc553f2d65fba549_viewer_walkthrough1_first_launch_full.png" alt="viewer walkthrough first launch screenshot">
+</picture>
+
 
 Depending on your display size, the panels may have a different arrangements. This does not yet look like the initial
 preview, but the remainder of this guide will walk you through how to configure the Viewer to meet your needs.
@@ -71,7 +84,13 @@ There are 4 main parts to this window:
 Each of the 3 side panels has a corresponding button in the upper right corner. Try clicking each of these to hide and
 show the corresponding panel.
 
-![Toggle Panel](https://static.rerun.io/817453aa3cb68881589a69a72f9250508902c958_viewer_walkthrough2_toggle_panel.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/65b3a60d28105aaabb1675e37f998f6fe4bd3f5a_viewer_walkthrough2_toggle_panel_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/6f71431a2946fa7ae0f5033b90ca23c664cc4856_viewer_walkthrough2_toggle_panel_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/b6a5ec42e21a88a55d1131501a4fd53b860290e9_viewer_walkthrough2_toggle_panel_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/5d3a114ba9b8695fa5897e6600a9ea58d57665fe_viewer_walkthrough2_toggle_panel_1200w.png">
+  <img src="https://static.rerun.io/26cba988d81f960832801bcda2c7d233c2b34401_viewer_walkthrough2_toggle_panel_full.png" alt="viewer walkthrough toggle panel screenshots">
+</picture>
 
 For now, leave the panels visible since we will use them through the remainder of this guide.
 
@@ -79,7 +98,14 @@ It is also possible to re-arrange the individual space views. Try grabbing any o
 dragging it to different locations in the Viewport. You can also resize individual views by grabbing the edge of the
 view.
 
-![Rearrange Views](https://static.rerun.io/b8de42db0aca90270e57a844f1c6aba653142280_viewer_walkthrough3_rearrange.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/27a97272519fc3f4185cb43d0ba80fbef5a5408e_viewer_walkthrough3_rearrangeOD_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/1c868e97537c1625c6bec0051bf7b7d184f79ebc_viewer_walkthrough3_rearrangeOD_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/bc7ee5a9a1a4a95f6ef8b1f29fb4ad73605833c5_viewer_walkthrough3_rearrangeOD_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/62e5c42de6c545b9b85582a6bb91a4feb8dccf99_viewer_walkthrough3_rearrangeOD_1200w.png">
+  <img src="https://static.rerun.io/ed7299b15ae5795d023d196a821e667a1a50591a_viewer_walkthrough3_rearrangeOD_full.png" alt="viewer walkthrough rearrange panels screenshot">
+</picture>
+
 
 Feel free to move the views around until you are happy with the layout.
 
@@ -98,7 +124,14 @@ You can find out more about these entities by hovering over them in the differen
 context popup with additional information. You can also click on entities to select them and see more details in the
 [Selection panel](../reference/viewer/selection.md).
 
-![Hover Data](https://static.rerun.io/6e297585d86b89e2bb00534045288277c8e686ac_viewer_walkthrough4_hover.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/f99a8f63f0b653dfac91476a60b3482edf8e638f_viewer_walkthrough4_hover_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/9567d3d33e8e6743de3f08c65fd3a285607bd082_viewer_walkthrough4_hover_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/f6a667b741dd05bed739a3e6838e33653af2e65c_viewer_walkthrough4_hover_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/90d296b819bf5f355853a01bfc7686265fd96905_viewer_walkthrough4_hover_1200w.png">
+  <img src="https://static.rerun.io/a22d892b0f00474aac948a3fce751a8cf559072d_viewer_walkthrough4_hover_full.png" alt="viewer walkthrough hover screenshot">
+</picture>
+
 
 Try each of the following:
  * Hover over the image to see a zoomed-in preview
@@ -116,7 +149,14 @@ also zoom using ctrl+scrollwheel or pinch gestures on a trackpad. Most views can
 double-clicking somewhere in the view. Every view has a "?" icon in the upper right hand corner. You can always mouse
 over this icon to find out more information about the specific view.
 
-![Adjust Scene Views](https://static.rerun.io/ffe2bb1db70357e68887eee2cf6fd80ce0145ca2_viewer_walkthrough5_nav.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/b87329150e8096e585956da2eebabe26219ca14f_viewer_walkthrough5_nav_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/ecb03b4fda5b0c55f06ab7252aacd3dbc7d883f6_viewer_walkthrough5_nav_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/86344228e1470c13888980f8441d774eb8d32315_viewer_walkthrough5_nav_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/33e87380305028a30b87f1303b588a8ee02a6f74_viewer_walkthrough5_nav_1200w.png">
+  <img src="https://static.rerun.io/7847244e2657a5555d90f4dd804e2650e4fde527_viewer_walkthrough5_nav_full.png" alt="viewer walkthrough rotate zoom and pan screenshot">
+</picture>
+
 
 Try each of the following:
  * Drag the camera image and zoom in on one of the stickers
@@ -135,7 +175,14 @@ To change the position on the timeline, simply grab the time indicator and pull 
 interested in seeing.  The space views will adjust accordingly. You can also use the play/pause/step/loop controls to
 playback the Rerun data as you might with a video file.
 
-![Adjust Time Slider](https://static.rerun.io/0fca0f1df6377028505699dac40e4a03738b4e44_viewer_walkthrough6_timeline.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/856f760b910a74a7ca0984b8ab06b3d2f67c5bcb_viewer_walkthrough6_timeline_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/2fa88a9a48ce575ec573fa71882137e8313e1454_viewer_walkthrough6_timeline_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/89772c671cf1bf3743b4d665122849968013ef95_viewer_walkthrough6_timeline_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/b196787f097b1ef4ba953a0487c1a1c48227c794_viewer_walkthrough6_timeline_1200w.png">
+  <img src="https://static.rerun.io/9816d7becf19399735bef1f17f1d4bb928c278f7_viewer_walkthrough6_timeline_full.png" alt="viewer walkthrough timeline screenshot">
+</picture>
+
 
 Try out the following:
   * Use the arrow buttons (or arrow keys on your keyboard) to step forward and backwards by a single frame
@@ -151,7 +198,14 @@ it's possible to also view the data in the specific order that it was logged.  C
 and switch it to "log_time." If you zoom in on the timeline (using ctrl+scrollwheel), you can see that these events were
 all logged at slightly different times.
 
-![Log Time](https://static.rerun.io/47ed33a74a8c9def1ca6c79801cb0fc305b0e0fe_viewer_walkthrough7_log_time.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/38a4a41b5814cbe157cb766440796047a369635f_viewer_walkthrough7_log_time_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/10741579d589ad806bdcdd39b05c51d1e11f501b_viewer_walkthrough7_log_time_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/210d91597ce9cea606ce8abfe3ea9c5ef7df7867_viewer_walkthrough7_log_time_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/e07ae99d7d1f36dbe19fd36facd2f354ac93ae01_viewer_walkthrough7_log_time_1200w.png">
+  <img src="https://static.rerun.io/b6a4ce41f51e338270240e394140bd4d8a68f6bf_viewer_walkthrough7_log_time_full.png" alt="viewer walkthrough change timeline screenshot">
+</picture>
+
 
 Feel free to spend a bit of time looking at the data across the different timelines. When you are done, switch back
 to the "frame" timeline and double-click the timeline panel to reset it to the default range.
@@ -176,7 +230,14 @@ show up in the view. This is making historical points, from farther back in time
 view. Because the points are logged in stationary 3d space, aggregating them here gives us a more complete view of the
 car. Leave the visible history with a value of 50.
 
-![Visible History](https://static.rerun.io/f3d7fd563aad90b506172217b8926ae8fc72d75e_viewer_walkthrough8_history.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/90fd21b61415776eafab8c9df07a5ea5df5186fd_viewer_walkthrough8_history_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/794677a662ba4dd755dadd118f1adf272da462eb_viewer_walkthrough8_history_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/25a6ac53a10461936ae019756ff3c4d53b7628c3_viewer_walkthrough8_history_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/be10b402dedc476ee1ac4d11402de6331b82fd83_viewer_walkthrough8_history_1200w.png">
+  <img src="https://static.rerun.io/9c6a01f4dd2059641d92d121f8f2772203c56cfa_viewer_walkthrough8_history_full.png" alt="viewer walkthrough adjusting visible history screenshot">
+</picture>
+)
 
 ### Modifying the contents of a space view
 Now select the `/ (Spatial)` view itself. We will start by giving this space view a different name. At the very
@@ -190,21 +251,42 @@ You can click on the "+" or "-" buttons to add or remove entities from this view
 completely disappear from the blueprint panel on the left. Entities that are incompatible with the selected view will be
 grayed out. For example, you cannot add a scalar to a spatial scene.
 
-![Add/Remove Entities](https://static.rerun.io/d703c542efad3c2bce2ae1f25019073ac64f5bef_viewer_walkthrough9_add_remove.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/982cd744bcbcdffc5161b84cae0c5b32fc58e819_viewer_walkthrough9_add_remove_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/90616f9dce6f28b18d4c4ee1d5750d43666a9748_viewer_walkthrough9_add_remove_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/a8669d788115df5671da92d814fa96951c569916_viewer_walkthrough9_add_remove_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/73bf1e30fe6878866fa1bc5e7652b30902f53506_viewer_walkthrough9_add_remove_1200w.png">
+  <img src="https://static.rerun.io/e22b231be49391998d6e6ef005b2dad0a85d2adf_viewer_walkthrough9_add_remove_full.png" alt="viewer walkthrough modifying contents of a space view screenshot">
+</picture>
+
 
 ## Creating new views
 New views can be created using the "+" button at the top of the Blueprint panel. When you click this button you will
 need to choose a root for your new space. This is the space that will act as your origin within the
 [transform system](../concepts/spaces-and-transforms.md).
 
-![Create a view](https://static.rerun.io/228a596464fd660dccba8d8259db8bdd02834c8d_viewer_walkthrough10_create.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/1bcf92925fceb39810a90110b26a1b26e2f6f5dc_viewer_walkthrough10_create_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/f621f5caf31bd0b7648b38bf10d8b3713c6ae043_viewer_walkthrough10_create_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/4267a02133317e071dabd92551567a84dc0136eb_viewer_walkthrough10_create_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/3b4788a2acd3823649589a8a4a52d915d12daed0_viewer_walkthrough10_create_1200w.png">
+  <img src="https://static.rerun.io/d89060f824af6b3f188e9187b8b5b9b1d7f75646_viewer_walkthrough10_create_full.png" alt="viewer walkthrough creating new view screenshot">
+</picture>
+
 
 After creating this new view, your view layout might be feeling a little cluttered. You can quickly hide views you're
 not using from the blueprint panel by hovering over the view and then clicking the icon that looks like an eye. Go ahead
 and hide the `image` and `avg_reproj_err` views, and collapse the expanded timeline panel using the button in the upper
 right corner. Note that even with the timeline collapsed you still have access to timeline controls, including a slider.
 
-![Toggle Vis](https://static.rerun.io/7eef1bd238ab85e8b4fc664da5bd0253eed46d2d_viewer_walkthrough11_toggle_vis.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/526e5dba02d3786045ff2b1d6dc20ade23325e4e_viewer_walkthrough11_toggle_vis_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/aa778e93172344fc1f340815564fa28ee33dcc54_viewer_walkthrough11_toggle_vis_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dcc33a360cf506b0b8dd61fe4f24c9030a0d0467_viewer_walkthrough11_toggle_vis_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/105b90940ff92ad296ef2d5dd74af9ca1256f4a6_viewer_walkthrough11_toggle_vis_1200w.png">
+  <img src="https://static.rerun.io/28d2720b63fbb2f3d3def0f37962f1ace3674085_viewer_walkthrough11_toggle_vis_full.png" alt="viewer walkthrough toggle visibility screenshot">
+</picture>
+
 
 ### Reusing what you've learned
 Finally, use what we covered in the previous section to change the contents of this view. Select the new `camera` view,
@@ -213,7 +295,14 @@ have visible history turned on -- that's because the blueprint is part of the vi
 Select the points within this view by clicking on them in the blueprint or the view itself, and then give them visible
 history as well. When you are done, your view should look like this:
 
-![Camera View](https://static.rerun.io/5fe3481a9696ba9c821818e26b0634011f4fffba_viewer_walkthrough12_cameraview.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/2bb43fcc8e3853d56ceb76f2db653d4c86331d5b_viewer_walkthrough12_cameraview_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/fd2a3990227a119cdc0adca137bd47f732ceaf7d_viewer_walkthrough12_cameraview_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/d6da109e6e4d6c71da6c6d18c18685713b3df917_viewer_walkthrough12_cameraview_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/0548051977569faf44ec3487b8c6285d4ca761f3_viewer_walkthrough12_cameraview_1200w.png">
+  <img src="https://static.rerun.io/3813b97238a2e3a8f5503ac3a408a8c9d0f5dadb_viewer_walkthrough12_cameraview_full.png" alt="viewer walkthrough camera view screenshot">
+</picture>
+
 
 Now move the slider back and forth and see what happens. Even though they are both views of the same camera and point
 entities, they behave quite differently. On the top the camera moves relative to the car, while on the bottom the car

--- a/docs/content/howto/extend-ui.md
+++ b/docs/content/howto/extend-ui.md
@@ -21,7 +21,14 @@ The best way to get started is by reading [the source code of the `extend_viewer
 
 ## Custom Space Views classes
 
-![The Rerun Viewer, extended with a custom Space View that is shown three times, each time showing points on a colored plane](https://static.rerun.io/9c04c0140552ff9ddd526f98381765382a71e86c_custom_space_view.jpeg)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/0ddce48924e92e4509c4caea3266d414ad76d961_custom_space_view_480w.jpeg">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/07fc2ec0fb45bd282cd942021bec82a8bf22929d_custom_space_view_768w.jpeg">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/2411b2c296230079e33bf075020510f10ccf086f_custom_space_view_1024w.jpeg">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/44ad47af559fbdd45aab5a663992f31e80876793_custom_space_view_1200w.jpeg">
+  <img src="https://static.rerun.io/dc8cfa50e309ba2e2cd2b7647391cd74b7a0477f_custom_space_view_full.jpeg" alt="The Rerun Viewer, extended with a custom Space View that is shown three times, each time showing points on a colored plane">
+</picture>
+
 
 Above screenshot shows the [`custom_space_view`](https://github.com/rerun-io/rerun/tree/main/examples/rust/custom_space_view) example.
 This example demonstrates how to add a fully custom Space View class to Rerun on startup.

--- a/docs/content/howto/ros2-nav-turtlebot.md
+++ b/docs/content/howto/ros2-nav-turtlebot.md
@@ -19,7 +19,13 @@ please consult the [ROS 2 Documentation](https://docs.ros.org/en/humble/index.ht
 All of the code for this guide can be found on GitHub in
 [rerun/examples/python/ros_node](https://github.com/rerun-io/rerun/blob/main/examples/python/ros_node/).
 
-![Rerun 3D view of ROS 2 turtlebot3 navigation demo](https://static.rerun.io/e51d3e26478661d11b339de5fdfed4f95d07c53c_ros1_preview.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/67b71229d4891875ccb2ad572f27d39189c777d1_ros1_preview_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/150376fc397ef97b8cc2a2f47b3037ade347dca8_ros1_preview_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/3f2d8247a448685da5f5c40b102677c3d52332a4_ros1_preview_1024w.png">
+  <img src="https://static.rerun.io/1a7818ed5bc11f6e9af6ac099df55fd7ee92953d_ros1_preview_full.png" alt="Rerun 3D view of ROS 2 turtlebot3 navigation demo">
+</picture>
+
 
 ## Prerequisites
 
@@ -79,7 +85,15 @@ With the previous dependencies installed, and gazebo running, you should now be 
 ```
 
 You should see a window similar to:
-![Initial window layout of Rerun 3D view of ROS 2 turtlebot3 navigation demo](https://static.rerun.io/c648219a13c044f5ca95aa2cb0e1f6729e6f37ac_ros2_launched.png)
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/503e1d77933852b686b2c8410bff77ba7b3e303a_ros2_launched_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/3c8c0d61cf8fb7861e6f637d8047bcc04b8596fb_ros2_launched_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/e1687fad31ec38cc83beef8ae87cc4c4b6780b45_ros2_launched_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/247d9761473c244d9087785c43d8a3b31abd922c_ros2_launched_1200w.png">
+  <img src="https://static.rerun.io/1a2c23c43ad171e7dc9f594487ec037204742cce_ros2_launched_full.png" alt="Initial window layout of Rerun 3D view of ROS 2 turtlebot3 navigation demo">
+</picture>
+
 
 Use rviz to send a new navigation goal and confirm that rerun updates with new data as turtlebot drives around
 the environment.

--- a/docs/content/reference/viewer/blueprint.md
+++ b/docs/content/reference/viewer/blueprint.md
@@ -11,7 +11,10 @@ This view shows the Blueprint for the active recording.
 Everything visible in the [Viewport](viewport.md) has a representation here,
 making it an easy way to select a Space View and the [Entities](../../concepts/entity-component.md) it shows.
 
-![blueprint view](https://static.rerun.io/6a2b37e56be8a98ddd3ddbeb67aaecb8e0b0e7d0_blueprint-view.png)
+<picture>
+  <img src="https://static.rerun.io/79c57ffce8e90fdf867b48f35c4088673f133445_blueprint-view_full.png" alt="screenshot of the blueprint view">
+</picture>
+
 
 Controls
 --------

--- a/docs/content/reference/viewer/overview.md
+++ b/docs/content/reference/viewer/overview.md
@@ -33,7 +33,13 @@ Command Palette
 ----------------------------
 The command palette is a powerful tool to reach arbitrary actions from anywhere via a simple text search.
 You reach it with `cmd/ctrl + P` or via the menu.
-![screenshot of the command palette](https://static.rerun.io/e0da898a5efe0d5d648a4b4ae632fa40ef5d72bf_command-palette.png)
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/7c73b6a15921f060e0469edbba64f1e15e5b8682_command-palette_480w.png">
+  <img src="https://static.rerun.io/1f9bd02ee38abc69cef538a7213d7e28a42080ad_command-palette_full.png" alt="screenshot of the command palette">
+</picture>
+
+
 Once it's open just start typing to filter and press `Enter` to execute the selected action or cancel with `Esc`.
 
 [TODO(#1132)](https://github.com/rerun-io/rerun/issues/1132): The command palette is too limited right now.
@@ -41,7 +47,12 @@ Once it's open just start typing to filter and press `Enter` to execute the sele
 Help icons
 ----------
 Most views have an info icon at the top right corner.
-![help icon](https://static.rerun.io/dc13919f6219c389a5cb6f4ebc4cc8633fa9e256_help-icon.png)
+
+<picture>
+  <img src="https://static.rerun.io/40f6fd35a750ae2723a2352f1064971d1cb4f1dd_help-icon_full.png" alt="help icon">
+</picture>
+
+
 On hover it displays additional information on how to use a view.
 
 Event Log

--- a/docs/content/reference/viewer/selection.md
+++ b/docs/content/reference/viewer/selection.md
@@ -13,7 +13,10 @@ and even the Selection view itself.
 Parts of the Selection view
 ---------------------------
 
-![selection overview](https://static.rerun.io/c2a568fe59991c828a4e8608aaea14e34f4b4343_selection-overview.png)
+<picture>
+  <img src="https://static.rerun.io/e44fe4ce530302b5a1e355202953e3a5af93a1a0_selection-overview_full.png" alt="overview of the selection panel">
+</picture>
+
 
 ### Selection history
 Rerun keeps a log of all your selections, allowing you to undo/redo previous selections

--- a/docs/content/reference/viewer/timeline.md
+++ b/docs/content/reference/viewer/timeline.md
@@ -8,7 +8,14 @@ Timeline controls
 
 The timeline controls sit at the top of the timeline panel and allow you to control the playback and what [timeline](../../concepts/timelines.md) is active.
 
-![timeline controls](https://static.rerun.io/3bef52fea54917b5eaf4f8789cb7c106f27e5c53_timeline-controls.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/a85cbec1719ea4b1d5f46e8404ded735a8c47821_timeline-controls_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/d9ad41384ce1d4840ec5e63aaf29e49556847c6b_timeline-controls_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/bb789b476b4d6ff58506371b25b90492b5deef2e_timeline-controls_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/fee224eba3615e91dd3ad66bb793ab37eeb51f90_timeline-controls_1200w.png">
+  <img src="https://static.rerun.io/a6fe67dc68457f0223f2d76d368b8138902101ac_timeline-controls_full.png" alt="timeline controls">
+</picture>
+
 
 It lets you select which timeline is currently active and control the replay of the timeline.
 These controls let you stop play/pause/step/loop time just like a video player.
@@ -20,7 +27,14 @@ Streams
 
 The Streams panel can be hidden with the layout config buttons at the top right corner of the viewer.
 
-![streams](https://static.rerun.io/751d6c07964614b9e3a205dc0b70efbcced439ff_streams.png)
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/2d48e68e858ac07444b24a887303f075ac8a14c9_streams_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/059cc0d921a02ae710e76fab62b58631ed092724_streams_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/02a9e7b576cd88242cc512cb9d87a06e91e1b670_streams_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/ce03f6bec1bf99b3440d133d89775d0e957dd74e_streams_1200w.png">
+  <img src="https://static.rerun.io/6e5e2b449f6f6ea150d68cfceae7eccb96b1c379_streams_full.png" alt="stream view">
+</picture>
+
 
 On the right side you see circles for each logged [event](../../concepts/timelines.md) on the currently selected timeline over time.
 You can use the mouse to scrub the vertical time selector line to jump to arbitrary moments in time.

--- a/docs/content/reference/viewer/viewport.md
+++ b/docs/content/reference/viewer/viewport.md
@@ -8,7 +8,11 @@ You can grab the title of any Space View to dock it to different parts of the vi
 
 View controls
 -------------
-![3d icon](https://static.rerun.io/7ff3366843e2d7cac96102e8415035c78c0bbe14_view-controls.png)
+
+<picture>
+  <img src="https://static.rerun.io/d93ec977f99173207c57ab790b8e3112131b1bc1_view-controls_full.png" alt="">
+</picture>
+
 
 Clicking on the title of a Space View has the same effect as selecting it in the [Blueprint view](blueprint.md)
 and will show additional information & settings in the [Selection view](selection.md) or other means.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -56,7 +56,8 @@
         "wxyz",
         "xyzw",
         "jleibs",
-        "Trimesh"
+        "Trimesh",
+        "srcset"
     ],
     "words": [
         "nyud",


### PR DESCRIPTION
### What

Update all documentation screenshots to optimised multi-resolution stacks. Existing screenshot that have rounded corners are left alone and will be redone in a subsequent PR (https://github.com/rerun-io/rerun/issues/2458). The intention of this PR is to convert screenshots that are ready for the new drop-shadow CSS to the `<picture>` tag, such that the CSS applies.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2457

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/f04f8f2/docs
Examples preview: https://rerun.io/preview/f04f8f2/examples
<!-- pr-link-docs:end -->
