### PR TITLE
Documentation improvements highlighting the loggable data types section

### DIFF
--- a/docs/code-examples/depth_image_3d.py
+++ b/docs/code-examples/depth_image_3d.py
@@ -1,0 +1,30 @@
+"""Create and log a depth image and pinhole camera."""
+
+import numpy as np
+import rerun as rr
+
+# Create a dummy depth image
+image = 65535 * np.ones((200, 300), dtype=np.uint16)
+image[50:150, 50:150] = 20000
+image[130:180, 100:280] = 45000
+
+
+rr.init("depth_image", spawn=True)
+
+# If we log a pinhole camera model, the depth gets automatically back-projected to 3D
+focal_length = 200
+rr.log_pinhole(
+    "world/camera",
+    child_from_parent=np.array(
+        (
+            (focal_length, 0, image.shape[1] / 2),
+            (0, focal_length, image.shape[0] / 2),
+            (0, 0, 1),
+        ),
+    ),
+    width=image.shape[1],
+    height=image.shape[0],
+)
+
+# Log the tensor, assigning names to each dimension
+rr.log_depth_image("world/camera/depth", image, meter=10000.0)

--- a/docs/code-examples/depth_image_simple.py
+++ b/docs/code-examples/depth_image_simple.py
@@ -8,23 +8,7 @@ image = 65535 * np.ones((200, 300), dtype=np.uint16)
 image[50:150, 50:150] = 20000
 image[130:180, 100:280] = 45000
 
-
 rr.init("depth_image", spawn=True)
 
-# We need a camera to register the depth image to
-focal_length = 200
-rr.log_pinhole(
-    "world/camera",
-    child_from_parent=np.array(
-        (
-            (focal_length, 0, image.shape[1] / 2),
-            (0, focal_length, image.shape[0] / 2),
-            (0, 0, 1),
-        ),
-    ),
-    width=image.shape[1],
-    height=image.shape[0],
-)
-
 # Log the tensor, assigning names to each dimension
