### PR TITLE
Exclude from `objectron/proto/objectron/proto.py` from `just py-format`

### DIFF
--- a/justfile
+++ b/justfile
@@ -62,7 +62,8 @@ py-format:
     set -euxo pipefail
     black --config rerun_py/pyproject.toml {{py_folders}}
     blackdoc {{py_folders}}
-    pyupgrade --py38-plus `find {{py_folders}} -name "*.py" -type f`
+    #Note: proto.py relies on old-style annotation to work, and pyupgrade is too opinionated to be disabled from comments
+    pyupgrade --py38-plus `find {{py_folders}} -name "*.py" -type f ! -path "examples/python/objectron/proto/objectron/proto.py"`
     ruff --fix --config rerun_py/pyproject.toml  {{py_folders}}
 
 # Check that all the requirements.txt files for all the examples are correct

--- a/justfile
+++ b/justfile
@@ -62,7 +62,8 @@ py-format:
     set -euxo pipefail
     black --config rerun_py/pyproject.toml {{py_folders}}
     blackdoc {{py_folders}}
-    #Note: proto.py relies on old-style annotation to work, and pyupgrade is too opinionated to be disabled from comments
+    # Note: proto.py relies on old-style annotation to work, and pyupgrade is too opinionated to be disabled from comments
+    # See https://github.com/rerun-io/rerun/pull/2559 for details
     pyupgrade --py38-plus `find {{py_folders}} -name "*.py" -type f ! -path "examples/python/objectron/proto/objectron/proto.py"`
     ruff --fix --config rerun_py/pyproject.toml  {{py_folders}}
 


### PR DESCRIPTION
### What

For some reason, `objectron/proto/objectron/proto.py` relies on old-style annotation, so it broke with #2361 and was subsequently fixed by #2559. `just py-format` insist on reverting that latest fix, so the file is explicitly excluded from `pyupgrade`. I used a pretty ugly hack because `pyupgrade` is [way too opinionated](https://github.com/asottile/pyupgrade/issues/809) to even accept comment-based disabling.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested https://demo.rerun.io/pr/2562 (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2562

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/4d0b2b4/docs
Examples preview: https://rerun.io/preview/4d0b2b4/examples
<!-- pr-link-docs:end -->
