### PR TITLE
New auto-layout of space views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.1.0"
-source = "git+https://github.com/rerun-io/egui_tiles.git?rev=f958d8af7ed27d925bc2ff7862fb1c1c45961b9e#f958d8af7ed27d925bc2ff7862fb1c1c45961b9e"
+source = "git+https://github.com/rerun-io/egui_tiles.git?rev=3fff2b01310aa3569e29d2dd3ee97b2e62c45870#3fff2b01310aa3569e29d2dd3ee97b2e62c45870"
 dependencies = [
  "ahash 0.8.3",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "f958d8af7ed27d925bc2ff7862fb1c1c45961b9e" }
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "3fff2b01310aa3569e29d2dd3ee97b2e62c45870" } # 2023-06-29: drag-and-drop fixes

--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -50,6 +50,10 @@ impl SpaceViewClass for BarChartSpaceView {
         None
     }
 
+    fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
+        re_viewer_context::SpaceViewClassLayoutPriority::Low
+    }
+
     fn selection_ui(
         &self,
         _ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/space_view_class.rs
+++ b/crates/re_space_view_spatial/src/space_view_class.rs
@@ -38,6 +38,10 @@ impl SpaceViewClass for SpatialSpaceView {
         }
     }
 
+    fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
+        re_viewer_context::SpaceViewClassLayoutPriority::High
+    }
+
     fn prepare_populate(
         &self,
         ctx: &mut re_viewer_context::ViewerContext<'_>,

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -139,6 +139,10 @@ impl SpaceViewClass for TensorSpaceView {
         None
     }
 
+    fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
+        re_viewer_context::SpaceViewClassLayoutPriority::Medium
+    }
+
     fn selection_ui(
         &self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_text/src/space_view_class.rs
+++ b/crates/re_space_view_text/src/space_view_class.rs
@@ -58,6 +58,10 @@ impl SpaceViewClass for TextSpaceView {
         Some(2.0) // Make text logs wide
     }
 
+    fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
+        re_viewer_context::SpaceViewClassLayoutPriority::Low
+    }
+
     fn selection_ui(
         &self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_text_box/src/space_view_class.rs
+++ b/crates/re_space_view_text_box/src/space_view_class.rs
@@ -53,6 +53,10 @@ impl SpaceViewClass for TextBoxSpaceView {
         "Displays text from a text entry components.".into()
     }
 
+    fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
+        re_viewer_context::SpaceViewClassLayoutPriority::Low
+    }
+
     fn selection_ui(
         &self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -59,6 +59,10 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         None
     }
 
+    fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
+        re_viewer_context::SpaceViewClassLayoutPriority::Low
+    }
+
     fn selection_ui(
         &self,
         _ctx: &mut ViewerContext<'_>,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -250,13 +250,15 @@ fn blueprint_ui(
                     space_view.class_name(),
                 );
 
-                space_view.class(ctx).selection_ui(
-                    ctx,
-                    ui,
-                    space_view_state,
-                    &space_view.space_origin,
-                    space_view.id,
-                );
+                space_view
+                    .class(ctx.space_view_class_registry)
+                    .selection_ui(
+                        ctx,
+                        ui,
+                        space_view_state,
+                        &space_view.space_origin,
+                        space_view.id,
+                    );
             }
         }
 

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -36,9 +36,10 @@ pub use selection_state::{
 };
 pub use space_view::{
     ArchetypeDefinition, DynSpaceViewClass, Scene, SceneContext, SceneContextPart, ScenePart,
-    ScenePartCollection, SceneQuery, SpaceViewClass, SpaceViewClassName, SpaceViewClassRegistry,
-    SpaceViewClassRegistryError, SpaceViewEntityHighlight, SpaceViewHighlights,
-    SpaceViewOutlineMasks, SpaceViewState, TypedScene,
+    ScenePartCollection, SceneQuery, SpaceViewClass, SpaceViewClassLayoutPriority,
+    SpaceViewClassName, SpaceViewClassRegistry, SpaceViewClassRegistryError,
+    SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewState,
+    TypedScene,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -15,6 +15,21 @@ re_string_interner::declare_new_type!(
     pub struct SpaceViewClassName;
 );
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, Ord, Eq)]
+pub enum SpaceViewClassLayoutPriority {
+    /// This space view can share space with others
+    ///
+    /// Used for boring things like text and plots.
+    Low,
+
+    #[default]
+    Medium,
+
+    /// Give this space view lots of space.
+    /// Used for spatial views (2D/3D).
+    High,
+}
+
 /// Defines a class of space view without any concrete types making it suitable for storage and interfacing.
 ///
 /// Implemented by [`crate::SpaceViewClass`].
