### PR TITLE
Added support for puling image from an URL to `upload_image.py`

### DIFF
--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -8,3 +8,5 @@ cryptography==38.0.4 # for scripts/upload_image.py
 google-cloud-storage==2.9.0 # for scripts/upload_image.py
 PyGithub==1.58.2 # for scripts/generate_pr_summary.py and scripts/pr_link_docs_preview.py
 Pillow # for scripts/upload_image.py
+tqdm
+requests


### PR DESCRIPTION
### What

Added support for puling image from an URL to `upload_image.py`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2462

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/34427c6/docs
Examples preview: https://rerun.io/preview/34427c6/examples
<!-- pr-link-docs:end -->
