### PR TITLE
Codegen'd Rust/Arrow (de)ser 9: Rust backport!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,6 +4279,7 @@ dependencies = [
  "re_log_types",
  "re_memory",
  "re_sdk_comms",
+ "re_types",
  "similar-asserts",
  "thiserror",
 ]

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -38,6 +38,7 @@ re_log_types.workspace = true
 re_log.workspace = true
 re_memory.workspace = true
 re_sdk_comms = { workspace = true, features = ["client"] }
+re_types = { workspace = true, features = ["ecolor", "glam"] }
 
 ahash.workspace = true
 crossbeam.workspace = true

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -94,6 +94,11 @@ pub mod coordinates {
     pub use re_components::coordinates::{Axis3, Handedness, Sign, SignedAxis3};
 }
 
+/// Experimental APIs, to try out upcoming Rerun features.
+pub mod experimental {
+    pub use re_types::{archetypes, components, datatypes, Archetype, Component, Datatype};
+}
+
 /// Re-exports of other crates.
 pub mod external {
     pub use re_log;

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -328,9 +328,6 @@ impl MsgSender {
         let timeless = self.timeless;
         let [row_standard, row_splats] = self.into_rows();
 
-        // dbg!(&row_standard);
-        // dbg!(&row_splats);
-
         if let Some(row_splats) = row_splats {
             rec_stream.record_row(row_splats, !timeless);
         }

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -1,4 +1,7 @@
-use re_log_types::{DataRow, DataTableError, InstanceKey, RowId, StoreId};
+use re_log_types::{
+    external::arrow2::datatypes::DataType, DataRow, DataTableError, InstanceKey, RowId, StoreId,
+};
+use re_types::Archetype;
 
 use crate::{
     log::DataCell,
@@ -100,6 +103,32 @@ impl MsgSender {
             instanced: Vec::new(),
             splatted: Vec::new(),
         }
+    }
+
+    /// Starts a new `MsgSender` for the given entity path, and fill it with the contents of the
+    /// passed-in [`Archetype`].
+    ///
+    /// WARNING: This is an experimental feature!
+    pub fn from_archetype(
+        ent_path: impl Into<EntityPath>,
+        arch: &impl Archetype,
+    ) -> Result<Self, MsgSenderError> {
+        let serialized = arch.to_arrow();
+
+        let mut this = Self::new(ent_path);
+        for (field, array) in serialized {
+            // NOTE: Unreachable, a top-level Field will always be a component, and thus an
+            // extension.
+            let DataType::Extension(_, _, legacy_fqname) = field.data_type else { unreachable!() };
+            this = this.with_cell(DataCell::from_arrow(
+                // NOTE: Unwrapping is safe as we always include the legacy fqname into the Field's
+                // metadata while migrating towards HOPE.
+                legacy_fqname.as_deref().unwrap().into(),
+                array,
+            ))?;
+        }
+
+        Ok(this)
     }
 
     /// Read the file at the given path and log it.
@@ -298,6 +327,9 @@ impl MsgSender {
 
         let timeless = self.timeless;
         let [row_standard, row_splats] = self.into_rows();
+
+        // dbg!(&row_standard);
+        // dbg!(&row_splats);
 
         if let Some(row_splats) = row_splats {
             rec_stream.record_row(row_splats, !timeless);

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-128cd542f3f9e6cf3b2a44aeb022cd5f3ad819b00ce5371eeb311300f3e9a7f1
+1bc85e88a4cba09634983459e912f32733988469df601cde17c710ecdacc7955

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-1bc85e88a4cba09634983459e912f32733988469df601cde17c710ecdacc7955
+e26b40398d30efb613c92ca5cd9352c34108f5acd86839ae336fb7124c963312

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-e26b40398d30efb613c92ca5cd9352c34108f5acd86839ae336fb7124c963312
+afc01539cb778ef699e8cef27436420fe8dc4ee078fdd56d874e2409b3749d88

--- a/crates/re_types/src/archetypes/fuzzy.rs
+++ b/crates/re_types/src/archetypes/fuzzy.rs
@@ -143,7 +143,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer1>::try_to_arrow([&self.fuzz1001], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer1".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer1".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1001", datatype, false),
                             array,
@@ -157,7 +161,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer2>::try_to_arrow([&self.fuzz1002], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer2".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer2".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1002", datatype, false),
                             array,
@@ -171,7 +179,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer3>::try_to_arrow([&self.fuzz1003], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer3".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer3".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1003", datatype, false),
                             array,
@@ -185,7 +197,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer4>::try_to_arrow([&self.fuzz1004], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer4".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer4".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1004", datatype, false),
                             array,
@@ -199,7 +215,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer5>::try_to_arrow([&self.fuzz1005], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer5".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer5".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1005", datatype, false),
                             array,
@@ -213,7 +233,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer6>::try_to_arrow([&self.fuzz1006], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer6".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer6".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1006", datatype, false),
                             array,
@@ -227,7 +251,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer7>::try_to_arrow([&self.fuzz1007], None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer7".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer7".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1007", datatype, false),
                             array,
@@ -241,7 +269,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer1>::try_to_arrow(self.fuzz1101.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer1".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer1".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1101", datatype, false),
                             array,
@@ -255,7 +287,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer2>::try_to_arrow(self.fuzz1102.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer2".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer2".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1102", datatype, false),
                             array,
@@ -269,7 +305,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer3>::try_to_arrow(self.fuzz1103.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer3".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer3".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1103", datatype, false),
                             array,
@@ -283,7 +323,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer4>::try_to_arrow(self.fuzz1104.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer4".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer4".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1104", datatype, false),
                             array,
@@ -297,7 +341,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer5>::try_to_arrow(self.fuzz1105.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer5".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer5".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1105", datatype, false),
                             array,
@@ -311,7 +359,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer6>::try_to_arrow(self.fuzz1106.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer6".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer6".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1106", datatype, false),
                             array,
@@ -325,7 +377,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     let array =
                         <crate::components::AffixFuzzer7>::try_to_arrow(self.fuzz1107.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.testing.components.AffixFuzzer7".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.testing.components.AffixFuzzer7".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("fuzz1107", datatype, false),
                             array,
@@ -340,7 +396,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer1>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer1".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer1".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2001", datatype, false),
                                 array,
@@ -355,7 +415,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer2>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer2".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer2".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2002", datatype, false),
                                 array,
@@ -370,7 +434,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer3>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer3".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer3".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2003", datatype, false),
                                 array,
@@ -385,7 +453,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer4>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer4".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer4".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2004", datatype, false),
                                 array,
@@ -400,7 +472,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer5>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer5".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer5".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2005", datatype, false),
                                 array,
@@ -415,7 +491,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer6>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer6".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer6".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2006", datatype, false),
                                 array,
@@ -430,7 +510,11 @@ impl crate::Archetype for AffixFuzzer1 {
                     .map(|single| {
                         let array = <crate::components::AffixFuzzer7>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer7".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer7".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2007", datatype, false),
                                 array,
@@ -446,7 +530,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer1>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer1".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer1".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2101", datatype, false),
                                 array,
@@ -462,7 +550,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer2>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer2".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer2".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2102", datatype, false),
                                 array,
@@ -478,7 +570,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer3>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer3".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer3".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2103", datatype, false),
                                 array,
@@ -494,7 +590,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer4>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer4".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer4".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2104", datatype, false),
                                 array,
@@ -510,7 +610,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer5>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer5".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer5".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2105", datatype, false),
                                 array,
@@ -526,7 +630,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer6>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer6".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer6".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2106", datatype, false),
                                 array,
@@ -542,7 +650,11 @@ impl crate::Archetype for AffixFuzzer1 {
                         let array =
                             <crate::components::AffixFuzzer7>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.testing.components.AffixFuzzer7".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.testing.components.AffixFuzzer7".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("fuzz2107", datatype, false),
                                 array,

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -111,7 +111,11 @@ impl crate::Archetype for Points2D {
                     let array =
                         <crate::components::Point2D>::try_to_arrow(self.points.iter(), None);
                     array.map(|array| {
-                        let datatype = array.data_type().clone();
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.components.Point2D".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.point2d".into()),
+                        );
                         (
                             ::arrow2::datatypes::Field::new("points", datatype, false),
                             array,
@@ -126,7 +130,11 @@ impl crate::Archetype for Points2D {
                     .map(|many| {
                         let array = <crate::components::Radius>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.Radius".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.radius".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("radii", datatype, false),
                                 array,
@@ -141,7 +149,11 @@ impl crate::Archetype for Points2D {
                     .map(|many| {
                         let array = <crate::components::Color>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.Color".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.colorrgba".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("colors", datatype, false),
                                 array,
@@ -156,7 +168,11 @@ impl crate::Archetype for Points2D {
                     .map(|many| {
                         let array = <crate::components::Label>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.Label".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.label".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("labels", datatype, false),
                                 array,
@@ -171,7 +187,11 @@ impl crate::Archetype for Points2D {
                     .map(|single| {
                         let array = <crate::components::DrawOrder>::try_to_arrow([single], None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.DrawOrder".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.draw_order".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("draw_order", datatype, false),
                                 array,
@@ -186,7 +206,11 @@ impl crate::Archetype for Points2D {
                     .map(|many| {
                         let array = <crate::components::ClassId>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.ClassId".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.class_id".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("class_ids", datatype, false),
                                 array,
@@ -202,7 +226,11 @@ impl crate::Archetype for Points2D {
                         let array =
                             <crate::components::KeypointId>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.KeypointId".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.keypoint_id".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("keypoint_ids", datatype, false),
                                 array,
@@ -218,7 +246,11 @@ impl crate::Archetype for Points2D {
                         let array =
                             <crate::components::InstanceKey>::try_to_arrow(many.iter(), None);
                         array.map(|array| {
-                            let datatype = array.data_type().clone();
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.InstanceKey".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.instance_key".into()),
+                            );
                             (
                                 ::arrow2::datatypes::Field::new("instance_keys", datatype, false),
                                 array,

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -38,11 +38,7 @@ impl crate::Component for ClassId {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.ClassId".to_owned(),
-            Box::new(DataType::UInt16),
-            None,
-        )
+        DataType::UInt16
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -79,6 +75,8 @@ impl crate::Component for ClassId {
                         Box::new(DataType::UInt16),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -48,11 +48,7 @@ impl crate::Component for Color {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.Color".to_owned(),
-            Box::new(DataType::UInt32),
-            None,
-        )
+        DataType::UInt32
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -89,6 +85,8 @@ impl crate::Component for Color {
                         Box::new(DataType::UInt32),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -43,11 +43,7 @@ impl crate::Component for DrawOrder {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.DrawOrder".to_owned(),
-            Box::new(DataType::Float32),
-            None,
-        )
+        DataType::Float32
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -84,6 +80,8 @@ impl crate::Component for DrawOrder {
                         Box::new(DataType::Float32),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -37,67 +37,59 @@ impl crate::Component for AffixFuzzer1 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer1".to_owned(),
-            Box::new(DataType::Extension(
-                "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                Box::new(DataType::Struct(vec![
-                    Field {
-                        name: "single_float_optional".to_owned(),
-                        data_type: DataType::Float32,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_required".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_optional".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_floats_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_required".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                ])),
-                None,
-            )),
-            None,
-        )
+        DataType::Struct(vec![
+            Field {
+                name: "single_float_optional".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_required".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_optional".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_floats_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_required".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: false,
+                    metadata: [].into(),
+                })),
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -185,67 +177,59 @@ impl crate::Component for AffixFuzzer2 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer2".to_owned(),
-            Box::new(DataType::Extension(
-                "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                Box::new(DataType::Struct(vec![
-                    Field {
-                        name: "single_float_optional".to_owned(),
-                        data_type: DataType::Float32,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_required".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_optional".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_floats_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_required".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                ])),
-                None,
-            )),
-            None,
-        )
+        DataType::Struct(vec![
+            Field {
+                name: "single_float_optional".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_required".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_optional".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_floats_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_required".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: false,
+                    metadata: [].into(),
+                })),
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -335,72 +319,64 @@ impl crate::Component for AffixFuzzer3 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer3".to_owned(),
-            Box::new(DataType::Struct(vec![Field {
-                name: "single_required".to_owned(),
-                data_type: DataType::Extension(
-                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                    Box::new(DataType::Struct(vec![
-                        Field {
-                            name: "single_float_optional".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_required".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_optional".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_floats_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_required".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                    ])),
-                    None,
-                ),
-                is_nullable: false,
-                metadata: [].into(),
-            }])),
-            None,
-        )
+        DataType::Struct(vec![Field {
+            name: "single_required".to_owned(),
+            data_type: DataType::Struct(vec![
+                Field {
+                    name: "single_float_optional".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "single_string_required".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: false,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "single_string_optional".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "many_floats_optional".to_owned(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: "item".to_owned(),
+                        data_type: DataType::Float32,
+                        is_nullable: true,
+                        metadata: [].into(),
+                    })),
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "many_strings_required".to_owned(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: "item".to_owned(),
+                        data_type: DataType::Utf8,
+                        is_nullable: false,
+                        metadata: [].into(),
+                    })),
+                    is_nullable: false,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "many_strings_optional".to_owned(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: "item".to_owned(),
+                        data_type: DataType::Utf8,
+                        is_nullable: true,
+                        metadata: [].into(),
+                    })),
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+            ]),
+            is_nullable: false,
+            metadata: [].into(),
+        }])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -426,7 +402,7 @@ impl crate::Component for AffixFuzzer3 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                if let Some(ext) = extension_wrapper {
+                (if let Some(ext) = extension_wrapper {
                     DataType::Extension(
                         ext.to_owned(),
                         Box::new(<crate::components::AffixFuzzer3>::to_arrow_datatype()),
@@ -434,7 +410,9 @@ impl crate::Component for AffixFuzzer3 {
                     )
                 } else {
                     <crate::components::AffixFuzzer3>::to_arrow_datatype()
-                },
+                })
+                .to_logical_type()
+                .clone(),
                 vec![{
                     let (somes, single_required): (Vec<_>, Vec<_>) = data
                         .iter()
@@ -546,67 +524,59 @@ impl crate::Component for AffixFuzzer4 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer4".to_owned(),
-            Box::new(DataType::Extension(
-                "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                Box::new(DataType::Struct(vec![
-                    Field {
-                        name: "single_float_optional".to_owned(),
-                        data_type: DataType::Float32,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_required".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_optional".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_floats_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_required".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                ])),
-                None,
-            )),
-            None,
-        )
+        DataType::Struct(vec![
+            Field {
+                name: "single_float_optional".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_required".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_optional".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_floats_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_required".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: false,
+                    metadata: [].into(),
+                })),
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -692,67 +662,59 @@ impl crate::Component for AffixFuzzer5 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer5".to_owned(),
-            Box::new(DataType::Extension(
-                "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                Box::new(DataType::Struct(vec![
-                    Field {
-                        name: "single_float_optional".to_owned(),
-                        data_type: DataType::Float32,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_required".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "single_string_optional".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_floats_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_required".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: false,
-                        metadata: [].into(),
-                    },
-                    Field {
-                        name: "many_strings_optional".to_owned(),
-                        data_type: DataType::List(Box::new(Field {
-                            name: "item".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        })),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    },
-                ])),
-                None,
-            )),
-            None,
-        )
+        DataType::Struct(vec![
+            Field {
+                name: "single_float_optional".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_required".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_optional".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_floats_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_required".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: false,
+                    metadata: [].into(),
+                })),
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: true,
+                    metadata: [].into(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -840,72 +802,64 @@ impl crate::Component for AffixFuzzer6 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer6".to_owned(),
-            Box::new(DataType::Struct(vec![Field {
-                name: "single_optional".to_owned(),
-                data_type: DataType::Extension(
-                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                    Box::new(DataType::Struct(vec![
-                        Field {
-                            name: "single_float_optional".to_owned(),
-                            data_type: DataType::Float32,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_required".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "single_string_optional".to_owned(),
-                            data_type: DataType::Utf8,
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_floats_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_required".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: false,
-                            metadata: [].into(),
-                        },
-                        Field {
-                            name: "many_strings_optional".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            })),
-                            is_nullable: true,
-                            metadata: [].into(),
-                        },
-                    ])),
-                    None,
-                ),
-                is_nullable: true,
-                metadata: [].into(),
-            }])),
-            None,
-        )
+        DataType::Struct(vec![Field {
+            name: "single_optional".to_owned(),
+            data_type: DataType::Struct(vec![
+                Field {
+                    name: "single_float_optional".to_owned(),
+                    data_type: DataType::Float32,
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "single_string_required".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: false,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "single_string_optional".to_owned(),
+                    data_type: DataType::Utf8,
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "many_floats_optional".to_owned(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: "item".to_owned(),
+                        data_type: DataType::Float32,
+                        is_nullable: true,
+                        metadata: [].into(),
+                    })),
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "many_strings_required".to_owned(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: "item".to_owned(),
+                        data_type: DataType::Utf8,
+                        is_nullable: false,
+                        metadata: [].into(),
+                    })),
+                    is_nullable: false,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "many_strings_optional".to_owned(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: "item".to_owned(),
+                        data_type: DataType::Utf8,
+                        is_nullable: true,
+                        metadata: [].into(),
+                    })),
+                    is_nullable: true,
+                    metadata: [].into(),
+                },
+            ]),
+            is_nullable: true,
+            metadata: [].into(),
+        }])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -931,7 +885,7 @@ impl crate::Component for AffixFuzzer6 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                if let Some(ext) = extension_wrapper {
+                (if let Some(ext) = extension_wrapper {
                     DataType::Extension(
                         ext.to_owned(),
                         Box::new(<crate::components::AffixFuzzer6>::to_arrow_datatype()),
@@ -939,7 +893,9 @@ impl crate::Component for AffixFuzzer6 {
                     )
                 } else {
                     <crate::components::AffixFuzzer6>::to_arrow_datatype()
-                },
+                })
+                .to_logical_type()
+                .clone(),
                 vec![{
                     let (somes, single_optional): (Vec<_>, Vec<_>) = data
                         .iter()
@@ -1052,130 +1008,122 @@ impl crate::Component for AffixFuzzer7 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.components.AffixFuzzer7".to_owned(),
-            Box::new(DataType::Struct(vec![
-                Field {
-                    name: "many_optional".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Extension(
-                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                            Box::new(DataType::Struct(vec![
-                                Field {
-                                    name: "single_float_optional".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_required".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "single_string_optional".to_owned(),
-                                    data_type: DataType::Utf8,
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_floats_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_required".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_strings_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ])),
-                            None,
-                        ),
-                        is_nullable: true,
-                        metadata: [].into(),
-                    })),
+        DataType::Struct(vec![
+            Field {
+                name: "many_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
+                    data_type: DataType::Struct(vec![
+                        Field {
+                            name: "single_float_optional".to_owned(),
+                            data_type: DataType::Float32,
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_string_required".to_owned(),
+                            data_type: DataType::Utf8,
+                            is_nullable: false,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "single_string_optional".to_owned(),
+                            data_type: DataType::Utf8,
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_floats_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Float32,
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_strings_required".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Utf8,
+                                is_nullable: false,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: false,
+                            metadata: [].into(),
+                        },
+                        Field {
+                            name: "many_strings_optional".to_owned(),
+                            data_type: DataType::List(Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Utf8,
+                                is_nullable: true,
+                                metadata: [].into(),
+                            })),
+                            is_nullable: true,
+                            metadata: [].into(),
+                        },
+                    ]),
                     is_nullable: true,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "single_float_optional".to_owned(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_float_optional".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_required".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_optional".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_floats_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: true,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "single_string_required".to_owned(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_required".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "single_string_optional".to_owned(),
+                })),
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: true,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "many_floats_optional".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Float32,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    })),
-                    is_nullable: true,
-                    metadata: [].into(),
-                },
-                Field {
-                    name: "many_strings_required".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: false,
-                        metadata: [].into(),
-                    })),
-                    is_nullable: false,
-                    metadata: [].into(),
-                },
-                Field {
-                    name: "many_strings_optional".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    })),
-                    is_nullable: true,
-                    metadata: [].into(),
-                },
-            ])),
-            None,
-        )
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -1201,7 +1149,7 @@ impl crate::Component for AffixFuzzer7 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                if let Some(ext) = extension_wrapper {
+                (if let Some(ext) = extension_wrapper {
                     DataType::Extension(
                         ext.to_owned(),
                         Box::new(<crate::components::AffixFuzzer7>::to_arrow_datatype()),
@@ -1209,7 +1157,9 @@ impl crate::Component for AffixFuzzer7 {
                     )
                 } else {
                     <crate::components::AffixFuzzer7>::to_arrow_datatype()
-                },
+                })
+                .to_logical_type()
+                .clone(),
                 vec![
                     {
                         let (somes, many_optional): (Vec<_>, Vec<_>) = data
@@ -1260,66 +1210,64 @@ impl crate::Component for AffixFuzzer7 {
                                     _ = extension_wrapper;
                                     DataType::List(Box::new(Field {
                                         name: "item".to_owned(),
-                                        data_type: DataType::Extension(
-                                            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                            Box::new(DataType::Struct(vec![
-                                                Field {
-                                                    name: "single_float_optional".to_owned(),
+                                        data_type: DataType::Struct(vec![
+                                            Field {
+                                                name: "single_float_optional".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "single_string_required".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "single_string_optional".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_floats_optional".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
                                                     data_type: DataType::Float32,
                                                     is_nullable: true,
                                                     metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_required".to_owned(),
+                                                })),
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_strings_required".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
                                                     data_type: DataType::Utf8,
                                                     is_nullable: false,
                                                     metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "single_string_optional".to_owned(),
+                                                })),
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_strings_optional".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
                                                     data_type: DataType::Utf8,
                                                     is_nullable: true,
                                                     metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_floats_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_required".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "many_strings_optional".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                            ])),
-                                            None,
-                                        ),
+                                                })),
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                        ]),
                                         is_nullable: true,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -1359,7 +1307,7 @@ impl crate::Component for AffixFuzzer7 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32
+                                DataType::Float32.to_logical_type().clone()
                             },
                             single_float_optional
                                 .into_iter()
@@ -1405,7 +1353,7 @@ impl crate::Component for AffixFuzzer7 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -1454,7 +1402,7 @@ impl crate::Component for AffixFuzzer7 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -1522,12 +1470,14 @@ impl crate::Component for AffixFuzzer7 {
                                         is_nullable: true,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 PrimitiveArray::new(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Float32
+                                        DataType::Float32.to_logical_type().clone()
                                     },
                                     many_floats_optional_inner_data
                                         .into_iter()
@@ -1596,6 +1546,8 @@ impl crate::Component for AffixFuzzer7 {
                                         is_nullable: false,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -1620,7 +1572,7 @@ impl crate::Component for AffixFuzzer7 {
                                         Utf8Array::<i32>::new_unchecked(
                                             {
                                                 _ = extension_wrapper;
-                                                DataType::Utf8
+                                                DataType::Utf8.to_logical_type().clone()
                                             },
                                             offsets,
                                             inner_data,
@@ -1692,6 +1644,8 @@ impl crate::Component for AffixFuzzer7 {
                                         is_nullable: true,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -1716,7 +1670,7 @@ impl crate::Component for AffixFuzzer7 {
                                         Utf8Array::<i32>::new_unchecked(
                                             {
                                                 _ = extension_wrapper;
-                                                DataType::Utf8
+                                                DataType::Utf8.to_logical_type().clone()
                                             },
                                             offsets,
                                             inner_data,
@@ -1781,63 +1735,59 @@ impl crate::Component for AffixFuzzer7 {
                         .into_iter()
                         .map(|v| {
                             v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Extension(
-                                    "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-                                    Box::new(DataType::Struct(vec![
-                                        Field {
-                                            name: "single_float_optional".to_owned(),
+                                datatype: DataType::Struct(vec![
+                                    Field {
+                                        name: "single_float_optional".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "single_string_required".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "single_string_optional".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "many_floats_optional".to_owned(),
+                                        data_type: DataType::List(Box::new(Field {
+                                            name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: true,
                                             metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "single_string_required".to_owned(),
+                                        })),
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "many_strings_required".to_owned(),
+                                        data_type: DataType::List(Box::new(Field {
+                                            name: "item".to_owned(),
                                             data_type: DataType::Utf8,
                                             is_nullable: false,
                                             metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "single_string_optional".to_owned(),
+                                        })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "many_strings_optional".to_owned(),
+                                        data_type: DataType::List(Box::new(Field {
+                                            name: "item".to_owned(),
                                             data_type: DataType::Utf8,
                                             is_nullable: true,
                                             metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "many_floats_optional".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "many_strings_required".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "many_strings_optional".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        },
-                                    ])),
-                                    None,
-                                ),
+                                        })),
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    },
+                                ]),
                             })
                         })
                         .collect::<crate::DeserializationResult<Vec<_>>>()?;

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -36,11 +36,7 @@ impl crate::Component for InstanceKey {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.InstanceKey".to_owned(),
-            Box::new(DataType::UInt64),
-            None,
-        )
+        DataType::UInt64
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -77,6 +73,8 @@ impl crate::Component for InstanceKey {
                         Box::new(DataType::UInt64),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -40,11 +40,7 @@ impl crate::Component for KeypointId {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.KeypointId".to_owned(),
-            Box::new(DataType::UInt16),
-            None,
-        )
+        DataType::UInt16
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -81,6 +77,8 @@ impl crate::Component for KeypointId {
                         Box::new(DataType::UInt16),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -37,11 +37,7 @@ impl crate::Component for Label {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.Label".to_owned(),
-            Box::new(DataType::Utf8),
-            None,
-        )
+        DataType::Utf8
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -90,6 +86,8 @@ impl crate::Component for Label {
                                 Box::new(DataType::Utf8),
                                 None,
                             )
+                            .to_logical_type()
+                            .clone()
                         },
                         offsets,
                         inner_data,

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -39,24 +39,20 @@ impl crate::Component for Point2D {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.Point2D".to_owned(),
-            Box::new(DataType::Struct(vec![
-                Field {
-                    name: "x".to_owned(),
-                    data_type: DataType::Float32,
-                    is_nullable: false,
-                    metadata: [].into(),
-                },
-                Field {
-                    name: "y".to_owned(),
-                    data_type: DataType::Float32,
-                    is_nullable: false,
-                    metadata: [].into(),
-                },
-            ])),
-            None,
-        )
+        DataType::Struct(vec![
+            Field {
+                name: "x".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "y".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -82,7 +78,7 @@ impl crate::Component for Point2D {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                if let Some(ext) = extension_wrapper {
+                (if let Some(ext) = extension_wrapper {
                     DataType::Extension(
                         ext.to_owned(),
                         Box::new(<crate::components::Point2D>::to_arrow_datatype()),
@@ -90,7 +86,9 @@ impl crate::Component for Point2D {
                     )
                 } else {
                     <crate::components::Point2D>::to_arrow_datatype()
-                },
+                })
+                .to_logical_type()
+                .clone(),
                 vec![
                     {
                         let (somes, x): (Vec<_>, Vec<_>) = data
@@ -110,7 +108,7 @@ impl crate::Component for Point2D {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32
+                                DataType::Float32.to_logical_type().clone()
                             },
                             x.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             x_bitmap,
@@ -135,7 +133,7 @@ impl crate::Component for Point2D {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32
+                                DataType::Float32.to_logical_type().clone()
                             },
                             y.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             y_bitmap,

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -36,11 +36,7 @@ impl crate::Component for Radius {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.components.Radius".to_owned(),
-            Box::new(DataType::Float32),
-            None,
-        )
+        DataType::Float32
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -77,6 +73,8 @@ impl crate::Component for Radius {
                         Box::new(DataType::Float32),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -42,63 +42,59 @@ impl crate::Datatype for AffixFuzzer1 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.datatypes.AffixFuzzer1".to_owned(),
-            Box::new(DataType::Struct(vec![
-                Field {
-                    name: "single_float_optional".to_owned(),
+        DataType::Struct(vec![
+            Field {
+                name: "single_float_optional".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_required".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "single_string_optional".to_owned(),
+                data_type: DataType::Utf8,
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_floats_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: true,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "single_string_required".to_owned(),
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_required".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "single_string_optional".to_owned(),
+                })),
+                is_nullable: false,
+                metadata: [].into(),
+            },
+            Field {
+                name: "many_strings_optional".to_owned(),
+                data_type: DataType::List(Box::new(Field {
+                    name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: true,
                     metadata: [].into(),
-                },
-                Field {
-                    name: "many_floats_optional".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Float32,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    })),
-                    is_nullable: true,
-                    metadata: [].into(),
-                },
-                Field {
-                    name: "many_strings_required".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: false,
-                        metadata: [].into(),
-                    })),
-                    is_nullable: false,
-                    metadata: [].into(),
-                },
-                Field {
-                    name: "many_strings_optional".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: "item".to_owned(),
-                        data_type: DataType::Utf8,
-                        is_nullable: true,
-                        metadata: [].into(),
-                    })),
-                    is_nullable: true,
-                    metadata: [].into(),
-                },
-            ])),
-            None,
-        )
+                })),
+                is_nullable: true,
+                metadata: [].into(),
+            },
+        ])
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -124,7 +120,7 @@ impl crate::Datatype for AffixFuzzer1 {
                 any_nones.then(|| somes.into())
             };
             StructArray::new(
-                if let Some(ext) = extension_wrapper {
+                (if let Some(ext) = extension_wrapper {
                     DataType::Extension(
                         ext.to_owned(),
                         Box::new(<crate::datatypes::AffixFuzzer1>::to_arrow_datatype()),
@@ -132,7 +128,9 @@ impl crate::Datatype for AffixFuzzer1 {
                     )
                 } else {
                     <crate::datatypes::AffixFuzzer1>::to_arrow_datatype()
-                },
+                })
+                .to_logical_type()
+                .clone(),
                 vec![
                     {
                         let (somes, single_float_optional): (Vec<_>, Vec<_>) = data
@@ -158,7 +156,7 @@ impl crate::Datatype for AffixFuzzer1 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32
+                                DataType::Float32.to_logical_type().clone()
                             },
                             single_float_optional
                                 .into_iter()
@@ -204,7 +202,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -253,7 +251,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -321,12 +319,14 @@ impl crate::Datatype for AffixFuzzer1 {
                                         is_nullable: true,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 PrimitiveArray::new(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Float32
+                                        DataType::Float32.to_logical_type().clone()
                                     },
                                     many_floats_optional_inner_data
                                         .into_iter()
@@ -395,6 +395,8 @@ impl crate::Datatype for AffixFuzzer1 {
                                         is_nullable: false,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -419,7 +421,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                         Utf8Array::<i32>::new_unchecked(
                                             {
                                                 _ = extension_wrapper;
-                                                DataType::Utf8
+                                                DataType::Utf8.to_logical_type().clone()
                                             },
                                             offsets,
                                             inner_data,
@@ -491,6 +493,8 @@ impl crate::Datatype for AffixFuzzer1 {
                                         is_nullable: true,
                                         metadata: [].into(),
                                     }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -515,7 +519,7 @@ impl crate::Datatype for AffixFuzzer1 {
                                         Utf8Array::<i32>::new_unchecked(
                                             {
                                                 _ = extension_wrapper;
-                                                DataType::Utf8
+                                                DataType::Utf8.to_logical_type().clone()
                                             },
                                             offsets,
                                             inner_data,
@@ -816,11 +820,7 @@ impl crate::Datatype for AffixFuzzer2 {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.testing.datatypes.AffixFuzzer2".to_owned(),
-            Box::new(DataType::Float32),
-            None,
-        )
+        DataType::Float32
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
@@ -859,6 +859,8 @@ impl crate::Datatype for AffixFuzzer2 {
                         Box::new(DataType::Float32),
                         None,
                     )
+                    .to_logical_type()
+                    .clone()
                 },
                 data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 data0_bitmap,

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -36,18 +36,14 @@ impl crate::Datatype for Vec2D {
     #[inline]
     fn to_arrow_datatype() -> arrow2::datatypes::DataType {
         use ::arrow2::datatypes::*;
-        DataType::Extension(
-            "rerun.datatypes.Vec2D".to_owned(),
-            Box::new(DataType::FixedSizeList(
-                Box::new(Field {
-                    name: "item".to_owned(),
-                    data_type: DataType::Float32,
-                    is_nullable: false,
-                    metadata: [].into(),
-                }),
-                2usize,
-            )),
-            None,
+        DataType::FixedSizeList(
+            Box::new(Field {
+                name: "item".to_owned(),
+                data_type: DataType::Float32,
+                is_nullable: false,
+                metadata: [].into(),
+            }),
+            2usize,
         )
     }
 
@@ -106,6 +102,8 @@ impl crate::Datatype for Vec2D {
                             )),
                             None,
                         )
+                        .to_logical_type()
+                        .clone()
                     },
                     PrimitiveArray::new(
                         {
@@ -115,6 +113,8 @@ impl crate::Datatype for Vec2D {
                                 Box::new(DataType::Float32),
                                 None,
                             )
+                            .to_logical_type()
+                            .clone()
                         },
                         data0_inner_data
                             .into_iter()

--- a/crates/re_types/tests/fuzzy.rs
+++ b/crates/re_types/tests/fuzzy.rs
@@ -168,10 +168,15 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name);
-        util::assert_extensions(
-            &**array,
-            expected_extensions[field.name.as_str()].as_slice(),
-        );
+
+        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
+        // has been fully replaced.
+        if false {
+            util::assert_extensions(
+                &**array,
+                expected_extensions[field.name.as_str()].as_slice(),
+            );
+        }
     }
 
     let deserialized = AffixFuzzer1::from_arrow(serialized);

--- a/crates/re_types/tests/points2d.rs
+++ b/crates/re_types/tests/points2d.rs
@@ -65,10 +65,15 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name);
-        util::assert_extensions(
-            &**array,
-            expected_extensions[field.name.as_str()].as_slice(),
-        );
+
+        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
+        // has been fully replaced.
+        if false {
+            util::assert_extensions(
+                &**array,
+                expected_extensions[field.name.as_str()].as_slice(),
+            );
+        }
     }
 
     let deserialized = Points2D::from_arrow(serialized);

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -604,7 +604,7 @@ fn quote_trait_impls_from_obj(
                     let component = obj_field.typ.fqname().unwrap();
                     let component = format_ident!("{}", component.rsplit_once('.').unwrap().1);
                     let component = quote!(crate::components::#component);
-                    
+
                     let fqname = obj_field.typ.fqname().unwrap();
                     let legacy_fqname = objects
                         .get(fqname)

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -609,7 +609,7 @@ fn quote_trait_impls_from_obj(
                     let legacy_fqname = objects
                         .get(fqname)
                         .try_get_attr::<String>(crate::ATTR_RERUN_LEGACY_FQNAME)
-                        .unwrap_or_else(|| obj_field.typ.fqname().unwrap().to_owned());
+                        .unwrap_or_else(|| fqname.to_owned());
 
                     let extract_datatype_and_return = quote! {
                         array.map(|array| {

--- a/examples/rust/api_demo/src/main.rs
+++ b/examples/rust/api_demo/src/main.rs
@@ -324,14 +324,15 @@ fn demo_2d_layering(rec_stream: &RecordingStream) -> anyhow::Result<()> {
         .send(rec_stream)?;
 
     // And some points in front of the rectangle.
-    MsgSender::new("2d_layering/points_between_top_and_middle")
-        .with_component(
-            &(0..256)
-                .map(|i| Point2D::new(32.0 + (i / 16) as f32 * 16.0, 64.0 + (i % 16) as f32 * 16.0))
-                .collect::<Vec<_>>(),
-        )?
-        .with_component(&[DrawOrder(1.51)])?
-        .send(rec_stream)?;
+    use rerun::experimental::archetypes::Points2D;
+    MsgSender::from_archetype(
+        "2d_layering/points_between_top_and_middle",
+        &Points2D::new(
+            (0..256).map(|i| (32.0 + (i / 16) as f32 * 16.0, 64.0 + (i % 16) as f32 * 16.0)),
+        )
+        .with_draw_order(1.51),
+    )?
+    .send(rec_stream)?;
 
     Ok(())
 }
@@ -365,39 +366,37 @@ fn demo_segmentation(rec_stream: &RecordingStream) -> anyhow::Result<()> {
         .send(rec_stream)?;
 
     // Log a bunch of classified 2D points
-    MsgSender::new("seg_demo/single_point")
-        .with_component(&[Point2D::new(64.0, 64.0)])?
-        .with_component(&[ClassId(13)])?
-        .send(rec_stream)?;
-    MsgSender::new("seg_demo/single_point_labeled")
-        .with_component(&[Point2D::new(90.0, 50.0)])?
-        .with_component(&[ClassId(13)])?
-        .with_component(&[Label("labeled point".into())])?
-        .send(rec_stream)?;
-    MsgSender::new("seg_demo/several_points0")
-        .with_component(&[
-            Point2D::new(20.0, 50.0),
-            Point2D::new(100.0, 70.0),
-            Point2D::new(60.0, 30.0),
-        ])?
-        .with_splat(ClassId(42))?
-        .send(rec_stream)?;
-    MsgSender::new("seg_demo/several_points1")
-        .with_component(&[
-            Point2D::new(40.0, 50.0),
-            Point2D::new(120.0, 70.0),
-            Point2D::new(80.0, 30.0),
-        ])?
-        .with_component(&[ClassId(13), ClassId(42), ClassId(99)])?
-        .send(rec_stream)?;
-    MsgSender::new("seg_demo/many points")
-        .with_component(
-            &(0..25)
-                .map(|i| Point2D::new(100.0 + (i / 5) as f32 * 2.0, 100.0 + (i % 5) as f32 * 2.0))
-                .collect::<Vec<_>>(),
-        )?
-        .with_splat(ClassId(42))?
-        .send(rec_stream)?;
+    use rerun::experimental::archetypes::Points2D;
+    MsgSender::from_archetype(
+        "seg_demo/single_point",
+        &Points2D::new([(64.0, 64.0)]).with_class_ids([13]),
+    )?
+    .send(rec_stream)?;
+    MsgSender::from_archetype(
+        "seg_demo/single_point_labeled",
+        &Points2D::new([(90.0, 50.0)])
+            .with_class_ids([13])
+            .with_labels(["labeled point"]),
+    )?
+    .send(rec_stream)?;
+    MsgSender::from_archetype(
+        "seg_demo/several_points0",
+        &Points2D::new([(20.0, 50.0), (100.0, 70.0), (60.0, 30.0)]).with_class_ids([42]),
+    )?
+    .send(rec_stream)?;
+    MsgSender::from_archetype(
+        "seg_demo/several_points1",
+        &Points2D::new([(40.0, 50.0), (120.0, 70.0), (80.0, 30.0)]).with_class_ids([13, 42, 99]),
+    )?
+    .send(rec_stream)?;
+    MsgSender::from_archetype(
+        "seg_demo/many points",
+        &Points2D::new(
+            (0..25).map(|i| (100.0 + (i / 5) as f32 * 2.0, 100.0 + (i % 5) as f32 * 2.0)),
+        )
+        .with_class_ids([42]),
+    )?
+    .send(rec_stream)?;
     log_info(
         rec_stream,
         "no rects, default colored points, a single point has a label",


### PR DESCRIPTION
**Best reviewed on a commit-by-commit basis; in particular the `rerun codegen` commit is nothing but generated code.**

You can now use archetypes with the existing SDK:
```rust
    use rerun::experimental::archetypes::Points2D;
    MsgSender::from_archetype(
        "2d_layering/points_between_top_and_middle",
        &Points2D::new(
            (0..256).map(|i| (32.0 + (i / 16) as f32 * 16.0, 64.0 + (i % 16) as f32 * 16.0)),
        )
        .with_draw_order(1.51),
    )?
    .send(rec_stream)?;
```

Closes #2387 

---

- #2484
- #2485 
- #2487 
- #2545
- #2546
- #2549
- #2554
- #2570
- #2571

---

* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
