### PR TITLE
Fix: always auto-layout spaceviews until the user interveens

### DIFF
--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -443,14 +443,21 @@ impl Viewport {
 
         self.space_views.insert(space_view_id, space_view);
 
-        if let Some(root_id) = self.tree.root {
+        if self.has_been_user_edited {
             // Try to insert it in the tree, in the top level:
-            let tile_id = self.tree.tiles.insert_pane(space_view_id);
-            if let Some(egui_tiles::Tile::Container(container)) = self.tree.tiles.get_mut(root_id) {
-                container.add_child(tile_id);
-            } else {
-                self.tree = Default::default(); // we'll just re-initialize later instead
+            if let Some(root_id) = self.tree.root {
+                let tile_id = self.tree.tiles.insert_pane(space_view_id);
+                if let Some(egui_tiles::Tile::Container(container)) =
+                    self.tree.tiles.get_mut(root_id)
+                {
+                    container.add_child(tile_id);
+                } else {
+                    self.tree = Default::default(); // we'll just re-initialize later instead
+                }
             }
+        } else {
+            // Re-run the auto-layout next frame:
+            self.tree = Default::default();
         }
 
         space_view_id


### PR DESCRIPTION
Fixes a bug where the first time you load a message stream the layout would be different than if you would hit the reset/auto-layout button.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2583) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2583)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fmore-auto-layout/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fmore-auto-layout/examples)