### PR TITLE
Codegen'd Rust/Arrow (de)ser 6: serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,6 +4521,7 @@ dependencies = [
 name = "re_types"
 version = "0.8.0-alpha.0"
 dependencies = [
+ "anyhow",
  "arrow2",
  "bytemuck",
  "document-features",
@@ -4531,6 +4532,7 @@ dependencies = [
  "re_build_tools",
  "re_types_builder",
  "similar-asserts",
+ "thiserror",
  "xshell",
 ]
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -11,9 +11,10 @@ extend-exclude = [
 
 
 [default.extend-words]
-lod = "lod" # level-of-detail
-teh = "teh" # part of @teh-cmc
-ND = "ND"   # np.NDArray
+lod = "lod"     # level-of-detail
+teh = "teh"     # part of @teh-cmc
+ND = "ND"       # np.NDArray
+somes = "somes" # many `Some`
 
 # American English:
 grey = "gray"

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -35,8 +35,11 @@ arrow2 = { workspace = true, features = [
   "io_print",
   "compute_concatenate",
 ] }
+anyhow.workspace = true
 bytemuck = { version = "1.11", features = ["derive", "extern_crate_alloc"] }
 document-features = "0.2"
+itertools.workspace = true
+thiserror.workspace = true
 
 # External (optional)
 ecolor = { workspace = true, optional = true }

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-32b9eccc275777c29b252374ea6dcd69a3f1a48c42ae79aa5138ec2556526b52
+70d271f9866784d9f0d25b818cd0d45fff1df72aec62ceae9f167f523a5c2d08

--- a/crates/re_types/src/archetypes/fuzzy.rs
+++ b/crates/re_types/src/archetypes/fuzzy.rs
@@ -110,25 +110,437 @@ impl AffixFuzzer1 {
 }
 
 impl crate::Archetype for AffixFuzzer1 {
+    #[inline]
     fn name() -> crate::ArchetypeName {
         crate::ArchetypeName::Borrowed("rerun.testing.archetypes.AffixFuzzer1")
     }
 
+    #[inline]
     fn required_components() -> Vec<crate::ComponentName> {
         Self::REQUIRED_COMPONENTS.to_vec()
     }
 
+    #[inline]
     fn recommended_components() -> Vec<crate::ComponentName> {
         Self::RECOMMENDED_COMPONENTS.to_vec()
     }
 
+    #[inline]
     fn optional_components() -> Vec<crate::ComponentName> {
         Self::OPTIONAL_COMPONENTS.to_vec()
     }
 
-    #[allow(clippy::todo)]
-    fn to_arrow_datatypes() -> Vec<arrow2::datatypes::DataType> {
-        todo!("query the registry for all fqnames");
+    #[inline]
+    fn try_to_arrow(
+        &self,
+    ) -> crate::SerializationResult<
+        Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
+    > {
+        use crate::Component as _;
+        Ok([
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer1>::try_to_arrow([&self.fuzz1001]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1001", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer2>::try_to_arrow([&self.fuzz1002]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1002", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer3>::try_to_arrow([&self.fuzz1003]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1003", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer4>::try_to_arrow([&self.fuzz1004]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1004", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer5>::try_to_arrow([&self.fuzz1005]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1005", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer6>::try_to_arrow([&self.fuzz1006]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1006", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array = <crate::components::AffixFuzzer7>::try_to_arrow([&self.fuzz1007]);
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1007", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer1>::try_to_arrow(self.fuzz1101.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1101", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer2>::try_to_arrow(self.fuzz1102.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1102", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer3>::try_to_arrow(self.fuzz1103.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1103", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer4>::try_to_arrow(self.fuzz1104.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1104", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer5>::try_to_arrow(self.fuzz1105.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1105", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer6>::try_to_arrow(self.fuzz1106.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1106", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                Some({
+                    let array =
+                        <crate::components::AffixFuzzer7>::try_to_arrow(self.fuzz1107.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("fuzz1107", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                self.fuzz2001
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer1>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2001", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2002
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer2>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2002", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2003
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer3>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2003", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2004
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer4>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2004", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2005
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer5>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2005", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2006
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer6>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2006", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2007
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::AffixFuzzer7>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2007", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2101
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer1>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2101", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2102
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer2>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2102", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2103
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer3>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2103", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2104
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer4>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2104", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2105
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer5>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2105", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2106
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer6>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2106", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.fuzz2107
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::AffixFuzzer7>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("fuzz2107", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+        ]
+        .into_iter()
+        .flatten()
+        .collect())
     }
 }
 

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -78,25 +78,156 @@ impl Points2D {
 }
 
 impl crate::Archetype for Points2D {
+    #[inline]
     fn name() -> crate::ArchetypeName {
         crate::ArchetypeName::Borrowed("rerun.archetypes.Points2D")
     }
 
+    #[inline]
     fn required_components() -> Vec<crate::ComponentName> {
         Self::REQUIRED_COMPONENTS.to_vec()
     }
 
+    #[inline]
     fn recommended_components() -> Vec<crate::ComponentName> {
         Self::RECOMMENDED_COMPONENTS.to_vec()
     }
 
+    #[inline]
     fn optional_components() -> Vec<crate::ComponentName> {
         Self::OPTIONAL_COMPONENTS.to_vec()
     }
 
-    #[allow(clippy::todo)]
-    fn to_arrow_datatypes() -> Vec<arrow2::datatypes::DataType> {
-        todo!("query the registry for all fqnames");
+    #[inline]
+    fn try_to_arrow(
+        &self,
+    ) -> crate::SerializationResult<
+        Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
+    > {
+        use crate::Component as _;
+        Ok([
+            {
+                Some({
+                    let array = <crate::components::Point2D>::try_to_arrow(self.points.iter());
+                    array.map(|array| {
+                        let datatype = array.data_type().clone();
+                        (
+                            ::arrow2::datatypes::Field::new("points", datatype, false),
+                            array,
+                        )
+                    })
+                })
+                .transpose()?
+            },
+            {
+                self.radii
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::Radius>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("radii", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.colors
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::Color>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("colors", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.labels
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::Label>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("labels", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.draw_order
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::DrawOrder>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("draw_order", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.class_ids
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::ClassId>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("class_ids", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.keypoint_ids
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::KeypointId>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("keypoint_ids", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+            {
+                self.instance_keys
+                    .as_ref()
+                    .map(|many| {
+                        let array = <crate::components::InstanceKey>::try_to_arrow(many.iter());
+                        array.map(|array| {
+                            let datatype = array.data_type().clone();
+                            (
+                                ::arrow2::datatypes::Field::new("instance_keys", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()?
+            },
+        ]
+        .into_iter()
+        .flatten()
+        .collect())
     }
 }
 

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -24,6 +24,20 @@
 #[repr(transparent)]
 pub struct Color(pub u32);
 
+impl<'a> From<Color> for ::std::borrow::Cow<'a, Color> {
+    #[inline]
+    fn from(value: Color) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a Color> for ::std::borrow::Cow<'a, Color> {
+    #[inline]
+    fn from(value: &'a Color) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
 impl crate::Component for Color {
     #[inline]
     fn name() -> crate::ComponentName {
@@ -39,5 +53,39 @@ impl crate::Component for Color {
             Box::new(DataType::UInt32),
             None,
         )
+    }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum.map(|datum| {
+                        let Self(data0) = datum.into_owned();
+                        data0
+                    });
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            PrimitiveArray::new(
+                DataType::UInt32,
+                data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
+                data0_bitmap,
+            )
+            .boxed()
+        })
     }
 }

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -13,6 +13,20 @@ pub struct AffixFuzzer1 {
     pub single_required: crate::datatypes::AffixFuzzer1,
 }
 
+impl<'a> From<AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
+    #[inline]
+    fn from(value: AffixFuzzer1) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer1) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
 impl crate::Component for AffixFuzzer1 {
     #[inline]
     fn name() -> crate::ComponentName {
@@ -85,10 +99,56 @@ impl crate::Component for AffixFuzzer1 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, single_required): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum.map(|datum| {
+                        let Self { single_required } = datum.into_owned();
+                        single_required
+                    });
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let single_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            {
+                _ = single_required_bitmap;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_required)?
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AffixFuzzer2(pub crate::datatypes::AffixFuzzer1);
+
+impl<'a> From<AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
+    #[inline]
+    fn from(value: AffixFuzzer2) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer2) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
 
 impl crate::Component for AffixFuzzer2 {
     #[inline]
@@ -162,11 +222,57 @@ impl crate::Component for AffixFuzzer2 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum.map(|datum| {
+                        let Self(data0) = datum.into_owned();
+                        data0
+                    });
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            {
+                _ = data0_bitmap;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(data0)?
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AffixFuzzer3 {
     pub single_required: crate::datatypes::AffixFuzzer1,
+}
+
+impl<'a> From<AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
+    #[inline]
+    fn from(value: AffixFuzzer3) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer3) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
 }
 
 impl crate::Component for AffixFuzzer3 {
@@ -246,11 +352,141 @@ impl crate::Component for AffixFuzzer3 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            StructArray::new(
+                DataType::Extension(
+                    "rerun.testing.components.AffixFuzzer3".to_owned(),
+                    Box::new(DataType::Struct(vec![Field {
+                        name: "single_required".to_owned(),
+                        data_type: DataType::Extension(
+                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
+                            Box::new(DataType::Struct(vec![
+                                Field {
+                                    name: "single_float_optional".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "single_string_required".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "single_string_optional".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_floats_optional".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_strings_required".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_strings_optional".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                            ])),
+                            None,
+                        ),
+                        is_nullable: false,
+                        metadata: [].into(),
+                    }])),
+                    None,
+                ),
+                vec![{
+                    let (somes, single_required): (Vec<_>, Vec<_>) = data
+                        .iter()
+                        .map(|datum| {
+                            let datum = datum.as_ref().map(|datum| {
+                                let Self {
+                                    single_required, ..
+                                } = &**datum;
+                                single_required.clone()
+                            });
+                            (datum.is_some(), datum)
+                        })
+                        .unzip();
+                    let single_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                        let any_nones = somes.iter().any(|some| !*some);
+                        any_nones.then(|| somes.into())
+                    };
+                    {
+                        _ = single_required_bitmap;
+                        crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_required)?
+                    }
+                }],
+                bitmap,
+            )
+            .boxed()
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AffixFuzzer4 {
     pub single_optional: Option<crate::datatypes::AffixFuzzer1>,
+}
+
+impl<'a> From<AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
+    #[inline]
+    fn from(value: AffixFuzzer4) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer4) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
 }
 
 impl crate::Component for AffixFuzzer4 {
@@ -325,10 +561,58 @@ impl crate::Component for AffixFuzzer4 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, single_optional): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum
+                        .map(|datum| {
+                            let Self { single_optional } = datum.into_owned();
+                            single_optional
+                        })
+                        .flatten();
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let single_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            {
+                _ = single_optional_bitmap;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_optional)?
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AffixFuzzer5(pub Option<crate::datatypes::AffixFuzzer1>);
+
+impl<'a> From<AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
+    #[inline]
+    fn from(value: AffixFuzzer5) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer5) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
 
 impl crate::Component for AffixFuzzer5 {
     #[inline]
@@ -402,11 +686,59 @@ impl crate::Component for AffixFuzzer5 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum
+                        .map(|datum| {
+                            let Self(data0) = datum.into_owned();
+                            data0
+                        })
+                        .flatten();
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            {
+                _ = data0_bitmap;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(data0)?
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AffixFuzzer6 {
     pub single_optional: Option<crate::datatypes::AffixFuzzer1>,
+}
+
+impl<'a> From<AffixFuzzer6> for ::std::borrow::Cow<'a, AffixFuzzer6> {
+    #[inline]
+    fn from(value: AffixFuzzer6) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer6> for ::std::borrow::Cow<'a, AffixFuzzer6> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer6) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
 }
 
 impl crate::Component for AffixFuzzer6 {
@@ -486,6 +818,125 @@ impl crate::Component for AffixFuzzer6 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            StructArray::new(
+                DataType::Extension(
+                    "rerun.testing.components.AffixFuzzer6".to_owned(),
+                    Box::new(DataType::Struct(vec![Field {
+                        name: "single_optional".to_owned(),
+                        data_type: DataType::Extension(
+                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
+                            Box::new(DataType::Struct(vec![
+                                Field {
+                                    name: "single_float_optional".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "single_string_required".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "single_string_optional".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_floats_optional".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_strings_required".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_strings_optional".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                            ])),
+                            None,
+                        ),
+                        is_nullable: true,
+                        metadata: [].into(),
+                    }])),
+                    None,
+                ),
+                vec![{
+                    let (somes, single_optional): (Vec<_>, Vec<_>) = data
+                        .iter()
+                        .map(|datum| {
+                            let datum = datum
+                                .as_ref()
+                                .map(|datum| {
+                                    let Self {
+                                        single_optional, ..
+                                    } = &**datum;
+                                    single_optional.clone()
+                                })
+                                .flatten();
+                            (datum.is_some(), datum)
+                        })
+                        .unzip();
+                    let single_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                        let any_nones = somes.iter().any(|some| !*some);
+                        any_nones.then(|| somes.into())
+                    };
+                    {
+                        _ = single_optional_bitmap;
+                        crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_optional)?
+                    }
+                }],
+                bitmap,
+            )
+            .boxed()
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -497,6 +948,20 @@ pub struct AffixFuzzer7 {
     pub many_floats_optional: Option<Vec<f32>>,
     pub many_strings_required: Vec<String>,
     pub many_strings_optional: Option<Vec<String>>,
+}
+
+impl<'a> From<AffixFuzzer7> for ::std::borrow::Cow<'a, AffixFuzzer7> {
+    #[inline]
+    fn from(value: AffixFuzzer7) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer7> for ::std::borrow::Cow<'a, AffixFuzzer7> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer7) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
 }
 
 impl crate::Component for AffixFuzzer7 {
@@ -633,5 +1098,646 @@ impl crate::Component for AffixFuzzer7 {
             ])),
             None,
         )
+    }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            StructArray::new(
+                DataType::Extension(
+                    "rerun.testing.components.AffixFuzzer7".to_owned(),
+                    Box::new(DataType::Struct(vec![
+                        Field {
+                            name: "many_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Extension(
+                                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
+                                    Box::new(DataType::Struct(vec![
+                                        Field {
+                                            name: "single_float_optional".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: true,
+                                            metadata: [].into(),
+                                        },
+                                        Field {
+                                            name: "single_string_required".to_owned(),
+                                            data_type: DataType::Utf8,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        },
+                                        Field {
+                                            name: "single_string_optional".to_owned(),
+                                            data_type: DataType::Utf8,
+                                            is_nullable: true,
+                                            metadata: [].into(),
+                                        },
+                                        Field {
+                                            name: "many_floats_optional".to_owned(),
+                                            data_type: DataType::List(Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            })),
+                                            is_nullable: true,
+                                            metadata: [].into(),
+                                        },
+                                        Field {
+                                            name: "many_strings_required".to_owned(),
+                                            data_type: DataType::List(Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            })),
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        },
+                                        Field {
+                                            name: "many_strings_optional".to_owned(),
+                                            data_type: DataType::List(Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            })),
+                                            is_nullable: true,
+                                            metadata: [].into(),
+                                        },
+                                    ])),
+                                    None,
+                                ),
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_float_optional".to_owned(),
+                            data_type: DataType::Float32,
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_string_required".to_owned(),
+                            data_type: DataType::Utf8,
+                            is_nullable: false,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_string_optional".to_owned(),
+                            data_type: DataType::Utf8,
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_floats_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Float32,
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_strings_required".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Utf8,
+                                is_nullable: false,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: false,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_strings_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Utf8,
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                    ])),
+                    None,
+                ),
+                vec![
+                    {
+                        let (somes, many_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self { many_optional, .. } = &**datum;
+                                        many_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_optional_inner_data: Vec<_> = many_optional
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_optional_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                                let any_nones =
+                                    many_optional_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_optional_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Extension(
+                                        "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
+                                        Box::new(DataType::Struct(vec![
+                                            Field {
+                                                name: "single_float_optional".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "single_string_required".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "single_string_optional".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_floats_optional".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                })),
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_strings_required".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                })),
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_strings_optional".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                })),
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                        ])),
+                                        None,
+                                    ),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                {
+                                    _ = many_optional_inner_bitmap;
+                                    crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                                        many_optional_inner_data,
+                                    )?
+                                },
+                                many_optional_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, single_float_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            single_float_optional,
+                                            ..
+                                        } = &**datum;
+                                        single_float_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let single_float_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        PrimitiveArray::new(
+                            DataType::Float32,
+                            single_float_optional
+                                .into_iter()
+                                .map(|v| v.unwrap_or_default())
+                                .collect(),
+                            single_float_optional_bitmap,
+                        )
+                        .boxed()
+                    },
+                    {
+                        let (somes, single_string_required): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum.as_ref().map(|datum| {
+                                    let Self {
+                                        single_string_required,
+                                        ..
+                                    } = &**datum;
+                                    single_string_required.clone()
+                                });
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let single_string_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            let inner_data: ::arrow2::buffer::Buffer<u8> = single_string_required
+                                .iter()
+                                .flatten()
+                                .flat_map(|s| s.bytes())
+                                .collect();
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                single_string_required.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                            unsafe {
+                                Utf8Array::<i32>::new_unchecked(
+                                    DataType::Utf8,
+                                    offsets,
+                                    inner_data,
+                                    single_string_required_bitmap,
+                                )
+                            }
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, single_string_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            single_string_optional,
+                                            ..
+                                        } = &**datum;
+                                        single_string_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let single_string_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            let inner_data: ::arrow2::buffer::Buffer<u8> = single_string_optional
+                                .iter()
+                                .flatten()
+                                .flat_map(|s| s.bytes())
+                                .collect();
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                single_string_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                            unsafe {
+                                Utf8Array::<i32>::new_unchecked(
+                                    DataType::Utf8,
+                                    offsets,
+                                    inner_data,
+                                    single_string_optional_bitmap,
+                                )
+                            }
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, many_floats_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            many_floats_optional,
+                                            ..
+                                        } = &**datum;
+                                        many_floats_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_floats_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_floats_optional_inner_data: Vec<_> = many_floats_optional
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_floats_optional_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = {
+                                let any_nones =
+                                    many_floats_optional_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_floats_optional_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_floats_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                PrimitiveArray::new(
+                                    DataType::Float32,
+                                    many_floats_optional_inner_data
+                                        .into_iter()
+                                        .map(|v| v.unwrap_or_default())
+                                        .collect(),
+                                    many_floats_optional_inner_bitmap,
+                                )
+                                .boxed(),
+                                many_floats_optional_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, many_strings_required): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum.as_ref().map(|datum| {
+                                    let Self {
+                                        many_strings_required,
+                                        ..
+                                    } = &**datum;
+                                    many_strings_required.clone()
+                                });
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_strings_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_strings_required_inner_data: Vec<_> = many_strings_required
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_strings_required_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = {
+                                let any_nones =
+                                    many_strings_required_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_strings_required_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_strings_required.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                {
+                                    let inner_data: ::arrow2::buffer::Buffer<u8> =
+                                        many_strings_required_inner_data
+                                            .iter()
+                                            .flatten()
+                                            .flat_map(|s| s.bytes())
+                                            .collect();
+                                    let offsets =
+                                        ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                            many_strings_required_inner_data.iter().map(|opt| {
+                                                opt.as_ref()
+                                                    .map(|datum| datum.len())
+                                                    .unwrap_or_default()
+                                            }),
+                                        )
+                                        .unwrap()
+                                        .into();
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe {
+                                        Utf8Array::<i32>::new_unchecked(
+                                            DataType::Utf8,
+                                            offsets,
+                                            inner_data,
+                                            many_strings_required_inner_bitmap,
+                                        )
+                                    }
+                                    .boxed()
+                                },
+                                many_strings_required_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, many_strings_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            many_strings_optional,
+                                            ..
+                                        } = &**datum;
+                                        many_strings_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_strings_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_strings_optional_inner_data: Vec<_> = many_strings_optional
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_strings_optional_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = {
+                                let any_nones =
+                                    many_strings_optional_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_strings_optional_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_strings_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                {
+                                    let inner_data: ::arrow2::buffer::Buffer<u8> =
+                                        many_strings_optional_inner_data
+                                            .iter()
+                                            .flatten()
+                                            .flat_map(|s| s.bytes())
+                                            .collect();
+                                    let offsets =
+                                        ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                            many_strings_optional_inner_data.iter().map(|opt| {
+                                                opt.as_ref()
+                                                    .map(|datum| datum.len())
+                                                    .unwrap_or_default()
+                                            }),
+                                        )
+                                        .unwrap()
+                                        .into();
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe {
+                                        Utf8Array::<i32>::new_unchecked(
+                                            DataType::Utf8,
+                                            offsets,
+                                            inner_data,
+                                            many_strings_optional_inner_bitmap,
+                                        )
+                                    }
+                                    .boxed()
+                                },
+                                many_strings_optional_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                ],
+                bitmap,
+            )
+            .boxed()
+        })
     }
 }

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -12,6 +12,20 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InstanceKey(pub u64);
 
+impl<'a> From<InstanceKey> for ::std::borrow::Cow<'a, InstanceKey> {
+    #[inline]
+    fn from(value: InstanceKey) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a InstanceKey> for ::std::borrow::Cow<'a, InstanceKey> {
+    #[inline]
+    fn from(value: &'a InstanceKey) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
 impl crate::Component for InstanceKey {
     #[inline]
     fn name() -> crate::ComponentName {
@@ -27,5 +41,39 @@ impl crate::Component for InstanceKey {
             Box::new(DataType::UInt64),
             None,
         )
+    }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum.map(|datum| {
+                        let Self(data0) = datum.into_owned();
+                        data0
+                    });
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            PrimitiveArray::new(
+                DataType::UInt64,
+                data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
+                data0_bitmap,
+            )
+            .boxed()
+        })
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -16,6 +16,20 @@
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeypointId(pub u16);
 
+impl<'a> From<KeypointId> for ::std::borrow::Cow<'a, KeypointId> {
+    #[inline]
+    fn from(value: KeypointId) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a KeypointId> for ::std::borrow::Cow<'a, KeypointId> {
+    #[inline]
+    fn from(value: &'a KeypointId) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
 impl crate::Component for KeypointId {
     #[inline]
     fn name() -> crate::ComponentName {
@@ -31,5 +45,39 @@ impl crate::Component for KeypointId {
             Box::new(DataType::UInt16),
             None,
         )
+    }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum.map(|datum| {
+                        let Self(data0) = datum.into_owned();
+                        data0
+                    });
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            PrimitiveArray::new(
+                DataType::UInt16,
+                data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
+                data0_bitmap,
+            )
+            .boxed()
+        })
     }
 }

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -12,6 +12,20 @@
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct Radius(pub f32);
 
+impl<'a> From<Radius> for ::std::borrow::Cow<'a, Radius> {
+    #[inline]
+    fn from(value: Radius) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a Radius> for ::std::borrow::Cow<'a, Radius> {
+    #[inline]
+    fn from(value: &'a Radius) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
 impl crate::Component for Radius {
     #[inline]
     fn name() -> crate::ComponentName {
@@ -27,5 +41,39 @@ impl crate::Component for Radius {
             Box::new(DataType::Float32),
             None,
         )
+    }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum.map(|datum| {
+                        let Self(data0) = datum.into_owned();
+                        data0
+                    });
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            PrimitiveArray::new(
+                DataType::Float32,
+                data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
+                data0_bitmap,
+            )
+            .boxed()
+        })
     }
 }

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -18,6 +18,20 @@ pub struct AffixFuzzer1 {
     pub many_strings_optional: Option<Vec<String>>,
 }
 
+impl<'a> From<AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
+    #[inline]
+    fn from(value: AffixFuzzer1) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer1) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
 impl crate::Datatype for AffixFuzzer1 {
     #[inline]
     fn name() -> crate::DatatypeName {
@@ -86,10 +100,479 @@ impl crate::Datatype for AffixFuzzer1 {
             None,
         )
     }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            StructArray::new(
+                DataType::Extension(
+                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
+                    Box::new(DataType::Struct(vec![
+                        Field {
+                            name: "single_float_optional".to_owned(),
+                            data_type: DataType::Float32,
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_string_required".to_owned(),
+                            data_type: DataType::Utf8,
+                            is_nullable: false,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_string_optional".to_owned(),
+                            data_type: DataType::Utf8,
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_floats_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Float32,
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_strings_required".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Utf8,
+                                is_nullable: false,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: false,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_strings_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Utf8,
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                    ])),
+                    None,
+                ),
+                vec![
+                    {
+                        let (somes, single_float_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            single_float_optional,
+                                            ..
+                                        } = &**datum;
+                                        single_float_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let single_float_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        PrimitiveArray::new(
+                            DataType::Float32,
+                            single_float_optional
+                                .into_iter()
+                                .map(|v| v.unwrap_or_default())
+                                .collect(),
+                            single_float_optional_bitmap,
+                        )
+                        .boxed()
+                    },
+                    {
+                        let (somes, single_string_required): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum.as_ref().map(|datum| {
+                                    let Self {
+                                        single_string_required,
+                                        ..
+                                    } = &**datum;
+                                    single_string_required.clone()
+                                });
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let single_string_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            let inner_data: ::arrow2::buffer::Buffer<u8> = single_string_required
+                                .iter()
+                                .flatten()
+                                .flat_map(|s| s.bytes())
+                                .collect();
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                single_string_required.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                            unsafe {
+                                Utf8Array::<i32>::new_unchecked(
+                                    DataType::Utf8,
+                                    offsets,
+                                    inner_data,
+                                    single_string_required_bitmap,
+                                )
+                            }
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, single_string_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            single_string_optional,
+                                            ..
+                                        } = &**datum;
+                                        single_string_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let single_string_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            let inner_data: ::arrow2::buffer::Buffer<u8> = single_string_optional
+                                .iter()
+                                .flatten()
+                                .flat_map(|s| s.bytes())
+                                .collect();
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                single_string_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                            unsafe {
+                                Utf8Array::<i32>::new_unchecked(
+                                    DataType::Utf8,
+                                    offsets,
+                                    inner_data,
+                                    single_string_optional_bitmap,
+                                )
+                            }
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, many_floats_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            many_floats_optional,
+                                            ..
+                                        } = &**datum;
+                                        many_floats_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_floats_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_floats_optional_inner_data: Vec<_> = many_floats_optional
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_floats_optional_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = {
+                                let any_nones =
+                                    many_floats_optional_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_floats_optional_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_floats_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                PrimitiveArray::new(
+                                    DataType::Float32,
+                                    many_floats_optional_inner_data
+                                        .into_iter()
+                                        .map(|v| v.unwrap_or_default())
+                                        .collect(),
+                                    many_floats_optional_inner_bitmap,
+                                )
+                                .boxed(),
+                                many_floats_optional_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, many_strings_required): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum.as_ref().map(|datum| {
+                                    let Self {
+                                        many_strings_required,
+                                        ..
+                                    } = &**datum;
+                                    many_strings_required.clone()
+                                });
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_strings_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_strings_required_inner_data: Vec<_> = many_strings_required
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_strings_required_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = {
+                                let any_nones =
+                                    many_strings_required_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_strings_required_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_strings_required.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                {
+                                    let inner_data: ::arrow2::buffer::Buffer<u8> =
+                                        many_strings_required_inner_data
+                                            .iter()
+                                            .flatten()
+                                            .flat_map(|s| s.bytes())
+                                            .collect();
+                                    let offsets =
+                                        ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                            many_strings_required_inner_data.iter().map(|opt| {
+                                                opt.as_ref()
+                                                    .map(|datum| datum.len())
+                                                    .unwrap_or_default()
+                                            }),
+                                        )
+                                        .unwrap()
+                                        .into();
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe {
+                                        Utf8Array::<i32>::new_unchecked(
+                                            DataType::Utf8,
+                                            offsets,
+                                            inner_data,
+                                            many_strings_required_inner_bitmap,
+                                        )
+                                    }
+                                    .boxed()
+                                },
+                                many_strings_required_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                    {
+                        let (somes, many_strings_optional): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .map(|datum| {
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| {
+                                        let Self {
+                                            many_strings_optional,
+                                            ..
+                                        } = &**datum;
+                                        many_strings_optional.clone()
+                                    })
+                                    .flatten();
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let many_strings_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let many_strings_optional_inner_data: Vec<_> = many_strings_optional
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let many_strings_optional_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = {
+                                let any_nones =
+                                    many_strings_optional_inner_data.iter().any(|v| v.is_none());
+                                any_nones.then(|| {
+                                    many_strings_optional_inner_data
+                                        .iter()
+                                        .map(|v| v.is_some())
+                                        .collect()
+                                })
+                            };
+                            let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                many_strings_optional.iter().map(|opt| {
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
+                                }),
+                            )
+                            .unwrap()
+                            .into();
+                            ListArray::new(
+                                DataType::List(Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Utf8,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                })),
+                                offsets,
+                                {
+                                    let inner_data: ::arrow2::buffer::Buffer<u8> =
+                                        many_strings_optional_inner_data
+                                            .iter()
+                                            .flatten()
+                                            .flat_map(|s| s.bytes())
+                                            .collect();
+                                    let offsets =
+                                        ::arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                            many_strings_optional_inner_data.iter().map(|opt| {
+                                                opt.as_ref()
+                                                    .map(|datum| datum.len())
+                                                    .unwrap_or_default()
+                                            }),
+                                        )
+                                        .unwrap()
+                                        .into();
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe {
+                                        Utf8Array::<i32>::new_unchecked(
+                                            DataType::Utf8,
+                                            offsets,
+                                            inner_data,
+                                            many_strings_optional_inner_bitmap,
+                                        )
+                                    }
+                                    .boxed()
+                                },
+                                many_strings_optional_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
+                ],
+                bitmap,
+            )
+            .boxed()
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AffixFuzzer2(pub Option<f32>);
+
+impl<'a> From<AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
+    #[inline]
+    fn from(value: AffixFuzzer2) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
+    #[inline]
+    fn from(value: &'a AffixFuzzer2) -> Self {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
 
 impl crate::Datatype for AffixFuzzer2 {
     #[inline]
@@ -106,5 +589,41 @@ impl crate::Datatype for AffixFuzzer2 {
             Box::new(DataType::Float32),
             None,
         )
+    }
+
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        use crate::{Component as _, Datatype as _};
+        use ::arrow2::{array::*, datatypes::*};
+        Ok({
+            let (somes, data0): (Vec<_>, Vec<_>) = data
+                .into_iter()
+                .map(|datum| {
+                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
+                    let datum = datum
+                        .map(|datum| {
+                            let Self(data0) = datum.into_owned();
+                            data0
+                        })
+                        .flatten();
+                    (datum.is_some(), datum)
+                })
+                .unzip();
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                let any_nones = somes.iter().any(|some| !*some);
+                any_nones.then(|| somes.into())
+            };
+            PrimitiveArray::new(
+                DataType::Float32,
+                data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
+                data0_bitmap,
+            )
+            .boxed()
+        })
     }
 }

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -71,36 +71,223 @@
 //! auto-generated class.
 //! The simplest way to get started is to look at any of the existing examples.
 
+// TODO(cmc): `Datatype` & `Component` being full-blown copies of each other is a bit dumb... but
+// things are bound to evolve very soon anyway (see e.g. Jeremy's paper).
+
 // ---
 
+/// The fully-qualified name of a [`Datatype`], e.g. `rerun.datatypes.Vec2D`.
 pub type DatatypeName = ::std::borrow::Cow<'static, str>;
 
-/// A [`Datatype`] describes plain old data.
+/// A [`Datatype`] describes plain old data that can be used by any number of [`Component`].
 pub trait Datatype {
+    /// The fully-qualified name of this datatype, e.g. `rerun.datatypes.Vec2D`.
     fn name() -> DatatypeName;
 
+    /// The underlying [`arrow2::datatypes::DataType`].
     fn to_arrow_datatype() -> arrow2::datatypes::DataType;
+
+    // ---
+
+    /// Given an iterator of owned or reference values to the current [`Datatype`], serializes
+    /// them into an Arrow array.
+    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
+    ///
+    /// Panics on failure.
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    ///
+    /// For the fallible version, see [`Datatype::try_to_arrow`].
+    #[inline]
+    fn to_arrow<'a>(
+        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+    ) -> Box<dyn ::arrow2::array::Array>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data.into_iter().map(Some)).unwrap()
+    }
+
+    /// Given an iterator of owned or reference values to the current [`Datatype`], serializes
+    /// them into an Arrow array.
+    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
+    ///
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    /// For the non-fallible version, see [`Datatype::to_arrow`].
+    #[inline]
+    fn try_to_arrow<'a>(
+        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data.into_iter().map(Some))
+    }
+
+    /// Given an iterator of options of owned or reference values to the current
+    /// [`Datatype`], serializes them into an Arrow array.
+    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
+    ///
+    /// Panics on failure.
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    ///
+    /// For the fallible version, see [`Datatype::try_to_arrow_opt`].
+    #[inline]
+    fn to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> Box<dyn ::arrow2::array::Array>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data).unwrap()
+    }
+
+    /// Given an iterator of options of owned or reference values to the current
+    /// [`Datatype`], serializes them into an Arrow array.
+    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
+    ///
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    /// For the non-fallible version, see [`Datatype::to_arrow_opt`].
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a;
 }
 
+/// The fully-qualified name of a [`Component`], e.g. `rerun.components.Point2D`.
 pub type ComponentName = ::std::borrow::Cow<'static, str>;
 
 pub trait Component {
+    /// The fully-qualified name of this component, e.g. `rerun.components.Point2D`.
     fn name() -> ComponentName;
 
+    /// The underlying [`arrow2::datatypes::DataType`].
     fn to_arrow_datatype() -> arrow2::datatypes::DataType;
+
+    // ---
+
+    /// Given an iterator of owned or reference values to the current [`Component`], serializes
+    /// them into an Arrow array.
+    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
+    ///
+    /// Panics on failure.
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    ///
+    /// For the fallible version, see [`Component::try_to_arrow`].
+    #[inline]
+    fn to_arrow<'a>(
+        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+    ) -> Box<dyn ::arrow2::array::Array>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data.into_iter().map(Some)).unwrap()
+    }
+
+    /// Given an iterator of owned or reference values to the current [`Component`], serializes
+    /// them into an Arrow array.
+    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
+    ///
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    /// For the non-fallible version, see [`Component::to_arrow`].
+    #[inline]
+    fn try_to_arrow<'a>(
+        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data.into_iter().map(Some))
+    }
+
+    /// Given an iterator of options of owned or reference values to the current
+    /// [`Component`], serializes them into an Arrow array.
+    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
+    ///
+    /// Panics on failure.
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    ///
+    /// For the fallible version, see [`Component::try_to_arrow_opt`].
+    #[inline]
+    fn to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> Box<dyn ::arrow2::array::Array>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data).unwrap()
+    }
+
+    /// Given an iterator of options of owned or reference values to the current
+    /// [`Component`], serializes them into an Arrow array.
+    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
+    ///
+    /// This will _never_ fail for Rerun's builtin [`Datatype`].
+    /// For the non-fallible version, see [`Component::to_arrow_opt`].
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a;
 }
 
