### PR TITLE
Remove defunct entity filter from Text Space View

### DIFF
--- a/crates/re_space_view_text/src/space_view_class.rs
+++ b/crates/re_space_view_text/src/space_view_class.rs
@@ -70,7 +70,6 @@ impl SpaceViewClass for TextSpaceView {
             col_timelines,
             col_entity_path,
             col_log_level,
-            row_entity_paths,
             row_log_levels,
         } = &mut state.filters;
 
@@ -82,14 +81,6 @@ impl SpaceViewClass for TextSpaceView {
                 }
                 ui.checkbox(col_entity_path, "Entity path");
                 ui.checkbox(col_log_level, "Log level");
-            });
-            ui.end_row();
-
-            ctx.re_ui.grid_left_hand_label(ui, "Entity Filter");
-            ui.vertical(|ui| {
-                for (entity_path, visible) in row_entity_paths {
-                    ui.checkbox(visible, &entity_path.to_string());
-                }
             });
             ui.end_row();
 
@@ -171,7 +162,6 @@ pub struct ViewTextFilters {
     pub col_log_level: bool,
 
     // Row filters: which rows should be visible?
-    pub row_entity_paths: BTreeMap<EntityPath, bool>,
     pub row_log_levels: BTreeMap<String, bool>,
 }
 
@@ -181,20 +171,12 @@ impl Default for ViewTextFilters {
             col_entity_path: true,
             col_log_level: true,
             col_timelines: Default::default(),
-            row_entity_paths: Default::default(),
             row_log_levels: Default::default(),
         }
     }
 }
 
 impl ViewTextFilters {
-    pub fn is_entity_path_visible(&self, entity_path: &EntityPath) -> bool {
-        self.row_entity_paths
-            .get(entity_path)
-            .copied()
-            .unwrap_or(true)
-    }
-
     pub fn is_log_level_visible(&self, level: &str) -> bool {
         self.row_log_levels.get(level).copied().unwrap_or(true)
     }
@@ -208,16 +190,11 @@ impl ViewTextFilters {
             col_timelines,
             col_entity_path: _,
             col_log_level: _,
-            row_entity_paths,
             row_log_levels,
         } = self;
 
         for timeline in ctx.store_db.timelines() {
             col_timelines.entry(*timeline).or_insert(true);
-        }
-
-        for entity_path in text_entries.iter().map(|te| &te.entity_path) {
-            row_entity_paths.entry(entity_path.clone()).or_insert(true);
         }
 
         for level in text_entries.iter().filter_map(|te| te.level.as_ref()) {


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Noticed while testing: Removed text entity filter ui; this was already defunct on main and is redundant to entity visibility property.

Was originally part of #2522 

Test via `python ./examples/python/text_logging/main.py`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2544

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/8e1e06b/docs
Examples preview: https://rerun.io/preview/8e1e06b/examples
<!-- pr-link-docs:end -->
