### PR TITLE
Update egui_tiles with fix for drag-and-drop-panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.1.0"
-source = "git+https://github.com/rerun-io/egui_tiles.git?rev=0127ad5eeed91beefd03b0ff1733200b32fb9a12#0127ad5eeed91beefd03b0ff1733200b32fb9a12"
+source = "git+https://github.com/rerun-io/egui_tiles.git?rev=f958d8af7ed27d925bc2ff7862fb1c1c45961b9e#f958d8af7ed27d925bc2ff7862fb1c1c45961b9e"
 dependencies = [
  "ahash 0.8.3",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "0127ad5eeed91beefd03b0ff1733200b32fb9a12" }
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "f958d8af7ed27d925bc2ff7862fb1c1c45961b9e" }


### PR DESCRIPTION
Easy fix: https://github.com/rerun-io/egui_tiles/commit/f958d8af7ed27d925bc2ff7862fb1c1c45961b9e

Closes https://github.com/rerun-io/rerun/issues/2552

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2555

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/7e89a6c/docs
Examples preview: https://rerun.io/preview/7e89a6c/examples
<!-- pr-link-docs:end -->