+/// The fully-qualified name of an [`Archetype`], e.g. `rerun.archetypes.Points2D`.
 pub type ArchetypeName = ::std::borrow::Cow<'static, str>;
 
 pub trait Archetype {
+    /// The fully-qualified name of this archetype, e.g. `rerun.archetypes.Points2D`.
     fn name() -> ArchetypeName;
 
+    // ---
+
+    /// The fully-qualified component names of every component that _must_ be provided by the user
+    /// when constructing this archetype.
     fn required_components() -> Vec<ComponentName>;
+
+    /// The fully-qualified component names of every component that _should_ be provided by the user
+    /// when constructing this archetype.
     fn recommended_components() -> Vec<ComponentName>;
+
+    /// The fully-qualified component names of every component that _could_ be provided by the user
+    /// when constructing this archetype.
     fn optional_components() -> Vec<ComponentName>;
 
-    fn to_arrow_datatypes() -> Vec<arrow2::datatypes::DataType>;
+    // ---
+
+    /// Serializes all non-null [`Component`]s of this [`Archetype`] into Arrow arrays.
+    ///
+    /// Panics on failure.
+    /// This can _never_ fail for Rerun's builtin archetypes.
+    ///
+    /// For the fallible version, see [`Archetype::try_to_arrow`].
+    #[inline]
+    fn to_arrow(&self) -> Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)> {
+        self.try_to_arrow().unwrap()
+    }
+
+    /// Serializes all non-null [`Component`]s of this [`Archetype`] into Arrow arrays.
+    ///
+    /// This can _never_ fail for Rerun's builtin archetypes.
+    /// For the non-fallible version, see [`Archetype::to_arrow`].
+    fn try_to_arrow(
+        &self,
+    ) -> SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>>;
 }
