### PR TITLE
Fix freeze/crash when logging large times

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
             "cwd": "${workspaceFolder}"
         },
         {
-            "name": "Debug 'rerun' data.rrd",
+            "name": "Debug 'rerun ../data.rrd'",
             "type": "lldb",
             "request": "launch",
             "cargo": {
@@ -65,28 +65,7 @@
             "cwd": "${workspaceFolder}"
         },
         {
-            "name": "Debug 'rerun' objectron.rrd",
-            "type": "lldb",
-            "request": "launch",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--package=rerun-cli",
-                    "--no-default-features",
-                    "--features=native_viewer"
-                ],
-                "filter": {
-                    "name": "rerun",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "../objectron.rrd"
-            ],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "name": "Debug re_renderer sample",
+            "name": "Debug re_renderer --example=multiview",
             "type": "lldb",
             "request": "launch",
             "cargo": {

--- a/crates/re_log_types/src/time_real.rs
+++ b/crates/re_log_types/src/time_real.rs
@@ -70,8 +70,11 @@ impl From<f32> for TimeReal {
     /// Saturating cast
     #[inline]
     fn from(value: f32) -> Self {
-        assert!(!value.is_nan());
-        if let Some(num) = FixedI128::checked_from_num(value) {
+        debug_assert!(!value.is_nan());
+        if value.is_nan() {
+            re_log::warn_once!("NaN time detected");
+            Self(0.into())
+        } else if let Some(num) = FixedI128::checked_from_num(value) {
             Self(num)
         } else if value < 0.0 {
             Self::MIN
@@ -85,8 +88,11 @@ impl From<f64> for TimeReal {
     /// Saturating cast
     #[inline]
     fn from(value: f64) -> Self {
-        assert!(!value.is_nan());
-        if let Some(num) = FixedI128::checked_from_num(value) {
+        debug_assert!(!value.is_nan());
+        if value.is_nan() {
+            re_log::warn_once!("NaN time detected");
+            Self(0.into())
+        } else if let Some(num) = FixedI128::checked_from_num(value) {
             Self(num)
         } else if value < 0.0 {
             Self::MIN

--- a/crates/re_log_types/src/time_real.rs
+++ b/crates/re_log_types/src/time_real.rs
@@ -73,13 +73,10 @@ impl From<f32> for TimeReal {
         assert!(!value.is_nan());
         if let Some(num) = FixedI128::checked_from_num(value) {
             Self(num)
+        } else if value < 0.0 {
+            Self::MIN
         } else {
-            // underflow or overflow
-            if value < 0.0 {
-                Self::MIN
-            } else {
-                Self::MAX
-            }
+            Self::MAX
         }
     }
 }
@@ -91,13 +88,10 @@ impl From<f64> for TimeReal {
         assert!(!value.is_nan());
         if let Some(num) = FixedI128::checked_from_num(value) {
             Self(num)
+        } else if value < 0.0 {
+            Self::MIN
         } else {
-            // unde
-            if value < 0.0 {
-                Self::MIN
-            } else {
-                Self::MAX
-            }
+            Self::MAX
         }
     }
 }

--- a/crates/re_log_types/src/time_real.rs
+++ b/crates/re_log_types/src/time_real.rs
@@ -20,6 +20,9 @@ use crate::TimeInt;
 pub struct TimeReal(FixedI128<typenum::U64>);
 
 impl TimeReal {
+    pub const MIN: Self = Self(FixedI128::MIN);
+    pub const MAX: Self = Self(FixedI128::MAX);
+
     #[inline]
     pub fn floor(&self) -> TimeInt {
         let int: i64 = self.0.saturating_floor().lossy_into();
@@ -64,16 +67,38 @@ impl From<i64> for TimeReal {
 }
 
 impl From<f32> for TimeReal {
+    /// Saturating cast
     #[inline]
     fn from(value: f32) -> Self {
-        Self(FixedI128::from_num(value))
+        assert!(!value.is_nan());
+        if let Some(num) = FixedI128::checked_from_num(value) {
+            Self(num)
+        } else {
+            // underflow or overflow
+            if value < 0.0 {
+                Self::MIN
+            } else {
+                Self::MAX
+            }
+        }
     }
 }
 
 impl From<f64> for TimeReal {
+    /// Saturating cast
     #[inline]
     fn from(value: f64) -> Self {
-        Self(FixedI128::from_num(value))
+        assert!(!value.is_nan());
+        if let Some(num) = FixedI128::checked_from_num(value) {
+            Self(num)
+        } else {
+            // unde
+            if value < 0.0 {
+                Self::MIN
+            } else {
+                Self::MAX
+            }
+        }
     }
 }
 
@@ -146,7 +171,7 @@ impl std::ops::Mul<f64> for TimeReal {
 
     #[inline]
     fn mul(self, rhs: f64) -> Self::Output {
-        Self(self.0.saturating_mul(FixedI128::from_num(rhs)))
+        Self(self.0.saturating_mul(Self::from(rhs).0))
     }
 }
 
@@ -259,4 +284,9 @@ fn test_time_value_f() {
             assert_eq!(T::from(f) - T::from(g), T::from(f - g));
         }
     }
+
+    assert_eq!(TimeReal::from(f32::NEG_INFINITY), TimeReal::MIN);
+    assert_eq!(TimeReal::from(f32::MIN), TimeReal::MIN);
+    assert_eq!(TimeReal::from(f32::INFINITY), TimeReal::MAX);
+    assert_eq!(TimeReal::from(f32::MAX), TimeReal::MAX);
 }

--- a/crates/re_time_panel/src/paint_ticks.rs
+++ b/crates/re_time_panel/src/paint_ticks.rs
@@ -170,7 +170,8 @@ fn paint_ticks(
     let mut current_time =
         time_range.min.floor().as_i64() / small_spacing_time * small_spacing_time;
 
-    while current_time <= time_range.max.ceil().as_i64() {
+    let end_time = time_range.max.ceil().as_i64().saturating_add(1);
+    while current_time < end_time {
         let line_x = x_from_time(current_time);
 
         if visible_rect.min.x <= line_x && line_x <= visible_rect.max.x {
@@ -210,7 +211,7 @@ fn paint_ticks(
             }
         }
 
-        current_time += small_spacing_time;
+        current_time = current_time.saturating_add(small_spacing_time);
     }
 
     shapes


### PR DESCRIPTION
### What
If the user logged times that were at the limit of i64 we would sometimes get freezes and crashes.

Closes https://github.com/rerun-io/rerun/issues/2582

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2588) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2588)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-freeze-on-large-times/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-freeze-on-large-times/examples)