@@ -55,6 +70,9 @@ pub trait DynSpaceViewClass {
 
     /// Preferred aspect ratio for the ui tiles of this space view.
     fn preferred_tile_aspect_ratio(&self, state: &dyn SpaceViewState) -> Option<f32>;
+
+    /// Controls how likely this space view will get a large tile in the ui.
+    fn layout_priority(&self) -> SpaceViewClassLayoutPriority;
 
     /// Executed before the scene is populated, can be use for heuristic & state updates before populating the scene.
     ///

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -15,7 +15,8 @@ mod space_view_class_placeholder;
 mod space_view_class_registry;
 
 pub use dyn_space_view_class::{
-    ArchetypeDefinition, DynSpaceViewClass, SpaceViewClassName, SpaceViewState,
+    ArchetypeDefinition, DynSpaceViewClass, SpaceViewClassLayoutPriority, SpaceViewClassName,
+    SpaceViewState,
 };
 pub use highlights::{SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks};
 pub use scene::{Scene, TypedScene};

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -48,6 +48,9 @@ pub trait SpaceViewClass: std::marker::Sized {
         None
     }
 
+    /// Controls how likely this space view will get a large tile in the ui.
+    fn layout_priority(&self) -> crate::SpaceViewClassLayoutPriority;
+
     /// Optional archetype of the Space View's blueprint properties.
     ///
     /// Blueprint components that only apply to the space view itself, not to the entities it displays.
@@ -123,6 +126,11 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
 
     fn preferred_tile_aspect_ratio(&self, state: &dyn SpaceViewState) -> Option<f32> {
         typed_state_wrapper(state, |state| self.preferred_tile_aspect_ratio(state))
+    }
+
+    #[inline]
+    fn layout_priority(&self) -> crate::SpaceViewClassLayoutPriority {
+        self.layout_priority()
     }
 
     fn blueprint_archetype(&self) -> Option<ArchetypeDefinition> {

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -22,6 +22,10 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
         "The Space View Class was not recognized.\nThis happens if either the Blueprint specifies an invalid Space View Class or this version of the Viewer does not know about this type.".into()
     }
 
+    fn layout_priority(&self) -> crate::SpaceViewClassLayoutPriority {
+        crate::SpaceViewClassLayoutPriority::Low
+    }
+
     fn selection_ui(
         &self,
         _ctx: &mut crate::ViewerContext<'_>,

--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -44,8 +44,7 @@ pub(crate) fn tree_from_space_views(
     let root = if space_make_infos.len() == 1 {
         tiles.insert_pane(space_make_infos[0].id)
     } else if space_make_infos.len() == 3 {
-        // Special-case this common case (that doesn't fit nicely in a grid!):
-        // tile_by_category(&mut tiles, &space_make_infos)
+        // Special-case for common case that doesn't fit nicely in a grid
         arrange_three(
             [
                 space_make_infos[0].clone(),

--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -1,56 +1,29 @@
 //! Code for automatic layout of space views.
 //!
-//! This uses rough heuristics and have a lot of room for improvement.
-//!
-//! Some of the heuristics include:
-//! * We want similar space views together. Similar can mean:
-//!   * Same category (2D vs text vs …)
-//!   * Similar entity path (common prefix)
-//! * We also want to pick aspect ratios that fit the data pretty well
-// TODO(emilk): fix O(N^2) execution time (where N = number of spaces)
+//! This uses some very rough heuristics and have a lot of room for improvement.
 
 use std::collections::BTreeMap;
 
-use ahash::HashMap;
-use egui::Vec2;
 use itertools::Itertools as _;
 
-use re_data_store::{EntityPath, EntityPathPart};
-use re_viewer_context::{SpaceViewId, ViewerContext};
+use re_viewer_context::SpaceViewId;
 
 use super::{space_view::SpaceViewBlueprint, view_category::ViewCategory};
 
 #[derive(Clone, Debug)]
-pub struct SpaceMakeInfo {
-    pub id: SpaceViewId,
-
-    /// Some path we use to group the views by
-    pub path: EntityPath,
-
-    pub category: ViewCategory,
-
-    /// Desired aspect ratio, if any.
-    pub aspect_ratio: Option<f32>,
-}
-
-enum LayoutSplit {
-    LeftRight(Box<LayoutSplit>, f32, Box<LayoutSplit>),
-    TopBottom(Box<LayoutSplit>, f32, Box<LayoutSplit>),
-    Leaf(SpaceMakeInfo),
-}
-
-enum SplitDirection {
-    LeftRight { left: Vec2, t: f32, right: Vec2 },
-    TopBottom { top: Vec2, t: f32, bottom: Vec2 },
+struct SpaceMakeInfo {
+    id: SpaceViewId,
+    category: ViewCategory,
 }
 
 pub(crate) fn tree_from_space_views(
-    ctx: &mut ViewerContext<'_>,
-    viewport_size: egui::Vec2,
     space_views: &BTreeMap<SpaceViewId, SpaceViewBlueprint>,
-    space_view_states: &HashMap<SpaceViewId, Box<dyn re_viewer_context::SpaceViewState>>,
 ) -> egui_tiles::Tree<SpaceViewId> {
-    let mut space_make_infos = space_views
+    if space_views.is_empty() {
+        return egui_tiles::Tree::empty();
+    }
+
+    let space_make_infos = space_views
         .iter()
         // Sort for determinism:
         .sorted_by_key(|(space_view_id, space_view)| {
@@ -60,234 +33,87 @@ pub(crate) fn tree_from_space_views(
                 *space_view_id,
             )
         })
-        .map(|(space_view_id, space_view)| {
-            let aspect_ratio = space_view_states.get(space_view_id).and_then(|state| {
-                space_view
-                    .class(ctx)
-                    .preferred_tile_aspect_ratio(state.as_ref())
-            });
-
-            SpaceMakeInfo {
-                id: *space_view_id,
-                path: space_view.space_origin.clone(),
-                category: space_view.category,
-                aspect_ratio,
-            }
+        .map(|(space_view_id, space_view)| SpaceMakeInfo {
+            id: *space_view_id,
+            category: space_view.category,
         })
         .collect_vec();
 
-    if space_make_infos.is_empty() {
-        egui_tiles::Tree::empty()
+    let mut tiles = egui_tiles::Tiles::default();
+
+    let root = if space_make_infos.len() == 1 {
+        tiles.insert_pane(space_make_infos[0].id)
+    } else if space_make_infos.len() == 3 {
+        // Special-case this common case (that doesn't fit nicely in a grid!):
+        // tile_by_category(&mut tiles, &space_make_infos)
+        arrange_three(
+            [
+                space_make_infos[0].clone(),
+                space_make_infos[1].clone(),
+                space_make_infos[2].clone(),
+            ],
+            &mut tiles,
+        )
     } else {
-        let mut tiles = egui_tiles::Tiles::default();
-        // Users often organize by path prefix, so we start by splitting along that
-        let layout = layout_by_path_prefix(viewport_size, &mut space_make_infos);
-        let root = tree_from_split(&mut tiles, &layout);
-        egui_tiles::Tree::new(root, tiles)
-    }
+        // Arrange it all in a grid that is responsive to changes in viewport size:
+        let child_tile_ids = space_make_infos
+            .into_iter()
+            .map(|smi| tiles.insert_pane(smi.id))
+            .collect_vec();
+        tiles.insert_grid_tile(child_tile_ids)
+    };
+
+    egui_tiles::Tree::new(root, tiles)
 }
 
-fn tree_from_split(
+fn arrange_three(
+    mut spaces: [SpaceMakeInfo; 3],
     tiles: &mut egui_tiles::Tiles<SpaceViewId>,
-    split: &LayoutSplit,
 ) -> egui_tiles::TileId {
-    match split {
-        LayoutSplit::LeftRight(left, fraction, right) => {
-            let container = egui_tiles::Linear::new_binary(
-                egui_tiles::LinearDir::Horizontal,
-                [tree_from_split(tiles, left), tree_from_split(tiles, right)],
-                *fraction,
-            );
-            tiles.insert_container(container)
-        }
-        LayoutSplit::TopBottom(top, fraction, bottom) => {
-            let container = egui_tiles::Linear::new_binary(
-                egui_tiles::LinearDir::Vertical,
-                [tree_from_split(tiles, top), tree_from_split(tiles, bottom)],
-                *fraction,
-            );
-            tiles.insert_container(container)
-        }
-        LayoutSplit::Leaf(space_info) => tiles.insert_pane(space_info.id),
-    }
-}
+    // We will arrange it like so:
+    //
+    // +-------------+
+    // |             |
+    // |             |
+    // |             |
+    // +-------+-----+
+    // |       |     |
+    // |       |     |
+    // +-------+-----+
+    //
+    // or like so:
+    //
+    // +-----------------------+
+    // |          |            |
+    // |          |            |
+    // |          +------------+
+    // |          |            |
+    // |          |            |
+    // |          |            |
+    // +----------+------------+
+    //
+    // But which space gets a full side, and which doesn't?
+    // Answer: we prioritize them by category:
 
-/// Group categories together, i.e. so that 2D stuff is next to 2D stuff, and text logs are next to text logs.
-fn layout_by_category(viewport_size: egui::Vec2, spaces: &mut [SpaceMakeInfo]) -> LayoutSplit {
-    assert!(!spaces.is_empty());
-
-    if spaces.len() == 1 {
-        LayoutSplit::Leaf(spaces[0].clone())
-    } else {
-        let groups = group_by_category(spaces);
-
-        if groups.len() == 1 {
-            // All same category
-            layout_by_path_prefix(viewport_size, spaces)
-        } else {
-            // Mixed categories.
-            split_groups(viewport_size, groups)
-        }
-    }
-}
-
-/// Put spaces with common path prefix close together.
-fn layout_by_path_prefix(viewport_size: egui::Vec2, spaces: &mut [SpaceMakeInfo]) -> LayoutSplit {
-    assert!(!spaces.is_empty());
-
-    if spaces.len() == 1 {
-        LayoutSplit::Leaf(spaces[0].clone())
-    } else {
-        let groups = group_by_path_prefix(spaces);
-
-        if groups.len() == 1 {
-            // failed to separate by group - try category instead:
-            layout_by_category(viewport_size, spaces)
-        } else {
-            split_groups(viewport_size, groups)
-        }
-    }
-}
-
-fn split_groups(viewport_size: egui::Vec2, groups: Vec<Vec<SpaceMakeInfo>>) -> LayoutSplit {
-    let (mut spaces, split_point) = find_group_split_point(groups);
-    split_spaces_at(viewport_size, &mut spaces, split_point)
-}
-
-fn find_group_split_point(groups: Vec<Vec<SpaceMakeInfo>>) -> (Vec<SpaceMakeInfo>, usize) {
-    assert!(groups.len() > 1);
-
-    let num_spaces: usize = groups.iter().map(|g| g.len()).sum();
-
-    let mut best_split = 0;
-    let mut rearranged_spaces = vec![];
-    for mut group in groups {
-        rearranged_spaces.append(&mut group);
-
-        let split_candidate = rearranged_spaces.len();
-
-        // Prefer the split that is closest to the middle:
-        if (split_candidate as f32 / num_spaces as f32 - 0.5).abs()
-            < (best_split as f32 / num_spaces as f32 - 0.5).abs()
-        {
-            best_split = split_candidate;
-        }
-    }
-    assert_eq!(rearranged_spaces.len(), num_spaces);
-    assert!(0 < best_split && best_split < num_spaces,);
-
-    (rearranged_spaces, best_split)
-}
-
-fn suggest_split_direction(
-    viewport_size: egui::Vec2,
-    spaces: &[SpaceMakeInfo],
-    split_index: usize,
-) -> SplitDirection {
-    use egui::vec2;
-
-    assert!(0 < split_index && split_index < spaces.len());
-
-    let t = split_index as f32 / spaces.len() as f32;
-
-    let desired_aspect_ratio = desired_aspect_ratio(spaces).unwrap_or(16.0 / 9.0);
-
-    if viewport_size.x > desired_aspect_ratio * viewport_size.y {
-        let left = vec2(viewport_size.x * t, viewport_size.y);
-        let right = vec2(viewport_size.x * (1.0 - t), viewport_size.y);
-        SplitDirection::LeftRight { left, t, right }
-    } else {
-        let top = vec2(viewport_size.x, viewport_size.y * t);
-        let bottom = vec2(viewport_size.x, viewport_size.y * (1.0 - t));
-        SplitDirection::TopBottom { top, t, bottom }
-    }
-}
-
-fn split_spaces_at(
-    viewport_size: egui::Vec2,
-    spaces: &mut [SpaceMakeInfo],
-    split_index: usize,
-) -> LayoutSplit {
-    assert!(0 < split_index && split_index < spaces.len());
-
-    match suggest_split_direction(viewport_size, spaces, split_index) {
-        SplitDirection::LeftRight { left, t, right } => {
-            let left = layout_by_path_prefix(left, &mut spaces[..split_index]);
-            let right = layout_by_path_prefix(right, &mut spaces[split_index..]);
-            LayoutSplit::LeftRight(left.into(), t, right.into())
-        }
-        SplitDirection::TopBottom { top, t, bottom } => {
-            let top = layout_by_path_prefix(top, &mut spaces[..split_index]);
-            let bottom = layout_by_path_prefix(bottom, &mut spaces[split_index..]);
-            LayoutSplit::TopBottom(top.into(), t, bottom.into())
-        }
-    }
-}
-
-/// If we need to pick only one aspect ratio for all these spaces, what is a good aspect ratio?
-///
-/// This is a very, VERY, rough heuristic. It really only work in a few cases:
-///
-/// * All spaces have similar aspect ration (e.g. all portrait or all landscape)
-/// * Only one space care about aspect ratio, and the other are flexible
-/// * A mix of the above
-///
-/// Still, it is better than nothing.
-fn desired_aspect_ratio(spaces: &[SpaceMakeInfo]) -> Option<f32> {
-    // Taking the arithmetic mean of all given aspect ratios.
-    // It makes very little sense, unless the aspect ratios are all close already.
-    // Perhaps a mode or median would make more sense?
-
-    let mut sum = 0.0;
-    let mut num = 0.0;
-    for space in spaces {
-        if let Some(aspect_ratio) = space.aspect_ratio {
-            if aspect_ratio.is_finite() {
-                sum += aspect_ratio;
-                num += 1.0;
-            }
+    /// lower is better
+    fn category_priority(category: ViewCategory) -> usize {
+        match category {
+            ViewCategory::Spatial => 0,
+            ViewCategory::Tensor => 1,
+            ViewCategory::TimeSeries => 2,
+            ViewCategory::BarChart => 3,
+            ViewCategory::TextBox => 4,
+            ViewCategory::Text => 5,
         }
     }
 
-    (num != 0.0).then_some(sum / num)
-}
+    spaces.sort_by_key(|smi| category_priority(smi.category));
 
-fn group_by_category(space_infos: &[SpaceMakeInfo]) -> Vec<Vec<SpaceMakeInfo>> {
-    let mut groups: BTreeMap<ViewCategory, Vec<SpaceMakeInfo>> = Default::default();
-    for info in space_infos {
-        groups.entry(info.category).or_default().push(info.clone());
-    }
-    groups.into_values().collect()
-}
-
-fn group_by_path_prefix(space_infos: &[SpaceMakeInfo]) -> Vec<Vec<SpaceMakeInfo>> {
-    if space_infos.len() < 2 {
-        return vec![space_infos.to_vec()];
-    }
-    re_tracing::profile_function!();
-
-    let paths = space_infos
-        .iter()
-        .map(|space_info| space_info.path.as_slice().to_vec())
+    let pane_ids = spaces
+        .into_iter()
+        .map(|smi| tiles.insert_pane(smi.id))
         .collect_vec();
 
-    for i in 0.. {
-        let mut groups: BTreeMap<Option<&EntityPathPart>, Vec<&SpaceMakeInfo>> = Default::default();
-        for (path, space) in paths.iter().zip(space_infos) {
-            groups.entry(path.get(i)).or_default().push(space);
-        }
-        if groups.len() == 1 && groups.contains_key(&None) {
-            break;
-        }
-        if groups.len() > 1 {
-            return groups
-                .values()
-                .map(|spaces| spaces.iter().cloned().cloned().collect())
-                .collect();
-        }
-    }
-    space_infos
-        .iter()
-        .map(|space| vec![space.clone()])
-        .collect()
+    let inner_grid = tiles.insert_grid_tile(vec![pane_ids[1], pane_ids[2]]);
+    tiles.insert_grid_tile(vec![pane_ids[0], inner_grid])
 }

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -45,7 +45,7 @@ pub mod item_ui {
             .re_ui
             .selectable_label_with_icon(
                 ui,
-                space_view.class(ctx).icon(),
+                space_view.class(ctx.space_view_class_registry).icon(),
                 space_view.display_name.clone(),
                 is_selected,
             )

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -77,9 +77,11 @@ impl SpaceViewBlueprint {
         &self.class_name
     }
 
-    pub fn class<'a>(&self, ctx: &ViewerContext<'a>) -> &'a dyn DynSpaceViewClass {
-        ctx.space_view_class_registry
-            .get_or_log_error(&self.class_name)
+    pub fn class<'a>(
+        &self,
+        space_view_class_registry: &'a re_viewer_context::SpaceViewClassRegistry,
+    ) -> &'a dyn DynSpaceViewClass {
+        space_view_class_registry.get_or_log_error(&self.class_name)
     }
 
     pub fn on_frame_start(
@@ -164,7 +166,7 @@ impl SpaceViewBlueprint {
             return;
         }
 
-        let class = self.class(ctx);
+        let class = self.class(ctx.space_view_class_registry);
 
         class.prepare_populate(
             ctx,

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -576,7 +576,7 @@ impl Viewport {
                     .re_ui
                     .selectable_label_with_icon(
                         ui,
-                        space_view.class(ctx).icon(),
+                        space_view.class(ctx.space_view_class_registry).icon(),
                         if space_view.space_origin.is_root() {
                             space_view.display_name.clone()
                         } else {
@@ -871,7 +871,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         }
 
         let help_text = space_view
-            .class(self.ctx)
+            .class(self.ctx.space_view_class_registry)
             .help_text(self.ctx.re_ui, space_view_state);
         re_ui::help_hover_button(ui).on_hover_text(help_text);
     }

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -536,7 +536,10 @@ impl Viewport {
             &mut maximized_tree
         } else {
             if self.tree.is_empty() {
-                self.tree = super::auto_layout::tree_from_space_views(&self.space_views);
+                self.tree = super::auto_layout::tree_from_space_views(
+                    ctx.space_view_class_registry,
+                    &self.space_views,
+                );
             }
             &mut self.tree
         };

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -535,7 +535,7 @@ impl Viewport {
             maximized_tree = egui_tiles::Tree::new(root, tiles);
             &mut maximized_tree
         } else {
-            if self.tree.root().is_none() {
+            if self.tree.is_empty() {
                 self.tree = super::auto_layout::tree_from_space_views(&self.space_views);
             }
             &mut self.tree

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -536,12 +536,7 @@ impl Viewport {
             &mut maximized_tree
         } else {
             if self.tree.root().is_none() {
-                self.tree = super::auto_layout::tree_from_space_views(
-                    ctx,
-                    ui.available_size(),
-                    &self.space_views,
-                    &state.space_view_states,
-                );
+                self.tree = super::auto_layout::tree_from_space_views(&self.space_views);
             }
             &mut self.tree
         };

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -5,8 +5,8 @@ use re_viewer::external::{
     re_log_types::EntityPath,
     re_ui,
     re_viewer_context::{
-        HoverHighlight, Item, SelectionHighlight, SpaceViewClass, SpaceViewClassName, SpaceViewId,
-        SpaceViewState, TypedScene, UiVerbosity, ViewerContext,
+        HoverHighlight, Item, SelectionHighlight, SpaceViewClass, SpaceViewClassLayoutPriority,
+        SpaceViewClassName, SpaceViewId, SpaceViewState, TypedScene, UiVerbosity, ViewerContext,
     },
 };
 
@@ -93,6 +93,10 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     fn preferred_tile_aspect_ratio(&self, _state: &Self::State) -> Option<f32> {
         // Prefer a square tile if possible.
         Some(1.0)
+    }
+
+    fn layout_priority(&self) -> SpaceViewClassLayoutPriority {
+        Default::default()
     }
 
     /// Additional UI displayed when the space view is selected.

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -92,8 +92,6 @@ def collect_examples(fast: bool) -> list[str]:
         skip_list = [
             # depth_sensor requires a specific piece of hardware to be attached
             "examples/python/live_depth_sensor/main.py",
-            # objectron currently broken; see https://github.com/rerun-io/rerun/issues/2557
-            "examples/python/objectron/main.py",
             # ros requires complex system dependencies to be installed
             "examples/python/ros_node/main.py",
         ]

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -93,9 +93,14 @@ def collect_examples(fast: bool) -> list[str]:
             "examples/python/text_logging",
         ]
     else:
-        # ros requires complex system dependencies to be installed
-        # depth_sensor requires a specific piece of hardware to be attached
-        skip_list = ["examples/python/ros_node/main.py", "examples/python/live_depth_sensor/main.py"]
+        skip_list = [
+            # depth_sensor requires a specific piece of hardware to be attached
+            "examples/python/live_depth_sensor/main.py",
+            # ros requires complex system dependencies to be installed
+            "examples/python/ros_node/main.py",
+            # objectron currently broken; see https://github.com/rerun-io/rerun/issues/2557
+            "examples/python/objectron/main.py",
+        ]
 
         return [
             os.path.dirname(main_path) for main_path in glob("examples/python/**/main.py") if main_path not in skip_list

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -26,7 +26,7 @@ HAS_NO_SAVE_ARG = {
 }
 
 
-def start_process(args: list[str], cwd: str, wait: bool) -> Any:
+def start_process(args: list[str], *, wait: bool, cwd: str | None = None) -> Any:
     process = subprocess.Popen(
         args,
         cwd=cwd,
@@ -58,14 +58,6 @@ def run_py_example(path: str, viewer_port: int | None = None, wait: bool = True,
 
     return start_process(
         args,
-        cwd=path,
-        wait=wait,
-    )
-
-
-def run_saved_example(path: str, wait: bool = True) -> Any:
-    return start_process(
-        ["cargo", "run", "-p", "rerun-cli", "--all-features", "--", "out.rrd"],
         cwd=path,
         wait=wait,
     )
@@ -228,6 +220,13 @@ def run_save(examples: list[str]) -> None:
             print_example_output(path, example)
 
 
+def run_saved_example(path: str, wait: bool) -> Any:
+    return start_process(
+        ["cargo", "run", "-p", "rerun-cli", "--all-features", "--", os.path.join(path, "out.rrd")],
+        wait=wait,
+    )
+
+
 def run_load(examples: list[str], separate: bool, close: bool) -> None:
     if separate:
         entries: list[tuple[str, Any]] = []
@@ -244,7 +243,7 @@ def run_load(examples: list[str], separate: bool, close: bool) -> None:
         # run all examples sequentially
         for path in examples:
             # each one must be closed for the next one to start running
-            example = run_saved_example(path)
+            example = run_saved_example(path, wait=True)
             print_example_output(path, example)
 
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -169,15 +169,16 @@ def run_sdk_build() -> None:
     assert returncode == 0, f"process exited with error code {returncode}"
 
 
-def run_viewer_build() -> None:
-    print("Building rerun…")
+def run_viewer_build(web: bool) -> None:
+    print("Building Rerun Viewer…")
     returncode = subprocess.Popen(
         [
             "cargo",
             "build",
             "-p",
             "rerun-cli",
-            "--all-features",
+            "--no-default-features",
+            "--features=web_viewer" if web else "--features=native_viewer",
             "--quiet",
         ]
     ).wait()
@@ -289,8 +290,10 @@ def main() -> None:
     examples = collect_examples(args.fast)
 
     if not args.skip_build:
-        run_sdk_build()
-        run_viewer_build()
+        if not args.load:
+            run_sdk_build()
+        if not args.save:
+            run_viewer_build(args.web)
 
     if args.web:
         run_web(examples, separate=args.separate)

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -61,9 +61,11 @@ def run_py_example(path: str, viewer_port: int | None = None, wait: bool = True,
         wait=wait,
     )
 
+
 # stdout and stderr
 def output_from_process(process: Any) -> str:
     return process.communicate()[0].decode("utf-8").rstrip()
+
 
 def get_free_port() -> int:
     with socket.socket() as s:
@@ -102,7 +104,7 @@ def collect_examples(fast: bool) -> list[str]:
 
 
 def print_example_output(path: str, example: Any) -> None:
-    output = example.communicate()[0].decode('utf-8').rstrip()
+    output = example.communicate()[0].decode("utf-8").rstrip()
     print(f"\nExample {path}:\n{output}\n")
 
 

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -19,10 +19,10 @@ EXTRA_ARGS = {
 }
 
 HAS_NO_SAVE_ARG = {
-    "examples/python/multiprocessing",
-    "examples/python/minimal",
-    "examples/python/dna",
     "examples/python/blueprint",
+    "examples/python/dna",
+    "examples/python/minimal",
+    "examples/python/multiprocessing",
 }
 
 
@@ -88,10 +88,10 @@ def collect_examples(fast: bool) -> list[str]:
         skip_list = [
             # depth_sensor requires a specific piece of hardware to be attached
             "examples/python/live_depth_sensor/main.py",
-            # ros requires complex system dependencies to be installed
-            "examples/python/ros_node/main.py",
             # objectron currently broken; see https://github.com/rerun-io/rerun/issues/2557
             "examples/python/objectron/main.py",
+            # ros requires complex system dependencies to be installed
+            "examples/python/ros_node/main.py",
         ]
 
         return [

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -228,6 +228,8 @@ def run_saved_example(path: str, wait: bool) -> Any:
 
 
 def run_load(examples: list[str], separate: bool, close: bool) -> None:
+    examples = [path for path in examples if path not in HAS_NO_SAVE_ARG]
+
     if separate:
         entries: list[tuple[str, Any]] = []
         for path in examples:


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2139

### What
This simplifies the auto-layout of space views.

We make heavy use of `egui_tiles::Grid`, which is responsive to the current viewport size. This means that space views may move around as you resize window in an effort to keep each one square-ish. In the future we can make `egui_tiles` smarter here and inform it of the desired aspect ratio of each space view.

We make an exception for the (common) case of exactly three space views, which doesn't fit nicely in a grid anyways.



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested https://demo.rerun.io/pr/2558 

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2558

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/e2ed87c/docs
Examples preview: https://rerun.io/preview/e2ed87c/examples
<!-- pr-link-docs:end -->


### Testing
In order to test this I used the `run_all.py` script and found a bunch of issues with is, so I fixed them.

![image](https://github.com/rerun-io/rerun/assets/1148717/af84bbde-7828-45f5-ab31-df20b3f099df)

![image](https://github.com/rerun-io/rerun/assets/1148717/d845a3b6-3c4d-4a2c-8317-90d35a1a423d)

![image](https://github.com/rerun-io/rerun/assets/1148717/c4005fd2-00c4-44bb-a120-f114f4e2bff8)

![image](https://github.com/rerun-io/rerun/assets/1148717/9844c977-d7a1-49a1-8255-e659288991ee)

![image](https://github.com/rerun-io/rerun/assets/1148717/6546b29f-2107-4713-bfe2-be1efd2cae1e)

![image](https://github.com/rerun-io/rerun/assets/1148717/05353922-02fb-4293-89c7-6b8372240e2b)