+
+// ---
+
+#[derive(thiserror::Error, Debug)]
+pub enum SerializationError {
+    #[error(
+        "Trying to serialize field {obj_field_fqname:?} with unsupported datatype: {datatype:#?}:"
+    )]
+    UnsupportedDatatype {
+        obj_field_fqname: String,
+        datatype: ::arrow2::datatypes::DataType,
+    },
+}
+
+pub type SerializationResult<T> = ::std::result::Result<T, SerializationError>;
 
 // ---
 

--- a/crates/re_types/tests/fuzzy.rs
+++ b/crates/re_types/tests/fuzzy.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_clone)]
 
-use re_types::archetypes::AffixFuzzer1;
+use re_types::{archetypes::AffixFuzzer1, Archetype as _};
 
 #[test]
 fn roundtrip() {
@@ -124,5 +124,13 @@ fn roundtrip() {
     .with_fuzz2106([fuzzy6.clone(), fuzzy6.clone(), fuzzy6.clone()]);
 
     eprintln!("arch = {arch:#?}");
-    // TODO(cmc): roundtrips
+    let serialized = arch.to_arrow();
+    for (field, array) in &serialized {
+        // NOTE: Keep those around please, very useful when debugging.
+        // eprintln!("field = {field:#?}");
+        // eprintln!("array = {array:#?}");
+        eprintln!("{} = {array:#?}", field.name);
+    }
+
+    // TODO(cmc): deserialize
 }

--- a/crates/re_types/tests/points2d.rs
+++ b/crates/re_types/tests/points2d.rs
@@ -1,18 +1,7 @@
-use re_types::{archetypes::Points2D, components};
+use re_types::{archetypes::Points2D, components, Archetype as _};
 
 #[test]
 fn roundtrip() {
-    // TODO(cmc): (de)serialization roundtrips
-
-    let arch = Points2D::new([(1.0, 2.0), (3.0, 4.0)])
-        .with_radii([42.0, 43.0])
-        .with_colors([0xAA0000CC, 0x00BB00DD])
-        .with_labels(["hello", "friend"])
-        .with_draw_order(300.0)
-        .with_class_ids([126, 127])
-        .with_keypoint_ids([2, 3])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
-
     let expected = Points2D {
         points: vec![
             components::Point2D::new(1.0, 2.0), //
@@ -45,5 +34,24 @@ fn roundtrip() {
         ]),
     };
 
+    let arch = Points2D::new([(1.0, 2.0), (3.0, 4.0)])
+        .with_radii([42.0, 43.0])
+        .with_colors([0xAA0000CC, 0x00BB00DD])
+        .with_labels(["hello", "friend"])
+        .with_draw_order(300.0)
+        .with_class_ids([126, 127])
+        .with_keypoint_ids([2, 3])
+        .with_instance_keys([u64::MAX - 1, u64::MAX]);
     similar_asserts::assert_eq!(expected, arch);
+
+    eprintln!("arch = {arch:#?}");
+    let serialized = arch.to_arrow();
+    for (field, array) in &serialized {
+        // NOTE: Keep those around please, very useful when debugging.
+        // eprintln!("field = {field:#?}");
+        // eprintln!("array = {array:#?}");
+        eprintln!("{} = {array:#?}", field.name);
+    }
+
+    // TODO(cmc): deserialize
 }


### PR DESCRIPTION
**Best reviewed on a commit-by-commit basis; in particular the `rerun codegen` commit is nothing but generated code.**

Implements serialization for the Rust codegen backend.

---

- #2484
- #2485 
- #2487 
- #2545
- #2546
- #2549
- #2554
- #2570
- #2571

---

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2487

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/87ca70a/docs
Examples preview: https://rerun.io/preview/87ca70a/examples
<!-- pr-link-docs:end -->