### PR TITLE
Codegen'd Rust/Arrow (de)ser 4: out-of-sync definitions CI detection

### DIFF
--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -20,14 +20,6 @@ const RUST_OUTPUT_DIR_PATH: &str = ".";
 const PYTHON_OUTPUT_DIR_PATH: &str = "../../rerun_py/rerun_sdk/rerun/_rerun2";
 
 fn main() {
-    if std::env::var("CI").is_ok() {
-        // Don't run on CI!
-        //
-        // The code we're generating here is actual source code that gets committed into the
-        // repository.
-        return;
-    }
-
     if !is_tracked_env_var_set("IS_IN_RERUN_WORKSPACE") {
         // Only run if we are in the rerun workspace, not on users machines.
         return;
@@ -62,6 +54,13 @@ fn main() {
             // to do anything at this point.
             return;
         }
+    }
+
+    // Detect desyncs between definitions and generated when running on CI, and
+    // crash the build accordingly.
+    #[allow(clippy::manual_assert)]
+    if std::env::var("CI").is_ok() {
+        panic!("re_types' fbs definitions and generated code are out-of-sync!");
     }
 
     let sh = Shell::new().unwrap();

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-c10dc39333002ce5c62d9e88a7feb4fca76098528fe643012a53665a9934581e
+ffa869371b5fc08da6c80ce53a84db674682b38152c458d958649decc8949f35

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -14,14 +14,6 @@ const SOURCE_HASH_PATH: &str = "./source_hash.txt";
 const FBS_REFLECTION_DEFINITION_PATH: &str = "./definitions/reflection.fbs";
 
 fn main() {
-    if std::env::var("CI").is_ok() {
-        // Don't run on CI!
-        //
-        // The code we're generating here is actual source code that gets committed into the
-        // repository.
-        return;
-    }
-
     if !is_tracked_env_var_set("IS_IN_RERUN_WORKSPACE") {
         // Only run if we are in the rerun workspace, not on users machines.
         return;
@@ -52,6 +44,13 @@ fn main() {
             // Source definition hasn't changed, no need to do anything.
             return;
         }
+    }
+
+    // Detect desyncs between definitions and generated when running on CI, and
+    // crash the build accordingly.
+    #[allow(clippy::manual_assert)]
+    if std::env::var("CI").is_ok() {
+        panic!("re_types_builder's fbs definitions and generated code are out-of-sync!");
     }
 
     // NOTE: This requires `flatc` to be in $PATH, but only for contributors, not end users.


### PR DESCRIPTION
Enables detection of out-of-sync fbs definitions on the CI now that things are stable enough.

---

- #2484
- #2485 
- #2487 
- #2545
- #2546
- #2549
- #2554
- #2570
- #2571

---

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2487

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/4200af1/docs
Examples preview: https://rerun.io/preview/4200af1/examples
<!-- pr-link-docs:end -->