### PR TITLE
`setup_dev.sh` now installs pngcrush

### DIFF
--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -14,4 +14,19 @@ cargo install just # Just a command runner
 cargo install taplo-cli --locked # toml formatter/linter/lsp
 cargo install typos-cli
 
+
+packagesNeeded='pngcrush'
+if [ -x "$(command -v brew)" ];      then brew install $packagesNeeded
+elif [ -x "$(command -v port)" ];    then sudo port install $packagesNeeded
+elif [ -x "$(command -v apt-get)" ]; then sudo apt-get -y install $packagesNeeded
+elif [ -x "$(command -v dnf)" ];     then sudo dnf install $packagesNeeded
+elif [ -x "$(command -v zypper)" ];  then sudo zypper install $packagesNeeded
+elif [ -x "$(command -v apk)" ];     then sudo apk add --no-cache $packagesNeeded
+elif [ -x "$(command -v winget)" ];  then sudo winget add --no-cache $packagesNeeded
+elif [ -x "$(command -v pacman)" ];  then sudo pacman -S $packagesNeeded
+else
+    echo "FAILED TO INSTALL PACKAGE: Package manager not found. You must manually install: $packagesNeeded">&2;
+    exit 1
+fi
+
 echo "setup_dev.sh completed!"


### PR DESCRIPTION
### What

`setup_dev.sh` now installs pngcrush, which is needed by the `upload_image.py`/`just upload` script.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] ~~I've included a screenshot or gif (if applicable)~~ 

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2470

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/63a7dff/docs
Examples preview: https://rerun.io/preview/63a7dff/examples
<!-- pr-link-docs:end -->
