### PR TITLE
add 'Dump datastore' command to palette

### DIFF
--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -56,6 +56,8 @@ pub enum UICommand {
     // Dev-tools:
     #[cfg(not(target_arch = "wasm32"))]
     ScreenshotWholeApp,
+    #[cfg(not(target_arch = "wasm32"))]
+    DumpDatastore,
 }
 
 impl UICommand {
@@ -143,6 +145,11 @@ impl UICommand {
                 "Screenshot",
                 "Copy screenshot of the whole app to clipboard",
             ),
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::DumpDatastore => (
+                "Dump datastore",
+                "Dumps the current state of the datastore to the console",
+            ),
         }
     }
 
@@ -207,6 +214,8 @@ impl UICommand {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ScreenshotWholeApp => None,
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::DumpDatastore => None,
         }
     }
 

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -57,7 +57,7 @@ pub enum UICommand {
     #[cfg(not(target_arch = "wasm32"))]
     ScreenshotWholeApp,
     #[cfg(not(target_arch = "wasm32"))]
-    DumpDatastore,
+    PrintDatastore,
 }
 
 impl UICommand {
@@ -146,9 +146,9 @@ impl UICommand {
                 "Copy screenshot of the whole app to clipboard",
             ),
             #[cfg(not(target_arch = "wasm32"))]
-            UICommand::DumpDatastore => (
-                "Dump datastore",
-                "Dumps the current state of the datastore to the console",
+            UICommand::PrintDatastore => (
+                "Print datastore",
+                "Prints the entire data store to the console. WARNING: this may be A LOT of text.",
             ),
         }
     }
@@ -215,7 +215,7 @@ impl UICommand {
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ScreenshotWholeApp => None,
             #[cfg(not(target_arch = "wasm32"))]
-            UICommand::DumpDatastore => None,
+            UICommand::PrintDatastore => None,
         }
     }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -406,7 +406,7 @@ impl App {
                 self.screenshotter.request_screenshot();
             }
             #[cfg(not(target_arch = "wasm32"))]
-            UICommand::DumpDatastore => {
+            UICommand::PrintDatastore => {
                 if let Some(ctx) = store_context {
                     if let Some(recording) = ctx.recording {
                         eprintln!("{}", recording.entity_db.data_store);

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -405,6 +405,14 @@ impl App {
             UICommand::ScreenshotWholeApp => {
                 self.screenshotter.request_screenshot();
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            UICommand::DumpDatastore => {
+                if let Some(ctx) = store_context {
+                    if let Some(recording) = ctx.recording {
+                        eprintln!("{}", recording.entity_db.data_store);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Credits to @abey79 for the great idea, see https://github.com/rerun-io/rerun/issues/404#issuecomment-1612545604.

Turns out I currently need this right now in order to debug some backported stuff, so here we go.

Far from the greatest debugger ever made, but infinitely better than the status quo.

---

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2564

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/3ea3463/docs
Examples preview: https://rerun.io/preview/3ea3463/examples
<!-- pr-link-docs:end -->
