### PR TITLE
Fix `scripts/lint.py` to ignore `.nox`

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -440,7 +440,7 @@ def main() -> None:
 
         extensions = ["fbs", "html", "js", "md", "py", "rs", "sh", "toml", "wgsl", "yml"]
 
-        exclude_dirs = {"env", "renv", "venv", "target", "target_ra", "target_wasm"}
+        exclude_dirs = {"env", "renv", "venv", "target", "target_ra", "target_wasm", ".nox"}
 
         exclude_paths = {
             "./CODE_STYLE.md",


### PR DESCRIPTION
### What

Adds `.nox` in the list of ignored directories for `scripts/lint.py`. This is created by nox, introduced in #2536.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2580) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2580)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Ffix-lint.py/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Ffix-lint.py/examples)