### PR TITLE
Fix out-of-sync codegen hash

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-c19f042ca7d4df439ce98030fdd82f4c8be1fec2f1046a525c48f4a91d5dc0e6
+0960d9b4f6df9136f7857a7b7280a4803f3eba7a085c98aa1ce7c95dcd88539e


### PR DESCRIPTION
I screwed up one the many `rebase me on myself` and then merged too early, so now `main` is having a bad case of split personality disorder.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested https://demo.rerun.io/pr/2567 (if applicable)

<!-- This line will get updated when the PR build summary job finishes. -->
PR Build Summary: https://build.rerun.io/pr/2567

<!-- pr-link-docs:start -->
Docs preview: https://rerun.io/preview/73a3b8b/docs
Examples preview: https://rerun.io/preview/73a3b8b/examples
<!-- pr-link-docs:end -->
