### PR TITLE
Add script to find external issues we haven't commented on

### DIFF
--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+"""Generate a list of GitHub issues that needs attention."""
+from __future__ import annotations
+
+import multiprocessing
+import sys
+
+import requests
+from tqdm import tqdm
+
+OWNER = "rerun-io"
+REPO = "rerun"
+OFFICIAL_RERUN_DEVS = [
+    "abey79",
+    "emilk",
+    "jleibs",
+    "jondo2010",
+    "jprochazk",
+    "karimo87",
+    "nikolausWest",
+    "roym899",
+    "teh-cmc",
+    "Wumpf",
+]
+
+
+def get_github_token() -> str:
+    import os
+
+    token = os.environ.get("GH_ACCESS_TOKEN", "")
+    if token != "":
+        return token
+
+    home_dir = os.path.expanduser("~")
+    token_file = os.path.join(home_dir, ".githubtoken")
+
+    try:
+        with open(token_file) as f:
+            token = f.read().strip()
+        return token
+    except Exception:
+        pass
+
+    print("ERROR: expected a GitHub token in the environment variable GH_ACCESS_TOKEN or in ~/.githubtoken")
+    sys.exit(1)
+
+
+def fetch_issue(issue_json: dict) -> dict:
+    url = issue_json["url"]
+    gh_access_token = get_github_token()
+    headers = {"Authorization": f"Token {gh_access_token}"}
+    response = requests.get(url, headers=headers)
+    return response.json()
+
+
+def main() -> None:
+    access_token = get_github_token()
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    all_issues = []
+
+    urls = [f"https://api.github.com/repos/{OWNER}/{REPO}/issues"]
+
+    while urls:
+        page_url = urls.pop()
+
+        print(f"Fetching {page_url}…")
+        response = requests.get(page_url, headers=headers)
+        json = response.json()
+
+        all_issues += list(json)
+
+        # Check if there is a next page:
+        if "Link" in response.headers:
+            links = response.headers["Link"].split(", ")
+            for link in links:
+                if 'rel="next"' in link:
+                    next_url = link.split(";")[0][1:-1]
+                    urls += [next_url]
+
+    pool = multiprocessing.Pool()
+    issues_list = list(
+        tqdm(
+            pool.imap(fetch_issue, all_issues),
+            total=len(all_issues),
+            desc="Fetching issue details",
+        )
+    )
+
+    issues_list.sort(key=lambda issue: issue["number"])
+
+    # Print the response content
+    for issue in issues_list:
+        author = issue["user"]["login"]
+        html_url = issue["html_url"]
+        comments = issue["comments"]
+        state = issue["state"]
+        if comments == 0 and state == "open" and author not in OFFICIAL_RERUN_DEVS:
+            print(f"{html_url} by {author} has {comments} comments")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -51,7 +51,11 @@ def fetch_issue(issue_json: dict) -> dict:
     gh_access_token = get_github_token()
     headers = {"Authorization": f"Token {gh_access_token}"}
     response = requests.get(url, headers=headers)
-    return response.json()
+    json = response.json()
+    if response.status_code != 200:
+        print(f"ERROR {url}: {response.status_code} - {json['message']}")
+        sys.exit(1)
+    return json
 
 
 def main() -> None:
@@ -64,11 +68,14 @@ def main() -> None:
     urls = [f"https://api.github.com/repos/{OWNER}/{REPO}/issues"]
 
     while urls:
-        page_url = urls.pop()
+        url = urls.pop()
 
-        print(f"Fetching {page_url}…")
-        response = requests.get(page_url, headers=headers)
+        print(f"Fetching {url}…")
+        response = requests.get(url, headers=headers)
         json = response.json()
+        if response.status_code != 200:
+            print(f"ERROR {url}: {response.status_code} - {json['message']}")
+            sys.exit(1)
 
         all_issues += list(json)
 


### PR DESCRIPTION
### What
We should make people who file issues feel seen by commenting on them

Example output:

```
https://github.com/rerun-io/rerun/issues/1529 by rasmusgo has 0 comments
https://github.com/rerun-io/rerun/issues/1544 by cortwave has 0 comments
https://github.com/rerun-io/rerun/issues/1571 by pablovela5620 has 0 comments
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2532

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/3a75191/docs
Examples preview: https://rerun.io/preview/3a75191/examples
<!-- pr-link-docs:end -->