-rr.log_depth_image("world/camera/depth", image, meter=10000.0)
+rr.log_depth_image("depth", image, meter=10000.0)

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -312,4 +312,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types.md) section for more simple examples of how to use the main datatypes.

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -312,4 +312,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-To go further, have a look at some of our other [examples](/examples).
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -312,4 +312,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types.md) section for more simple examples of how to use the main datatypes.
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](../reference/data_types.md) section for more simple examples of how to use the main datatypes.

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -304,4 +304,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main data types.
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types.md) section for more simple examples of how to use the main data types.

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -304,4 +304,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main data types.

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -304,4 +304,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-To go further, have a look at some of our other [examples](/examples).
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -304,4 +304,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
-As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](reference/data_types.md) section for more simple examples of how to use the main data types.
+As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](../reference/data_types.md) section for more simple examples of how to use the main data types.

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -123,4 +123,4 @@ If you're ready to move on to more advanced topics, check out the [Viewer Walkth
 more advanced guide for [Logging Data in Python](logging-python.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
 
-If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types.md) section for more simple examples of how to use the main  s.
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](../reference/data_types.md) section for more simple examples of how to use the main  s.

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -123,4 +123,4 @@ If you're ready to move on to more advanced topics, check out the [Viewer Walkth
 more advanced guide for [Logging Data in Python](logging-python.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
 
-If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main  s.

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -122,3 +122,5 @@ rr.log_points("my_points", positions=positions, colors=colors, radii=0.5)
 If you're ready to move on to more advanced topics, check out the [Viewer Walkthrough](viewer-walkthrough.md) or our
 more advanced guide for [Logging Data in Python](logging-python.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
+
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -123,4 +123,4 @@ If you're ready to move on to more advanced topics, check out the [Viewer Walkth
 more advanced guide for [Logging Data in Python](logging-python.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
 
-If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main  s.
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types.md) section for more simple examples of how to use the main  s.

--- a/docs/content/getting-started/rust.md
+++ b/docs/content/getting-started/rust.md
@@ -80,4 +80,4 @@ If you're ready to move on to more advanced topics, check out the [Viewer Walkth
 more advanced guide for [Logging Data in Rust](logging-rust.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
 
-If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main data types.
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](../reference/data_types.md) section for more simple examples of how to use the main data types.

--- a/docs/content/getting-started/rust.md
+++ b/docs/content/getting-started/rust.md
@@ -80,4 +80,4 @@ If you're ready to move on to more advanced topics, check out the [Viewer Walkth
 more advanced guide for [Logging Data in Rust](logging-rust.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
 
-If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main data types.

--- a/docs/content/getting-started/rust.md
+++ b/docs/content/getting-started/rust.md
@@ -79,3 +79,5 @@ If you're facing any difficulties, don't hesitate to [open an issue](https://git
 If you're ready to move on to more advanced topics, check out the [Viewer Walkthrough](viewer-walkthrough.md) or our
 more advanced guide for [Logging Data in Rust](logging-rust.md) where we will explore the core concepts that make
 Rerun tick and log our first non-trivial dataset.
+
+If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Loggable Data Types](reference/data_types) section for more simple examples of how to use the main datatypes.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -21,7 +21,7 @@ or try out some [live demos](https://demo.rerun.io/) directly in your browser.
 - Follow up with a [walkthrough of the viewer](getting-started/viewer-walkthrough.md) and a tutorial on logging data with [Python](getting-started/logging-python.md) or [Rust](getting-started/logging-rust.md).
 - Dive deeper in the [Concepts](concepts) section.
 - The [Reference](reference) covers data types, configuration and API details.
-    - Including simple examples of how to use each of the [loggable data types](reference/data_types)
+    - Including simple examples of how to use each of the [loggable data types](reference/data_types.md)
 
 ## How does it work?
 It's quite simple:
@@ -30,7 +30,7 @@ It's quite simple:
 2. The data you log gets sent to our viewer that automatically visualizes it live.
 3. You can then use the UI to interactively explore the data and customize layout and visualization options.
 4. Save recordings to file for later replay.
-5. You can also [extend Rerun in Rust](howto/extend-ui) to meet your specific needs.
+5. You can also [extend Rerun in Rust](howto/extend-ui.md) to meet your specific needs.
 
 Under the hood Rerun:
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -3,31 +3,48 @@ title: Documentation
 order: 0
 ---
 
-## Learn how to use Rerun to build CV systems faster
+## Use Rerun to build intelligent software faster
 
-Rerun is built to help developers debug and understand computer vision and robotics systems
+Rerun helps developers debug and understand their systems
 by quickly visualizing internal state and data.
 
-- Jump right in with the a quick start for [Python](getting-started/python.md) or [Rust](getting-started/rust.md).
-- Follow it up with the [Viewer Walkthrough](getting-started/viewer-walkthrough.md) and a tutorial on logging data with [Python](getting-started/logging-python.md) or [Rust](getting-started/logging-rust.md).
+It's primarily focused on visualizing 2D and 3D computer vision and robotics data over time,
+but is under active development to expand support for more use-cases and datatypes.
+
+To get a sense of what you can do with Rerun right now,
+check out the [example gallery](/examples)
+or try out some [live demos](https://demo.rerun.io/) directly in your browser.
+
+## Start learning
+
+- Jump right in with [Python](getting-started/python.md) or [Rust](getting-started/rust.md).
+- Follow up with a [walkthrough of the viewer](getting-started/viewer-walkthrough.md) and a tutorial on logging data with [Python](getting-started/logging-python.md) or [Rust](getting-started/logging-rust.md).
 - Dive deeper in the [Concepts](concepts) section.
-- The [Reference](reference) covers specific primitives, configuration and API details.
+- The [Reference](reference) covers datatypes, configuration and API details.
+    - Including simple examples of how to use each of the [loggable data types](reference/data_types)
 
-## What is Rerun?
+## How does it work?
+It's quite simple:
 
-Rerun is a tool for logging and visually exploring computer vision and robotics data over time. It's used to debug and understand the internal state and data of your systems with minimal code.
-Over time, Rerun will evolve from a tool to a fully customizable toolkit,
-where you’ll have control over everything from layout to data transforms and shaders.
-You’ll even be able to embed single views inside other applications.
+1. Use the Rerun SDK to log data like text, tensors, images, point clouds, or metrics.
+2. The data you log gets sent to our viewer that automatically visualizes it live.
+3. You can then use the UI to interactively explore the data and customize layout and visualization options.
+4. Save recordings to file for later replay.
+5. You can also [extend Rerun in Rust](howto/extend-ui) to meet your specific needs.
 
-It's made up of the Rerun SDK and the Rerun Viewer
+Under the hood Rerun:
 
-- The Rerun SDK lets you log data from [Python](getting-started/python.md) or [Rust](getting-started/rust.md)
-- The [Rerun Viewer](reference/viewer/overview.md) lets you view data live or from a recording.
+1. Serializes the data.
+2. Sends it to the viewer, on the same machine or across the network.
+3. Receives and deserializes the data, potentially coming in out-of-order from from multiple sources.
+4. Indexes it into our super fast in-memory time-series like database.
+5. Serves and renders that data at lightning speed as you interactively inspect and scroll back and forth in time.
 
+### Example Visualization
 ![overview](https://static.rerun.io/9a555db43ccdc24a5a0d9afb3e9bf5c80b55f271_docs_overview.png)
 
 ## Can't find what you're looking for?
 
 - Drop in to the [Rerun Community Discord](https://discord.gg/xwcxHUjD35)
 - Or [submit an issue](https://github.com/rerun-io/rerun/issues) in the Rerun GitHub project
+

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -9,7 +9,7 @@ Rerun helps developers debug and understand their systems
 by quickly visualizing internal state and data.
 
 It's primarily focused on visualizing 2D and 3D computer vision and robotics data over time,
-but is under active development to expand support for more use-cases and datatypes.
+but is under active development to expand support for more use-cases and data types.
 
 To get a sense of what you can do with Rerun right now,
 check out the [example gallery](/examples)
@@ -20,7 +20,7 @@ or try out some [live demos](https://demo.rerun.io/) directly in your browser.
 - Jump right in with [Python](getting-started/python.md) or [Rust](getting-started/rust.md).
 - Follow up with a [walkthrough of the viewer](getting-started/viewer-walkthrough.md) and a tutorial on logging data with [Python](getting-started/logging-python.md) or [Rust](getting-started/logging-rust.md).
 - Dive deeper in the [Concepts](concepts) section.
-- The [Reference](reference) covers datatypes, configuration and API details.
+- The [Reference](reference) covers data types, configuration and API details.
     - Including simple examples of how to use each of the [loggable data types](reference/data_types)
 
 ## How does it work?

--- a/docs/content/reference/data_types/depth_image.md
+++ b/docs/content/reference/data_types/depth_image.md
@@ -21,10 +21,21 @@ Rust API: [Tensor](https://docs.rs/rerun/latest/rerun/components/struct.Tensor.h
 code-example: depth_image_simple
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/5ed6b5ce014c0fbbc70dc4241c117b10610e1ce7_depth_image_simple_480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/8786f135fc56814d968002249cec00f74b93947c_depth_image_simple_768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/fd5130f688b8dcb8b4d7a39cae373b94e72f0dd6_depth_image_simple_1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/a978c1f8dbb3d7d86f0895f649999f779a02c12e_depth_image_simple_1200w.png">
-  <img src="https://static.rerun.io/f78674bdae0eb25786c6173307693c5338f38b87_depth_image_simple_full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/b4c48684d79ffa304c6a36a0a3b38b1fc886e881_depth_image_simple_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/07bb774cbf292f59dc76d9bb558b55c3bcb12266_depth_image_simple_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/0866fa98427f03d17d09e3f9fa407aae8357ecd0_depth_image_simple_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/3a7ded4c82cfa7c18cfb2c743b3cad9902a5eeaa_depth_image_simple_1200w.png">
+  <img src="https://static.rerun.io/9598554977873ace2577bddd79184ac120ceb0b0_depth_image_simple_full.png" alt="">
 </picture>
 
+## Depth to 3D example
+
+code-example: depth_image_3d
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/5ed6b5ce014c0fbbc70dc4241c117b10610e1ce7_depth_image_3d_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/8786f135fc56814d968002249cec00f74b93947c_depth_image_3d_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/fd5130f688b8dcb8b4d7a39cae373b94e72f0dd6_depth_image_3d_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/a978c1f8dbb3d7d86f0895f649999f779a02c12e_depth_image_3d_1200w.png">
+  <img src="https://static.rerun.io/f78674bdae0eb25786c6173307693c5338f38b87_depth_image_3d_full.png" alt="">
+</picture>


### PR DESCRIPTION
Some (hopefully) improvements of the documentation site including
- Splitting the DepthImage example into simple (2D) and slightly more complex (auto 3D)
- Rewriting the docs landing page
- Referring to the new Loggable Data Types page from more places

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2493

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/3fbb959/docs
Examples preview: https://rerun.io/preview/3fbb959/examples
<!-- pr-link-docs:end -->
