### PR TITLE
Fix 2D->3D projection ray using incorrect length for "hit/white part"

### DIFF
--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -575,7 +575,7 @@ fn show_projections_from_2d_space(
                     // Render a thick line to the actual z value if any and a weaker one as an extension
                     // If we don't have a z value, we only render the thick one.
                     let thick_ray_length = if pos.z.is_finite() && pos.z > 0.0 {
-                        pos.z
+                        pos.length()
                     } else {
                         cam.picture_plane_distance
                     };


### PR DESCRIPTION
### What

Fixes #2459
* #2459

After:
<img width="855" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/123f396e-e261-4214-85c5-7c01eed1e7ca">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2480

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/3e2374e/docs
Examples preview: https://rerun.io/preview/3e2374e/examples
<!-- pr-link-docs:end -->
