### PR TITLE
Change capitalization and order of examples

### DIFF
--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -40,56 +40,8 @@ root:
     set up in a `requirements.txt` next to the example. These are noted in the
     individual example sections below.
   children:
-    - name: setup
-      title: Setup
-      prelude: |
-        Make sure you have the Rerun repository checked out and the latest SDK installed.
-
-        ```bash
-        pip install --upgrade rerun-sdk  # install the latest Rerun SDK
-        git clone git@github.com:rerun-io/rerun.git  # Clone the repository
-        cd rerun
-        git checkout latest  # Check out the commit matching the latest SDK release
-        ```
-        > Note: Make sure your SDK version matches the examples.
-        For example, if your SDK version is `0.3.1`, check out the matching tag
-        in the Rerun repository by running `git checkout v0.3.1`.
-
-    - name: artificial-data
-      title: Examples with Artificial Data
-      prelude: |
-        The following examples serve to illustrate various uses of the Rerun logging SDK.
-        They should not require any additional data downloads, and should run offline.
-      children:
-        - name: minimal
-          python: python/minimal
-          rust: rust/minimal
-
-        - name: api-demo
-          python: python/api_demo
-          rust: rust/api_demo
-
-        - name: car
-          python: python/car
-
-        - name: clock
-          python: python/clock
-          rust: rust/clock
-
-        - name: multiprocessing
-          python: python/multiprocessing
-
-        - name: multithreading
-          python: python/multithreading
-
-        - name: plots
-          python: python/plots
-
-        - name: text-logging
-          python: python/text_logging
-
     - name: real-data
-      title: Examples with Real Data
+      title: Examples with real data
       prelude: |
         The following examples illustrate using the Rerun logging SDK with potential real-world (if toy) use cases.
         They all require additional data to be downloaded, so an internet connection is needed at least once.
@@ -141,3 +93,50 @@ root:
         - name: face-tracking
           python: python/face_tracking
 
+    - name: artificial-data
+      title: Examples with artificial data
+      prelude: |
+        The following examples serve to illustrate various uses of the Rerun logging SDK.
+        They should not require any additional data downloads, and should run offline.
+      children:
+        - name: minimal
+          python: python/minimal
+          rust: rust/minimal
+
+        - name: api-demo
+          python: python/api_demo
+          rust: rust/api_demo
+
+        - name: car
+          python: python/car
+
+        - name: clock
+          python: python/clock
+          rust: rust/clock
+
+        - name: multiprocessing
+          python: python/multiprocessing
+
+        - name: multithreading
+          python: python/multithreading
+
+        - name: plots
+          python: python/plots
+
+        - name: text-logging
+          python: python/text_logging
+
+    - name: setup
+      title: Setup
+      prelude: |
+        Make sure you have the Rerun repository checked out and the latest SDK installed.
+
+        ```bash
+        pip install --upgrade rerun-sdk  # install the latest Rerun SDK
+        git clone git@github.com:rerun-io/rerun.git  # Clone the repository
+        cd rerun
+        git checkout latest  # Check out the commit matching the latest SDK release
+        ```
+        > Note: Make sure your SDK version matches the examples.
+        For example, if your SDK version is `0.3.1`, check out the matching tag
+        in the Rerun repository by running `git checkout v0.3.1`.


### PR DESCRIPTION
The current order is counter-intuitive:

<img width="563" alt="image" src="https://github.com/rerun-io/rerun/assets/875708/2a7b4d60-38a8-4c57-8d33-f155612eef9a">

This PR changes the order so that it becomes `real data`, `artificial data`, `setup`. That way, you land on the first item when you click "examples" in the main nav.

<img width="565" alt="image" src="https://github.com/rerun-io/rerun/assets/875708/67c2f1b6-0c16-41a2-971c-658fe2da6bec">

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2498

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/02ed94b/docs
Examples preview: https://rerun.io/preview/02ed94b/examples
<!-- pr-link-docs:end -->
