### PR TITLE
Clip image zoom rectangle

### DIFF
--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -462,6 +462,7 @@ fn try_show_zoomed_image_region(
 
     painter.rect_filled(zoom_rect, 0.0, ui.visuals().extreme_bg_color);
 
+    // Paint the zoomed in region:
     {
         let image_rect_on_screen = egui::Rect::from_min_size(
             zoom_rect.center()

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -449,10 +449,10 @@ fn try_show_zoomed_image_region(
     debug_name: &str,
     center_texel: [isize; 2],
 ) -> anyhow::Result<()> {
+    let Some([height, width, _]) = tensor.image_height_width_channels() else { return Ok(()); };
+
     let texture =
         gpu_bridge::tensor_to_gpu(render_ctx, debug_name, tensor, tensor_stats, annotations)?;
-
-    let Some([height, width, _]) = tensor.image_height_width_channels() else { return Ok(()); };
 
     const POINTS_PER_TEXEL: f32 = 5.0;
     let size = Vec2::splat((ZOOMED_IMAGE_TEXEL_RADIUS * 2 + 1) as f32 * POINTS_PER_TEXEL);

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -807,7 +807,8 @@ pub fn picking(
                                         egui::vec2(w, h),
                                     );
                                     show_zoomed_image_region_area_outline(
-                                        ui,
+                                        ui.ctx(),
+                                        ui_clip_rect,
                                         &tensor,
                                         [coords[0] as _, coords[1] as _],
                                         space_from_ui.inverse().transform_rect(rect),

--- a/examples/python/api_demo/main.py
+++ b/examples/python/api_demo/main.py
@@ -76,6 +76,14 @@ def run_segmentation() -> None:
     rr.log_text_entry("logs/seg_demo_log", "label1 disappears and everything with label3 is now default colored again")
 
 
+def small_image() -> None:
+    img = [
+        [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+        [[0, 0, 255], [255, 0, 0], [0, 255, 0]],
+    ]
+    rr.log_image("small_image", img)
+
+
 def run_2d_layering() -> None:
     rr.set_time_seconds("sim_time", 1)
 
@@ -405,6 +413,7 @@ def main() -> None:
         "raw_mesh": raw_mesh,
         "rects": run_rects,
         "segmentation": run_segmentation,
+        "small_image": small_image,
         "text": run_text_logs,
         "transforms_rigid_3d": transforms_rigid_3d,
         "transform_test": transform_test,


### PR DESCRIPTION
### What
When hovering an image we show the source region as a rectangle. This is now properly clipped to the source ui.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: {{ pr-build-summary }}

<!-- This comment will be replaced by a link to the documentation preview -->
