### PR TITLE
Docs: link to `rr.save` and suggest `rerun` instead of `python -m rerun`

### DIFF
--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -290,11 +290,11 @@ Rerun offers several solutions for these use cases.
 
 ### Logging data over the network
 
-At any time, you can start a Rerun Viewer by running `python -m rerun`. This viewer is in fact a server that's ready to accept data over TCP (it's listening on `0.0.0.0:9876` by default).
+At any time, you can start a Rerun Viewer by running `rerun`. This viewer is in fact a server that's ready to accept data over TCP (it's listening on `0.0.0.0:9876` by default).
 
 On the logger side, simply use [`rr.connect`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.connect) instead of [`rr.spawn`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.spawn) to start sending the data over to any TCP address.
 
-Checkout `python -m rerun --help` for more options.
+Checkout `rerun --help` for more options.
 
 ### Saving & loading to/from RRD files
 
@@ -302,7 +302,7 @@ Sometimes, sending the data over the network is not an option. Maybe you'd like 
 
 Rerun has you covered:
 - Use [`rr.save`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.save) to stream all logged data to disk.
-- Visualize it via `python -m rerun path/to/recording.rrd`
+- View it with `rerun path/to/recording.rrd`
 
 You can also save a recording (or a portion of it) as you're visualizing it, directly from the viewer.
 

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -30,7 +30,7 @@ Call [`rr.spawn`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__
 
 Connects to a remote Rerun Viewer and streams all the data via TCP.
 
-You will need to start a stand-alone viewer first, either by using `python -m rerun` if you've installed via `pip`, or simply `rerun` if you've installed via `cargo`.
+You will need to start a stand-alone viewer first by typing `rerun` in your terminal.
 
 #### `Python`
 
@@ -54,9 +54,9 @@ Use [`rr.serve`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/
 
 ## Save
 
-Saves all the data buffered so far into an `rrd` file on disk, which can then be loaded into a stand-alone viewer.
+Streams all logging data into an `.rrd` file on disk, which can then be loaded into a stand-alone viewer.
 
-To visualize the saved file, use `python -m rerun path/to/file.rrd` if you've installed via `pip`, or simply `rerun path/to/file.rrd` if you've installed via `cargo`.
+To view the saved file, use `rerun path/to/file.rrd`.
 
 ⚠️  [RRD files don't yet handle versioning!](https://github.com/rerun-io/rerun/issues/873) ⚠️
 

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -27,7 +27,7 @@ pip install -r examples/python/requirements.txt
 ## Running the examples
 By default, the examples spawn a Rerun Viewer and stream log data to it.
 
-You can instead save the log data to an `.rrd` file using `examples/python/car/main.py --save data.rrd`. You can then open that `.rrd` file with `rerun data.rrd`.
+You can instead save the log data to an `.rrd` file using `examples/python/car/main.py --save data.rrd`. You can then view that `.rrd` file with `rerun data.rrd`.
 
 (`rerun` is an alias for `python -m rerun`).
 

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -50,7 +50,7 @@ SECTION_TABLE: Final[list[Section]] = [
     Section(
         title="Initialization",
         module_summary=None,
-        func_list=["init", "connect", "disconnect", "spawn", "serve", "memory_recording"],
+        func_list=["init", "connect", "disconnect", "spawn", "serve", "save", "memory_recording"],
         class_list=[],
     ),
     Section(

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -14,7 +14,7 @@ def connect(addr: str | None = None, recording: RecordingStream | None = None) -
     """
     Connect to a remote Rerun Viewer on the given ip:port.
 
-    Requires that you first start a Rerun Viewer, e.g. with 'python -m rerun'
+    Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.
 
     This function returns immediately.
 
@@ -111,7 +111,7 @@ def serve(
     """
     Serve log-data over WebSockets and serve a Rerun web viewer over HTTP.
 
-    You can connect to this server using `python -m rerun`.
+    You can also connect to this server with the native viewer using `rerun localhost:9090`.
 
     WARNING: This is an experimental feature.
 


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2586) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2586)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fupdate-docs/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fupdate-docs/examples)