### PR TITLE
Fix incorrect site_url

### DIFF
--- a/rerun_py/mkdocs.yml
+++ b/rerun_py/mkdocs.yml
@@ -2,7 +2,7 @@
 # Top-level config for mkdocs
 # See: https://www.mkdocs.org/user-guide/configuration/
 site_name: Rerun Python APIs
-site_url: https://ref.rerun.io/docs/python/latest
+site_url: https://ref.rerun.io/docs/python/
 repo_url: https://github.com/rerun-io/rerun/
 
 # Use the material theme
@@ -62,3 +62,4 @@ extra:
   version:
     provider: mike
     default: latest
+


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

When building via `mkdocs build` locally, the sitemap URLs pointed to the correct place, but when building via `mike deploy`, they were incorrect, so Google was also picking up the wrong URLs which all point to 404.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
