### PR TITLE
Add a simple example to display Open Photogrammetry Format datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 **/target_wasm
 
 # Python virtual environment:
-**/venv
+**/venv*
 
 # Python build artifacts:
 __pycache__

--- a/BUILD.md
+++ b/BUILD.md
@@ -69,6 +69,7 @@ First, a local virtual environment must be created and the necessary dependencie
 
 ```sh
 just py-dev-env
+source venv/bin/activate
 ```
 
 Then, the SDK can be compiled and installed in the virtual environment using the following command:

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -186,7 +186,7 @@ impl SpatialSpaceViewState {
             if properties.pinhole_image_plane_distance.is_auto() {
                 let scene_size = self.scene_bbox_accum.size().length();
                 let default_image_plane_distance = if scene_size.is_finite() && scene_size > 0.0 {
-                    scene_size * 0.05
+                    scene_size * 0.02 // Works pretty well for `examples/python/open_photogrammetry_format/main.py --no-frames`
                 } else {
                     1.0
                 };

--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -112,6 +112,7 @@ impl<'a> AppBlueprint<'a> {
 }
 
 fn load_panel_state(path: &EntityPath, blueprint_db: &re_data_store::StoreDb) -> Option<bool> {
+    re_tracing::profile_function!();
     blueprint_db
         .store()
         .query_timeless_component::<PanelState>(path)

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -141,8 +141,6 @@ impl AppState {
         egui::CentralPanel::default()
             .frame(central_panel_frame)
             .show_inside(ui, |ui| {
-                re_tracing::profile_function!();
-
                 let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
 
                 blueprint.viewport.on_frame_start(&mut ctx, &spaces_info);

--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -62,7 +62,7 @@ pub(crate) fn tree_from_space_views(
             ],
             &mut tiles,
         )
-    } else if space_make_infos.len() < 12 {
+    } else if space_make_infos.len() <= 12 {
         // Arrange it all in a grid that is responsive to changes in viewport size:
         let child_tile_ids = space_make_infos
             .into_iter()

--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -6,13 +6,14 @@ use std::collections::BTreeMap;
 
 use itertools::Itertools as _;
 
-use re_viewer_context::SpaceViewId;
+use re_viewer_context::{SpaceViewClassName, SpaceViewId};
 
 use super::space_view::SpaceViewBlueprint;
 
 #[derive(Clone, Debug)]
 struct SpaceMakeInfo {
     id: SpaceViewId,
+    class_name: SpaceViewClassName,
     layout_priority: re_viewer_context::SpaceViewClassLayoutPriority,
 }
 
@@ -35,11 +36,13 @@ pub(crate) fn tree_from_space_views(
             )
         })
         .map(|(space_view_id, space_view)| {
+            let class_name = *space_view.class_name();
             let layout_priority = space_view
                 .class(space_view_class_registry)
                 .layout_priority();
             SpaceMakeInfo {
                 id: *space_view_id,
+                class_name,
                 layout_priority,
             }
         })
@@ -59,13 +62,45 @@ pub(crate) fn tree_from_space_views(
             ],
             &mut tiles,
         )
-    } else {
+    } else if space_make_infos.len() < 12 {
         // Arrange it all in a grid that is responsive to changes in viewport size:
         let child_tile_ids = space_make_infos
             .into_iter()
             .map(|smi| tiles.insert_pane(smi.id))
             .collect_vec();
         tiles.insert_grid_tile(child_tile_ids)
+    } else {
+        // So many space views - lets group by class and put the members of each group into tabs:
+        let mut grouped_by_class: BTreeMap<SpaceViewClassName, Vec<SpaceMakeInfo>> =
+            Default::default();
+        for smi in space_make_infos {
+            grouped_by_class
+                .entry(smi.class_name)
+                .or_default()
+                .push(smi);
+        }
+
+        let groups = grouped_by_class
+            .values()
+            .cloned()
+            .sorted_by_key(|group| -(group[0].layout_priority as isize));
+
+        let tabs = groups
+            .into_iter()
+            .map(|group| {
+                let children = group
+                    .into_iter()
+                    .map(|smi| tiles.insert_pane(smi.id))
+                    .collect_vec();
+                tiles.insert_tab_tile(children)
+            })
+            .collect_vec();
+
+        if tabs.len() == 1 {
+            tabs[0]
+        } else {
+            tiles.insert_grid_tile(tabs)
+        }
     };
 
     egui_tiles::Tree::new(root, tiles)

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -28,6 +28,8 @@ pub struct ViewportBlueprint<'a> {
 
 impl<'a> ViewportBlueprint<'a> {
     pub fn from_db(blueprint_db: &'a re_data_store::StoreDb) -> Self {
+        re_tracing::profile_function!();
+
         let space_views: HashMap<SpaceViewId, SpaceViewBlueprint> = if let Some(space_views) =
             blueprint_db
                 .entity_db
@@ -128,6 +130,7 @@ fn load_space_view(
     path: &EntityPath,
     blueprint_db: &re_data_store::StoreDb,
 ) -> Option<SpaceViewBlueprint> {
+    re_tracing::profile_function!();
     blueprint_db
         .store()
         .query_timeless_component::<SpaceViewComponent>(path)
@@ -138,6 +141,7 @@ fn load_viewport(
     blueprint_db: &re_data_store::StoreDb,
     space_views: HashMap<SpaceViewId, SpaceViewBlueprint>,
 ) -> Viewport {
+    re_tracing::profile_function!();
     let auto_space_views = blueprint_db
         .store()
         .query_timeless_component::<AutoSpaceViews>(&VIEWPORT_PATH.into())

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -1,0 +1,23 @@
+---
+title: Open Photogrammetry Format
+python: https://github.com/rerun-io/rerun/tree/latest/examples/python/open_photogrammetry_format/main.py
+tags: [2d, 3d, camera, photogrammetry]
+thumbnail: https://static.rerun.io/20716c6a10ffaa3960a212673adcbfff36da682e_open_photogrammetry_format_480w.png
+---
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/20716c6a10ffaa3960a212673adcbfff36da682e_open_photogrammetry_format_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/ed4a35b86775020956963cd464a0b32278761345_open_photogrammetry_format_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/832c4fe63b6abe665c5723e5664d80bf19e9c6e1_open_photogrammetry_format_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/3bb25c43fa2a4c367d036c27943812ebfe3e4d42_open_photogrammetry_format_1200w.png">
+  <img src="https://static.rerun.io/603d5605f9670889bc8bce3365f16b831fce1eb1_open_photogrammetry_format_full.png" alt="">
+</picture>
+
+
+Use [pyopf](https://github.com/Pix4D/pyopf) to load and display a photogrammetrically reconstructed 3D point cloud in the Open Photogrammetry Format (OPF).
+
+
+```bash
+pip install -r examples/python/open_photogrammetry_format/requirements.txt
+python examples/python/open_photogrammetry_format/main.py
+```

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -21,3 +21,5 @@ Use [pyopf](https://github.com/Pix4D/pyopf) to load and display a photogrammetri
 pip install -r examples/python/open_photogrammetry_format/requirements.txt
 python examples/python/open_photogrammetry_format/main.py
 ```
+
+Requires Python 3.10 or higher because of [pyopf](https://pypi.org/project/pyopf/).

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -159,6 +159,8 @@ class OPFProject:
                 )
             )
 
+            # TODO(ab): this is probably affected by https://github.com/rerun-io/rerun/issues/2244. The code will be
+            # cleaner (and less buggy) once that is fixed.
             rr.log_pinhole(
                 entity + "/image",
                 child_from_parent=intrinsics,

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -1,0 +1,200 @@
+"""
+Load an Open Photogrammetry Format (OFP) project and display the cameras and point cloud.
+
+OPF specification: https://pix4d.github.io/opf-spec/index.html
+Dataset source: https://support.pix4d.com/hc/en-us/articles/360000235126-Example-projects-real-photogrammetry-data#OPF1
+pyopf: https://github.com/Pix4D/pyopf
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+import requests
+import rerun as rr
+import tqdm
+from pyopf.io import load
+from pyopf.resolve import resolve
+
+
+@dataclass
+class DatasetSpec:
+    dir_name: str
+    url: str
+
+
+DATASETS = {
+    "olympic": DatasetSpec(
+        "olympic_flame", "https://s3.amazonaws.com/mics.pix4d.com/example_datasets/olympic_flame.zip"
+    ),
+    "rainwater": DatasetSpec(
+        "catch_rainwater_demo", "https://s3.amazonaws.com/mics.pix4d.com/example_datasets/catch_rainwater_demo.zip"
+    ),
+    "rivaz": DatasetSpec("rivaz_demo", "https://s3.amazonaws.com/mics.pix4d.com/example_datasets/rivaz_demo.zip"),
+}
+
+# Path to the example project file.
+PROJECT_DIR = Path("/Users/hhip/Downloads/rivaz_demo")
+EXAMPLE_DIR: Final = Path(__file__).parent
+DATASET_DIR: Final = EXAMPLE_DIR / "dataset"
+
+
+def download_file(url: str, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    logging.info("Downloading %s to %s", url, path)
+    response = requests.get(url, stream=True)
+    with tqdm.tqdm.wrapattr(
+        open(path, "wb"),
+        "write",
+        miniters=1,
+        total=int(response.headers.get("content-length", 0)),
+        desc=f"Downloading {path.name}",
+    ) as f:
+        for chunk in response.iter_content(chunk_size=4096):
+            f.write(chunk)
+
+
+def unzip_dir(archive: Path, destination: Path) -> None:
+    """Unzip the archive to the destination, using tqdm to display progress."""
+    logging.info("Extracting %s to %s", archive, destination)
+    with zipfile.ZipFile(archive, "r") as zip_ref:
+        zip_ref.extractall(destination)
+
+
+class OPFProject:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.project = resolve(load(str(path)))
+
+    @classmethod
+    def from_dataset(cls, dataset: str) -> "OPFProject":
+        """Download the dataset if necessary and return the project file."""
+        spec = DATASETS[dataset]
+        if not (DATASET_DIR / spec.dir_name).exists():
+            zip_file = DATASET_DIR / f"{dataset}.zip"
+            if not zip_file.exists():
+                download_file(DATASETS[dataset].url, zip_file)
+            unzip_dir(DATASET_DIR / f"{dataset}.zip", DATASET_DIR)
+
+        return cls(DATASET_DIR / spec.dir_name / "project.opf")
+
+    def log_point_cloud(self) -> None:
+        """Log the project's point cloud."""
+        pcl = self.project.point_cloud_objs[0]
+        rr.log_points("world/pcl", positions=pcl.nodes[0].position, colors=pcl.nodes[0].color, timeless=True)
+
+    def log_cameras_as_frames(self) -> None:
+        """
+        Log the project's calibrated cameras as individual frames.
+
+        Logging all cameras in a single frame is also possible, but clutter the default view with too many image views.
+        """
+        sensor_map = {sensor.id: sensor for sensor in self.project.input_cameras.sensors}
+        calib_sensor_map = {sensor.id: sensor for sensor in self.project.calibration.calibrated_cameras.sensors}
+
+        for i, (camera, calib_camera) in enumerate(
+            zip(
+                self.project.camera_list.cameras,
+                self.project.calibration.calibrated_cameras.cameras,
+            )
+        ):
+            if not str(camera.uri).endswith(".jpg"):
+                continue
+
+            rr.set_time_sequence("image", i)
+            entity = "world/cameras"
+
+            sensor = sensor_map[calib_camera.sensor_id]
+            calib_sensor = calib_sensor_map[calib_camera.sensor_id]
+
+            omega, phi, kappa = tuple(np.deg2rad(a) for a in calib_camera.orientation_deg)
+            rot = (
+                np.array(
+                    [
+                        [1, 0, 0],
+                        [0, np.cos(omega), -np.sin(omega)],
+                        [0, np.sin(omega), np.cos(omega)],
+                    ]
+                )
+                @ np.array(
+                    [
+                        [np.cos(phi), 0, np.sin(phi)],
+                        [0, 1, 0],
+                        [-np.sin(phi), 0, np.cos(phi)],
+                    ]
+                )
+                @ np.array(
+                    [
+                        [np.cos(kappa), -np.sin(kappa), 0],
+                        [np.sin(kappa), np.cos(kappa), 0],
+                        [0, 0, 1],
+                    ]
+                )
+                @ np.array(  # somehow needed to have the camera point at the right direction
+                    [
+                        [1, 0, 0],
+                        [0, -1, 0],
+                        [0, 0, -1],
+                    ]
+                )
+            )
+
+            rr.log_transform3d(entity, rr.TranslationAndMat3(translation=calib_camera.position, matrix=rot))
+
+            assert calib_sensor.internals.type == "perspective"
+
+            focal_length = calib_sensor.internals.focal_length_px
+            u_center = calib_sensor.internals.principal_point_px[0]
+            v_center = calib_sensor.internals.principal_point_px[1]
+            intrinsics = np.array(
+                (
+                    (focal_length, 0, u_center),
+                    (0, focal_length, v_center),
+                    (0, 0, 1),
+                )
+            )
+
+            rr.log_pinhole(
+                entity + "/image",
+                child_from_parent=intrinsics,
+                width=sensor.image_size_px[0],
+                height=sensor.image_size_px[1],
+            )
+            rr.log_image_file(entity + "/image/rgb", img_path=self.path.parent / camera.uri)
+
+
+def main() -> None:
+    logging.getLogger().addHandler(logging.StreamHandler())
+    logging.getLogger().setLevel("INFO")
+
+    parser = argparse.ArgumentParser(description="Uses the MediaPipe Face Detection to track a human pose in video.")
+    parser.add_argument(
+        "--dataset",
+        choices=DATASETS.keys(),
+        default="olympic",
+        help="Run on a demo image automatically downloaded",
+    )
+
+    rr.script_add_args(parser)
+
+    args, unknown = parser.parse_known_args()
+    for arg in unknown:
+        logging.warning(f"unknown arg: {arg}")
+
+    # load the data set
+    project = OPFProject.from_dataset(args.dataset)
+
+    # display everything in Rerun
+    rr.script_setup(args, "open_photogrammetry_format")
+    project.log_point_cloud()
+    project.log_cameras_as_frames()
+    rr.script_teardown(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Load an Open Photogrammetry Format (OFP) project and display the cameras and point cloud.
 

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -5,6 +5,8 @@ Load an Open Photogrammetry Format (OFP) project and display the cameras and poi
 OPF specification: https://pix4d.github.io/opf-spec/index.html
 Dataset source: https://support.pix4d.com/hc/en-us/articles/360000235126-Example-projects-real-photogrammetry-data#OPF1
 pyopf: https://github.com/Pix4D/pyopf
+
+Requires Python 3.10 or higher because of [pyopf](https://pypi.org/project/pyopf/).
 """
 from __future__ import annotations
 

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -134,6 +134,8 @@ class OPFProject:
             sensor = sensor_map[calib_camera.sensor_id]
             calib_sensor = calib_sensor_map[calib_camera.sensor_id]
 
+            # Specification for the omega, phi, kappa angles:
+            # https://pix4d.github.io/opf-spec/specification/calibrated_cameras.html#calibrated-camera
             omega, phi, kappa = tuple(np.deg2rad(a) for a in calib_camera.orientation_deg)
             rot = (
                 np.array(

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -172,6 +172,9 @@ class OPFProject:
 
             assert calib_sensor.internals.type == "perspective"
 
+            # TODO(ab): the correction matrix term as well as the intrinsics definition are a work-around for
+            #  https://github.com/rerun-io/rerun/issues/2244. Should be cleaned up once this is addressed.
+
             focal_length = calib_sensor.internals.focal_length_px
             u_center = calib_sensor.internals.principal_point_px[0]
             v_center = calib_sensor.internals.principal_point_px[1]
@@ -183,8 +186,6 @@ class OPFProject:
                 ]
             )
 
-            # TODO(ab): this is probably affected by https://github.com/rerun-io/rerun/issues/2244. The code will be
-            # cleaner (and less buggy) once that is fixed.
             rr.log_pinhole(
                 entity + "/image",
                 child_from_parent=intrinsics,

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -174,11 +174,11 @@ class OPFProject:
             u_center = calib_sensor.internals.principal_point_px[0]
             v_center = calib_sensor.internals.principal_point_px[1]
             intrinsics = np.array(
-                (
-                    (focal_length, 0, u_center),
-                    (0, focal_length, v_center),
-                    (0, 0, 1),
-                )
+                [
+                    [focal_length, 0, u_center],
+                    [0, focal_length, v_center],
+                    [0, 0, 1],
+                ]
             )
 
             # TODO(ab): this is probably affected by https://github.com/rerun-io/rerun/issues/2244. The code will be

--- a/examples/python/open_photogrammetry_format/requirements.txt
+++ b/examples/python/open_photogrammetry_format/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pyopf
+pyopf; python_version >= '3.10'  # silence error if this requirements.txt gets pulled in a <3.10 venv
 requests
 rerun-sdk
 tqdm

--- a/examples/python/open_photogrammetry_format/requirements.txt
+++ b/examples/python/open_photogrammetry_format/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 pyopf
 requests
 rerun-sdk

--- a/examples/python/open_photogrammetry_format/requirements.txt
+++ b/examples/python/open_photogrammetry_format/requirements.txt
@@ -1,0 +1,4 @@
+pyopf
+requests
+rerun-sdk
+tqdm

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -17,6 +17,7 @@
 -r multithreading/requirements.txt
 -r notebook/requirements.txt
 -r objectron/requirements.txt
+-r open_photogrammetry_format/requirements.txt
 -r plots/requirements.txt
 -r raw_mesh/requirements.txt
 -r rgbd/requirements.txt

--- a/justfile
+++ b/justfile
@@ -50,7 +50,6 @@ py-build *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     unset CONDA_PREFIX && \
-        source venv/bin/activate && \
         maturin develop \
             --manifest-path rerun_py/Cargo.toml \
             --extras="tests" \

--- a/rerun_py/README.md
+++ b/rerun_py/README.md
@@ -94,6 +94,7 @@ For ease of development you can build and install in "editable" mode. This means
 ```sh
 # Build the SDK and install in develop mode into the virtualenv
 # Re-run this if the Rust code has changed!
+source venv/bin/activate
 just py-build
 ```
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import socket
 import subprocess
+import sys
 import time
 from glob import glob
 from pathlib import Path
@@ -25,6 +26,18 @@ HAS_NO_SAVE_ARG = {
     "examples/python/minimal",
     "examples/python/multiprocessing",
 }
+
+MIN_PYTHON_REQUIREMENTS: dict[str : tuple[int, int]] = {
+    # pyopf requires Python 3.10
+    "examples/python/open_photogrammetry_format": (3, 10),
+}
+
+SKIP_LIST = [
+    # depth_sensor requires a specific piece of hardware to be attached
+    "examples/python/live_depth_sensor",
+    # ros requires complex system dependencies to be installed
+    "examples/python/ros_node",
+]
 
 
 def start_process(args: list[str], *, wait: bool) -> Any:
@@ -76,7 +89,7 @@ def get_free_port() -> int:
 
 def collect_examples(fast: bool) -> list[str]:
     if fast:
-        # cherry picked
+        # cherry-picked
         return [
             "examples/python/api_demo",
             "examples/python/car",
@@ -90,16 +103,22 @@ def collect_examples(fast: bool) -> list[str]:
             "examples/python/text_logging",
         ]
     else:
-        skip_list = [
-            # depth_sensor requires a specific piece of hardware to be attached
-            "examples/python/live_depth_sensor/main.py",
-            # ros requires complex system dependencies to be installed
-            "examples/python/ros_node/main.py",
-        ]
+        examples = []
+        for main_path in glob("examples/python/**/main.py"):
+            example = os.path.dirname(main_path)
 
-        return [
-            os.path.dirname(main_path) for main_path in glob("examples/python/**/main.py") if main_path not in skip_list
-        ]
+            if example in SKIP_LIST:
+                continue
+
+            if example in MIN_PYTHON_REQUIREMENTS:
+                req_major, req_minor = MIN_PYTHON_REQUIREMENTS[example]
+                major, minor, *_ = sys.version_info
+                if major < req_major or (major == req_major and minor < req_minor):
+                    continue
+
+            examples.append(example)
+
+        return examples
 
 
 def print_example_output(path: str, example: Any) -> None:


### PR DESCRIPTION
### What

Add a simple example to display Open Photogrammetry Format datasets

![](https://static.rerun.io/3bb25c43fa2a4c367d036c27943812ebfe3e4d42_open_photogrammetry_format_1200w.png)

This example is currently minimalist in that there is lots more in the OPF that could be displayed, such as uncalibrated vs. calibrated cameras, matches between points and cameras, etc. Also, I opted to display each calibrated camera as individual frames in the timeline, as displaying them currently spams the viewer with image views.

Closes #2246

Would greatly benefit from #1136
Blocked by #2244 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2512

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/c1fd3e3/docs
Examples preview: https://rerun.io/preview/c1fd3e3/examples
<!-- pr-link-docs:end -->