### PR TITLE
Added docs/code-examples to the directories checked by py-lint and py-format

### DIFF
--- a/docs/code-examples/annotation-context/example.py
+++ b/docs/code-examples/annotation-context/example.py
@@ -1,3 +1,5 @@
+import rerun as rr
+
 # Annotation context with two classes, using two labeled classes, of which ones defines a color.
 rr.log_annotation_context(
     "masks",  # Applies to all entities below "masks".

--- a/docs/code-examples/default-off-session/example.py
+++ b/docs/code-examples/default-off-session/example.py
@@ -1,2 +1,3 @@
 import rerun as rr
+
 rr.init("my_app", default_enabled=False)

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ lint: toml-lint py-lint rs-lint
 
 ### Python
 
-py_folders := "examples rerun_py scripts"
+py_folders := "examples rerun_py scripts docs/code-examples"
 
 # Set up a Pythonvirtual environment for development
 py-dev-env:

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -93,6 +93,7 @@ select = [
 
 [tool.ruff.per-file-ignores]
 "docs/code-examples/*" = ["I002"]
+"docs/code-examples/extension-components/example.py" = ["F821"]
 
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"


### PR DESCRIPTION
### What

This PR:
- Adds `docs/code-examples` to the directories checked by `just py-lint` and `just py-format`.
- Fixes existing examples such that the pass the lint: most needed an explicit `import rerun as rr`. In most case I figured that this change was ok. In one case I decided to add an exception in `pyproject.toml` instead.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] ~~I've included a screenshot or gif (if applicable)~~

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2476

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/a45ad9c/docs
Examples preview: https://rerun.io/preview/a45ad9c/examples
<!-- pr-link-docs:end -->
