### PR TITLE
Fix projected ray length

### DIFF
--- a/crates/re_components/src/pinhole.rs
+++ b/crates/re_components/src/pinhole.rs
@@ -110,6 +110,25 @@ impl Pinhole {
     pub fn aspect_ratio(&self) -> Option<f32> {
         self.resolution.map(|r| r[0] / r[1])
     }
+
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn offset(&self) -> glam::Vec2 {
+        let [x, y, _] = self.image_from_cam[2].0;
+        glam::vec2(x, y)
+    }
+
+    /// Given pixel coordinates and a world-space depth,
+    /// return a position in the camera space.
+    ///
+    /// The returned z is the same as the input z (depth).
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn unproject(&self, pixel: glam::Vec3) -> glam::Vec3 {
+        ((pixel.truncate() - self.offset()) * pixel.z
+            / glam::Vec2::from(self.focal_length_in_pixels()))
+        .extend(pixel.z)
+    }
 }
 
 #[test]

--- a/crates/re_components/src/pinhole.rs
+++ b/crates/re_components/src/pinhole.rs
@@ -118,6 +118,16 @@ impl Pinhole {
         glam::vec2(x, y)
     }
 
+    /// Project camera-space coordinates into pixel coordinates,
+    /// returning the same z/depth.
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn project(&self, pixel: glam::Vec3) -> glam::Vec3 {
+        ((pixel.truncate() * glam::Vec2::from(self.focal_length_in_pixels())) / pixel.z
+            + self.offset())
+        .extend(pixel.z)
+    }
+
     /// Given pixel coordinates and a world-space depth,
     /// return a position in the camera space.
     ///

--- a/crates/re_space_view_spatial/src/space_camera_3d.rs
+++ b/crates/re_space_view_spatial/src/space_camera_3d.rs
@@ -1,4 +1,4 @@
-use glam::{vec3, Affine3A, Mat3, Quat, Vec2, Vec3};
+use glam::{Affine3A, Mat3, Quat, Vec2, Vec3};
 use macaw::{IsoTransform, Ray3};
 
 use re_components::{Pinhole, ViewCoordinates};
@@ -52,31 +52,12 @@ impl SpaceCamera3D {
         }
     }
 
-    /// Projects image coordinates into world coordinates
-    pub fn world_from_image(&self) -> Option<Affine3A> {
+    /// Returns x, y, and depth in image/pixel coordinates.
+    pub fn project_onto_2d(&self, point_in_world: Vec3) -> Option<Vec3> {
         let pinhole = self.pinhole?;
-        let world_from_cam = self.world_from_cam();
-        let image_from_cam: Mat3 = pinhole.image_from_cam.into();
-        let cam_from_image = Affine3A::from_mat3(image_from_cam.inverse());
-        Some(world_from_cam * cam_from_image)
-    }
-
-    /// Projects world coordinates onto 2D image coordinates
-    pub fn image_from_world(&self) -> Option<Affine3A> {
-        let pinhole = self.pinhole?;
-        let cam_from_world = self.cam_from_world();
-
-        let image_from_cam = pinhole.image_from_cam.into();
-        let image_from_cam = Affine3A::from_mat3(image_from_cam);
-        Some(image_from_cam * cam_from_world)
-    }
-
-    /// Returns x, y, and depth in image coordinates.
-    pub fn project_onto_2d(&self, pos3d: Vec3) -> Option<Vec3> {
-        self.image_from_world().map(|pixel_from_world| {
-            let point = pixel_from_world.transform_point3(pos3d);
-            vec3(point.x / point.z, point.y / point.z, point.z)
-        })
+        let point_in_cam = self.cam_from_world().transform_point3(point_in_world);
+        let point_in_image = pinhole.project(point_in_cam);
+        Some(point_in_image)
     }
 
     /// Unproject a 2D image coordinate as a ray in 3D space
@@ -84,10 +65,9 @@ impl SpaceCamera3D {
         let pinhole = self.pinhole?;
 
         let depth = 1.0; // whatever will do
-        let stop_in_camera = pinhole.unproject(pos2d.extend(depth));
-        let stop = self.world_from_camera.transform_point3(stop_in_camera);
-        let origin = self.position();
-        Some(Ray3::from_origin_dir(origin, (stop - origin).normalize()))
+        let stop = pinhole.unproject(pos2d.extend(depth));
+        let ray_in_camera = Ray3::from_origin_dir(Vec3::ZERO, stop);
+        Some(self.world_from_camera * ray_in_camera)
     }
 }
 

--- a/crates/re_space_view_spatial/src/space_camera_3d.rs
+++ b/crates/re_space_view_spatial/src/space_camera_3d.rs
@@ -81,12 +81,13 @@ impl SpaceCamera3D {
 
     /// Unproject a 2D image coordinate as a ray in 3D space
     pub fn unproject_as_ray(&self, pos2d: Vec2) -> Option<Ray3> {
-        self.world_from_image().map(|world_from_pixel| {
-            let origin = self.position();
-            let stop = world_from_pixel.transform_point3(pos2d.extend(1.0));
-            let dir = (stop - origin).normalize();
-            Ray3::from_origin_dir(origin, dir)
-        })
+        let pinhole = self.pinhole?;
+
+        let depth = 1.0; // whatever will do
+        let stop_in_camera = pinhole.unproject(pos2d.extend(depth));
+        let stop = self.world_from_camera.transform_point3(stop_in_camera);
+        let origin = self.position();
+        Some(Ray3::from_origin_dir(origin, (stop - origin).normalize()))
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2459

<img width="491" alt="Screenshot 2023-06-19 at 20 35 42" src="https://github.com/rerun-io/rerun/assets/1148717/11dda2e2-b4ac-4c8a-8e7e-45c24dd8eb2b">

### What
We where taking pinhole matrices and squeezing them into `Affine3A` with predictably bad results.

The offending methods have been removed and replaced with more direct, simpler steps.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
