### PR TITLE
Double-click to select entity

### DIFF
--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -254,9 +254,9 @@ pub fn select_hovered_on_click(
 
     if response.clicked() {
         if response.ctx.input(|i| i.modifiers.command) {
-            selection_state.toggle_selection(selection_state.hovered().to_vec());
+            selection_state.toggle_selection(items.to_vec());
         } else {
-            selection_state.set_selection(selection_state.hovered().clone().into_iter());
+            selection_state.set_selection(items.iter().cloned());
         }
     }
 }

--- a/crates/re_log_types/src/instance_key.rs
+++ b/crates/re_log_types/src/instance_key.rs
@@ -19,17 +19,7 @@ use crate::Component;
 /// assert_eq!(InstanceKey::data_type(), DataType::UInt64);
 /// ```
 #[derive(
-    Copy,
-    Clone,
-    Debug,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    ArrowField,
-    ArrowSerialize,
-    ArrowDeserialize,
+    Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, ArrowField, ArrowSerialize, ArrowDeserialize,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[arrow_field(transparent)]
@@ -76,6 +66,17 @@ impl InstanceKey {
     /// Retrieves 2d image coordinates (x, y) encoded in an instance key
     pub fn to_2d_image_coordinate(self, image_width: u64) -> [u32; 2] {
         [(self.0 % image_width) as u32, (self.0 / image_width) as u32]
+    }
+}
+
+impl std::fmt::Debug for InstanceKey {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_splat() {
+            "splat".fmt(f)
+        } else {
+            self.0.fmt(f)
+        }
     }
 }
 

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -17,6 +17,13 @@ use crate::{
     DebugLabel, RectInt, Rgba, Size,
 };
 
