### PR TITLE
Codegen'd Rust/Arrow (de)ser 8: carry extension metadata across transparency layers

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-7d42813c538b5c4716e75e225572409d5799dc142ede36243043ef82fc90399e
+128cd542f3f9e6cf3b2a44aeb022cd5f3ad819b00ce5371eeb311300f3e9a7f1

--- a/crates/re_types/src/archetypes/fuzzy.rs
+++ b/crates/re_types/src/archetypes/fuzzy.rs
@@ -140,7 +140,8 @@ impl crate::Archetype for AffixFuzzer1 {
         Ok([
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer1>::try_to_arrow([&self.fuzz1001]);
+                    let array =
+                        <crate::components::AffixFuzzer1>::try_to_arrow([&self.fuzz1001], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -153,7 +154,8 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer2>::try_to_arrow([&self.fuzz1002]);
+                    let array =
+                        <crate::components::AffixFuzzer2>::try_to_arrow([&self.fuzz1002], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -166,7 +168,8 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer3>::try_to_arrow([&self.fuzz1003]);
+                    let array =
+                        <crate::components::AffixFuzzer3>::try_to_arrow([&self.fuzz1003], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -179,7 +182,8 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer4>::try_to_arrow([&self.fuzz1004]);
+                    let array =
+                        <crate::components::AffixFuzzer4>::try_to_arrow([&self.fuzz1004], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -192,7 +196,8 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer5>::try_to_arrow([&self.fuzz1005]);
+                    let array =
+                        <crate::components::AffixFuzzer5>::try_to_arrow([&self.fuzz1005], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -205,7 +210,8 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer6>::try_to_arrow([&self.fuzz1006]);
+                    let array =
+                        <crate::components::AffixFuzzer6>::try_to_arrow([&self.fuzz1006], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -218,7 +224,8 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 Some({
-                    let array = <crate::components::AffixFuzzer7>::try_to_arrow([&self.fuzz1007]);
+                    let array =
+                        <crate::components::AffixFuzzer7>::try_to_arrow([&self.fuzz1007], None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -232,7 +239,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer1>::try_to_arrow(self.fuzz1101.iter());
+                        <crate::components::AffixFuzzer1>::try_to_arrow(self.fuzz1101.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -246,7 +253,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer2>::try_to_arrow(self.fuzz1102.iter());
+                        <crate::components::AffixFuzzer2>::try_to_arrow(self.fuzz1102.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -260,7 +267,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer3>::try_to_arrow(self.fuzz1103.iter());
+                        <crate::components::AffixFuzzer3>::try_to_arrow(self.fuzz1103.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -274,7 +281,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer4>::try_to_arrow(self.fuzz1104.iter());
+                        <crate::components::AffixFuzzer4>::try_to_arrow(self.fuzz1104.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -288,7 +295,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer5>::try_to_arrow(self.fuzz1105.iter());
+                        <crate::components::AffixFuzzer5>::try_to_arrow(self.fuzz1105.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -302,7 +309,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer6>::try_to_arrow(self.fuzz1106.iter());
+                        <crate::components::AffixFuzzer6>::try_to_arrow(self.fuzz1106.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -316,7 +323,7 @@ impl crate::Archetype for AffixFuzzer1 {
             {
                 Some({
                     let array =
-                        <crate::components::AffixFuzzer7>::try_to_arrow(self.fuzz1107.iter());
+                        <crate::components::AffixFuzzer7>::try_to_arrow(self.fuzz1107.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -331,7 +338,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2001
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer1>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer1>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -346,7 +353,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2002
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer2>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer2>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -361,7 +368,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2003
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer3>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer3>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -376,7 +383,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2004
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer4>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer4>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -391,7 +398,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2005
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer5>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer5>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -406,7 +413,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2006
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer6>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer6>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -421,7 +428,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2007
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::AffixFuzzer7>::try_to_arrow([single]);
+                        let array = <crate::components::AffixFuzzer7>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -436,7 +443,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2101
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer1>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer1>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -451,7 +459,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2102
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer2>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer2>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -466,7 +475,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2103
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer3>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer3>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -481,7 +491,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2104
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer4>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer4>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -496,7 +507,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2105
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer5>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer5>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -511,7 +523,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2106
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer6>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer6>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -526,7 +539,8 @@ impl crate::Archetype for AffixFuzzer1 {
                 self.fuzz2107
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::AffixFuzzer7>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::AffixFuzzer7>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -108,7 +108,8 @@ impl crate::Archetype for Points2D {
         Ok([
             {
                 Some({
-                    let array = <crate::components::Point2D>::try_to_arrow(self.points.iter());
+                    let array =
+                        <crate::components::Point2D>::try_to_arrow(self.points.iter(), None);
                     array.map(|array| {
                         let datatype = array.data_type().clone();
                         (
@@ -123,7 +124,7 @@ impl crate::Archetype for Points2D {
                 self.radii
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::Radius>::try_to_arrow(many.iter());
+                        let array = <crate::components::Radius>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -138,7 +139,7 @@ impl crate::Archetype for Points2D {
                 self.colors
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::Color>::try_to_arrow(many.iter());
+                        let array = <crate::components::Color>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -153,7 +154,7 @@ impl crate::Archetype for Points2D {
                 self.labels
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::Label>::try_to_arrow(many.iter());
+                        let array = <crate::components::Label>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -168,7 +169,7 @@ impl crate::Archetype for Points2D {
                 self.draw_order
                     .as_ref()
                     .map(|single| {
-                        let array = <crate::components::DrawOrder>::try_to_arrow([single]);
+                        let array = <crate::components::DrawOrder>::try_to_arrow([single], None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -183,7 +184,7 @@ impl crate::Archetype for Points2D {
                 self.class_ids
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::ClassId>::try_to_arrow(many.iter());
+                        let array = <crate::components::ClassId>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -198,7 +199,8 @@ impl crate::Archetype for Points2D {
                 self.keypoint_ids
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::KeypointId>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::KeypointId>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (
@@ -213,7 +215,8 @@ impl crate::Archetype for Points2D {
                 self.instance_keys
                     .as_ref()
                     .map(|many| {
-                        let array = <crate::components::InstanceKey>::try_to_arrow(many.iter());
+                        let array =
+                            <crate::components::InstanceKey>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
                             let datatype = array.data_type().clone();
                             (

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -48,6 +48,7 @@ impl crate::Component for ClassId {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -71,7 +72,14 @@ impl crate::Component for ClassId {
                 any_nones.then(|| somes.into())
             };
             PrimitiveArray::new(
-                DataType::UInt16,
+                {
+                    _ = extension_wrapper;
+                    DataType::Extension(
+                        "rerun.components.ClassId".to_owned(),
+                        Box::new(DataType::UInt16),
+                        None,
+                    )
+                },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,
             )
@@ -96,11 +104,7 @@ impl crate::Component for ClassId {
             .map(|v| v.copied())
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.components.ClassId".to_owned(),
-                        Box::new(DataType::UInt16),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|v| Some(Self(v))))

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -58,6 +58,7 @@ impl crate::Component for Color {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -81,7 +82,14 @@ impl crate::Component for Color {
                 any_nones.then(|| somes.into())
             };
             PrimitiveArray::new(
-                DataType::UInt32,
+                {
+                    _ = extension_wrapper;
+                    DataType::Extension(
+                        "rerun.components.Color".to_owned(),
+                        Box::new(DataType::UInt32),
+                        None,
+                    )
+                },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,
             )
@@ -106,11 +114,7 @@ impl crate::Component for Color {
             .map(|v| v.copied())
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.components.Color".to_owned(),
-                        Box::new(DataType::UInt32),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|v| Some(Self(v))))

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -103,6 +103,7 @@ impl crate::Component for AffixFuzzer1 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -127,7 +128,11 @@ impl crate::Component for AffixFuzzer1 {
             };
             {
                 _ = single_required_bitmap;
-                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_required)?
+                _ = extension_wrapper;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                    single_required,
+                    Some("rerun.testing.components.AffixFuzzer1"),
+                )?
             }
         })
     }
@@ -145,67 +150,7 @@ impl crate::Component for AffixFuzzer1 {
             .into_iter()
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.testing.components.AffixFuzzer1".to_owned(),
-                        Box::new(DataType::Extension(
-                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                            Box::new(DataType::Struct(vec![
-                                Field {
-                                    name: "single_float_optional".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_required".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_optional".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_floats_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_required".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ])),
-                            None,
-                        )),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|single_required| Some(Self { single_required })))
@@ -306,6 +251,7 @@ impl crate::Component for AffixFuzzer2 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -330,7 +276,11 @@ impl crate::Component for AffixFuzzer2 {
             };
             {
                 _ = data0_bitmap;
-                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(data0)?
+                _ = extension_wrapper;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                    data0,
+                    Some("rerun.testing.components.AffixFuzzer2"),
+                )?
             }
         })
     }
@@ -348,67 +298,7 @@ impl crate::Component for AffixFuzzer2 {
             .into_iter()
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.testing.components.AffixFuzzer2".to_owned(),
-                        Box::new(DataType::Extension(
-                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                            Box::new(DataType::Struct(vec![
-                                Field {
-                                    name: "single_float_optional".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_required".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_optional".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_floats_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_required".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ])),
-                            None,
-                        )),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|v| Some(Self(v))))
@@ -516,6 +406,7 @@ impl crate::Component for AffixFuzzer3 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -535,72 +426,15 @@ impl crate::Component for AffixFuzzer3 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                DataType::Extension(
-                    "rerun.testing.components.AffixFuzzer3".to_owned(),
-                    Box::new(DataType::Struct(vec![Field {
-                        name: "single_required".to_owned(),
-                        data_type: DataType::Extension(
-                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                            Box::new(DataType::Struct(vec![
-                                Field {
-                                    name: "single_float_optional".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_required".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_optional".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_floats_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_required".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ])),
-                            None,
-                        ),
-                        is_nullable: false,
-                        metadata: [].into(),
-                    }])),
-                    None,
-                ),
+                if let Some(ext) = extension_wrapper {
+                    DataType::Extension(
+                        ext.to_owned(),
+                        Box::new(<crate::components::AffixFuzzer3>::to_arrow_datatype()),
+                        None,
+                    )
+                } else {
+                    <crate::components::AffixFuzzer3>::to_arrow_datatype()
+                },
                 vec![{
                     let (somes, single_required): (Vec<_>, Vec<_>) = data
                         .iter()
@@ -620,7 +454,11 @@ impl crate::Component for AffixFuzzer3 {
                     };
                     {
                         _ = single_required_bitmap;
-                        crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_required)?
+                        _ = extension_wrapper;
+                        crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                            single_required,
+                            None::<&str>,
+                        )?
                     }
                 }],
                 bitmap,
@@ -643,72 +481,7 @@ impl crate::Component for AffixFuzzer3 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::StructArray>()
                 .ok_or_else(|| crate::DeserializationError::SchemaMismatch {
-                    expected: DataType::Extension(
-                        "rerun.testing.components.AffixFuzzer3".to_owned(),
-                        Box::new(DataType::Struct(vec![Field {
-                            name: "single_required".to_owned(),
-                            data_type: DataType::Extension(
-                                "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                Box::new(DataType::Struct(vec![
-                                    Field {
-                                        name: "single_float_optional".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "single_string_required".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "single_string_optional".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_floats_optional".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_strings_required".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_strings_optional".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                ])),
-                                None,
-                            ),
-                            is_nullable: false,
-                            metadata: [].into(),
-                        }])),
-                        None,
-                    ),
+                    expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
             let (data_fields, data_arrays, data_bitmap) =
@@ -732,84 +505,7 @@ impl crate::Component for AffixFuzzer3 {
                             Ok(Self {
                                 single_required: single_required.ok_or_else(|| {
                                     crate::DeserializationError::MissingData {
-                                        datatype: DataType::Extension(
-                                            "rerun.testing.components.AffixFuzzer3".to_owned(),
-                                            Box::new(DataType::Struct(vec![Field {
-                                                name: "single_required".to_owned(),
-                                                data_type: DataType::Extension(
-                                                    "rerun.testing.datatypes.AffixFuzzer1"
-                                                        .to_owned(),
-                                                    Box::new(DataType::Struct(vec![
-                                                        Field {
-                                                            name: "single_float_optional"
-                                                                .to_owned(),
-                                                            data_type: DataType::Float32,
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "single_string_required"
-                                                                .to_owned(),
-                                                            data_type: DataType::Utf8,
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "single_string_optional"
-                                                                .to_owned(),
-                                                            data_type: DataType::Utf8,
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "many_floats_optional".to_owned(),
-                                                            data_type: DataType::List(Box::new(
-                                                                Field {
-                                                                    name: "item".to_owned(),
-                                                                    data_type: DataType::Float32,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            )),
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "many_strings_required"
-                                                                .to_owned(),
-                                                            data_type: DataType::List(Box::new(
-                                                                Field {
-                                                                    name: "item".to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            )),
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "many_strings_optional"
-                                                                .to_owned(),
-                                                            data_type: DataType::List(Box::new(
-                                                                Field {
-                                                                    name: "item".to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            )),
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                    ])),
-                                                    None,
-                                                ),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            }])),
-                                            None,
-                                        ),
+                                        datatype: data.data_type().clone(),
                                     }
                                 })?,
                             })
@@ -916,6 +612,7 @@ impl crate::Component for AffixFuzzer4 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -942,7 +639,11 @@ impl crate::Component for AffixFuzzer4 {
             };
             {
                 _ = single_optional_bitmap;
-                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_optional)?
+                _ = extension_wrapper;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                    single_optional,
+                    Some("rerun.testing.components.AffixFuzzer4"),
+                )?
             }
         })
     }
@@ -1057,6 +758,7 @@ impl crate::Component for AffixFuzzer5 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -1083,7 +785,11 @@ impl crate::Component for AffixFuzzer5 {
             };
             {
                 _ = data0_bitmap;
-                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(data0)?
+                _ = extension_wrapper;
+                crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                    data0,
+                    Some("rerun.testing.components.AffixFuzzer5"),
+                )?
             }
         })
     }
@@ -1205,6 +911,7 @@ impl crate::Component for AffixFuzzer6 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -1224,72 +931,15 @@ impl crate::Component for AffixFuzzer6 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                DataType::Extension(
-                    "rerun.testing.components.AffixFuzzer6".to_owned(),
-                    Box::new(DataType::Struct(vec![Field {
-                        name: "single_optional".to_owned(),
-                        data_type: DataType::Extension(
-                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                            Box::new(DataType::Struct(vec![
-                                Field {
-                                    name: "single_float_optional".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_required".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_optional".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_floats_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_required".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ])),
-                            None,
-                        ),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    }])),
-                    None,
-                ),
+                if let Some(ext) = extension_wrapper {
+                    DataType::Extension(
+                        ext.to_owned(),
+                        Box::new(<crate::components::AffixFuzzer6>::to_arrow_datatype()),
+                        None,
+                    )
+                } else {
+                    <crate::components::AffixFuzzer6>::to_arrow_datatype()
+                },
                 vec![{
                     let (somes, single_optional): (Vec<_>, Vec<_>) = data
                         .iter()
@@ -1312,7 +962,11 @@ impl crate::Component for AffixFuzzer6 {
                     };
                     {
                         _ = single_optional_bitmap;
-                        crate::datatypes::AffixFuzzer1::try_to_arrow_opt(single_optional)?
+                        _ = extension_wrapper;
+                        crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
+                            single_optional,
+                            None::<&str>,
+                        )?
                     }
                 }],
                 bitmap,
@@ -1335,72 +989,7 @@ impl crate::Component for AffixFuzzer6 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::StructArray>()
                 .ok_or_else(|| crate::DeserializationError::SchemaMismatch {
-                    expected: DataType::Extension(
-                        "rerun.testing.components.AffixFuzzer6".to_owned(),
-                        Box::new(DataType::Struct(vec![Field {
-                            name: "single_optional".to_owned(),
-                            data_type: DataType::Extension(
-                                "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                Box::new(DataType::Struct(vec![
-                                    Field {
-                                        name: "single_float_optional".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "single_string_required".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "single_string_optional".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_floats_optional".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_strings_required".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_strings_optional".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                ])),
-                                None,
-                            ),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        }])),
-                        None,
-                    ),
+                    expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
             let (data_fields, data_arrays, data_bitmap) =
@@ -1592,6 +1181,7 @@ impl crate::Component for AffixFuzzer7 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -1611,130 +1201,15 @@ impl crate::Component for AffixFuzzer7 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                DataType::Extension(
-                    "rerun.testing.components.AffixFuzzer7".to_owned(),
-                    Box::new(DataType::Struct(vec![
-                        Field {
-                            name: "many_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Extension(
-                                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                    Box::new(DataType::Struct(vec![
-                                        Field {
-                                            name: "single_float_optional".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "single_string_required".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "single_string_optional".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "many_floats_optional".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "many_strings_required".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "many_strings_optional".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        },
-                                    ])),
-                                    None,
-                                ),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_float_optional".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_required".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_optional".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_floats_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_required".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                    ])),
-                    None,
-                ),
+                if let Some(ext) = extension_wrapper {
+                    DataType::Extension(
+                        ext.to_owned(),
+                        Box::new(<crate::components::AffixFuzzer7>::to_arrow_datatype()),
+                        None,
+                    )
+                } else {
+                    <crate::components::AffixFuzzer7>::to_arrow_datatype()
+                },
                 vec![
                     {
                         let (somes, many_optional): (Vec<_>, Vec<_>) = data
@@ -1781,73 +1256,78 @@ impl crate::Component for AffixFuzzer7 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Extension(
-                                        "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                        Box::new(DataType::Struct(vec![
-                                            Field {
-                                                name: "single_float_optional".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_required".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_optional".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_floats_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Extension(
+                                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
+                                            Box::new(DataType::Struct(vec![
+                                                Field {
+                                                    name: "single_float_optional".to_owned(),
                                                     data_type: DataType::Float32,
                                                     is_nullable: true,
                                                     metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_required".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
+                                                },
+                                                Field {
+                                                    name: "single_string_required".to_owned(),
                                                     data_type: DataType::Utf8,
                                                     is_nullable: false,
                                                     metadata: [].into(),
-                                                })),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
+                                                },
+                                                Field {
+                                                    name: "single_string_optional".to_owned(),
                                                     data_type: DataType::Utf8,
                                                     is_nullable: true,
                                                     metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                        ])),
-                                        None,
-                                    ),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
+                                                },
+                                                Field {
+                                                    name: "many_floats_optional".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Float32,
+                                                        is_nullable: true,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_strings_required".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Utf8,
+                                                        is_nullable: false,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_strings_optional".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Utf8,
+                                                        is_nullable: true,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                            ])),
+                                            None,
+                                        ),
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 {
                                     _ = many_optional_inner_bitmap;
+                                    _ = extension_wrapper;
                                     crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
                                         many_optional_inner_data,
+                                        None::<&str>,
                                     )?
                                 },
                                 many_optional_bitmap,
@@ -1877,7 +1357,10 @@ impl crate::Component for AffixFuzzer7 {
                             any_nones.then(|| somes.into())
                         };
                         PrimitiveArray::new(
-                            DataType::Float32,
+                            {
+                                _ = extension_wrapper;
+                                DataType::Float32
+                            },
                             single_float_optional
                                 .into_iter()
                                 .map(|v| v.unwrap_or_default())
@@ -1920,7 +1403,10 @@ impl crate::Component for AffixFuzzer7 {
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
-                                    DataType::Utf8,
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Utf8
+                                    },
                                     offsets,
                                     inner_data,
                                     single_string_required_bitmap,
@@ -1966,7 +1452,10 @@ impl crate::Component for AffixFuzzer7 {
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
-                                    DataType::Utf8,
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Utf8
+                                    },
                                     offsets,
                                     inner_data,
                                     single_string_optional_bitmap,
@@ -2025,15 +1514,21 @@ impl crate::Component for AffixFuzzer7 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 PrimitiveArray::new(
-                                    DataType::Float32,
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Float32
+                                    },
                                     many_floats_optional_inner_data
                                         .into_iter()
                                         .map(|v| v.unwrap_or_default())
@@ -2093,12 +1588,15 @@ impl crate::Component for AffixFuzzer7 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                })),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 {
                                     let inner_data: ::arrow2::buffer::Buffer<u8> =
@@ -2120,7 +1618,10 @@ impl crate::Component for AffixFuzzer7 {
                                     #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                     unsafe {
                                         Utf8Array::<i32>::new_unchecked(
-                                            DataType::Utf8,
+                                            {
+                                                _ = extension_wrapper;
+                                                DataType::Utf8
+                                            },
                                             offsets,
                                             inner_data,
                                             many_strings_required_inner_bitmap,
@@ -2183,12 +1684,15 @@ impl crate::Component for AffixFuzzer7 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 {
                                     let inner_data: ::arrow2::buffer::Buffer<u8> =
@@ -2210,7 +1714,10 @@ impl crate::Component for AffixFuzzer7 {
                                     #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                     unsafe {
                                         Utf8Array::<i32>::new_unchecked(
-                                            DataType::Utf8,
+                                            {
+                                                _ = extension_wrapper;
+                                                DataType::Utf8
+                                            },
                                             offsets,
                                             inner_data,
                                             many_strings_optional_inner_bitmap,
@@ -2244,130 +1751,7 @@ impl crate::Component for AffixFuzzer7 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::StructArray>()
                 .ok_or_else(|| crate::DeserializationError::SchemaMismatch {
-                    expected: DataType::Extension(
-                        "rerun.testing.components.AffixFuzzer7".to_owned(),
-                        Box::new(DataType::Struct(vec![
-                            Field {
-                                name: "many_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Extension(
-                                        "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                        Box::new(DataType::Struct(vec![
-                                            Field {
-                                                name: "single_float_optional".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_required".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_optional".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_floats_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_required".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                        ])),
-                                        None,
-                                    ),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_float_optional".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_string_required".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_string_optional".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_floats_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_strings_required".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_strings_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                        ])),
-                        None,
-                    ),
+                    expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
             let (data_fields, data_arrays, data_bitmap) =
@@ -2382,6 +1766,7 @@ impl crate::Component for AffixFuzzer7 {
                 let data = &**arrays_by_name["many_optional"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -2469,82 +1854,7 @@ impl crate::Component for AffixFuzzer7 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Extension(
-                                                        "rerun.testing.datatypes.AffixFuzzer1"
-                                                            .to_owned(),
-                                                        Box::new(DataType::Struct(vec![
-                                                            Field {
-                                                                name: "single_float_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Float32,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "single_string_required"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Utf8,
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "single_string_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Utf8,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_floats_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type:
-                                                                            DataType::Float32,
-                                                                        is_nullable: true,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_strings_required"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type: DataType::Utf8,
-                                                                        is_nullable: false,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_strings_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type: DataType::Utf8,
-                                                                        is_nullable: true,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                        ])),
-                                                        None,
-                                                    ),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -2586,6 +1896,7 @@ impl crate::Component for AffixFuzzer7 {
                 let data = &**arrays_by_name["many_floats_optional"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -2621,12 +1932,7 @@ impl crate::Component for AffixFuzzer7 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -2641,6 +1947,7 @@ impl crate::Component for AffixFuzzer7 {
                 let data = &**arrays_by_name["many_strings_required"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -2676,12 +1983,7 @@ impl crate::Component for AffixFuzzer7 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -2696,6 +1998,7 @@ impl crate::Component for AffixFuzzer7 {
                 let data = &**arrays_by_name["many_strings_optional"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -2731,12 +2034,7 @@ impl crate::Component for AffixFuzzer7 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -2777,292 +2075,14 @@ impl crate::Component for AffixFuzzer7 {
                                 single_float_optional,
                                 single_string_required: single_string_required.ok_or_else(
                                     || crate::DeserializationError::MissingData {
-                                        datatype: DataType::Extension(
-                                            "rerun.testing.components.AffixFuzzer7".to_owned(),
-                                            Box::new(DataType::Struct(vec![
-                                                Field {
-                                                    name: "many_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Extension(
-                                                            "rerun.testing.datatypes.AffixFuzzer1"
-                                                                .to_owned(),
-                                                            Box::new(DataType::Struct(vec![
-                                                                Field {
-                                                                    name: "single_float_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::Float32,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "single_string_required"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "single_string_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "many_floats_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::List(
-                                                                        Box::new(Field {
-                                                                            name: "item".to_owned(),
-                                                                            data_type:
-                                                                                DataType::Float32,
-                                                                            is_nullable: true,
-                                                                            metadata: [].into(),
-                                                                        }),
-                                                                    ),
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "many_strings_required"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::List(
-                                                                        Box::new(Field {
-                                                                            name: "item".to_owned(),
-                                                                            data_type:
-                                                                                DataType::Utf8,
-                                                                            is_nullable: false,
-                                                                            metadata: [].into(),
-                                                                        }),
-                                                                    ),
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "many_strings_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::List(
-                                                                        Box::new(Field {
-                                                                            name: "item".to_owned(),
-                                                                            data_type:
-                                                                                DataType::Utf8,
-                                                                            is_nullable: true,
-                                                                            metadata: [].into(),
-                                                                        }),
-                                                                    ),
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            ])),
-                                                            None,
-                                                        ),
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_float_optional".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_required".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_optional".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_floats_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_required".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                            ])),
-                                            None,
-                                        ),
+                                        datatype: data.data_type().clone(),
                                     },
                                 )?,
                                 single_string_optional,
                                 many_floats_optional,
                                 many_strings_required: many_strings_required.ok_or_else(|| {
                                     crate::DeserializationError::MissingData {
-                                        datatype: DataType::Extension(
-                                            "rerun.testing.components.AffixFuzzer7".to_owned(),
-                                            Box::new(DataType::Struct(vec![
-                                                Field {
-                                                    name: "many_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Extension(
-                                                            "rerun.testing.datatypes.AffixFuzzer1"
-                                                                .to_owned(),
-                                                            Box::new(DataType::Struct(vec![
-                                                                Field {
-                                                                    name: "single_float_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::Float32,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "single_string_required"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "single_string_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "many_floats_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::List(
-                                                                        Box::new(Field {
-                                                                            name: "item".to_owned(),
-                                                                            data_type:
-                                                                                DataType::Float32,
-                                                                            is_nullable: true,
-                                                                            metadata: [].into(),
-                                                                        }),
-                                                                    ),
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "many_strings_required"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::List(
-                                                                        Box::new(Field {
-                                                                            name: "item".to_owned(),
-                                                                            data_type:
-                                                                                DataType::Utf8,
-                                                                            is_nullable: false,
-                                                                            metadata: [].into(),
-                                                                        }),
-                                                                    ),
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                                Field {
-                                                                    name: "many_strings_optional"
-                                                                        .to_owned(),
-                                                                    data_type: DataType::List(
-                                                                        Box::new(Field {
-                                                                            name: "item".to_owned(),
-                                                                            data_type:
-                                                                                DataType::Utf8,
-                                                                            is_nullable: true,
-                                                                            metadata: [].into(),
-                                                                        }),
-                                                                    ),
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            ])),
-                                                            None,
-                                                        ),
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_float_optional".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_required".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_optional".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_floats_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_required".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                            ])),
-                                            None,
-                                        ),
+                                        datatype: data.data_type().clone(),
                                     }
                                 })?,
                                 many_strings_optional,

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -50,6 +50,7 @@ impl crate::Component for KeypointId {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -73,7 +74,14 @@ impl crate::Component for KeypointId {
                 any_nones.then(|| somes.into())
             };
             PrimitiveArray::new(
-                DataType::UInt16,
+                {
+                    _ = extension_wrapper;
+                    DataType::Extension(
+                        "rerun.components.KeypointId".to_owned(),
+                        Box::new(DataType::UInt16),
+                        None,
+                    )
+                },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,
             )
@@ -98,11 +106,7 @@ impl crate::Component for KeypointId {
             .map(|v| v.copied())
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.components.KeypointId".to_owned(),
-                        Box::new(DataType::UInt16),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|v| Some(Self(v))))

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -47,6 +47,7 @@ impl crate::Component for Label {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -82,7 +83,14 @@ impl crate::Component for Label {
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {
                     Utf8Array::<i32>::new_unchecked(
-                        DataType::Utf8,
+                        {
+                            _ = extension_wrapper;
+                            DataType::Extension(
+                                "rerun.components.Label".to_owned(),
+                                Box::new(DataType::Utf8),
+                                None,
+                            )
+                        },
                         offsets,
                         inner_data,
                         data0_bitmap,
@@ -110,11 +118,7 @@ impl crate::Component for Label {
             .map(|v| v.map(ToOwned::to_owned))
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.components.Label".to_owned(),
-                        Box::new(DataType::Utf8),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|v| Some(Self(v))))

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -62,6 +62,7 @@ impl crate::Component for Point2D {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -81,24 +82,15 @@ impl crate::Component for Point2D {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                DataType::Extension(
-                    "rerun.components.Point2D".to_owned(),
-                    Box::new(DataType::Struct(vec![
-                        Field {
-                            name: "x".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "y".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                    ])),
-                    None,
-                ),
+                if let Some(ext) = extension_wrapper {
+                    DataType::Extension(
+                        ext.to_owned(),
+                        Box::new(<crate::components::Point2D>::to_arrow_datatype()),
+                        None,
+                    )
+                } else {
+                    <crate::components::Point2D>::to_arrow_datatype()
+                },
                 vec![
                     {
                         let (somes, x): (Vec<_>, Vec<_>) = data
@@ -116,7 +108,10 @@ impl crate::Component for Point2D {
                             any_nones.then(|| somes.into())
                         };
                         PrimitiveArray::new(
-                            DataType::Float32,
+                            {
+                                _ = extension_wrapper;
+                                DataType::Float32
+                            },
                             x.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             x_bitmap,
                         )
@@ -138,7 +133,10 @@ impl crate::Component for Point2D {
                             any_nones.then(|| somes.into())
                         };
                         PrimitiveArray::new(
-                            DataType::Float32,
+                            {
+                                _ = extension_wrapper;
+                                DataType::Float32
+                            },
                             y.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             y_bitmap,
                         )
@@ -165,24 +163,7 @@ impl crate::Component for Point2D {
                 .as_any()
                 .downcast_ref::<::arrow2::array::StructArray>()
                 .ok_or_else(|| crate::DeserializationError::SchemaMismatch {
-                    expected: DataType::Extension(
-                        "rerun.components.Point2D".to_owned(),
-                        Box::new(DataType::Struct(vec![
-                            Field {
-                                name: "x".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "y".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                        ])),
-                        None,
-                    ),
+                    expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
             let (data_fields, data_arrays, data_bitmap) =
@@ -218,44 +199,10 @@ impl crate::Component for Point2D {
                         .then(|| {
                             Ok(Self {
                                 x: x.ok_or_else(|| crate::DeserializationError::MissingData {
-                                    datatype: DataType::Extension(
-                                        "rerun.components.Point2D".to_owned(),
-                                        Box::new(DataType::Struct(vec![
-                                            Field {
-                                                name: "x".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "y".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                        ])),
-                                        None,
-                                    ),
+                                    datatype: data.data_type().clone(),
                                 })?,
                                 y: y.ok_or_else(|| crate::DeserializationError::MissingData {
-                                    datatype: DataType::Extension(
-                                        "rerun.components.Point2D".to_owned(),
-                                        Box::new(DataType::Struct(vec![
-                                            Field {
-                                                name: "x".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "y".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                        ])),
-                                        None,
-                                    ),
+                                    datatype: data.data_type().clone(),
                                 })?,
                             })
                         })

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -46,6 +46,7 @@ impl crate::Component for Radius {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -69,7 +70,14 @@ impl crate::Component for Radius {
                 any_nones.then(|| somes.into())
             };
             PrimitiveArray::new(
-                DataType::Float32,
+                {
+                    _ = extension_wrapper;
+                    DataType::Extension(
+                        "rerun.components.Radius".to_owned(),
+                        Box::new(DataType::Float32),
+                        None,
+                    )
+                },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,
             )
@@ -94,11 +102,7 @@ impl crate::Component for Radius {
             .map(|v| v.copied())
             .map(|v| {
                 v.ok_or_else(|| crate::DeserializationError::MissingData {
-                    datatype: DataType::Extension(
-                        "rerun.components.Radius".to_owned(),
-                        Box::new(DataType::Float32),
-                        None,
-                    ),
+                    datatype: data.data_type().clone(),
                 })
             })
             .map(|res| res.map(|v| Some(Self(v))))

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -104,6 +104,7 @@ impl crate::Datatype for AffixFuzzer1 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -123,63 +124,15 @@ impl crate::Datatype for AffixFuzzer1 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                DataType::Extension(
-                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                    Box::new(DataType::Struct(vec![
-                        Field {
-                            name: "single_float_optional".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_required".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_optional".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_floats_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_required".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                    ])),
-                    None,
-                ),
+                if let Some(ext) = extension_wrapper {
+                    DataType::Extension(
+                        ext.to_owned(),
+                        Box::new(<crate::datatypes::AffixFuzzer1>::to_arrow_datatype()),
+                        None,
+                    )
+                } else {
+                    <crate::datatypes::AffixFuzzer1>::to_arrow_datatype()
+                },
                 vec![
                     {
                         let (somes, single_float_optional): (Vec<_>, Vec<_>) = data
@@ -203,7 +156,10 @@ impl crate::Datatype for AffixFuzzer1 {
                             any_nones.then(|| somes.into())
                         };
                         PrimitiveArray::new(
-                            DataType::Float32,
+                            {
+                                _ = extension_wrapper;
+                                DataType::Float32
+                            },
                             single_float_optional
                                 .into_iter()
                                 .map(|v| v.unwrap_or_default())
@@ -246,7 +202,10 @@ impl crate::Datatype for AffixFuzzer1 {
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
-                                    DataType::Utf8,
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Utf8
+                                    },
                                     offsets,
                                     inner_data,
                                     single_string_required_bitmap,
@@ -292,7 +251,10 @@ impl crate::Datatype for AffixFuzzer1 {
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
-                                    DataType::Utf8,
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Utf8
+                                    },
                                     offsets,
                                     inner_data,
                                     single_string_optional_bitmap,
@@ -351,15 +313,21 @@ impl crate::Datatype for AffixFuzzer1 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 PrimitiveArray::new(
-                                    DataType::Float32,
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Float32
+                                    },
                                     many_floats_optional_inner_data
                                         .into_iter()
                                         .map(|v| v.unwrap_or_default())
@@ -419,12 +387,15 @@ impl crate::Datatype for AffixFuzzer1 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                })),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 {
                                     let inner_data: ::arrow2::buffer::Buffer<u8> =
@@ -446,7 +417,10 @@ impl crate::Datatype for AffixFuzzer1 {
                                     #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                     unsafe {
                                         Utf8Array::<i32>::new_unchecked(
-                                            DataType::Utf8,
+                                            {
+                                                _ = extension_wrapper;
+                                                DataType::Utf8
+                                            },
                                             offsets,
                                             inner_data,
                                             many_strings_required_inner_bitmap,
@@ -509,12 +483,15 @@ impl crate::Datatype for AffixFuzzer1 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                },
                                 offsets,
                                 {
                                     let inner_data: ::arrow2::buffer::Buffer<u8> =
@@ -536,7 +513,10 @@ impl crate::Datatype for AffixFuzzer1 {
                                     #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                     unsafe {
                                         Utf8Array::<i32>::new_unchecked(
-                                            DataType::Utf8,
+                                            {
+                                                _ = extension_wrapper;
+                                                DataType::Utf8
+                                            },
                                             offsets,
                                             inner_data,
                                             many_strings_optional_inner_bitmap,
@@ -570,63 +550,7 @@ impl crate::Datatype for AffixFuzzer1 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::StructArray>()
                 .ok_or_else(|| crate::DeserializationError::SchemaMismatch {
-                    expected: DataType::Extension(
-                        "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                        Box::new(DataType::Struct(vec![
-                            Field {
-                                name: "single_float_optional".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_string_required".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_string_optional".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_floats_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_strings_required".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_strings_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                        ])),
-                        None,
-                    ),
+                    expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
             let (data_fields, data_arrays, data_bitmap) =
@@ -668,6 +592,7 @@ impl crate::Datatype for AffixFuzzer1 {
                 let data = &**arrays_by_name["many_floats_optional"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -703,12 +628,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -723,6 +643,7 @@ impl crate::Datatype for AffixFuzzer1 {
                 let data = &**arrays_by_name["many_strings_required"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -758,12 +679,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -778,6 +694,7 @@ impl crate::Datatype for AffixFuzzer1 {
                 let data = &**arrays_by_name["many_strings_optional"];
 
                 {
+                    let datatype = data.data_type();
                     let data = data
                         .as_any()
                         .downcast_ref::<::arrow2::array::ListArray<i32>>()
@@ -813,12 +730,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                             crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
-                                                datatype: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
+                                                datatype: datatype.clone(),
                                             }
                                         })?
                                         .to_vec())
@@ -856,126 +768,14 @@ impl crate::Datatype for AffixFuzzer1 {
                                 single_float_optional,
                                 single_string_required: single_string_required.ok_or_else(
                                     || crate::DeserializationError::MissingData {
-                                        datatype: DataType::Extension(
-                                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                            Box::new(DataType::Struct(vec![
-                                                Field {
-                                                    name: "single_float_optional".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_required".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_optional".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_floats_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_required".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                            ])),
-                                            None,
-                                        ),
+                                        datatype: data.data_type().clone(),
                                     },
                                 )?,
                                 single_string_optional,
                                 many_floats_optional,
                                 many_strings_required: many_strings_required.ok_or_else(|| {
                                     crate::DeserializationError::MissingData {
-                                        datatype: DataType::Extension(
-                                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                            Box::new(DataType::Struct(vec![
-                                                Field {
-                                                    name: "single_float_optional".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_required".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_optional".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_floats_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_required".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                            ])),
-                                            None,
-                                        ),
+                                        datatype: data.data_type().clone(),
                                     }
                                 })?,
                                 many_strings_optional,
@@ -1026,6 +826,7 @@ impl crate::Datatype for AffixFuzzer2 {
     #[allow(unused_imports, clippy::wildcard_imports)]
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
@@ -1051,7 +852,14 @@ impl crate::Datatype for AffixFuzzer2 {
                 any_nones.then(|| somes.into())
             };
             PrimitiveArray::new(
-                DataType::Float32,
+                {
+                    _ = extension_wrapper;
+                    DataType::Extension(
+                        "rerun.testing.datatypes.AffixFuzzer2".to_owned(),
+                        Box::new(DataType::Float32),
+                        None,
+                    )
+                },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -100,11 +100,12 @@ pub trait Datatype {
     #[inline]
     fn to_arrow<'a>(
         data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+        extension_wrapper: Option<&str>,
     ) -> Box<dyn ::arrow2::array::Array>
     where
         Self: Clone + 'a,
     {
-        Self::try_to_arrow_opt(data.into_iter().map(Some)).unwrap()
+        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper).unwrap()
     }
 
     /// Given an iterator of owned or reference values to the current [`Datatype`], serializes
@@ -116,11 +117,12 @@ pub trait Datatype {
     #[inline]
     fn try_to_arrow<'a>(
         data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+        extension_wrapper: Option<&str>,
     ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        Self::try_to_arrow_opt(data.into_iter().map(Some))
+        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper)
     }
 
     /// Given an iterator of options of owned or reference values to the current
@@ -134,11 +136,12 @@ pub trait Datatype {
     #[inline]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> Box<dyn ::arrow2::array::Array>
     where
         Self: Clone + 'a,
     {
-        Self::try_to_arrow_opt(data).unwrap()
+        Self::try_to_arrow_opt(data, extension_wrapper).unwrap()
     }
 
     /// Given an iterator of options of owned or reference values to the current
@@ -149,6 +152,7 @@ pub trait Datatype {
     /// For the non-fallible version, see [`Datatype::to_arrow_opt`].
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a;
@@ -238,11 +242,12 @@ pub trait Component {
     #[inline]
     fn to_arrow<'a>(
         data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+        extension_wrapper: Option<&str>,
     ) -> Box<dyn ::arrow2::array::Array>
     where
         Self: Clone + 'a,
     {
-        Self::try_to_arrow_opt(data.into_iter().map(Some)).unwrap()
+        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper).unwrap()
     }
 
     /// Given an iterator of owned or reference values to the current [`Component`], serializes
@@ -254,11 +259,12 @@ pub trait Component {
     #[inline]
     fn try_to_arrow<'a>(
         data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+        extension_wrapper: Option<&str>,
     ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        Self::try_to_arrow_opt(data.into_iter().map(Some))
+        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper)
     }
 
     /// Given an iterator of options of owned or reference values to the current
@@ -272,11 +278,12 @@ pub trait Component {
     #[inline]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> Box<dyn ::arrow2::array::Array>
     where
         Self: Clone + 'a,
     {
-        Self::try_to_arrow_opt(data).unwrap()
+        Self::try_to_arrow_opt(data, extension_wrapper).unwrap()
     }
 
     /// Given an iterator of options of owned or reference values to the current
@@ -287,6 +294,7 @@ pub trait Component {
     /// For the non-fallible version, see [`Component::to_arrow_opt`].
     fn try_to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
     ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: Clone + 'a;

--- a/crates/re_types/tests/fuzzy.rs
+++ b/crates/re_types/tests/fuzzy.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::redundant_clone)]
 
+use std::collections::HashMap;
+
 use re_types::{archetypes::AffixFuzzer1, Archetype as _};
 
 #[test]
@@ -123,6 +125,42 @@ fn roundtrip() {
     .with_fuzz2104([fuzzy4.clone(), fuzzy4.clone(), fuzzy4.clone()])
     .with_fuzz2106([fuzzy6.clone(), fuzzy6.clone(), fuzzy6.clone()]);
 
+    #[rustfmt::skip]
+    let expected_extensions: HashMap<_, _> = [
+        ("fuzz1001", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1002", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1003", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1004", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1005", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1006", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1007", vec!["rerun.testing.components.AffixFuzzer7", "rerun.testing.datatypes.AffixFuzzer1"]),
+
+        ("fuzz1101", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1102", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1103", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1104", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1105", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1106", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz1107", vec!["rerun.testing.components.AffixFuzzer7", "rerun.testing.datatypes.AffixFuzzer1"]),
+
+        ("fuzz2001", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2002", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2003", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2004", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2005", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2006", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2007", vec!["rerun.testing.components.AffixFuzzer7", "rerun.testing.datatypes.AffixFuzzer1"]),
+
+        ("fuzz2101", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2102", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2103", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2104", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2105", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2106", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
+        ("fuzz2107", vec!["rerun.testing.components.AffixFuzzer7", "rerun.testing.datatypes.AffixFuzzer1"]),
+    ]
+    .into();
+
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow();
     for (field, array) in &serialized {
@@ -130,8 +168,14 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name);
+        util::assert_extensions(
+            &**array,
+            expected_extensions[field.name.as_str()].as_slice(),
+        );
     }
 
     let deserialized = AffixFuzzer1::from_arrow(serialized);
     similar_asserts::assert_eq!(arch, deserialized);
 }
+
+mod util;

--- a/crates/re_types/tests/points2d.rs
+++ b/crates/re_types/tests/points2d.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use re_types::{archetypes::Points2D, components, Archetype as _};
 
 #[test]
@@ -44,6 +46,18 @@ fn roundtrip() {
         .with_instance_keys([u64::MAX - 1, u64::MAX]);
     similar_asserts::assert_eq!(expected, arch);
 
+    let expected_extensions: HashMap<_, _> = [
+        ("points", vec!["rerun.components.Point2D"]),
+        ("radii", vec!["rerun.components.Radius"]),
+        ("colors", vec!["rerun.components.Color"]),
+        ("labels", vec!["rerun.components.Label"]),
+        ("draw_order", vec!["rerun.components.DrawOrder"]),
+        ("class_ids", vec!["rerun.components.ClassId"]),
+        ("keypoint_ids", vec!["rerun.components.KeypointId"]),
+        ("instance_keys", vec!["rerun.components.InstanceKey"]),
+    ]
+    .into();
+
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow();
     for (field, array) in &serialized {
@@ -51,8 +65,14 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name);
+        util::assert_extensions(
+            &**array,
+            expected_extensions[field.name.as_str()].as_slice(),
+        );
     }
 
     let deserialized = Points2D::from_arrow(serialized);
     similar_asserts::assert_eq!(expected, deserialized);
 }
+
+mod util;

--- a/crates/re_types/tests/util.rs
+++ b/crates/re_types/tests/util.rs
@@ -1,0 +1,25 @@
+pub fn assert_extensions(array: &dyn ::arrow2::array::Array, expected: &[&str]) {
+    let mut extracted = vec![];
+    extract_extensions(array.data_type(), &mut extracted);
+    similar_asserts::assert_eq!(expected, extracted);
+}
+
+pub fn extract_extensions(datatype: &::arrow2::datatypes::DataType, acc: &mut Vec<String>) {
+    match datatype {
+        arrow2::datatypes::DataType::List(field)
+        | arrow2::datatypes::DataType::FixedSizeList(field, _)
+        | arrow2::datatypes::DataType::LargeList(field) => {
+            extract_extensions(field.data_type(), acc);
+        }
+        arrow2::datatypes::DataType::Struct(fields) => {
+            for field in fields {
+                extract_extensions(field.data_type(), acc);
+            }
+        }
+        arrow2::datatypes::DataType::Extension(fqname, inner, _) => {
+            acc.push(fqname.clone());
+            extract_extensions(inner, acc);
+        }
+        _ => {}
+    }
+}


### PR DESCRIPTION
**Best reviewed on a commit-by-commit basis; in particular the `rerun codegen` commit is nothing but generated code.**

This PR makes it so that arrow extension metadata doesn't get lost across transparency layers, and adds regression tests to make sure this doesn't happen again.

It also introduce simple codegen optimizations that greatly reduce the size of the output code (yay wasm!).

This is Rust only for now, we need things to stabilize on the Python side before we can apply the same kind of logic and tests.

---

- #2484
- #2485 
- #2487 
- #2545
- #2546
- #2549
- #2554
- #2570
- #2571

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)