### PR TITLE
Codegen'd Rust/Arrow (de)ser 3: misc fixes & improvements

### DIFF
--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -46,7 +46,7 @@ pub type DataRowResult<T> = ::std::result::Result<T, DataRowError>;
 
 // ---
 
-type DataCellVec = SmallVec<[DataCell; 4]>;
+pub type DataCellVec = SmallVec<[DataCell; 4]>;
 
 /// A row's worth of [`DataCell`]s: a collection of independent [`DataCell`]s with different
 /// underlying datatypes and pointing to different parts of the heap.

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 pub use self::arrow_msg::ArrowMsg;
 pub use self::component::{Component, DeserializableComponent, SerializableComponent};
 pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult};
-pub use self::data_row::{DataRow, DataRowError, DataRowResult, RowId};
+pub use self::data_row::{DataCellVec, DataRow, DataRowError, DataRowResult, RowId};
 pub use self::data_table::{
     DataCellColumn, DataCellOptVec, DataTable, DataTableError, DataTableResult, EntityPathVec,
     ErasedTimeVec, NumInstancesVec, RowIdVec, TableId, TimePointVec, COLUMN_ENTITY_PATH,

--- a/crates/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -11,6 +11,7 @@ namespace rerun.archetypes;
 // TODO(#2372): archetype IDL definitions must refer to objects of kind component
 // TODO(#2373): `attr.rerun.component_required` implies `required`
 // TODO(#2427): distinguish optional vs. recommended in language backends
+// TODO(#2521): always derive debug & clone for rust backend
 
 /// A 2D point cloud with positions and optional colors, radii, labels, etc.
 table Points2D (

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-0efa9d8e1a2e468bfa5b77cdc4c29bf2bd82fead0eeedafdd568834e79d7ea4c
+c10dc39333002ce5c62d9e88a7feb4fca76098528fe643012a53665a9934581e

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-0960d9b4f6df9136f7857a7b7280a4803f3eba7a085c98aa1ce7c95dcd88539e
+0efa9d8e1a2e468bfa5b77cdc4c29bf2bd82fead0eeedafdd568834e79d7ea4c

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -14,6 +14,10 @@ impl crate::Component for ClassId {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::UInt16
+        DataType::Extension(
+            "rerun.components.ClassId".to_owned(),
+            Box::new(DataType::UInt16),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -24,6 +24,10 @@ impl crate::Component for Color {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::UInt32
+        DataType::Extension(
+            "rerun.components.Color".to_owned(),
+            Box::new(DataType::UInt32),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -19,6 +19,10 @@ impl crate::Component for DrawOrder {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Float32
+        DataType::Extension(
+            "rerun.components.DrawOrder".to_owned(),
+            Box::new(DataType::Float32),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -12,6 +12,10 @@ impl crate::Component for InstanceKey {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::UInt64
+        DataType::Extension(
+            "rerun.components.InstanceKey".to_owned(),
+            Box::new(DataType::UInt64),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -16,6 +16,10 @@ impl crate::Component for KeypointId {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::UInt16
+        DataType::Extension(
+            "rerun.components.KeypointId".to_owned(),
+            Box::new(DataType::UInt16),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -13,6 +13,10 @@ impl crate::Component for Label {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Utf8
+        DataType::Extension(
+            "rerun.components.Label".to_owned(),
+            Box::new(DataType::Utf8),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -21,13 +21,13 @@ impl crate::Component for Point2D {
                 Field {
                     name: "x".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 },
                 Field {
                     name: "y".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 },
             ])),

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -12,6 +12,10 @@ impl crate::Component for Radius {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Float32
+        DataType::Extension(
+            "rerun.components.Radius".to_owned(),
+            Box::new(DataType::Float32),
+            None,
+        )
     }
 }

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -12,14 +12,18 @@ impl crate::Datatype for Vec2D {
     #[allow(clippy::wildcard_imports)]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            Box::new(Field {
-                name: "item".to_owned(),
-                data_type: DataType::Float32,
-                is_nullable: false,
-                metadata: [].into(),
-            }),
-            2usize,
+        DataType::Extension(
+            "rerun.datatypes.Vec2D".to_owned(),
+            Box::new(DataType::FixedSizeList(
+                Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: false,
+                    metadata: [].into(),
+                }),
+                2usize,
+            )),
+            None,
         )
     }
 }

--- a/crates/re_types_builder/src/arrow_registry.rs
+++ b/crates/re_types_builder/src/arrow_registry.rs
@@ -4,7 +4,9 @@ use anyhow::Context as _;
 use arrow2::datatypes::{DataType, Field, UnionMode};
 use std::collections::{BTreeMap, HashMap};
 
-use crate::{ElementType, Object, Type, ATTR_ARROW_SPARSE_UNION, ATTR_ARROW_TRANSPARENT};
+use crate::{
+    ElementType, Object, ObjectField, Type, ATTR_ARROW_SPARSE_UNION, ATTR_ARROW_TRANSPARENT,
+};
 
 // --- Registry ---
 
@@ -18,7 +20,7 @@ pub struct ArrowRegistry {
 impl ArrowRegistry {
     /// Computes the Arrow datatype for the specified object and stores it in the registry, to be
     /// resolved later on.
-    pub fn register(&mut self, obj: &Object) {
+    pub fn register(&mut self, obj: &mut Object) {
         let (fqname, datatype) = (obj.fqname.clone(), self.arrow_datatype_from_object(obj));
         self.registry.insert(fqname, datatype);
     }
@@ -48,7 +50,7 @@ impl ArrowRegistry {
 
     // ---
 
-    fn arrow_datatype_from_object(&self, obj: &Object) -> LazyDatatype {
+    fn arrow_datatype_from_object(&mut self, obj: &mut Object) -> LazyDatatype {
         let is_struct = obj.is_struct();
         let is_transparent = obj.try_get_attr::<String>(ATTR_ARROW_TRANSPARENT).is_some();
         let num_fields = obj.fields.len();
@@ -72,11 +74,10 @@ impl ArrowRegistry {
                 obj.fqname.clone(),
                 Box::new(LazyDatatype::Struct(
                     obj.fields
-                        .iter()
+                        .iter_mut()
                         .map(|field| LazyField {
                             name: field.name.clone(),
-                            datatype: self.arrow_datatype_from_type(&field.typ),
-                            is_nullable: field.required,
+                            datatype: self.arrow_datatype_from_type(field.typ.clone(), field),
                             is_nullable: !field.required,
                             metadata: Default::default(),
                         })
@@ -92,10 +93,10 @@ impl ArrowRegistry {
                 obj.fqname.clone(),
                 Box::new(LazyDatatype::Union(
                     obj.fields
-                        .iter()
+                        .iter_mut()
                         .map(|field| LazyField {
                             name: field.name.clone(),
-                            datatype: self.arrow_datatype_from_type(&field.typ),
+                            datatype: self.arrow_datatype_from_type(field.typ.clone(), field),
                             is_nullable: false,
                             metadata: Default::default(),
                         })
@@ -109,11 +110,18 @@ impl ArrowRegistry {
                 )),
                 None,
             )
+        };
+
+        // NOTE: Arrow-transparent objects by definition don't have a datatype of their own.
+        if !is_transparent {
+            obj.datatype = datatype.clone().into();
         }
+
+        datatype
     }
 
-    fn arrow_datatype_from_type(&self, typ: &Type) -> LazyDatatype {
-        match typ {
+    fn arrow_datatype_from_type(&mut self, typ: Type, field: &mut ObjectField) -> LazyDatatype {
+        let datatype = match typ {
             Type::UInt8 => LazyDatatype::UInt8,
             Type::UInt16 => LazyDatatype::UInt16,
             Type::UInt32 => LazyDatatype::UInt32,
@@ -134,7 +142,7 @@ impl ArrowRegistry {
                     is_nullable: false,
                     metadata: Default::default(),
                 }),
-                *length,
+                length,
             ),
             Type::Vector { elem_type } => LazyDatatype::List(Box::new(LazyField {
                 name: "item".into(),
@@ -142,11 +150,16 @@ impl ArrowRegistry {
                 is_nullable: false,
                 metadata: Default::default(),
             })),
-            Type::Object(fqname) => LazyDatatype::Unresolved(fqname.clone()),
-        }
+            Type::Object(fqname) => LazyDatatype::Unresolved(fqname),
+        };
+
+        field.datatype = datatype.clone().into();
+        self.registry.insert(field.fqname.clone(), datatype.clone());
+
+        datatype
     }
 
-    fn arrow_datatype_from_element_type(&self, typ: &ElementType) -> LazyDatatype {
+    fn arrow_datatype_from_element_type(&self, typ: ElementType) -> LazyDatatype {
         _ = self;
         match typ {
             ElementType::UInt8 => LazyDatatype::UInt8,
@@ -162,7 +175,7 @@ impl ArrowRegistry {
             ElementType::Float32 => LazyDatatype::Float32,
             ElementType::Float64 => LazyDatatype::Float64,
             ElementType::String => LazyDatatype::Utf8,
-            ElementType::Object(fqname) => LazyDatatype::Unresolved(fqname.clone()),
+            ElementType::Object(fqname) => LazyDatatype::Unresolved(fqname),
         }
     }
 }

--- a/crates/re_types_builder/src/arrow_registry.rs
+++ b/crates/re_types_builder/src/arrow_registry.rs
@@ -71,6 +71,7 @@ impl ArrowRegistry {
                             name: field.name.clone(),
                             datatype: self.arrow_datatype_from_type(&field.typ),
                             is_nullable: field.required,
+                            is_nullable: !field.required,
                             metadata: Default::default(),
                         })
                         .collect(),

--- a/crates/re_types_builder/src/arrow_registry.rs
+++ b/crates/re_types_builder/src/arrow_registry.rs
@@ -59,8 +59,14 @@ impl ArrowRegistry {
             obj.fqname,
         );
 
-        if is_transparent {
-            self.arrow_datatype_from_type(&obj.fields[0].typ)
+        let datatype = if is_transparent {
+            LazyDatatype::Extension(
+                obj.fqname.clone(),
+                Box::new(
+                    self.arrow_datatype_from_type(obj.fields[0].typ.clone(), &mut obj.fields[0]),
+                ),
+                None,
+            )
         } else if is_struct {
             LazyDatatype::Extension(
                 obj.fqname.clone(),

--- a/crates/re_types_builder/src/arrow_registry.rs
+++ b/crates/re_types_builder/src/arrow_registry.rs
@@ -140,7 +140,7 @@ impl ArrowRegistry {
                 Box::new(LazyField {
                     name: "item".into(),
                     datatype: self.arrow_datatype_from_element_type(elem_type),
-                    is_nullable: false,
+                    is_nullable: field.is_nullable,
                     metadata: Default::default(),
                 }),
                 length,
@@ -148,7 +148,7 @@ impl ArrowRegistry {
             Type::Vector { elem_type } => LazyDatatype::List(Box::new(LazyField {
                 name: "item".into(),
                 datatype: self.arrow_datatype_from_element_type(elem_type),
-                is_nullable: false,
+                is_nullable: field.is_nullable,
                 metadata: Default::default(),
             })),
             Type::Object(fqname) => LazyDatatype::Unresolved(fqname),

--- a/crates/re_types_builder/src/arrow_registry.rs
+++ b/crates/re_types_builder/src/arrow_registry.rs
@@ -75,10 +75,11 @@ impl ArrowRegistry {
                 Box::new(LazyDatatype::Struct(
                     obj.fields
                         .iter_mut()
-                        .map(|field| LazyField {
-                            name: field.name.clone(),
-                            datatype: self.arrow_datatype_from_type(field.typ.clone(), field),
-                            is_nullable: !field.required,
+                        .map(|obj_field| LazyField {
+                            name: obj_field.name.clone(),
+                            datatype: self
+                                .arrow_datatype_from_type(obj_field.typ.clone(), obj_field),
+                            is_nullable: obj_field.is_nullable,
                             metadata: Default::default(),
                         })
                         .collect(),

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -922,10 +922,17 @@ fn quote_arrow_datatype(datatype: &DataType) -> String {
         DataType::LargeBinary => "pa.large_binary()".to_owned(),
         DataType::Utf8 => "pa.utf8()".to_owned(),
         DataType::LargeUtf8 => "pa.large_utf8()".to_owned(),
+
+        DataType::List(field) => {
+            let field = quote_arrow_field(field);
+            format!("pa.list_({field})")
+        }
+
         DataType::FixedSizeList(field, length) => {
             let field = quote_arrow_field(field);
             format!("pa.list_({field}, {length})")
         }
+
         DataType::Union(fields, _, mode) => {
             let fields = fields
                 .iter()
@@ -937,6 +944,7 @@ fn quote_arrow_datatype(datatype: &DataType) -> String {
                 UnionMode::Sparse => format!(r#"pa.sparse_union([{fields}])"#),
             }
         }
+
         DataType::Struct(fields) => {
             let fields = fields
                 .iter()
@@ -945,7 +953,9 @@ fn quote_arrow_datatype(datatype: &DataType) -> String {
                 .join(", ");
             format!("pa.struct([{fields}])")
         }
+
         DataType::Extension(_, datatype, _) => quote_arrow_datatype(datatype),
+
         _ => unimplemented!("{datatype:#?}"), // NOLINT
     }
 }

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -292,8 +292,8 @@ impl QuotedObject {
                 docs,
                 typ: _,
                 attrs: _,
-                required: _,
-                deprecated: _,
+                is_nullable,
+                is_deprecated: _,
                 datatype: _,
             } = field;
 
@@ -304,10 +304,10 @@ impl QuotedObject {
             } else {
                 typ
             };
-            let typ = if field.required {
-                typ
-            } else {
+            let typ = if *is_nullable {
                 format!("{typ} | None = None")
+            } else {
+                typ
             };
 
             code.push_text(format!("{name}: {typ}"), 1, 4);
@@ -388,8 +388,8 @@ impl QuotedObject {
                 docs,
                 typ: _,
                 attrs: _,
-                required: _,
-                deprecated: _,
+                is_nullable: _,
+                is_deprecated: _,
                 datatype: _,
             } = field;
 
@@ -827,12 +827,12 @@ fn quote_builder_from_obj(objects: &Objects, obj: &Object) -> String {
     let required = obj
         .fields
         .iter()
-        .filter(|field| field.required)
+        .filter(|field| !field.is_nullable)
         .collect::<Vec<_>>();
     let optional = obj
         .fields
         .iter()
-        .filter(|field| !field.required)
+        .filter(|field| field.is_nullable)
         .collect::<Vec<_>>();
 
     let mut code = String::new();

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -41,7 +41,7 @@ impl CodeGenerator for PythonCodeGenerator {
                 datatypes_path,
                 arrow_registry,
                 objs,
-                &objs.ordered_datatypes(),
+                &objs.ordered_objects(ObjectKind::Datatype.into()),
             )
             .0,
         );
@@ -55,7 +55,7 @@ impl CodeGenerator for PythonCodeGenerator {
                 components_path,
                 arrow_registry,
                 objs,
-                &objs.ordered_components(),
+                &objs.ordered_objects(ObjectKind::Component.into()),
             )
             .0,
         );
@@ -68,7 +68,7 @@ impl CodeGenerator for PythonCodeGenerator {
             archetypes_path,
             arrow_registry,
             objs,
-            &objs.ordered_archetypes(),
+            &objs.ordered_objects(ObjectKind::Archetype.into()),
         );
         filepaths.extend(paths);
 

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -255,6 +255,7 @@ impl QuotedObject {
             attrs: _,
             fields,
             specifics: _,
+            datatype: _,
         } = obj;
 
         let mut code = String::new();
@@ -293,6 +294,7 @@ impl QuotedObject {
                 attrs: _,
                 required: _,
                 deprecated: _,
+                datatype: _,
             } = field;
 
             let (typ, _) = quote_field_type_from_field(objects, field, false);
@@ -349,6 +351,7 @@ impl QuotedObject {
             attrs: _,
             fields,
             specifics: _,
+            datatype: _,
         } = obj;
 
         let mut code = String::new();
@@ -387,6 +390,7 @@ impl QuotedObject {
                 attrs: _,
                 required: _,
                 deprecated: _,
+                datatype: _,
             } = field;
 
             let (typ, _) = quote_field_type_from_field(objects, field, false);

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -42,7 +42,7 @@ impl CodeGenerator for RustCodeGenerator {
         filepaths.extend(create_files(
             datatypes_path,
             arrow_registry,
-            &objects.ordered_datatypes(),
+            &objects.ordered_objects(ObjectKind::Datatype.into()),
         ));
 
         let components_path = self.crate_path.join("src/components");
@@ -52,7 +52,7 @@ impl CodeGenerator for RustCodeGenerator {
         filepaths.extend(create_files(
             components_path,
             arrow_registry,
-            &objects.ordered_components(),
+            &objects.ordered_objects(ObjectKind::Component.into()),
         ));
 
         let archetypes_path = self.crate_path.join("src/archetypes");
@@ -62,7 +62,7 @@ impl CodeGenerator for RustCodeGenerator {
         filepaths.extend(create_files(
             archetypes_path,
             arrow_registry,
-            &objects.ordered_archetypes(),
+            &objects.ordered_objects(ObjectKind::Archetype.into()),
         ));
 
         filepaths

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -189,6 +189,7 @@ impl QuotedObject {
             attrs: _,
             fields,
             specifics: _,
+            datatype: _,
         } = obj;
 
         let name = format_ident!("{name}");
@@ -247,6 +248,7 @@ impl QuotedObject {
             attrs: _,
             fields,
             specifics: _,
+            datatype: _,
         } = obj;
 
         let name = format_ident!("{name}");
@@ -266,6 +268,7 @@ impl QuotedObject {
                 attrs: _,
                 required: _,
                 deprecated: _,
+                datatype: _,
             } = obj_field;
 
             let name = format_ident!("{name}");
@@ -323,6 +326,7 @@ impl quote::ToTokens for ObjectFieldTokenizer<'_> {
             required,
             // TODO(#2366): support for deprecation notices
             deprecated: _,
+            datatype: _,
         } = obj_field;
 
         let quoted_docs = quote_doc_from_docs(docs);
@@ -460,6 +464,7 @@ fn quote_trait_impls_from_obj(arrow_registry: &ArrowRegistry, obj: &Object) -> T
         attrs: _,
         fields: _,
         specifics: _,
+        datatype: _,
     } = obj;
 
     let name = format_ident!("{name}");
@@ -564,6 +569,7 @@ fn quote_builder_from_obj(obj: &Object) -> TokenStream {
         attrs: _,
         fields,
         specifics: _,
+        datatype: _,
     } = obj;
 
     let name = format_ident!("{name}");

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -93,7 +93,7 @@ mod codegen;
 #[allow(clippy::unimplemented)]
 mod objects;
 
-pub use self::arrow_registry::ArrowRegistry;
+pub use self::arrow_registry::{ArrowRegistry, LazyDatatype, LazyField};
 pub use self::codegen::{CodeGenerator, PythonCodeGenerator, RustCodeGenerator};
 pub use self::objects::{
     Attributes, Docs, ElementType, Object, ObjectField, ObjectKind, Objects, Type,
@@ -184,7 +184,7 @@ fn generate_lang_agnostic(
     binary_entrypoint_path.set_extension("bfbs");
 
     // semantic pass: high level objects from low-level reflection data
-    let objects = Objects::from_buf(
+    let mut objects = Objects::from_buf(
         sh.read_binary_file(tmp.path().join(binary_entrypoint_path))
             .unwrap()
             .as_slice(),
@@ -192,7 +192,7 @@ fn generate_lang_agnostic(
 
     // create and fill out arrow registry
     let mut arrow_registry = ArrowRegistry::default();
-    for obj in objects.ordered_objects(None) {
+    for obj in objects.ordered_objects_mut(None) {
         arrow_registry.register(obj);
     }
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -448,13 +448,13 @@ pub struct ObjectField {
     /// Whether the field is required.
     ///
     /// Always true for IDL definitions using flatbuffers' `struct` type (as opposed to `table`).
-    pub required: bool,
+    pub is_nullable: bool,
 
     /// Whether the field is deprecated.
     //
     // TODO(#2366): do something with this
     // TODO(#2367): implement custom attr to specify deprecation reason
-    pub deprecated: bool,
+    pub is_deprecated: bool,
 
     /// The Arrow datatype of this `ObjectField`.
     ///
@@ -488,8 +488,8 @@ impl ObjectField {
         let typ = Type::from_raw_type(enums, objs, field.type_());
         let attrs = Attributes::from_raw_attrs(field.attributes());
 
-        let required = field.required() || obj.is_struct();
-        let deprecated = field.deprecated();
+        let is_nullable = !obj.is_struct() && !field.required();
+        let is_deprecated = field.deprecated();
 
         Self {
             filepath,
@@ -499,8 +499,8 @@ impl ObjectField {
             docs,
             typ,
             attrs,
-            required,
-            deprecated,
+            is_nullable,
+            is_deprecated,
             datatype: None,
         }
     }
@@ -536,8 +536,8 @@ impl ObjectField {
         let attrs = Attributes::from_raw_attrs(val.attributes());
 
         // TODO(cmc): not sure about this, but fbs unions are a bit weird that way
-        let required = true;
-        let deprecated = false;
+        let is_nullable = false;
+        let is_deprecated = false;
 
         Self {
             filepath,
@@ -547,8 +547,8 @@ impl ObjectField {
             docs,
             typ,
             attrs,
-            required,
-            deprecated,
+            is_nullable,
+            is_deprecated,
             datatype: None,
         }
     }

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -244,6 +244,12 @@ pub struct Object {
 
     /// Properties that only apply to either structs or unions.
     pub specifics: ObjectSpecifics,
+
+    /// The Arrow datatype of this `Object`, or `None` if the object is Arrow-transparent.
+    ///
+    /// This is lazily computed when the parent object gets registered into the Arrow registry and
+    /// will be `None` until then.
+    pub datatype: Option<crate::LazyDatatype>,
 }
 
 impl Object {
@@ -293,6 +299,7 @@ impl Object {
             attrs,
             fields,
             specifics: ObjectSpecifics::Struct {},
+            datatype: None,
         }
     }
 
@@ -352,6 +359,7 @@ impl Object {
             attrs,
             fields,
             specifics: ObjectSpecifics::Union { utype },
+            datatype: None,
         }
     }
 
@@ -447,6 +455,12 @@ pub struct ObjectField {
     // TODO(#2366): do something with this
     // TODO(#2367): implement custom attr to specify deprecation reason
     pub deprecated: bool,
+
+    /// The Arrow datatype of this `ObjectField`.
+    ///
+    /// This is lazily computed when the parent object gets registered into the Arrow registry and
+    /// will be `None` until then.
+    pub datatype: Option<crate::LazyDatatype>,
 }
 
 impl ObjectField {
@@ -487,6 +501,7 @@ impl ObjectField {
             attrs,
             required,
             deprecated,
+            datatype: None,
         }
     }
 
@@ -534,6 +549,7 @@ impl ObjectField {
             attrs,
             required,
             deprecated,
+            datatype: None,
         }
     }
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points2d.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-__all__ = ["Points2D"]
-
-
 from dataclasses import dataclass
 
+__all__ = ["Points2D"]
+
 from .. import components
+
+## --- Points2D --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/class_id.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["ClassId", "ClassIdArray", "ClassIdArrayLike", "ClassIdLike", "ClassIdType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["ClassId", "ClassIdArray", "ClassIdArrayLike", "ClassIdLike", "ClassIdType"]
+
+
+## --- ClassId --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/color.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["Color", "ColorArray", "ColorArrayLike", "ColorLike", "ColorType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["Color", "ColorArray", "ColorArrayLike", "ColorLike", "ColorType"]
+
+
+## --- Color --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/draw_order.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["DrawOrder", "DrawOrderArray", "DrawOrderArrayLike", "DrawOrderLike", "DrawOrderType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["DrawOrder", "DrawOrderArray", "DrawOrderArrayLike", "DrawOrderLike", "DrawOrderType"]
+
+
+## --- DrawOrder --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/instance_key.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/instance_key.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["InstanceKey", "InstanceKeyArray", "InstanceKeyArrayLike", "InstanceKeyLike", "InstanceKeyType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["InstanceKey", "InstanceKeyArray", "InstanceKeyArrayLike", "InstanceKeyLike", "InstanceKeyType"]
+
+
+## --- InstanceKey --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/keypoint_id.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["KeypointId", "KeypointIdArray", "KeypointIdArrayLike", "KeypointIdLike", "KeypointIdType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["KeypointId", "KeypointIdArray", "KeypointIdArrayLike", "KeypointIdLike", "KeypointIdType"]
+
+
+## --- KeypointId --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/label.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/label.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-__all__ = ["Label", "LabelArray", "LabelArrayLike", "LabelLike", "LabelType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import pyarrow as pa
+
+__all__ = ["Label", "LabelArray", "LabelArrayLike", "LabelLike", "LabelType"]
+
+
+## --- Label --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/point2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/point2d.py
@@ -34,7 +34,7 @@ class Point2DType(pa.ExtensionType):  # type: ignore[misc]
     def __init__(self: type[pa.ExtensionType]) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.struct([pa.field("x", pa.float32(), True, {}), pa.field("y", pa.float32(), True, {})]),
+            pa.struct([pa.field("x", pa.float32(), False, {}), pa.field("y", pa.float32(), False, {})]),
             "rerun.point2d",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/point2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/point2d.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["Point2D", "Point2DArray", "Point2DArrayLike", "Point2DLike", "Point2DType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["Point2D", "Point2DArray", "Point2DArrayLike", "Point2DLike", "Point2DType"]
+
+
+## --- Point2D --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/radius.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["Radius", "RadiusArray", "RadiusArrayLike", "RadiusLike", "RadiusType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["Radius", "RadiusArray", "RadiusArrayLike", "RadiusLike", "RadiusType"]
+
+
+## --- Radius --- ##
 
 
 @dataclass

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec2d.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-__all__ = ["Vec2D", "Vec2DArray", "Vec2DArrayLike", "Vec2DLike", "Vec2DType"]
-
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+
+__all__ = ["Vec2D", "Vec2DArray", "Vec2DArrayLike", "Vec2DLike", "Vec2DType"]
+
+
+## --- Vec2D --- ##
 
 
 @dataclass

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -438,7 +438,7 @@ def main() -> None:
         root_dirpath = os.path.abspath(f"{script_dirpath}/..")
         os.chdir(root_dirpath)
 
-        extensions = ["html", "js", "md", "py", "rs", "sh", "toml", "wgsl", "yml"]
+        extensions = ["fbs", "html", "js", "md", "py", "rs", "sh", "toml", "wgsl", "yml"]
 
         exclude_dirs = {"env", "renv", "venv", "target", "target_ra", "target_wasm"}
 


### PR DESCRIPTION
**Best reviewed on a commit-by-commit basis; in particular the `rerun codegen` commit is nothing but generated code.**

This PR implements miscellaneous fixes and improvements to the semantic pass and arrow registry that came up when implementing (de)serialization routines for the Rust SDK. 

---

- #2484
- #2485 
- #2487 
- #2545
- #2546
- #2549
- #2554
- #2570
- #2571

---

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2487

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/8976c19/docs
Examples preview: https://rerun.io/preview/8976c19/examples
<!-- pr-link-docs:end -->