+// These are only used if the point sizes are not already set.
+// Rerun always sets explicit sizes, so these are only used for other
+// users of re_renderer (mostly examples).
+// Unit: UI points.
+const AUTO_POINT_RADIUS: f32 = 2.5;
+const AUTO_LINE_RADIUS: f32 = 1.5;
+
 #[derive(thiserror::Error, Debug)]
 pub enum ViewBuilderError {
     #[error("Screenshot was already scheduled.")]
@@ -418,12 +425,12 @@ impl ViewBuilder {
         let projection_from_world = projection_from_view * view_from_world;
 
         let auto_size_points = if config.auto_size_config.point_radius.is_auto() {
-            Size::new_points(2.5)
+            Size::new_points(AUTO_POINT_RADIUS)
         } else {
             config.auto_size_config.point_radius
         };
         let auto_size_lines = if config.auto_size_config.line_radius.is_auto() {
-            Size::new_points(1.5)
+            Size::new_points(AUTO_LINE_RADIUS)
         } else {
             config.auto_size_config.line_radius
         };

--- a/crates/re_space_view_spatial/src/scene/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/arrows3d.rs
@@ -6,7 +6,7 @@ use re_viewer_context::{
     ArchetypeDefinition, DefaultColor, ScenePart, SceneQuery, SpaceViewHighlights, ViewerContext,
 };
 
-use super::{instance_key_to_picking_id, SpatialScenePartData, SpatialSpaceViewState};
+use super::{picking_id_from_instance_key, SpatialScenePartData, SpatialSpaceViewState};
 use crate::{
     scene::{
         contexts::{SpatialSceneContext, SpatialSceneEntityContext},
@@ -74,7 +74,7 @@ impl Arrows3DPart {
                             | LineStripFlags::FLAG_CAP_START_ROUND
                             | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS,
                     )
-                    .picking_instance_id(instance_key_to_picking_id(instance_key));
+                    .picking_instance_id(picking_id_from_instance_key(instance_key));
 
                 if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                     segment.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/arrows3d.rs
@@ -74,11 +74,7 @@ impl Arrows3DPart {
                             | LineStripFlags::FLAG_CAP_START_ROUND
                             | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS,
                     )
-                    .picking_instance_id(instance_key_to_picking_id(
-                        instance_key,
-                        ent_view.num_instances(),
-                        ent_context.highlight.any_selection_highlight,
-                    ));
+                    .picking_instance_id(instance_key_to_picking_id(instance_key));
 
                 if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                     segment.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/boxes2d.rs
@@ -47,12 +47,7 @@ impl Boxes2DPart {
              radius: Option<Radius>,
              label: Option<Label>,
              class_id: Option<ClassId>| {
-                let instance_hash = instance_path_hash_for_picking(
-                    ent_path,
-                    instance_key,
-                    ent_view.num_instances(),
-                    ent_context.highlight.any_selection_highlight,
-                );
+                let instance_hash = instance_path_hash_for_picking(ent_path, instance_key);
 
                 let annotation_info = ent_context
                     .annotations
@@ -81,11 +76,7 @@ impl Boxes2DPart {
                     )
                     .color(color)
                     .radius(radius)
-                    .picking_instance_id(instance_key_to_picking_id(
-                        instance_key,
-                        ent_view.num_instances(),
-                        ent_context.highlight.any_selection_highlight,
-                    ));
+                    .picking_instance_id(instance_key_to_picking_id(instance_key));
 
                 if let Some(outline_mask_ids) = ent_context
                     .highlight

--- a/crates/re_space_view_spatial/src/scene/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/boxes2d.rs
@@ -7,7 +7,7 @@ use re_viewer_context::{
 };
 
 use super::{
-    instance_key_to_picking_id, instance_path_hash_for_picking, SpatialScenePartData,
+    instance_path_hash_for_picking, picking_id_from_instance_key, SpatialScenePartData,
     SpatialSpaceViewState,
 };
 use crate::{
@@ -76,7 +76,7 @@ impl Boxes2DPart {
                     )
                     .color(color)
                     .radius(radius)
-                    .picking_instance_id(instance_key_to_picking_id(instance_key));
+                    .picking_instance_id(picking_id_from_instance_key(instance_key));
 
                 if let Some(outline_mask_ids) = ent_context
                     .highlight

--- a/crates/re_space_view_spatial/src/scene/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/boxes2d.rs
@@ -6,10 +6,6 @@ use re_viewer_context::{
     ArchetypeDefinition, DefaultColor, ScenePart, SceneQuery, SpaceViewHighlights, ViewerContext,
 };
 
-use super::{
-    instance_path_hash_for_picking, picking_id_from_instance_key, SpatialScenePartData,
-    SpatialSpaceViewState,
-};
 use crate::{
     scene::{
         contexts::{SpatialSceneContext, SpatialSceneEntityContext},
@@ -18,6 +14,8 @@ use crate::{
     },
     SpatialSpaceView,
 };
+
+use super::{picking_id_from_instance_key, SpatialScenePartData, SpatialSpaceViewState};
 
 #[derive(Default)]
 pub struct Boxes2DPart(SpatialScenePartData);
@@ -47,7 +45,8 @@ impl Boxes2DPart {
              radius: Option<Radius>,
              label: Option<Label>,
              class_id: Option<ClassId>| {
-                let instance_hash = instance_path_hash_for_picking(ent_path, instance_key);
+                let instance_hash =
+                    re_data_store::InstancePathHash::instance(ent_path, instance_key);
 
                 let annotation_info = ent_context
                     .annotations

--- a/crates/re_space_view_spatial/src/scene/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/boxes3d.rs
@@ -67,11 +67,7 @@ impl Boxes3DPart {
                 .add_box_outline(transform)
                 .radius(radius)
                 .color(color)
-                .picking_instance_id(instance_key_to_picking_id(
-                    instance_key,
-                    ent_view.num_instances(),
-                    ent_context.highlight.any_selection_highlight,
-                ));
+                .picking_instance_id(instance_key_to_picking_id(instance_key));
 
             if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                 box_lines.outline_mask_ids(*outline_mask_ids);
@@ -84,12 +80,7 @@ impl Boxes3DPart {
                         ent_context.world_from_obj.transform_point3(tran),
                     ),
                     color,
-                    labeled_instance: instance_path_hash_for_picking(
-                        ent_path,
-                        instance_key,
-                        ent_view.num_instances(),
-                        ent_context.highlight.any_selection_highlight,
-                    ),
+                    labeled_instance: instance_path_hash_for_picking(ent_path, instance_key),
                 });
             }
 

--- a/crates/re_space_view_spatial/src/scene/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/boxes3d.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    instance_key_to_picking_id, instance_path_hash_for_picking, SpatialScenePartData,
+    instance_path_hash_for_picking, picking_id_from_instance_key, SpatialScenePartData,
     SpatialSpaceViewState,
 };
 
@@ -67,7 +67,7 @@ impl Boxes3DPart {
                 .add_box_outline(transform)
                 .radius(radius)
                 .color(color)
-                .picking_instance_id(instance_key_to_picking_id(instance_key));
+                .picking_instance_id(picking_id_from_instance_key(instance_key));
 
             if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                 box_lines.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/boxes3d.rs
@@ -17,10 +17,7 @@ use crate::{
     SpatialSpaceView,
 };
 
-use super::{
-    instance_path_hash_for_picking, picking_id_from_instance_key, SpatialScenePartData,
-    SpatialSpaceViewState,
-};
+use super::{picking_id_from_instance_key, SpatialScenePartData, SpatialSpaceViewState};
 
 #[derive(Default)]
 pub struct Boxes3DPart(SpatialScenePartData);
@@ -80,7 +77,10 @@ impl Boxes3DPart {
                         ent_context.world_from_obj.transform_point3(tran),
                     ),
                     color,
-                    labeled_instance: instance_path_hash_for_picking(ent_path, instance_key),
+                    labeled_instance: re_data_store::InstancePathHash::instance(
+                        ent_path,
+                        instance_key,
+                    ),
                 });
             }
 

--- a/crates/re_space_view_spatial/src/scene/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/cameras.rs
@@ -8,11 +8,12 @@ use re_viewer_context::{ArchetypeDefinition, ScenePart, TimeControl};
 use re_viewer_context::{SceneQuery, ViewerContext};
 use re_viewer_context::{SpaceViewHighlights, SpaceViewOutlineMasks};
 
-use super::{instance_path_hash_for_picking, SpatialScenePartData, SpatialSpaceViewState};
 use crate::{
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
     scene::contexts::SpatialSceneContext, space_camera_3d::SpaceCamera3D, SpatialSpaceView,
 };
+
+use super::{SpatialScenePartData, SpatialSpaceViewState};
 
 const CAMERA_COLOR: re_renderer::Color32 = re_renderer::Color32::from_rgb(150, 150, 150);
 
@@ -152,7 +153,8 @@ impl CamerasPart {
         ];
 
         let radius = re_renderer::Size::new_points(1.0);
-        let instance_path_for_picking = instance_path_hash_for_picking(ent_path, instance_key);
+        let instance_path_for_picking =
+            re_data_store::InstancePathHash::instance(ent_path, instance_key);
         let instance_layer_id = picking_layer_id_from_instance_path_hash(instance_path_for_picking);
 
         let mut line_builder = scene_context.shared_render_builders.lines();

--- a/crates/re_space_view_spatial/src/scene/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/cameras.rs
@@ -152,13 +152,7 @@ impl CamerasPart {
         ];
 
         let radius = re_renderer::Size::new_points(1.0);
-        let num_instances = 1; // There is only ever one instance of `Transform` per entity.
-        let instance_path_for_picking = instance_path_hash_for_picking(
-            ent_path,
-            instance_key,
-            num_instances,
-            entity_highlight.any_selection_highlight,
-        );
+        let instance_path_for_picking = instance_path_hash_for_picking(ent_path, instance_key);
         let instance_layer_id = picking_layer_id_from_instance_path_hash(instance_path_for_picking);
 
         let mut line_builder = scene_context.shared_render_builders.lines();

--- a/crates/re_space_view_spatial/src/scene/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/lines2d.rs
@@ -14,7 +14,7 @@ use crate::{
     SpatialSpaceView,
 };
 
-use super::{instance_key_to_picking_id, SpatialScenePartData, SpatialSpaceViewState};
+use super::{picking_id_from_instance_key, SpatialScenePartData, SpatialSpaceViewState};
 
 #[derive(Default)]
 pub struct Lines2DPart(SpatialScenePartData);
@@ -54,7 +54,7 @@ impl Lines2DPart {
                 .add_strip_2d(strip.0.into_iter().map(|v| v.into()))
                 .color(color)
                 .radius(radius)
-                .picking_instance_id(instance_key_to_picking_id(instance_key));
+                .picking_instance_id(picking_id_from_instance_key(instance_key));
 
             if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                 lines.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/lines2d.rs
@@ -54,11 +54,7 @@ impl Lines2DPart {
                 .add_strip_2d(strip.0.into_iter().map(|v| v.into()))
                 .color(color)
                 .radius(radius)
-                .picking_instance_id(instance_key_to_picking_id(
-                    instance_key,
-                    ent_view.num_instances(),
-                    ent_context.highlight.any_selection_highlight,
-                ));
+                .picking_instance_id(instance_key_to_picking_id(instance_key));
 
             if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                 lines.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/lines3d.rs
@@ -54,11 +54,7 @@ impl Lines3DPart {
                 .add_strip(strip.0.into_iter().map(|v| v.into()))
                 .color(color)
                 .radius(radius)
-                .picking_instance_id(instance_key_to_picking_id(
-                    instance_key,
-                    ent_view.num_instances(),
-                    ent_context.highlight.any_selection_highlight,
-                ));
+                .picking_instance_id(instance_key_to_picking_id(instance_key));
 
             if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                 lines.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/lines3d.rs
@@ -14,7 +14,7 @@ use crate::{
     SpatialSpaceView,
 };
 
-use super::{instance_key_to_picking_id, SpatialScenePartData, SpatialSpaceViewState};
+use super::{picking_id_from_instance_key, SpatialScenePartData, SpatialSpaceViewState};
 
 #[derive(Default)]
 pub struct Lines3DPart(SpatialScenePartData);
@@ -54,7 +54,7 @@ impl Lines3DPart {
                 .add_strip(strip.0.into_iter().map(|v| v.into()))
                 .color(color)
                 .radius(radius)
-                .picking_instance_id(instance_key_to_picking_id(instance_key));
+                .picking_instance_id(picking_id_from_instance_key(instance_key));
 
             if let Some(outline_mask_ids) = ent_context.highlight.instances.get(&instance_key) {
                 lines.outline_mask_ids(*outline_mask_ids);

--- a/crates/re_space_view_spatial/src/scene/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/meshes.rs
@@ -33,12 +33,7 @@ impl MeshPart {
         let visitor = |instance_key: InstanceKey,
                        mesh: re_components::Mesh3D,
                        _color: Option<ColorRGBA>| {
-            let picking_instance_hash = instance_path_hash_for_picking(
-                ent_path,
-                instance_key,
-                ent_view.num_instances(),
-                ent_context.highlight.any_selection_highlight,
-            );
+            let picking_instance_hash = instance_path_hash_for_picking(ent_path, instance_key);
 
             let outline_mask_ids = ent_context.highlight.index_outline_mask(instance_key);
 

--- a/crates/re_space_view_spatial/src/scene/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/meshes.rs
@@ -14,7 +14,7 @@ use crate::scene::{
 };
 use crate::SpatialSpaceView;
 
-use super::{instance_path_hash_for_picking, SpatialScenePartData, SpatialSpaceViewState};
+use super::{SpatialScenePartData, SpatialSpaceViewState};
 
 #[derive(Default)]
 pub struct MeshPart(SpatialScenePartData);
@@ -33,7 +33,8 @@ impl MeshPart {
         let visitor = |instance_key: InstanceKey,
                        mesh: re_components::Mesh3D,
                        _color: Option<ColorRGBA>| {
-            let picking_instance_hash = instance_path_hash_for_picking(ent_path, instance_key);
+            let picking_instance_hash =
+                re_data_store::InstancePathHash::instance(ent_path, instance_key);
 
             let outline_mask_ids = ent_context.highlight.index_outline_mask(instance_key);
 

--- a/crates/re_space_view_spatial/src/scene/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/mod.rs
@@ -117,39 +117,15 @@ impl SpatialScenePartCollection {
 pub fn instance_path_hash_for_picking(
     ent_path: &EntityPath,
     instance_key: re_log_types::InstanceKey,
-    num_instances: usize,
-    any_part_selected: bool,
 ) -> InstancePathHash {
-    InstancePathHash::instance(
-        ent_path,
-        instance_key_for_picking(instance_key, num_instances, any_part_selected),
-    )
-}
-
-/// Computes the instance key that should be used for picking (in turn for selecting/hover)
-///
-/// Assumes the entity is interactive.
-///
-/// TODO(andreas): Resolve the hash-for-picking when retrieving the picking result instead of doing it ahead of time here to speed up things.
-///                 (gpu picking would always get the "most fine grained hash" which we could then resolve to groups etc. depending on selection state)
-/// Right now this is a bit hard to do since number of instances depends on the Primary. This is expected to change soon.
-pub fn instance_key_for_picking(
-    instance_key: re_log_types::InstanceKey,
-    _num_instances: usize,
-    _any_part_selected: bool,
-) -> re_log_types::InstanceKey {
-    instance_key
+    InstancePathHash::instance(ent_path, instance_key)
 }
 
 /// See [`instance_key_for_picking`]
 pub fn instance_key_to_picking_id(
     instance_key: re_log_types::InstanceKey,
-    num_instances: usize,
-    any_part_selected: bool,
 ) -> re_renderer::PickingLayerInstanceId {
-    re_renderer::PickingLayerInstanceId(
-        instance_key_for_picking(instance_key, num_instances, any_part_selected).0,
-    )
+    re_renderer::PickingLayerInstanceId(instance_key.0)
 }
 
 /// Process [`ColorRGBA`] components using annotations and default colors.

--- a/crates/re_space_view_spatial/src/scene/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/mod.rs
@@ -20,7 +20,7 @@ use ahash::HashMap;
 use std::sync::Arc;
 
 use re_components::{ClassId, ColorRGBA, KeypointId, Radius};
-use re_data_store::{EntityPath, InstancePathHash};
+use re_data_store::EntityPath;
 use re_viewer_context::{
     Annotations, DefaultColor, ResolvedAnnotationInfo, ScenePartCollection, SceneQuery,
 };
@@ -107,18 +107,6 @@ impl SpatialScenePartCollection {
         }
         ui_labels
     }
-}
-
-/// Computes the instance hash that should be used for picking (in turn for selecting/hover)
-///
-/// TODO(andreas): Resolve the hash-for-picking when retrieving the picking result instead of doing it ahead of time here to speed up things.
-///                 (gpu picking would always get the "most fine grained hash" which we could then resolve to groups etc. depending on selection state)
-/// Right now this is a bit hard to do since number of instances depends on the Primary. This is expected to change soon.
-pub fn instance_path_hash_for_picking(
-    ent_path: &EntityPath,
-    instance_key: re_log_types::InstanceKey,
-) -> InstancePathHash {
-    InstancePathHash::instance(ent_path, instance_key)
 }
 
 pub fn picking_id_from_instance_key(

--- a/crates/re_space_view_spatial/src/scene/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/mod.rs
@@ -135,17 +135,10 @@ pub fn instance_path_hash_for_picking(
 /// Right now this is a bit hard to do since number of instances depends on the Primary. This is expected to change soon.
 pub fn instance_key_for_picking(
     instance_key: re_log_types::InstanceKey,
-    num_instances: usize,
-    any_part_selected: bool,
+    _num_instances: usize,
+    _any_part_selected: bool,
 ) -> re_log_types::InstanceKey {
-    // If no part of the entity is selected or if there is only one instance, selecting
-    // should select the entire entity, not the specific instance.
-    // (the splat key means that no particular instance is selected but all at once instead)
-    if num_instances == 1 || !any_part_selected {
-        re_log_types::InstanceKey::SPLAT
-    } else {
-        instance_key
-    }
+    instance_key
 }
 
 /// See [`instance_key_for_picking`]

--- a/crates/re_space_view_spatial/src/scene/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/mod.rs
@@ -121,8 +121,7 @@ pub fn instance_path_hash_for_picking(
     InstancePathHash::instance(ent_path, instance_key)
 }
 
-/// See [`instance_key_for_picking`]
-pub fn instance_key_to_picking_id(
+pub fn picking_id_from_instance_key(
     instance_key: re_log_types::InstanceKey,
 ) -> re_renderer::PickingLayerInstanceId {
     re_renderer::PickingLayerInstanceId(instance_key.0)

--- a/crates/re_space_view_spatial/src/scene/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/points2d.rs
@@ -92,14 +92,7 @@ impl Points2DPart {
                 re_tracing::profile_scope!("instance_hashes");
                 ent_view
                     .iter_instance_keys()
-                    .map(|instance_key| {
-                        instance_path_hash_for_picking(
-                            ent_path,
-                            instance_key,
-                            ent_view.num_instances(),
-                            ent_context.highlight.any_selection_highlight,
-                        )
-                    })
+                    .map(|instance_key| instance_path_hash_for_picking(ent_path, instance_key))
                     .collect::<Vec<_>>()
             };
 
@@ -131,13 +124,9 @@ impl Points2DPart {
                     .filter_map(|pt| pt.map(glam::Vec2::from))
             };
 
-            let picking_instance_ids = ent_view.iter_instance_keys().map(|instance_key| {
-                instance_key_to_picking_id(
-                    instance_key,
-                    ent_view.num_instances(),
-                    ent_context.highlight.any_selection_highlight,
-                )
-            });
+            let picking_instance_ids = ent_view
+                .iter_instance_keys()
+                .map(instance_key_to_picking_id);
 
             let mut point_range_builder = point_batch.add_points_2d(
                 ent_view.num_instances(),

--- a/crates/re_space_view_spatial/src/scene/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/points2d.rs
@@ -19,8 +19,9 @@ use crate::{
 };
 
 use super::{
-    instance_key_to_picking_id, instance_path_hash_for_picking, process_annotations_and_keypoints,
-    process_colors, process_radii, SpatialScenePartData, SpatialSpaceViewState,
+    instance_path_hash_for_picking, picking_id_from_instance_key,
+    process_annotations_and_keypoints, process_colors, process_radii, SpatialScenePartData,
+    SpatialSpaceViewState,
 };
 
 pub struct Points2DPart {
@@ -126,7 +127,7 @@ impl Points2DPart {
 
             let picking_instance_ids = ent_view
                 .iter_instance_keys()
-                .map(instance_key_to_picking_id);
+                .map(picking_id_from_instance_key);
 
             let mut point_range_builder = point_batch.add_points_2d(
                 ent_view.num_instances(),

--- a/crates/re_space_view_spatial/src/scene/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/points2d.rs
@@ -19,9 +19,8 @@ use crate::{
 };
 
 use super::{
-    instance_path_hash_for_picking, picking_id_from_instance_key,
-    process_annotations_and_keypoints, process_colors, process_radii, SpatialScenePartData,
-    SpatialSpaceViewState,
+    picking_id_from_instance_key, process_annotations_and_keypoints, process_colors, process_radii,
+    SpatialScenePartData, SpatialSpaceViewState,
 };
 
 pub struct Points2DPart {
@@ -93,7 +92,7 @@ impl Points2DPart {
                 re_tracing::profile_scope!("instance_hashes");
                 ent_view
                     .iter_instance_keys()
-                    .map(|instance_key| instance_path_hash_for_picking(ent_path, instance_key))
+                    .map(|instance_key| InstancePathHash::instance(ent_path, instance_key))
                     .collect::<Vec<_>>()
             };
 

--- a/crates/re_space_view_spatial/src/scene/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/points3d.rs
@@ -95,14 +95,7 @@ impl Points3DPart {
                 re_tracing::profile_scope!("instance_hashes");
                 ent_view
                     .iter_instance_keys()
-                    .map(|instance_key| {
-                        instance_path_hash_for_picking(
-                            ent_path,
-                            instance_key,
-                            ent_view.num_instances(),
-                            ent_context.highlight.any_selection_highlight,
-                        )
-                    })
+                    .map(|instance_key| instance_path_hash_for_picking(ent_path, instance_key))
                     .collect::<Vec<_>>()
             };
 
@@ -130,13 +123,9 @@ impl Points3DPart {
                     .filter_map(|pt| pt.map(glam::Vec3::from))
             };
 
-            let picking_instance_ids = ent_view.iter_instance_keys().map(|instance_key| {
-                instance_key_to_picking_id(
-                    instance_key,
-                    ent_view.num_instances(),
-                    ent_context.highlight.any_selection_highlight,
-                )
-            });
+            let picking_instance_ids = ent_view
+                .iter_instance_keys()
+                .map(instance_key_to_picking_id);
             let mut point_range_builder = point_batch.add_points(
                 ent_view.num_instances(),
                 point_positions,

--- a/crates/re_space_view_spatial/src/scene/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/points3d.rs
@@ -19,8 +19,9 @@ use crate::{
 };
 
 use super::{
-    instance_key_to_picking_id, instance_path_hash_for_picking, process_annotations_and_keypoints,
-    process_colors, process_radii, SpatialScenePartData, SpatialSpaceViewState,
+    instance_path_hash_for_picking, picking_id_from_instance_key,
+    process_annotations_and_keypoints, process_colors, process_radii, SpatialScenePartData,
+    SpatialSpaceViewState,
 };
 
 pub struct Points3DPart {
@@ -125,7 +126,7 @@ impl Points3DPart {
 
             let picking_instance_ids = ent_view
                 .iter_instance_keys()
-                .map(instance_key_to_picking_id);
+                .map(picking_id_from_instance_key);
             let mut point_range_builder = point_batch.add_points(
                 ent_view.num_instances(),
                 point_positions,

--- a/crates/re_space_view_spatial/src/scene/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/scene/parts/points3d.rs
@@ -19,9 +19,8 @@ use crate::{
 };
 
 use super::{
-    instance_path_hash_for_picking, picking_id_from_instance_key,
-    process_annotations_and_keypoints, process_colors, process_radii, SpatialScenePartData,
-    SpatialSpaceViewState,
+    picking_id_from_instance_key, process_annotations_and_keypoints, process_colors, process_radii,
+    SpatialScenePartData, SpatialSpaceViewState,
 };
 
 pub struct Points3DPart {
@@ -96,7 +95,7 @@ impl Points3DPart {
                 re_tracing::profile_scope!("instance_hashes");
                 ent_view
                     .iter_instance_keys()
-                    .map(|instance_key| instance_path_hash_for_picking(ent_path, instance_key))
+                    .map(|instance_key| InstancePathHash::instance(ent_path, instance_key))
                     .collect::<Vec<_>>()
             };
 

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -29,6 +29,12 @@ use crate::{
     ui_3d::{view_3d, SpaceSpecs},
 };
 
+/// Default auto point radius in UI points.
+const AUTO_POINT_RADIUS: f32 = 1.5;
+
+/// Default auto line radius in UI points.
+const AUTO_LINE_RADIUS: f32 = 1.5;
+
 /// Describes how the scene is navigated, determining if it is a 2D or 3D experience.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum SpatialNavigationMode {
@@ -121,10 +127,10 @@ impl SpatialSpaceViewState {
     pub fn auto_size_config(&self) -> re_renderer::AutoSizeConfig {
         let mut config = self.auto_size_config;
         if config.point_radius.is_auto() {
-            config.point_radius = re_renderer::Size::new_points(1.5); // default point radius
+            config.point_radius = re_renderer::Size::new_points(AUTO_POINT_RADIUS);
         }
         if config.line_radius.is_auto() {
-            config.line_radius = re_renderer::Size::new_points(1.5); // default line radius
+            config.line_radius = re_renderer::Size::new_points(AUTO_LINE_RADIUS);
         }
         config
     }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -683,8 +683,8 @@ pub fn picking(
 
     let picking_rect_size =
         super::scene::PickingContext::UI_INTERACTION_RADIUS * parent_ui.ctx().pixels_per_point();
-    // Make the picking rect bigger than necessary so we can use it to counter act delays.
-    // (by the time the picking rectangle read back, the cursor may have moved on).
+    // Make the picking rect bigger than necessary so we can use it to counter-act delays.
+    // (by the time the picking rectangle is read back, the cursor may have moved on).
     let picking_rect_size = (picking_rect_size * 2.0)
         .ceil()
         .at_least(8.0)
@@ -718,6 +718,11 @@ pub fn picking(
     for hit in &picking_result.hits {
         let Some(mut instance_path) = hit.instance_path_hash.resolve(&ctx.store_db.entity_db)
             else { continue; };
+
+        if response.double_clicked() {
+            // Select entire entity on double-click:
+            instance_path.instance_key = re_log_types::InstanceKey::SPLAT;
+        }
 
         if scene
             .context

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -162,7 +162,7 @@ impl SpatialSpaceViewState {
         let size = self.scene_bbox_accum.size();
         let mut sorted_components = size.to_array();
         sorted_components.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        // Median is more robust against outlier in one direction (as such pretty pour still though)
+        // Median is more robust against outlier in one direction (as such pretty poor still though)
         let median_extent = sorted_components[1];
         // sqrt would make more sense but using a smaller root works better in practice.
         let heuristic1 =

--- a/crates/re_viewer_context/src/space_view/highlights.rs
+++ b/crates/re_viewer_context/src/space_view/highlights.rs
@@ -36,7 +36,6 @@ impl<'a> OptionalSpaceViewEntityHighlight<'a> {
 pub struct SpaceViewOutlineMasks {
     pub overall: OutlineMaskPreference,
     pub instances: ahash::HashMap<InstanceKey, OutlineMaskPreference>,
-    pub any_selection_highlight: bool,
 }
 
 lazy_static! {

--- a/crates/re_viewport/src/space_view_highlights.rs
+++ b/crates/re_viewport/src/space_view_highlights.rs
@@ -59,7 +59,6 @@ pub fn highlights_for_space_view(
                                     outlines_masks.entry(entity_path.hash()).or_default();
                                 outline_mask_ids.overall =
                                     selection_mask.with_fallback_to(outline_mask_ids.overall);
-                                outline_mask_ids.any_selection_highlight = true;
                             },
                         );
                     }
@@ -94,7 +93,6 @@ pub fn highlights_for_space_view(
                     let outline_mask_ids = outlines_masks
                         .entry(selected_instance.entity_path.hash())
                         .or_default();
-                    outline_mask_ids.any_selection_highlight = true;
                     let outline_mask_target = if let Some(selected_index) =
                         selected_instance.instance_key.specific_index()
                     {


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2214

Hovering a point cloud now hovers individual points. Clicking once selects a point (a single instance). Double-clicking selects the entire point-cloud (the entire entity).

### What
With this PR, we always set the full instance key in the GPU picking buffer. When reading we decide whether to look at both entity and instance (hover/click single instances) or to only look at the entity path (select whole point-cloud on double-click).

Previously what was put in the GPU picking buffer depended on what was already selected. The new code is a lot simpler.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2504

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/c7f9332/docs
Examples preview: https://rerun.io/preview/c7f9332/examples
<!-- pr-link-docs:end -->
