### PR TITLE
Basic persistence for blueprints

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🪳 bug, C/C++ SDK, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, , 🟦 blueprint, 🪳 bug, C/C++ SDK, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cocoa",
+ "directories-next",
  "eframe",
  "egui",
  "egui-wgpu",
@@ -4609,6 +4610,7 @@ dependencies = [
  "re_viewport",
  "re_ws_comms",
  "rfd",
+ "sanitize-filename",
  "serde",
  "time",
  "wasm-bindgen-futures",
@@ -5033,6 +5035,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sanitize-filename"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c502bdb638f1396509467cb0580ef3b29aa2a45c5d43e5d84928241280296c"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,6 @@ dependencies = [
  "re_viewport",
  "re_ws_comms",
  "rfd",
- "sanitize-filename",
  "serde",
  "time",
  "wasm-bindgen-futures",
@@ -5035,16 +5034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "sanitize-filename"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c502bdb638f1396509467cb0580ef3b29aa2a45c5d43e5d84928241280296c"
-dependencies = [
- "lazy_static",
- "regex",
 ]
 
 [[package]]

--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -36,7 +36,7 @@ pub mod polars_util;
 pub mod test_util;
 
 pub use self::arrow_util::ArrayExt;
-pub use self::store::{DataStore, DataStoreConfig};
+pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
 pub use self::store_gc::GarbageCollectionTarget;
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats};

--- a/crates/re_arrow_store/src/store.rs
+++ b/crates/re_arrow_store/src/store.rs
@@ -264,6 +264,10 @@ impl DataStore {
         "rerun.insert_id".into()
     }
 
+    pub fn last_insert_id(&self) -> u64 {
+        self.insert_id
+    }
+
     /// See [`Self::cluster_key`] for more information about the cluster key.
     pub fn cluster_key(&self) -> ComponentName {
         self.cluster_key

--- a/crates/re_arrow_store/src/store.rs
+++ b/crates/re_arrow_store/src/store.rs
@@ -156,7 +156,7 @@ impl std::ops::DerefMut for ClusterCellCache {
 // ---
 
 /// Incremented on each edit
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StoreGeneration(u64);
 
 /// A complete data store: covers all timelines, all entities, everything.

--- a/crates/re_arrow_store/src/store.rs
+++ b/crates/re_arrow_store/src/store.rs
@@ -155,6 +155,10 @@ impl std::ops::DerefMut for ClusterCellCache {
 
 // ---
 
+/// Incremented on each edit
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StoreGeneration(u64);
+
 /// A complete data store: covers all timelines, all entities, everything.
 ///
 /// ## Debugging
@@ -264,8 +268,10 @@ impl DataStore {
         "rerun.insert_id".into()
     }
 
-    pub fn last_insert_id(&self) -> u64 {
-        self.insert_id
+    /// Return the current `StoreGeneration`. This can be used to determine whether the
+    /// database has been modified since the last time it was queried.
+    pub fn generation(&self) -> StoreGeneration {
+        StoreGeneration(self.insert_id)
     }
 
     /// See [`Self::cluster_key`] for more information about the cluster key.

--- a/crates/re_data_store/src/editable_auto_value.rs
+++ b/crates/re_data_store/src/editable_auto_value.rs
@@ -51,12 +51,12 @@ where
     }
 
     /// Determine whether this `EditableAutoValue` has user-edits relative to another `EditableAutoValue`
-    /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
-    pub fn unedited(&self, other: &Self) -> bool {
+    /// If both values are `Auto`, then it is not considered edited.
+    pub fn has_edits(&self, other: &Self) -> bool {
         match (self, other) {
-            (EditableAutoValue::UserEdited(s), EditableAutoValue::UserEdited(o)) => s == o,
-            (EditableAutoValue::Auto(_), EditableAutoValue::Auto(_)) => true,
-            _ => false,
+            (EditableAutoValue::UserEdited(s), EditableAutoValue::UserEdited(o)) => s != o,
+            (EditableAutoValue::Auto(_), EditableAutoValue::Auto(_)) => false,
+            _ => true,
         }
     }
 }

--- a/crates/re_data_store/src/editable_auto_value.rs
+++ b/crates/re_data_store/src/editable_auto_value.rs
@@ -49,4 +49,14 @@ where
             self
         }
     }
+
+    /// Determine whether this `EditableAutoValue` has user-edits relative to another `EditableAutoValue`
+    /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
+    pub fn unedited(&self, other: &Self) -> bool {
+        match (self, other) {
+            (EditableAutoValue::UserEdited(s), EditableAutoValue::UserEdited(o)) => s == o,
+            (EditableAutoValue::Auto(_), EditableAutoValue::Auto(_)) => true,
+            _ => false,
+        }
+    }
 }

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -36,14 +36,13 @@ impl EntityPropertyMap {
     }
 
     /// Determine whether this `EntityPropertyMap` has user-edits relative to another `EntityPropertyMap`
-    /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
-    pub fn unedited(&self, other: &Self) -> bool {
-        self.props.len() == other.props.len()
-            && self
+    pub fn has_edits(&self, other: &Self) -> bool {
+        self.props.len() != other.props.len()
+            || self
                 .props
                 .iter()
                 .zip(other.props.iter())
-                .all(|(x, y)| x.0 == y.0 && x.1.unedited(y.1))
+                .any(|(x, y)| x.0 != y.0 || x.1.has_edits(y.1))
     }
 }
 
@@ -129,8 +128,7 @@ impl EntityProperties {
     }
 
     /// Determine whether this `EntityProperty` has user-edits relative to another `EntityProperty`
-    /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
-    pub fn unedited(&self, other: &Self) -> bool {
+    pub fn has_edits(&self, other: &Self) -> bool {
         let Self {
             visible,
             visible_history,
@@ -142,14 +140,14 @@ impl EntityProperties {
             backproject_radius_scale,
         } = self;
 
-        visible == &other.visible
-            && visible_history == &other.visible_history
-            && interactive == &other.interactive
-            && color_mapper.unedited(&other.color_mapper)
-            && pinhole_image_plane_distance.unedited(&other.pinhole_image_plane_distance)
-            && backproject_depth.unedited(&other.backproject_depth)
-            && depth_from_world_scale.unedited(&other.depth_from_world_scale)
-            && backproject_radius_scale.unedited(&other.backproject_radius_scale)
+        visible != &other.visible
+            || visible_history != &other.visible_history
+            || interactive != &other.interactive
+            || color_mapper.has_edits(&other.color_mapper)
+            || pinhole_image_plane_distance.has_edits(&other.pinhole_image_plane_distance)
+            || backproject_depth.has_edits(&other.backproject_depth)
+            || depth_from_world_scale.has_edits(&other.depth_from_world_scale)
+            || backproject_radius_scale.has_edits(&other.backproject_radius_scale)
     }
 }
 

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -38,11 +38,12 @@ impl EntityPropertyMap {
     /// Determine whether this `EntityPropertyMap` has user-edits relative to another `EntityPropertyMap`
     pub fn has_edits(&self, other: &Self) -> bool {
         self.props.len() != other.props.len()
-            || self
-                .props
-                .iter()
-                .zip(other.props.iter())
-                .any(|(x, y)| x.0 != y.0 || x.1.has_edits(y.1))
+            || self.props.iter().any(|(key, val)| {
+                other
+                    .props
+                    .get(key)
+                    .map_or(true, |other_val| val.has_edits(other_val))
+            })
     }
 }
 

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -34,6 +34,15 @@ impl EntityPropertyMap {
     pub fn iter(&self) -> impl Iterator<Item = (&EntityPath, &EntityProperties)> {
         self.props.iter()
     }
+
+    /// Determine whether this `EntityPropertyMap` has user-edits relative to another `EntityPropertyMap`
+    /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
+    pub fn unedited(&self, other: &Self) -> bool {
+        self.props
+            .iter()
+            .zip(other.props.iter())
+            .all(|(x, y)| x.0 == y.0 && x.1.unedited(y.1))
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -115,6 +124,30 @@ impl EntityProperties {
                 .or(&child.backproject_radius_scale)
                 .clone(),
         }
+    }
+
+    /// Determine whether this `EntityProperty` has user-edits relative to another `EntityProperty`
+    /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
+    pub fn unedited(&self, other: &Self) -> bool {
+        let Self {
+            visible,
+            visible_history,
+            interactive,
+            color_mapper,
+            pinhole_image_plane_distance,
+            backproject_depth,
+            depth_from_world_scale,
+            backproject_radius_scale,
+        } = self;
+
+        visible == &other.visible
+            && visible_history == &other.visible_history
+            && interactive == &other.interactive
+            && color_mapper.unedited(&other.color_mapper)
+            && pinhole_image_plane_distance.unedited(&other.pinhole_image_plane_distance)
+            && backproject_depth.unedited(&other.backproject_depth)
+            && depth_from_world_scale.unedited(&other.depth_from_world_scale)
+            && backproject_radius_scale.unedited(&other.backproject_radius_scale)
     }
 }
 

--- a/crates/re_data_store/src/entity_properties.rs
+++ b/crates/re_data_store/src/entity_properties.rs
@@ -38,10 +38,12 @@ impl EntityPropertyMap {
     /// Determine whether this `EntityPropertyMap` has user-edits relative to another `EntityPropertyMap`
     /// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
     pub fn unedited(&self, other: &Self) -> bool {
-        self.props
-            .iter()
-            .zip(other.props.iter())
-            .all(|(x, y)| x.0 == y.0 && x.1.unedited(y.1))
+        self.props.len() == other.props.len()
+            && self
+                .props
+                .iter()
+                .zip(other.props.iter())
+                .all(|(x, y)| x.0 == y.0 && x.1.unedited(y.1))
     }
 }
 

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -292,8 +292,10 @@ impl StoreDb {
             + self.entity_db.data_store.num_temporal_rows() as usize
     }
 
-    pub fn last_insert_id(&self) -> u64 {
-        self.entity_db.data_store.last_insert_id()
+    /// Return the current `StoreGeneration`. This can be used to determine whether the
+    /// database has been modified since the last time it was queried.
+    pub fn generation(&self) -> re_arrow_store::StoreGeneration {
+        self.entity_db.data_store.generation()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -292,6 +292,10 @@ impl StoreDb {
             + self.entity_db.data_store.num_temporal_rows() as usize
     }
 
+    pub fn last_insert_id(&self) -> u64 {
+        self.entity_db.data_store.last_insert_id()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.recording_msg.is_none() && self.num_rows() == 0
     }

--- a/crates/re_space_view/src/data_blueprint.rs
+++ b/crates/re_space_view/src/data_blueprint.rs
@@ -115,12 +115,13 @@ impl DataBlueprintTree {
             data_blueprints,
         } = self;
 
-        // Note: this could fail unexpectedly if slotmap iteration order is unstable.
         groups.len() != other.groups.len()
-            || groups
-                .iter()
-                .zip(other.groups.iter())
-                .any(|(x, y)| x.0 != y.0 || x.1.has_edits(y.1))
+            || groups.iter().any(|(key, val)| {
+                other
+                    .groups
+                    .get(key)
+                    .map_or(true, |other_val| val.has_edits(other_val))
+            })
             || *path_to_group != other.path_to_group
             || *entity_paths != other.entity_paths
             || *root_group_handle != other.root_group_handle

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -88,7 +88,6 @@ image = { workspace = true, default-features = false, features = ["png"] }
 itertools = { workspace = true }
 poll-promise = "0.2"
 rfd.workspace = true
-sanitize-filename = "0.4.0"
 serde = { version = "1", features = ["derive"] }
 time = { workspace = true, features = ["formatting"] }
 web-time.workspace = true

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -75,6 +75,7 @@ arrow2.workspace = true
 arrow2_convert.workspace = true
 bytemuck.workspace = true
 cfg-if.workspace = true
+directories-next = "2.0.0"
 eframe = { workspace = true, default-features = false, features = [
   "default_fonts",
   "persistence",
@@ -87,6 +88,7 @@ image = { workspace = true, default-features = false, features = ["png"] }
 itertools = { workspace = true }
 poll-promise = "0.2"
 rfd.workspace = true
+sanitize-filename = "0.4.0"
 serde = { version = "1", features = ["derive"] }
 time = { workspace = true, features = ["formatting"] }
 web-time.workspace = true

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -782,7 +782,7 @@ impl eframe::App for App {
             eframe::set_value(storage, eframe::APP_KEY, &self.state);
 
             // Save the blueprints
-            // TODO(jleibs): implement web-storage for blueprints as well
+            // TODO(2579): implement web-storage for blueprints as well
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(hub) = &self.store_hub {
                 match hub.persist_app_blueprints() {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -275,7 +275,8 @@ impl App {
             }
             #[cfg(not(target_arch = "wasm32"))]
             SystemCommand::LoadRrd(path) => {
-                if let Some(rrd) = crate::loading::load_file_path(&path) {
+                let with_notification = true;
+                if let Some(rrd) = crate::loading::load_file_path(&path, with_notification) {
                     store_hub.add_bundle(rrd);
                 }
             }
@@ -763,7 +764,8 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(path) = &file.path {
-                if let Some(rrd) = crate::loading::load_file_path(path) {
+                let with_notification = true;
+                if let Some(rrd) = crate::loading::load_file_path(path, with_notification) {
                     self.on_rrd_loaded(store_hub, rrd);
                 }
             }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -778,7 +778,20 @@ impl eframe::App for App {
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         if self.startup_options.persist_state {
+            // Save the app state
             eframe::set_value(storage, eframe::APP_KEY, &self.state);
+
+            // Save the blueprints
+            // TODO(jleibs): implement web-storage for blueprints as well
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Some(hub) = &self.store_hub {
+                match hub.persist_app_blueprints() {
+                    Ok(f) => f,
+                    Err(err) => {
+                        re_log::error!("Saving blueprints failed: {err}");
+                    }
+                };
+            }
         }
     }
 
@@ -1032,6 +1045,8 @@ fn save(
     store_context: Option<&StoreContext<'_>>,
     loop_selection: Option<(re_data_store::Timeline, re_log_types::TimeRangeF)>,
 ) {
+    use crate::saving::save_database_to_file;
+
     let Some(store_db) = store_context.as_ref().and_then(|view| view.recording) else {
             // NOTE: Can only happen if saving through the command palette.
             re_log::error!("No data to save!");
@@ -1061,68 +1076,4 @@ fn save(
             re_log::error!("File saving failed: {err}");
         }
     }
-}
-
-/// Returns a closure that, when run, will save the contents of the current database
-/// to disk, at the specified `path`.
-///
-/// If `time_selection` is specified, then only data for that specific timeline over that
-/// specific time range will be accounted for.
-#[cfg(not(target_arch = "wasm32"))]
-fn save_database_to_file(
-    store_db: &StoreDb,
-    path: std::path::PathBuf,
-    time_selection: Option<(re_data_store::Timeline, re_log_types::TimeRangeF)>,
-) -> anyhow::Result<impl FnOnce() -> anyhow::Result<std::path::PathBuf>> {
-    use itertools::Itertools as _;
-    use re_arrow_store::TimeRange;
-
-    re_tracing::profile_scope!("dump_messages");
-
-    let begin_rec_msg = store_db
-        .recording_msg()
-        .map(|msg| LogMsg::SetStoreInfo(msg.clone()));
-
-    let ent_op_msgs = store_db
-        .iter_entity_op_msgs()
-        .map(|msg| LogMsg::EntityPathOpMsg(store_db.store_id().clone(), msg.clone()))
-        .collect_vec();
-
-    let time_filter = time_selection.map(|(timeline, range)| {
-        (
-            timeline,
-            TimeRange::new(range.min.floor(), range.max.ceil()),
-        )
-    });
-    let data_msgs: Result<Vec<_>, _> = store_db
-        .entity_db
-        .data_store
-        .to_data_tables(time_filter)
-        .map(|table| {
-            table
-                .to_arrow_msg()
-                .map(|msg| LogMsg::ArrowMsg(store_db.store_id().clone(), msg))
-        })
-        .collect();
-
-    use anyhow::Context as _;
-    let data_msgs = data_msgs.with_context(|| "Failed to export to data tables")?;
-
-    let msgs = std::iter::once(begin_rec_msg)
-        .flatten() // option
-        .chain(ent_op_msgs)
-        .chain(data_msgs);
-
-    Ok(move || {
-        re_tracing::profile_scope!("save_to_file");
-
-        use anyhow::Context as _;
-        let file = std::fs::File::create(path.as_path())
-            .with_context(|| format!("Failed to create file at {path:?}"))?;
-
-        let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
-        re_log_encoding::encoder::encode_owned(encoding_options, msgs, file)
-            .map(|_| path)
-            .context("Message encode")
-    })
 }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -784,7 +784,7 @@ impl eframe::App for App {
             // Save the blueprints
             // TODO(2579): implement web-storage for blueprints as well
             #[cfg(not(target_arch = "wasm32"))]
-            if let Some(hub) = &self.store_hub {
+            if let Some(hub) = &mut self.store_hub {
                 match hub.persist_app_blueprints() {
                     Ok(f) => f,
                     Err(err) => {

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -13,6 +13,7 @@ mod loading;
 #[cfg(not(target_arch = "wasm32"))]
 mod profiler;
 mod remote_viewer_app;
+mod saving;
 mod screenshotter;
 mod store_hub;
 mod ui;

--- a/crates/re_viewer/src/loading.rs
+++ b/crates/re_viewer/src/loading.rs
@@ -2,7 +2,7 @@ use crate::StoreBundle;
 
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
-pub fn load_file_path(path: &std::path::Path) -> Option<StoreBundle> {
+pub fn load_file_path(path: &std::path::Path, with_notifications: bool) -> Option<StoreBundle> {
     fn load_file_path_impl(path: &std::path::Path) -> anyhow::Result<StoreBundle> {
         re_tracing::profile_function!();
         use anyhow::Context as _;
@@ -10,11 +10,15 @@ pub fn load_file_path(path: &std::path::Path) -> Option<StoreBundle> {
         StoreBundle::from_rrd(file)
     }
 
-    re_log::info!("Loading {path:?}…");
+    if with_notifications {
+        re_log::info!("Loading {path:?}…");
+    }
 
     match load_file_path_impl(path) {
         Ok(mut rrd) => {
-            re_log::info!("Loaded {path:?}");
+            if with_notifications {
+                re_log::info!("Loaded {path:?}");
+            }
             for store_db in rrd.store_dbs_mut() {
                 store_db.data_source = Some(re_smart_channel::SmartChannelSource::Files {
                     paths: vec![path.into()],

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -44,11 +44,9 @@ pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::pat
             // so insert the hash.
             if sanitized_app_id != app_id.0 {
                 // Hash the original app-id.
-                let salt: u64 = 0xc927_d8cd_910d_16a3;
 
                 let hash = {
                     let mut hasher = ahash::RandomState::with_seeds(1, 2, 3, 4).build_hasher();
-                    salt.hash(&mut hasher);
                     app_id.0.hash(&mut hasher);
                     hasher.finish()
                 };

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -1,0 +1,128 @@
+use re_data_store::StoreDb;
+
+#[cfg(not(target_arch = "wasm32"))]
+use re_log_types::ApplicationId;
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Determine the default path for a blueprint based on its `ApplicationId`
+/// This path should be determnistic and unique.
+// TODO(jleibs): Implement equivalent for web
+pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::path::PathBuf> {
+    use std::hash::{BuildHasher, Hash as _, Hasher as _};
+
+    use anyhow::Context;
+
+    // TODO(jleibs) is there a better way to get this folder from egui?
+    if let Some(proj_dirs) = directories_next::ProjectDirs::from("", "", "rerun") {
+        let data_dir = proj_dirs.data_dir().join("blueprints");
+        if let Err(err) = std::fs::create_dir_all(&data_dir) {
+            re_log::warn!(
+                "Saving blueprints disabled: Failed to create blueprint directory at {:?}: {}",
+                data_dir,
+                err
+            );
+            Err(err).context("Could not create blueprint save directory.")
+        } else {
+            // We want a unique filename (not a directory) for each app-id.
+
+            // First we sanitize to remove disallowed characters
+            // TODO(jleibs): Maybe we should just restrict app-ids to valid filename characters.
+            let options = sanitize_filename::Options {
+                truncate: true,
+                windows: true,
+                replacement: "-",
+            };
+
+            let mut sanitized_app_id = sanitize_filename::sanitize_with_options(&app_id.0, options);
+
+            // Make sure we are leaving space for the hash and file extension
+            const MAX_LENGTH: usize = 255 - 16 - 1 - ".blueprint".len();
+            sanitized_app_id.truncate(MAX_LENGTH);
+
+            // If the sanitization actually did something, we no longer have a uniqueness guarantee,
+            // so insert the hash.
+            if sanitized_app_id != app_id.0 {
+                // Hash the original app-id.
+                let salt: u64 = 0xc927_d8cd_910d_16a3;
+
+                let hash = {
+                    let mut hasher = ahash::RandomState::with_seeds(1, 2, 3, 4).build_hasher();
+                    salt.hash(&mut hasher);
+                    app_id.0.hash(&mut hasher);
+                    hasher.finish()
+                };
+
+                sanitized_app_id = format!("{sanitized_app_id}-{hash:x}");
+            }
+
+            Ok(data_dir.join(format!("{sanitized_app_id}.blueprint")))
+        }
+    } else {
+        anyhow::bail!("Error finding project directory for blueprints.")
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Returns a closure that, when run, will save the contents of the current database
+/// to disk, at the specified `path`.
+///
+/// If `time_selection` is specified, then only data for that specific timeline over that
+/// specific time range will be accounted for.
+pub fn save_database_to_file(
+    store_db: &StoreDb,
+    path: std::path::PathBuf,
+    time_selection: Option<(re_data_store::Timeline, re_log_types::TimeRangeF)>,
+) -> anyhow::Result<impl FnOnce() -> anyhow::Result<std::path::PathBuf>> {
+    use itertools::Itertools as _;
+    use re_arrow_store::TimeRange;
+
+    re_tracing::profile_scope!("dump_messages");
+
+    let begin_rec_msg = store_db
+        .recording_msg()
+        .map(|msg| LogMsg::SetStoreInfo(msg.clone()));
+
+    let ent_op_msgs = store_db
+        .iter_entity_op_msgs()
+        .map(|msg| LogMsg::EntityPathOpMsg(store_db.store_id().clone(), msg.clone()))
+        .collect_vec();
+
+    let time_filter = time_selection.map(|(timeline, range)| {
+        (
+            timeline,
+            TimeRange::new(range.min.floor(), range.max.ceil()),
+        )
+    });
+    let data_msgs: Result<Vec<_>, _> = store_db
+        .entity_db
+        .data_store
+        .to_data_tables(time_filter)
+        .map(|table| {
+            table
+                .to_arrow_msg()
+                .map(|msg| LogMsg::ArrowMsg(store_db.store_id().clone(), msg))
+        })
+        .collect();
+
+    use anyhow::Context as _;
+    use re_log_types::LogMsg;
+    let data_msgs = data_msgs.with_context(|| "Failed to export to data tables")?;
+
+    let msgs = std::iter::once(begin_rec_msg)
+        .flatten() // option
+        .chain(ent_op_msgs)
+        .chain(data_msgs);
+
+    Ok(move || {
+        re_tracing::profile_scope!("save_to_file");
+
+        use anyhow::Context as _;
+        let file = std::fs::File::create(path.as_path())
+            .with_context(|| format!("Failed to create file at {path:?}"))?;
+
+        let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
+        re_log_encoding::encoder::encode_owned(encoding_options, msgs, file)
+            .map(|_| path)
+            .context("Message encode")
+    })
+}

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -6,7 +6,7 @@ use re_log_types::ApplicationId;
 #[cfg(not(target_arch = "wasm32"))]
 /// Determine the default path for a blueprint based on its `ApplicationId`
 /// This path should be determnistic and unique.
-// TODO(jleibs): Implement equivalent for web
+// TODO(2579): Implement equivalent for web
 pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::path::PathBuf> {
     use std::hash::{BuildHasher, Hash as _, Hasher as _};
 

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 use re_data_store::StoreDb;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -4,6 +4,7 @@ use re_data_store::StoreDb;
 #[cfg(not(target_arch = "wasm32"))]
 use re_log_types::ApplicationId;
 
+#[cfg(not(target_arch = "wasm32"))]
 /// Convert to lowercase and replace any character that is not a fairly common
 /// filename character with '-'
 fn sanitize_app_id(app_id: &ApplicationId) -> String {

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -1,9 +1,12 @@
 use ahash::HashMap;
 use itertools::Itertools;
-use re_arrow_store::{DataStoreConfig, DataStoreStats, StoreGeneration};
+use re_arrow_store::{DataStoreConfig, DataStoreStats};
 use re_data_store::StoreDb;
 use re_log_types::{ApplicationId, StoreId, StoreKind};
 use re_viewer_context::StoreContext;
+
+#[cfg(not(target_arch = "wasm32"))]
+use re_arrow_store::StoreGeneration;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -116,7 +116,7 @@ impl StoreHub {
         #[cfg(not(target_arch = "wasm32"))]
         if !self.blueprint_by_app_id.contains_key(&app_id) {
             if let Err(err) = self.try_to_load_persisted_blueprint(&app_id) {
-                re_log::warn!("Failed to load persisted blueprint: {err:?}");
+                re_log::warn!("Failed to load persisted blueprint: {err}");
             }
         }
 

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -5,6 +5,7 @@ use re_data_store::StoreDb;
 use re_log_types::{ApplicationId, StoreId, StoreKind};
 use re_viewer_context::StoreContext;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::{
     loading::load_file_path,
     saving::{default_blueprint_path, save_database_to_file},

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -202,7 +202,8 @@ impl StoreHub {
         let blueprint_path = default_blueprint_path(app_id)?;
         if blueprint_path.exists() {
             re_log::debug!("Trying to load blueprint for {app_id} from {blueprint_path:?}",);
-            if let Some(mut bundle) = load_file_path(&blueprint_path) {
+            let with_notification = false;
+            if let Some(mut bundle) = load_file_path(&blueprint_path, with_notification) {
                 for store in bundle.drain_store_dbs() {
                     if store.store_kind() == StoreKind::Blueprint && store.app_id() == Some(app_id)
                     {

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -104,7 +104,7 @@ impl StoreHub {
     pub fn set_app_id(&mut self, app_id: ApplicationId) {
         // If we don't know of a blueprint for this `ApplicationId` yet,
         // try to load one from the persisted store
-        // TODO(jleibs): implement web-storage for blueprints as well
+        // TODO(2579): implement web-storage for blueprints as well
         #[cfg(not(target_arch = "wasm32"))]
         if !self.blueprint_by_app_id.contains_key(&app_id) {
             self.try_to_load_persisted_blueprint(&app_id).ok();
@@ -156,8 +156,8 @@ impl StoreHub {
         self.store_dbs.contains_recording(id)
     }
 
-    ///
-    // TODO(jleibs): implement persistence for web
+    /// Persist any in-use blueprints to durable storage.
+    // TODO(2579): implement persistence for web
     #[cfg(not(target_arch = "wasm32"))]
     pub fn persist_app_blueprints(&self) -> anyhow::Result<()> {
         // Because we save blueprints based on their `ApplicationId`, we only
@@ -178,8 +178,8 @@ impl StoreHub {
         Ok(())
     }
 
-    /// Try to load the persisted blueprint for the current `ApplicationId`
-    // TODO(jleibs): implement persistence for web
+    /// Try to load the persisted blueprint for the given `ApplicationId`
+    // TODO(2579): implement persistence for web
     #[cfg(not(target_arch = "wasm32"))]
     pub fn try_to_load_persisted_blueprint(
         &mut self,

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -27,6 +27,7 @@ pub struct StoreHub {
     store_dbs: StoreBundle,
 
     // The number of rows in the blueprint the last time it was saved
+    #[cfg(not(target_arch = "wasm32"))]
     blueprint_last_save: HashMap<StoreId, u64>,
 }
 

--- a/crates/re_viewport/src/blueprint_components/space_view.rs
+++ b/crates/re_viewport/src/blueprint_components/space_view.rs
@@ -61,5 +61,5 @@ fn test_spaceview() {
     assert!(data
         .iter()
         .zip(ret)
-        .all(|(l, r)| l.space_view.unedited(&r.space_view)));
+        .all(|(l, r)| !l.space_view.has_edits(&r.space_view)));
 }

--- a/crates/re_viewport/src/blueprint_components/space_view.rs
+++ b/crates/re_viewport/src/blueprint_components/space_view.rs
@@ -18,7 +18,7 @@ use crate::space_view::SpaceViewBlueprint;
 ///     ])
 /// );
 /// ```
-#[derive(Clone, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
+#[derive(Clone, ArrowField, ArrowSerialize, ArrowDeserialize)]
 pub struct SpaceViewComponent {
     #[arrow_field(type = "SerdeField<SpaceViewBlueprint>")]
     pub space_view: SpaceViewBlueprint,
@@ -57,5 +57,9 @@ fn test_spaceview() {
     let data = [SpaceViewComponent { space_view }];
     let array: Box<dyn arrow2::array::Array> = data.try_into_arrow().unwrap();
     let ret: Vec<SpaceViewComponent> = array.try_into_collection().unwrap();
-    assert_eq!(&data, ret.as_slice());
+    assert_eq!(data.len(), ret.len());
+    assert!(data
+        .iter()
+        .zip(ret)
+        .all(|(l, r)| l.space_view.unedited(&r.space_view)));
 }

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -41,9 +41,8 @@ pub struct SpaceViewBlueprint {
 }
 
 /// Determine whether this `SpaceViewBlueprint` has user-edits relative to another `SpaceViewBlueprint`
-/// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
 impl SpaceViewBlueprint {
-    pub fn unedited(&self, other: &Self) -> bool {
+    pub fn has_edits(&self, other: &Self) -> bool {
         let Self {
             id,
             display_name,
@@ -54,13 +53,13 @@ impl SpaceViewBlueprint {
             entities_determined_by_user,
         } = self;
 
-        id == &other.id
-            && display_name == &other.display_name
-            && class_name == &other.class_name
-            && space_origin == &other.space_origin
-            && data_blueprint.unedited(&other.data_blueprint)
-            && category == &other.category
-            && entities_determined_by_user == &other.entities_determined_by_user
+        id != &other.id
+            || display_name != &other.display_name
+            || class_name != &other.class_name
+            || space_origin != &other.space_origin
+            || data_blueprint.has_edits(&other.data_blueprint)
+            || category != &other.category
+            || entities_determined_by_user != &other.entities_determined_by_user
     }
 }
 

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -16,7 +16,7 @@ use crate::{
 // ----------------------------------------------------------------------------
 
 /// A view of a space.
-#[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub struct SpaceViewBlueprint {
     pub id: SpaceViewId,
     pub display_name: String,
@@ -38,6 +38,30 @@ pub struct SpaceViewBlueprint {
 
     /// True if the user is expected to add entities themselves. False otherwise.
     pub entities_determined_by_user: bool,
+}
+
+/// Determine whether this `SpaceViewBlueprint` has user-edits relative to another `SpaceViewBlueprint`
+/// This is similar in concept to `PartialEq`, but more forgiving of Auto taking on different values.
+impl SpaceViewBlueprint {
+    pub fn unedited(&self, other: &Self) -> bool {
+        let Self {
+            id,
+            display_name,
+            class_name,
+            space_origin,
+            data_blueprint,
+            category,
+            entities_determined_by_user,
+        } = self;
+
+        id == &other.id
+            && display_name == &other.display_name
+            && class_name == &other.class_name
+            && space_origin == &other.space_origin
+            && data_blueprint.unedited(&other.data_blueprint)
+            && category == &other.category
+            && entities_determined_by_user == &other.entities_determined_by_user
+    }
 }
 
 impl SpaceViewBlueprint {

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -353,7 +353,7 @@ pub fn sync_space_view(
     space_view: &SpaceViewBlueprint,
     snapshot: Option<&SpaceViewBlueprint>,
 ) {
-    if Some(space_view) != snapshot {
+    if snapshot.map_or(true, |snapshot| space_view.unedited(snapshot)) {
         let entity_path = EntityPath::from(format!(
             "{}/{}",
             SpaceViewComponent::SPACEVIEW_PREFIX,

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -353,7 +353,7 @@ pub fn sync_space_view(
     space_view: &SpaceViewBlueprint,
     snapshot: Option<&SpaceViewBlueprint>,
 ) {
-    if snapshot.map_or(true, |snapshot| space_view.unedited(snapshot)) {
+    if snapshot.map_or(true, |snapshot| space_view.has_edits(snapshot)) {
         let entity_path = EntityPath::from(format!(
             "{}/{}",
             SpaceViewComponent::SPACEVIEW_PREFIX,

--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -25,14 +25,14 @@ def main() -> None:
         rr.init(
             "Blueprint demo",
             init_logging=False,
-            exp_init_blueprint=True,
+            exp_init_blueprint=not args.skip_blueprint,
             exp_add_to_app_default_blueprint=args.no_append_default,
             spawn=True,
         )
     else:
         rr.init(
             "Blueprint demo",
-            exp_init_blueprint=True,
+            exp_init_blueprint=not args.skip_blueprint,
             exp_add_to_app_default_blueprint=args.no_append_default,
             spawn=True,
         )


### PR DESCRIPTION
### What
When moving over to the new blueprint store, we temporarily lost the ability to persist blueprints.

This is one of the major regressions currently preventing us from releasing main (See: #2529)

This PR adds new methods to the `store_hub`:
 - `persist_app_blueprints`
 - `try_to_load_persisted_blueprint`
 
 The blueprints are stored using the standard rrd file format. They go into a sub-directory of our app-state storage:
- Linux: /home/UserName/.local/share/rerun/blueprints/
- macOS: /Users/UserName/Library/Application Support/rerun/blueprints/
- Windows: C:\Users\UserName\AppData\Roaming\rerun\blueprints\

We only store a single blueprint in this folder per app-id. 

Any time we change the app_id via the `store_hub` (such as when loading an rrd) we will search the directory for a persisted blueprint and then load it. We track the `insert_id` on the active blueprint to determine if we need to save back out to disk again. I've tested to confirm that in most cases when we restore from blueprint we don't do anything weird like re-modify the blueprint and save it again.

### Additional Notes:
The way that DataBlueprint/AutoValues work required a workaround that I don't particularly love, but does seems to be workable until we refactor to get rid of more of the serde business.
   - After implementing blueprint-loading, I noticed that every time we start the app fresh, we see a cycle where the AutoValue for `pinhole_image_plane_distance` goes from Auto(100.06751) -> Auto(1) ->  Auto(100.03121). Even ignoring the transient jump due to view bounds being a frame delayed to populate, the Auto-value itself is unstable from run to run.  This meant that every time we started the app, we would do a new insertion which would cause the blueprint to immediately get saved again.
   - The work-around is to replace the usage of `!=` (PartialEq) with a conceptually equivalent method `has_edits` for the DataBlueprintTree.  We now consider all values of Auto to be considered a match. This seems to work out fine since we (should?) always recompute Auto values at the beginning of each frame.
   - Longer term, I think the right solution is to move the Auto values out of the blueprint and into the AppState so they persist frame-to-frame and don't even show up in the blueprint comparison logic. However, DataBlueprintTree is a complicated piece of work, and plumbing through that state is proving to be challenging.
   
### Future work
This currently only implements file-backed storage, so doesn't work with web-view.
 - https://github.com/rerun-io/rerun/issues/2579

### Testing:
* Run colmap fiat:
```
python examples/python/structure_from_motion/main.py --dataset colmap_fiat
```
* Adjust views
* Exit application
* Check the md5sum of the blueprint:
```
$ md5sum /home/jleibs/.local/share/rerun/blueprints/structure_from_motion.blueprint 
03fab330d9c23ac3da1163c854aa8518  /home/jleibs/.local/share/rerun/blueprints/structure_from_motion.blueprint
```
* Run colmap fiat a *second* time.
* Confirm the layout persists:
![image](https://github.com/rerun-io/rerun/assets/3312232/036d6ae9-6d3e-4abf-a981-cc46a7b6fe71)
* Close rerun and verify the blueprint hasn't been changed:
```
$ md5sum /home/jleibs/.local/share/rerun/blueprints/structure_from_motion.blueprint 
03fab330d9c23ac3da1163c854aa8518  /home/jleibs/.local/share/rerun/blueprints/structure_from_motion.blueprint
```


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2578) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2578)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Fsave_blueprints/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Fsave_blueprints/examples)