### PR TITLE
Disable codegen on windows

### DIFF
--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -20,6 +20,11 @@ const RUST_OUTPUT_DIR_PATH: &str = ".";
 const PYTHON_OUTPUT_DIR_PATH: &str = "../../rerun_py/rerun_sdk/rerun/_rerun2";
 
 fn main() {
+    if cfg!(target_os = "windows") {
+        // TODO(#2591): Codegen is temporarily disabled on Windows due to hashing issues.
+        return;
+    }
+
     if !is_tracked_env_var_set("IS_IN_RERUN_WORKSPACE") {
         // Only run if we are in the rerun workspace, not on users machines.
         return;

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-2482cd3e136880416056a88c296bd419d5b01626d2db3914e5e375c614123bcc
+5cac23400a6084eaaa53fba54885d12daefa92fdbdb057c8221ec343dcdd9586

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -14,6 +14,11 @@ const SOURCE_HASH_PATH: &str = "./source_hash.txt";
 const FBS_REFLECTION_DEFINITION_PATH: &str = "./definitions/reflection.fbs";
 
 fn main() {
+    if cfg!(target_os = "windows") {
+        // TODO(#2591): Codegen is temporarily disabled on Windows due to hashing issues.
+        return;
+    }
+
     if !is_tracked_env_var_set("IS_IN_RERUN_WORKSPACE") {
         // Only run if we are in the rerun workspace, not on users machines.
         return;


### PR DESCRIPTION
See #2591:
> Codegen (specifically, `re_types_builder/build.rs` & `re_types/build.rs`) has been disabled on Windows in #2592 because it was somehow computing different sha256 sums (??) and thus breaking the CI.
> 
> This isn't too bad of an issue as it only affects contributors on windows that are trying to modify IDL definitions but should nonetheless be fixed sooner than later.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
