### PR TITLE
Fix CI: Don't pin Pillow version

### DIFF
--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -243,7 +243,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          "pip install deprecated numpy>=1.23 pillow>=10,<11 pyarrow==10.0.1 pytest==7.1.2"
+          pip install deprecated numpy>=1.23 "pillow>=10,<11" pyarrow==10.0.1 pytest==7.1.2
 
       - name: Install built wheel
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -243,7 +243,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install deprecated numpy>=1.23 pillow>=9.5.0 pyarrow==10.0.1 pytest==7.1.2
+          pip install deprecated numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2
 
       - name: Install built wheel
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -243,7 +243,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install deprecated numpy>=1.23 "pillow>=10,<11" pyarrow==10.0.1 pytest==7.1.2
+          pip install deprecated numpy>=1.23 pillow==10.0.0 pyarrow==10.0.1 pytest==7.1.2
 
       - name: Install built wheel
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -243,7 +243,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install deprecated numpy>=1.23 pillow==10.0.0 pyarrow==10.0.1 pytest==7.1.2
+          pip install deprecated numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2
 
       - name: Install built wheel
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -243,7 +243,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install deprecated numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2
+          "pip install deprecated numpy>=1.23 pillow>=10,<11 pyarrow==10.0.1 pytest==7.1.2"
 
       - name: Install built wheel
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   # Must match list in `.github/workflows/reusable_build_and_test_wheels.yml`
   "deprecated",
   "numpy>=1.23",
-  "pillow==10.0.0",  # Used for JPEG encoding
+  "pillow",          # Used for JPEG encoding
   "pyarrow==10.0.1",
 ]
 description = "The Rerun Logging SDK"

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   # Must match list in `.github/workflows/reusable_build_and_test_wheels.yml`
   "deprecated",
   "numpy>=1.23",
-  "pillow>=9.5.0,<10", # Used for JPEG encoding
+  "pillow",          # Used for JPEG encoding
   "pyarrow==10.0.1",
 ]
 description = "The Rerun Logging SDK"

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   # Must match list in `.github/workflows/reusable_build_and_test_wheels.yml`
   "deprecated",
   "numpy>=1.23",
-  "pillow>=10,<11",  # Used for JPEG encoding
+  "pillow==10.0.0",  # Used for JPEG encoding
   "pyarrow==10.0.1",
 ]
 description = "The Rerun Logging SDK"

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   # Must match list in `.github/workflows/reusable_build_and_test_wheels.yml`
   "deprecated",
   "numpy>=1.23",
-  "pillow",          # Used for JPEG encoding
+  "pillow>=10,<11",  # Used for JPEG encoding
   "pyarrow==10.0.1",
 ]
 description = "The Rerun Logging SDK"


### PR DESCRIPTION
We had mismatching strings on CI and in `pyproject.toml`, leading the CI to install Pillow 10.0.0 (released two days ago), and the pyproject requiring 9.5.0, which then wasn't found.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2584) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2584)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-pillow/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-pillow/examples)