### PR TITLE
Minor doc fix in image archetype's docs related to signed ints

### DIFF
--- a/docs/content/reference/data_types/image.md
+++ b/docs/content/reference/data_types/image.md
@@ -5,9 +5,9 @@ order: 20
 
 `Image` represents a 2D raster image with various pixel format. They are a special case of 2D [Tensor](tensor.md) with an optional 3rd dimension when multiple color channels are used. Image with 1 (grayscale), 3 (RGB), or 4 (RGBA) channels are supported. Color channel maybe represented by any of the common scalar datatypes:
 
-- `uint8`, `uint16`, `uint32`, `uint64`: color channels in 0-`max_uint` sRGB gamma space, alpha in 0-`max_int` linear space
-- `float16`, `float32`, `float64`: color channels in the 0.0-1.0 sRGB gamma space, alpha in 0.0-1.0 linear space
-- `int8`, `int16`, `int32`, `int64`: signed integers are cast into their unsigned counterpart without clipping
+- `uint8`, `uint16`, `uint32`, `uint64`: Color channels in 0-`max_uint` sRGB gamma space, alpha in 0-`max_int` linear space.
+- `float16`, `float32`, `float64`: Color channels in the 0.0-1.0 sRGB gamma space, alpha in 0.0-1.0 linear space.
+- `int8`, `int16`, `int32`, `int64`: If all pixels are positive, they are interpreted as their unsigned counterparts. Otherwise, the image is normalized before display (the pixel with the lowest value is black and the pixel with the highest value is white).
 
 The `colorrgba` component for the image applies a multiplicative tint.
 


### PR DESCRIPTION
### What

Current text is vague and possibly wrong. The intent is to sync with #2477

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] ~~I've included a screenshot or gif (if applicable)~~

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2492

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/7d005e0/docs
Examples preview: https://rerun.io/preview/7d005e0/examples
<!-- pr-link-docs:end -->
