### PR TITLE
Refactor: Swap the naming of Viewport and ViewportBlueprint

### DIFF
--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -101,7 +101,7 @@ impl AppState {
             store_db,
         )
         .selection_state
-        .on_frame_start(|item| viewport.blueprint.is_item_valid(item));
+        .on_frame_start(|item| viewport.is_item_valid(item));
 
         let rec_cfg = recording_config_entry(
             recording_configs,

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -7,7 +7,7 @@ use re_viewer_context::{
     AppOptions, Caches, CommandSender, ComponentUiRegistry, PlayState, RecordingConfig,
     SpaceViewClassRegistry, StoreContext, ViewerContext,
 };
-use re_viewport::{SpaceInfoCollection, ViewportBlueprint, ViewportState};
+use re_viewport::{SpaceInfoCollection, Viewport, ViewportState};
 
 use crate::{app_blueprint::AppBlueprint, store_hub::StoreHub, ui::blueprint_panel_ui};
 
@@ -83,8 +83,6 @@ impl AppState {
     ) {
         re_tracing::profile_function!();
 
-        let mut blueprint = ViewportBlueprint::from_db(store_context.blueprint);
-
         let Self {
             app_options,
             cache,
@@ -94,6 +92,8 @@ impl AppState {
             viewport_state,
         } = self;
 
+        let mut viewport = Viewport::from_db(store_context.blueprint, viewport_state);
+
         recording_config_entry(
             recording_configs,
             store_db.store_id().clone(),
@@ -101,7 +101,7 @@ impl AppState {
             store_db,
         )
         .selection_state
-        .on_frame_start(|item| blueprint.is_item_valid(item));
+        .on_frame_start(|item| viewport.blueprint.is_item_valid(item));
 
         let rec_cfg = recording_config_entry(
             recording_configs,
@@ -125,10 +125,9 @@ impl AppState {
 
         time_panel.show_panel(&mut ctx, ui, app_blueprint.time_panel_expanded);
         selection_panel.show_panel(
-            viewport_state,
             &mut ctx,
             ui,
-            &mut blueprint,
+            &mut viewport,
             app_blueprint.selection_panel_expanded,
         );
 
@@ -143,10 +142,10 @@ impl AppState {
             .show_inside(ui, |ui| {
                 let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
 
-                blueprint.viewport.on_frame_start(&mut ctx, &spaces_info);
+                viewport.blueprint.on_frame_start(&mut ctx, &spaces_info);
 
                 blueprint_panel_ui(
-                    &mut blueprint,
+                    &mut viewport.blueprint,
                     &mut ctx,
                     ui,
                     &spaces_info,
@@ -161,16 +160,16 @@ impl AppState {
                 egui::CentralPanel::default()
                     .frame(viewport_frame)
                     .show_inside(ui, |ui| {
-                        blueprint.viewport.viewport_ui(viewport_state, ui, &mut ctx);
+                        viewport.viewport_ui(ui, &mut ctx);
                     });
 
                 // If the viewport was user-edited, then disable auto space views
-                if blueprint.viewport.has_been_user_edited {
-                    blueprint.viewport.auto_space_views = false;
+                if viewport.blueprint.has_been_user_edited {
+                    viewport.blueprint.auto_space_views = false;
                 }
             });
 
-        blueprint.sync_changes(command_sender);
+        viewport.sync_blueprint_changes(command_sender);
 
         {
             // We move the time at the very end of the frame,

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -142,7 +142,7 @@ impl AppState {
             .show_inside(ui, |ui| {
                 let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
 
-                viewport.blueprint.on_frame_start(&mut ctx, &spaces_info);
+                viewport.on_frame_start(&mut ctx, &spaces_info);
 
                 blueprint_panel_ui(
                     &mut viewport.blueprint,

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -1,9 +1,9 @@
 use re_viewer_context::ViewerContext;
-use re_viewport::{SpaceInfoCollection, Viewport, ViewportBlueprint};
+use re_viewport::{SpaceInfoCollection, ViewportBlueprint};
 
 /// Show the left-handle panel based on the current [`ViewportBlueprint`]
 pub fn blueprint_panel_ui(
-    blueprint: &mut ViewportBlueprint<'_>,
+    blueprint: &mut ViewportBlueprint,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
@@ -28,13 +28,13 @@ pub fn blueprint_panel_ui(
             ..Default::default()
         }
         .show(ui, |ui| {
-            blueprint.viewport.tree_ui(ctx, ui);
+            blueprint.tree_ui(ctx, ui);
         });
     });
 }
 
 fn title_bar_ui(
-    blueprint: &mut ViewportBlueprint<'_>,
+    blueprint: &mut ViewportBlueprint,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
@@ -54,9 +54,7 @@ fn title_bar_ui(
                     ui.available_size_before_wrap(),
                     egui::Layout::right_to_left(egui::Align::Center),
                     |ui| {
-                        blueprint
-                            .viewport
-                            .add_new_spaceview_button_ui(ctx, ui, spaces_info);
+                        blueprint.add_new_spaceview_button_ui(ctx, ui, spaces_info);
                         reset_button_ui(blueprint, ctx, ui, spaces_info);
                     },
                 );
@@ -65,7 +63,7 @@ fn title_bar_ui(
 }
 
 fn reset_button_ui(
-    blueprint: &mut ViewportBlueprint<'_>,
+    blueprint: &mut ViewportBlueprint,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
@@ -76,6 +74,6 @@ fn reset_button_ui(
         .on_hover_text("Re-populate Viewport with automatically chosen Space Views")
         .clicked()
     {
-        blueprint.viewport = Viewport::new(ctx, spaces_info);
+        *blueprint = ViewportBlueprint::new(ctx, spaces_info);
     }
 }

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -3,7 +3,7 @@ use re_viewport::{SpaceInfoCollection, ViewportBlueprint};
 
 /// Show the left-handle panel based on the current [`ViewportBlueprint`]
 pub fn blueprint_panel_ui(
-    blueprint: &mut ViewportBlueprint,
+    blueprint: &mut ViewportBlueprint<'_>,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
@@ -34,7 +34,7 @@ pub fn blueprint_panel_ui(
 }
 
 fn title_bar_ui(
-    blueprint: &mut ViewportBlueprint,
+    blueprint: &mut ViewportBlueprint<'_>,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
@@ -63,7 +63,7 @@ fn title_bar_ui(
 }
 
 fn reset_button_ui(
-    blueprint: &mut ViewportBlueprint,
+    blueprint: &mut ViewportBlueprint<'_>,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
@@ -74,6 +74,6 @@ fn reset_button_ui(
         .on_hover_text("Re-populate Viewport with automatically chosen Space Views")
         .clicked()
     {
-        *blueprint = ViewportBlueprint::new(ctx, spaces_info);
+        blueprint.reset(ctx, spaces_info);
     }
 }

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -14,7 +14,7 @@ impl SelectionHistoryUi {
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,
-        blueprint: &ViewportBlueprint<'_>,
+        blueprint: &ViewportBlueprint,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
         ui.horizontal_centered(|ui| {
@@ -36,7 +36,7 @@ impl SelectionHistoryUi {
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,
-        blueprint: &ViewportBlueprint<'_>,
+        blueprint: &ViewportBlueprint,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
         // undo selection
@@ -80,7 +80,7 @@ impl SelectionHistoryUi {
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,
-        blueprint: &ViewportBlueprint<'_>,
+        blueprint: &ViewportBlueprint,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
         // redo selection
@@ -123,7 +123,7 @@ impl SelectionHistoryUi {
     #[allow(clippy::unused_self)]
     fn history_item_ui(
         &mut self,
-        blueprint: &ViewportBlueprint<'_>,
+        blueprint: &ViewportBlueprint,
         ui: &mut egui::Ui,
         index: usize,
         history: &mut SelectionHistory,
@@ -154,7 +154,7 @@ fn item_kind_ui(ui: &mut egui::Ui, sel: &Item) {
     ui.weak(RichText::new(format!("({})", sel.kind())));
 }
 
-fn item_collection_to_string(blueprint: &ViewportBlueprint<'_>, items: &ItemCollection) -> String {
+fn item_collection_to_string(blueprint: &ViewportBlueprint, items: &ItemCollection) -> String {
     assert!(!items.is_empty()); // history never contains empty selections.
     if items.len() == 1 {
         item_to_string(blueprint, items.iter().next().unwrap())
@@ -165,10 +165,10 @@ fn item_collection_to_string(blueprint: &ViewportBlueprint<'_>, items: &ItemColl
     }
 }
 
-fn item_to_string(blueprint: &ViewportBlueprint<'_>, item: &Item) -> String {
+fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
     match item {
         Item::SpaceView(sid) => {
-            if let Some(space_view) = blueprint.viewport.space_view(sid) {
+            if let Some(space_view) = blueprint.space_view(sid) {
                 space_view.display_name.clone()
             } else {
                 "<removed space view>".to_owned()
@@ -176,7 +176,7 @@ fn item_to_string(blueprint: &ViewportBlueprint<'_>, item: &Item) -> String {
         }
         Item::InstancePath(_, entity_path) => entity_path.to_string(),
         Item::DataBlueprintGroup(sid, handle) => {
-            if let Some(space_view) = blueprint.viewport.space_view(sid) {
+            if let Some(space_view) = blueprint.space_view(sid) {
                 if let Some(group) = space_view.data_blueprint.group(*handle) {
                     group.display_name.clone()
                 } else {

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -14,7 +14,7 @@ impl SelectionHistoryUi {
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,
-        blueprint: &ViewportBlueprint,
+        blueprint: &ViewportBlueprint<'_>,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
         ui.horizontal_centered(|ui| {
@@ -36,7 +36,7 @@ impl SelectionHistoryUi {
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,
-        blueprint: &ViewportBlueprint,
+        blueprint: &ViewportBlueprint<'_>,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
         // undo selection
@@ -80,7 +80,7 @@ impl SelectionHistoryUi {
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,
-        blueprint: &ViewportBlueprint,
+        blueprint: &ViewportBlueprint<'_>,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
         // redo selection
@@ -123,7 +123,7 @@ impl SelectionHistoryUi {
     #[allow(clippy::unused_self)]
     fn history_item_ui(
         &mut self,
-        blueprint: &ViewportBlueprint,
+        blueprint: &ViewportBlueprint<'_>,
         ui: &mut egui::Ui,
         index: usize,
         history: &mut SelectionHistory,
@@ -154,7 +154,7 @@ fn item_kind_ui(ui: &mut egui::Ui, sel: &Item) {
     ui.weak(RichText::new(format!("({})", sel.kind())));
 }
 
-fn item_collection_to_string(blueprint: &ViewportBlueprint, items: &ItemCollection) -> String {
+fn item_collection_to_string(blueprint: &ViewportBlueprint<'_>, items: &ItemCollection) -> String {
     assert!(!items.is_empty()); // history never contains empty selections.
     if items.len() == 1 {
         item_to_string(blueprint, items.iter().next().unwrap())
@@ -165,7 +165,7 @@ fn item_collection_to_string(blueprint: &ViewportBlueprint, items: &ItemCollecti
     }
 }
 
-fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
+fn item_to_string(blueprint: &ViewportBlueprint<'_>, item: &Item) -> String {
     match item {
         Item::SpaceView(sid) => {
             if let Some(space_view) = blueprint.space_view(sid) {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -124,7 +124,7 @@ fn has_data_section(item: &Item) -> bool {
 fn what_is_selected_ui(
     ui: &mut egui::Ui,
     ctx: &mut ViewerContext<'_>,
-    viewport: &mut ViewportBlueprint,
+    viewport: &mut ViewportBlueprint<'_>,
     item: &Item,
 ) {
     match item {
@@ -315,7 +315,7 @@ fn list_existing_data_blueprints(
     ui: &mut egui::Ui,
     ctx: &mut ViewerContext<'_>,
     entity_path: &EntityPath,
-    blueprint: &ViewportBlueprint,
+    blueprint: &ViewportBlueprint<'_>,
 ) {
     let space_views_with_path = blueprint.space_views_containing_entity_path(entity_path);
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -5,7 +5,7 @@ use re_data_store::{ColorMapper, Colormap, EditableAutoValue, EntityPath, Entity
 use re_data_ui::{item_ui, DataUi};
 use re_log_types::TimeType;
 use re_viewer_context::{Item, SpaceViewId, UiVerbosity, ViewerContext};
-use re_viewport::{Viewport, ViewportBlueprint, ViewportState};
+use re_viewport::{Viewport, ViewportBlueprint};
 
 use super::selection_history_ui::SelectionHistoryUi;
 
@@ -21,10 +21,9 @@ pub(crate) struct SelectionPanel {
 impl SelectionPanel {
     pub fn show_panel(
         &mut self,
-        viewport_state: &mut ViewportState,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        blueprint: &mut ViewportBlueprint<'_>,
+        viewport: &mut Viewport<'_, '_>,
         expanded: bool,
     ) {
         let screen_width = ui.ctx().screen_rect().width();
@@ -50,7 +49,7 @@ impl SelectionPanel {
                     if let Some(selection) = self.selection_state_ui.selection_ui(
                         ctx.re_ui,
                         ui,
-                        blueprint,
+                        &viewport.blueprint,
                         &mut ctx.selection_state_mut().history,
                     ) {
                         ctx.selection_state_mut()
@@ -66,7 +65,7 @@ impl SelectionPanel {
                         ..Default::default()
                     }
                     .show(ui, |ui| {
-                        self.contents(viewport_state, ctx, ui, blueprint);
+                        self.contents(ctx, ui, viewport);
                     });
                 });
         });
@@ -75,10 +74,9 @@ impl SelectionPanel {
     #[allow(clippy::unused_self)]
     fn contents(
         &mut self,
-        viewport_state: &mut ViewportState,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        blueprint: &mut ViewportBlueprint<'_>,
+        viewport: &mut Viewport<'_, '_>,
     ) {
         re_tracing::profile_function!();
 
@@ -92,7 +90,7 @@ impl SelectionPanel {
         let selection = ctx.selection().to_vec();
         for (i, item) in selection.iter().enumerate() {
             ui.push_id(i, |ui| {
-                what_is_selected_ui(ui, ctx, &mut blueprint.viewport, item);
+                what_is_selected_ui(ui, ctx, &mut viewport.blueprint, item);
 
                 if has_data_section(item) {
                     ctx.re_ui.large_collapsing_header(ui, "Data", true, |ui| {
@@ -102,7 +100,7 @@ impl SelectionPanel {
 
                 ctx.re_ui
                     .large_collapsing_header(ui, "Blueprint", true, |ui| {
-                        blueprint_ui(viewport_state, ui, ctx, blueprint, item);
+                        blueprint_ui(ui, ctx, viewport, item);
                     });
 
                 if i + 1 < num_selections {
@@ -126,7 +124,7 @@ fn has_data_section(item: &Item) -> bool {
 fn what_is_selected_ui(
     ui: &mut egui::Ui,
     ctx: &mut ViewerContext<'_>,
-    viewport: &mut Viewport,
+    viewport: &mut ViewportBlueprint,
     item: &Item,
 ) {
     match item {
@@ -205,15 +203,19 @@ fn what_is_selected_ui(
 
 /// What is the blueprint stuff for this item?
 fn blueprint_ui(
-    viewport_state: &mut ViewportState,
     ui: &mut egui::Ui,
     ctx: &mut ViewerContext<'_>,
-    blueprint: &mut ViewportBlueprint<'_>,
+    viewport: &mut Viewport<'_, '_>,
     item: &Item,
 ) {
     match item {
         Item::ComponentPath(component_path) => {
-            list_existing_data_blueprints(ui, ctx, component_path.entity_path(), blueprint);
+            list_existing_data_blueprints(
+                ui,
+                ctx,
+                component_path.entity_path(),
+                &viewport.blueprint,
+            );
         }
 
         Item::SpaceView(space_view_id) => {
@@ -223,7 +225,7 @@ fn blueprint_ui(
                     .on_hover_text("Manually add or remove entities from the Space View.")
                     .clicked()
                 {
-                    viewport_state
+                    viewport
                         .show_add_remove_entities_window(*space_view_id);
                 }
 
@@ -232,19 +234,19 @@ fn blueprint_ui(
                     .on_hover_text("Create an exact duplicate of this Space View including all blueprint settings")
                     .clicked()
                 {
-                    if let Some(space_view) = blueprint.viewport.space_view(space_view_id) {
+                    if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
                         let mut new_space_view = space_view.clone();
                         new_space_view.id = SpaceViewId::random();
-                        blueprint.viewport.add_space_view(new_space_view);
-                        blueprint.viewport.mark_user_interaction();
+                        viewport.blueprint.add_space_view(new_space_view);
+                        viewport.blueprint.mark_user_interaction();
                     }
                 }
             });
 
             ui.add_space(ui.spacing().item_spacing.y);
 
-            if let Some(space_view) = blueprint.viewport.space_view_mut(space_view_id) {
-                let space_view_state = viewport_state.space_view_state_mut(
+            if let Some(space_view) = viewport.blueprint.space_view_mut(space_view_id) {
+                let space_view_state = viewport.state.space_view_state_mut(
                     ctx.space_view_class_registry,
                     space_view.id,
                     space_view.class_name(),
@@ -264,7 +266,7 @@ fn blueprint_ui(
 
         Item::InstancePath(space_view_id, instance_path) => {
             if let Some(space_view_id) = space_view_id {
-                if let Some(space_view) = blueprint.viewport.space_view_mut(space_view_id) {
+                if let Some(space_view) = viewport.blueprint.space_view_mut(space_view_id) {
                     if instance_path.instance_key.is_specific() {
                         ui.horizontal(|ui| {
                             ui.label("Part of");
@@ -285,12 +287,17 @@ fn blueprint_ui(
                     }
                 }
             } else {
-                list_existing_data_blueprints(ui, ctx, &instance_path.entity_path, blueprint);
+                list_existing_data_blueprints(
+                    ui,
+                    ctx,
+                    &instance_path.entity_path,
+                    &viewport.blueprint,
+                );
             }
         }
 
         Item::DataBlueprintGroup(space_view_id, data_blueprint_group_handle) => {
-            if let Some(space_view) = blueprint.viewport.space_view_mut(space_view_id) {
+            if let Some(space_view) = viewport.blueprint.space_view_mut(space_view_id) {
                 if let Some(group) = space_view
                     .data_blueprint
                     .group_mut(*data_blueprint_group_handle)
@@ -308,11 +315,9 @@ fn list_existing_data_blueprints(
     ui: &mut egui::Ui,
     ctx: &mut ViewerContext<'_>,
     entity_path: &EntityPath,
-    blueprint: &ViewportBlueprint<'_>,
+    blueprint: &ViewportBlueprint,
 ) {
-    let space_views_with_path = blueprint
-        .viewport
-        .space_views_containing_entity_path(entity_path);
+    let space_views_with_path = blueprint.space_views_containing_entity_path(entity_path);
 
     if space_views_with_path.is_empty() {
         ui.weak("(Not shown in any Space View)");
@@ -322,7 +327,7 @@ fn list_existing_data_blueprints(
 
         ui.indent("list of data blueprints indent", |ui| {
             for space_view_id in &space_views_with_path {
-                if let Some(space_view) = blueprint.viewport.space_view(space_view_id) {
+                if let Some(space_view) = blueprint.space_view(space_view_id) {
                     item_ui::entity_path_button_to(
                         ctx,
                         ui,

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -11,6 +11,7 @@ mod space_view_highlights;
 mod view_category;
 mod viewport;
 mod viewport_blueprint;
+mod viewport_blueprint_ui;
 
 pub mod blueprint_components;
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -1,626 +1,23 @@
-//! The viewport panel.
-//!
-//! Contains all space views.
-
 use std::collections::BTreeMap;
 
 use ahash::HashMap;
-use itertools::Itertools as _;
 
-use re_data_store::EntityPath;
-use re_data_ui::item_ui;
-use re_space_view::DataBlueprintGroup;
+use re_data_store::StoreDb;
+
 use re_viewer_context::{
-    DataBlueprintGroupHandle, Item, SpaceViewClassName, SpaceViewClassRegistry,
-    SpaceViewHighlights, SpaceViewId, SpaceViewState, ViewerContext,
+    CommandSender, Item, SpaceViewClassName, SpaceViewClassRegistry, SpaceViewHighlights,
+    SpaceViewId, SpaceViewState, SystemCommand, SystemCommandSender, ViewerContext,
 };
 
 use crate::{
-    space_info::SpaceInfoCollection,
-    space_view::SpaceViewBlueprint,
     space_view_entity_picker::SpaceViewEntityPicker,
-    space_view_heuristics::{all_possible_space_views, default_created_space_views},
     space_view_highlights::highlights_for_space_view,
+    viewport_blueprint::{load_viewport_blueprint, sync_viewport_blueprint},
+    SpaceViewBlueprint, ViewportBlueprint,
 };
 
-#[must_use]
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum TreeAction {
-    Keep,
-    Remove,
-}
-
 // ----------------------------------------------------------------------------
-
-/// Describes the layout and contents of the Viewport Panel.
-#[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
-#[serde(default)]
-pub struct Viewport {
-    /// Where the space views are stored.
-    ///
-    /// Not a hashmap in order to preserve the order of the space views.
-    pub space_views: BTreeMap<SpaceViewId, SpaceViewBlueprint>,
-
-    /// The layouts of all the space views.
-    pub tree: egui_tiles::Tree<SpaceViewId>,
-
-    /// Show one tab as maximized?
-    pub maximized: Option<SpaceViewId>,
-
-    /// Set to `true` the first time the user messes around with the viewport blueprint.
-    pub has_been_user_edited: bool,
-
-    /// Whether or not space views should be created automatically.
-    pub auto_space_views: bool,
-}
-
-impl Viewport {
-    /// Create a default suggested blueprint using some heuristics.
-    pub fn new(ctx: &mut ViewerContext<'_>, spaces_info: &SpaceInfoCollection) -> Self {
-        re_tracing::profile_function!();
-
-        let mut viewport = Self::default();
-        for space_view in default_created_space_views(ctx, spaces_info) {
-            viewport.add_space_view(space_view);
-        }
-        viewport
-    }
-
-    pub fn space_view_ids(&self) -> impl Iterator<Item = &SpaceViewId> + '_ {
-        self.space_views.keys()
-    }
-
-    pub fn space_view(&self, space_view: &SpaceViewId) -> Option<&SpaceViewBlueprint> {
-        self.space_views.get(space_view)
-    }
-
-    pub fn space_view_mut(
-        &mut self,
-        space_view_id: &SpaceViewId,
-    ) -> Option<&mut SpaceViewBlueprint> {
-        self.space_views.get_mut(space_view_id)
-    }
-
-    pub(crate) fn remove(&mut self, space_view_id: &SpaceViewId) -> Option<SpaceViewBlueprint> {
-        let Self {
-            space_views,
-            tree,
-            maximized,
-            has_been_user_edited,
-            auto_space_views: _,
-        } = self;
-
-        *has_been_user_edited = true;
-
-        if *maximized == Some(*space_view_id) {
-            *maximized = None;
-        }
-
-        if let Some(tile_id) = tree.tiles.find_pane(space_view_id) {
-            tree.tiles.remove(tile_id);
-        }
-
-        space_views.remove(space_view_id)
-    }
-
-    /// Show the blueprint panel tree view.
-    pub fn tree_ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
-        re_tracing::profile_function!();
-
-        egui::ScrollArea::both()
-            .auto_shrink([true, false])
-            .show(ui, |ui| {
-                if let Some(root) = self.tree.root() {
-                    if self.tile_ui(ctx, ui, root) == TreeAction::Remove {
-                        self.tree.root = None;
-                    }
-                }
-            });
-    }
-
-    /// If a group or spaceview has a total of this number of elements, show its subtree by default?
-    fn default_open_for_group(group: &DataBlueprintGroup) -> bool {
-        let num_children = group.children.len() + group.entities.len();
-        2 <= num_children && num_children <= 3
-    }
-
-    fn tile_ui(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
-    ) -> TreeAction {
-        // Temporarily remove the tile so we don't get borrow checker fights:
-        let Some(mut tile) = self.tree.tiles.remove(tile_id) else { return TreeAction::Remove; };
-
-        let action = match &mut tile {
-            egui_tiles::Tile::Container(container) => {
-                self.container_tree_ui(ctx, ui, tile_id, container)
-            }
-            egui_tiles::Tile::Pane(space_view_id) => {
-                // A space view
-                self.space_view_entry_ui(ctx, ui, tile_id, space_view_id)
-            }
-        };
-
-        self.tree.tiles.insert(tile_id, tile);
-
-        if action == TreeAction::Remove {
-            for tile in self.tree.tiles.remove_recursively(tile_id) {
-                if let egui_tiles::Tile::Pane(space_view_id) = tile {
-                    self.remove(&space_view_id);
-                }
-            }
-        }
-
-        action
-    }
-
-    fn container_tree_ui(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
-        container: &mut egui_tiles::Container,
-    ) -> TreeAction {
-        if let Some(child_id) = container.only_child() {
-            // Maybe a tab container with only one child - collapse it in the tree view to make it more easily understood.
-            // This means we won't be showing the visibility button of the parent container,
-            // so if the child is made invisible, we should do the same for the parent.
-            let child_is_visible = self.tree.is_visible(child_id);
-            self.tree.set_visible(tile_id, child_is_visible);
-            return self.tile_ui(ctx, ui, child_id);
-        }
-
-        let mut visibility_changed = false;
-        let mut action = TreeAction::Keep;
-        let mut visible = self.tree.is_visible(tile_id);
-
-        let default_open = true;
-        egui::collapsing_header::CollapsingState::load_with_default_open(
-            ui.ctx(),
-            egui::Id::new((tile_id, "tree")),
-            default_open,
-        )
-        .show_header(ui, |ui| {
-            blueprint_row_with_buttons(
-                ctx.re_ui,
-                ui,
-                true,
-                visible,
-                |ui| ui.label(format!("{:?}", container.kind())),
-                |re_ui, ui| {
-                    visibility_changed =
-                        visibility_button_ui(re_ui, ui, true, &mut visible).changed();
-                    if re_ui
-                        .small_icon_button(ui, &re_ui::icons::REMOVE)
-                        .on_hover_text("Remove container")
-                        .clicked()
-                    {
-                        action = TreeAction::Remove;
-                    }
-                },
-            );
-        })
-        .body(|ui| container.retain(|child| self.tile_ui(ctx, ui, child) == TreeAction::Keep));
-
-        if visibility_changed {
-            self.has_been_user_edited = true;
-            self.tree.set_visible(tile_id, visible);
-        }
-
-        action
-    }
-
-    fn space_view_entry_ui(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
-        space_view_id: &SpaceViewId,
-    ) -> TreeAction {
-        let Some(space_view) = self.space_views.get_mut(space_view_id) else {
-            re_log::warn_once!("Bug: asked to show a ui for a Space View that doesn't exist");
-            return TreeAction::Remove;
-        };
-        debug_assert_eq!(space_view.id, *space_view_id);
-
-        let mut visibility_changed = false;
-        let mut action = TreeAction::Keep;
-        let mut visible = self.tree.is_visible(tile_id);
-
-        let root_group = space_view.data_blueprint.root_group();
-        let default_open = Self::default_open_for_group(root_group);
-        let collapsing_header_id = ui.id().with(space_view.id);
-        egui::collapsing_header::CollapsingState::load_with_default_open(
-            ui.ctx(),
-            collapsing_header_id,
-            default_open,
-        )
-        .show_header(ui, |ui| {
-            blueprint_row_with_buttons(
-                ctx.re_ui,
-                ui,
-                true,
-                visible,
-                |ui| {
-                    let response = crate::item_ui::space_view_button(ctx, ui, space_view);
-                    if response.clicked() {
-                        focus_tab(&mut self.tree, space_view_id);
-                    }
-                    response
-                },
-                |re_ui, ui| {
-                    visibility_changed =
-                        visibility_button_ui(re_ui, ui, true, &mut visible).changed();
-                    if re_ui
-                        .small_icon_button(ui, &re_ui::icons::REMOVE)
-                        .on_hover_text("Remove Space View from the viewport.")
-                        .clicked()
-                    {
-                        action = TreeAction::Remove;
-                    }
-                },
-            );
-        })
-        .body(|ui| {
-            Self::data_blueprint_tree_ui(
-                ctx,
-                ui,
-                space_view.data_blueprint.root_handle(),
-                space_view,
-                visible,
-            );
-        });
-
-        if visibility_changed {
-            self.has_been_user_edited = true;
-            self.tree.set_visible(tile_id, visible);
-        }
-
-        if action == TreeAction::Remove {
-            self.remove(space_view_id);
-        }
-
-        action
-    }
-
-    fn data_blueprint_tree_ui(
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        group_handle: DataBlueprintGroupHandle,
-        space_view: &mut SpaceViewBlueprint,
-        space_view_visible: bool,
-    ) {
-        let Some(group) = space_view.data_blueprint.group(group_handle) else {
-            debug_assert!(false, "Invalid group handle in blueprint group tree");
-            return;
-        };
-
-        // TODO(andreas): These clones are workarounds against borrowing multiple times from data_blueprint_tree.
-        let children = group.children.clone();
-        let entities = group.entities.clone();
-        let group_name = group.display_name.clone();
-        let group_is_visible = group.properties_projected.visible && space_view_visible;
-
-        for entity_path in &entities {
-            if entity_path.is_root() {
-                continue;
-            }
-
-            ui.horizontal(|ui| {
-                let mut properties = space_view
-                    .data_blueprint
-                    .data_blueprints_individual()
-                    .get(entity_path);
-                blueprint_row_with_buttons(
-                    ctx.re_ui,
-                    ui,
-                    group_is_visible,
-                    properties.visible,
-                    |ui| {
-                        let name = entity_path.iter().last().unwrap().to_string();
-                        let label = format!("🔹 {name}");
-                        item_ui::data_blueprint_button_to(
-                            ctx,
-                            ui,
-                            label,
-                            space_view.id,
-                            entity_path,
-                        )
-                    },
-                    |re_ui, ui| {
-                        if visibility_button_ui(
-                            re_ui,
-                            ui,
-                            group_is_visible,
-                            &mut properties.visible,
-                        )
-                        .changed()
-                        {
-                            space_view
-                                .data_blueprint
-                                .data_blueprints_individual()
-                                .set(entity_path.clone(), properties);
-                        }
-                        if re_ui
-                            .small_icon_button(ui, &re_ui::icons::REMOVE)
-                            .on_hover_text("Remove Entity from the space view.")
-                            .clicked()
-                        {
-                            space_view.data_blueprint.remove_entity(entity_path);
-                            space_view.entities_determined_by_user = true;
-                        }
-                    },
-                );
-            });
-        }
-
-        for child_group_handle in &children {
-            let Some(child_group) = space_view.data_blueprint.group_mut(*child_group_handle) else {
-                debug_assert!(false, "Data blueprint group {group_name} has an invalid child");
-                continue;
-            };
-
-            let mut remove_group = false;
-            let default_open = Self::default_open_for_group(child_group);
-            egui::collapsing_header::CollapsingState::load_with_default_open(
-                ui.ctx(),
-                ui.id().with(child_group_handle),
-                default_open,
-            )
-            .show_header(ui, |ui| {
-                blueprint_row_with_buttons(
-                    ctx.re_ui,
-                    ui,
-                    group_is_visible,
-                    child_group.properties_individual.visible,
-                    |ui| {
-                        item_ui::data_blueprint_group_button_to(
-                            ctx,
-                            ui,
-                            child_group.display_name.clone(),
-                            space_view.id,
-                            *child_group_handle,
-                        )
-                    },
-                    |re_ui, ui| {
-                        visibility_button_ui(
-                            re_ui,
-                            ui,
-                            group_is_visible,
-                            &mut child_group.properties_individual.visible,
-                        );
-                        if re_ui
-                            .small_icon_button(ui, &re_ui::icons::REMOVE)
-                            .on_hover_text("Remove group and all its children from the space view.")
-                            .clicked()
-                        {
-                            remove_group = true;
-                        }
-                    },
-                );
-            })
-            .body(|ui| {
-                Self::data_blueprint_tree_ui(
-                    ctx,
-                    ui,
-                    *child_group_handle,
-                    space_view,
-                    space_view_visible,
-                );
-            });
-            if remove_group {
-                space_view.data_blueprint.remove_group(*child_group_handle);
-                space_view.entities_determined_by_user = true;
-            }
-        }
-    }
-
-    pub fn mark_user_interaction(&mut self) {
-        self.has_been_user_edited = true;
-    }
-
-    pub fn add_space_view(&mut self, mut space_view: SpaceViewBlueprint) -> SpaceViewId {
-        let space_view_id = space_view.id;
-
-        // Find a unique name for the space view
-        let mut candidate_name = space_view.display_name.clone();
-        let mut append_count = 1;
-        let unique_name = 'outer: loop {
-            for view in &self.space_views {
-                if candidate_name == view.1.display_name {
-                    append_count += 1;
-                    candidate_name = format!("{} ({})", space_view.display_name, append_count);
-
-                    continue 'outer;
-                }
-            }
-            break candidate_name;
-        };
-
-        space_view.display_name = unique_name;
-
-        self.space_views.insert(space_view_id, space_view);
-
-        if self.has_been_user_edited {
-            // Try to insert it in the tree, in the top level:
-            if let Some(root_id) = self.tree.root {
-                let tile_id = self.tree.tiles.insert_pane(space_view_id);
-                if let Some(egui_tiles::Tile::Container(container)) =
-                    self.tree.tiles.get_mut(root_id)
-                {
-                    container.add_child(tile_id);
-                } else {
-                    self.tree = Default::default(); // we'll just re-initialize later instead
-                }
-            }
-        } else {
-            // Re-run the auto-layout next frame:
-            self.tree = Default::default();
-        }
-
-        space_view_id
-    }
-
-    pub fn on_frame_start(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        spaces_info: &SpaceInfoCollection,
-    ) {
-        re_tracing::profile_function!();
-
-        for space_view in self.space_views.values_mut() {
-            space_view.on_frame_start(ctx, spaces_info);
-        }
-
-        if self.auto_space_views {
-            for space_view_candidate in default_created_space_views(ctx, spaces_info) {
-                if self.should_auto_add_space_view(&space_view_candidate) {
-                    self.add_space_view(space_view_candidate);
-                }
-            }
-        }
-    }
-
-    fn should_auto_add_space_view(&self, space_view_candidate: &SpaceViewBlueprint) -> bool {
-        for existing_view in self.space_views.values() {
-            if existing_view.space_origin == space_view_candidate.space_origin {
-                if existing_view.entities_determined_by_user {
-                    // Since the user edited a space view with the same space path, we can't be sure our new one isn't redundant.
-                    // So let's skip that.
-                    return false;
-                }
-
-                if space_view_candidate
-                    .data_blueprint
-                    .entity_paths()
-                    .is_subset(existing_view.data_blueprint.entity_paths())
-                {
-                    // This space view wouldn't add anything we haven't already
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-
-    pub fn viewport_ui(
-        &mut self,
-        state: &mut ViewportState,
-        ui: &mut egui::Ui,
-        ctx: &mut ViewerContext<'_>,
-    ) {
-        if let Some(window) = &mut state.space_view_entity_window {
-            if let Some(space_view) = self.space_views.get_mut(&window.space_view_id) {
-                if !window.ui(ctx, ui, space_view) {
-                    state.space_view_entity_window = None;
-                }
-            } else {
-                // The space view no longer exist, close the window!
-                state.space_view_entity_window = None;
-            }
-        }
-
-        let is_zero_sized_viewport = ui.available_size().min_elem() <= 0.0;
-        if is_zero_sized_viewport {
-            return;
-        }
-
-        if let Some(space_view_id) = self.maximized {
-            if !self.space_views.contains_key(&space_view_id) {
-                self.maximized = None; // protect against bad deserialized data
-            }
-        }
-
-        let mut maximized_tree;
-
-        let tree = if let Some(space_view_id) = self.maximized {
-            let mut tiles = egui_tiles::Tiles::default();
-            let root = tiles.insert_pane(space_view_id);
-            maximized_tree = egui_tiles::Tree::new(root, tiles);
-            &mut maximized_tree
-        } else {
-            if self.tree.is_empty() {
-                self.tree = super::auto_layout::tree_from_space_views(
-                    ctx.space_view_class_registry,
-                    &self.space_views,
-                );
-            }
-            &mut self.tree
-        };
-
-        ui.scope(|ui| {
-            let mut tab_viewer = TabViewer {
-                ctx,
-                viewport_state: state,
-                space_views: &mut self.space_views,
-                maximized: &mut self.maximized,
-            };
-            ui.spacing_mut().item_spacing.x = re_ui::ReUi::view_padding();
-
-            re_tracing::profile_scope!("tree.ui");
-            tree.ui(&mut tab_viewer, ui);
-        });
-    }
-
-    pub fn add_new_spaceview_button_ui(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        spaces_info: &SpaceInfoCollection,
-    ) {
-        #![allow(clippy::collapsible_if)]
-
-        let icon_image = ctx.re_ui.icon_image(&re_ui::icons::ADD);
-        let texture_id = icon_image.texture_id(ui.ctx());
-        ui.menu_image_button(texture_id, re_ui::ReUi::small_icon_size(), |ui| {
-            ui.style_mut().wrap = Some(false);
-
-            for space_view in all_possible_space_views(ctx, spaces_info)
-                .into_iter()
-                .sorted_by_key(|space_view| space_view.space_origin.to_string())
-            {
-                if ctx
-                    .re_ui
-                    .selectable_label_with_icon(
-                        ui,
-                        space_view.class(ctx.space_view_class_registry).icon(),
-                        if space_view.space_origin.is_root() {
-                            space_view.display_name.clone()
-                        } else {
-                            space_view.space_origin.to_string()
-                        },
-                        false,
-                    )
-                    .clicked()
-                {
-                    ui.close_menu();
-                    let new_space_view_id = self.add_space_view(space_view);
-                    ctx.set_single_selection(Item::SpaceView(new_space_view_id));
-                }
-            }
-        })
-        .response
-        .on_hover_text("Add new space view.");
-    }
-
-    pub fn space_views_containing_entity_path(&self, path: &EntityPath) -> Vec<SpaceViewId> {
-        self.space_views
-            .iter()
-            .filter_map(|(space_view_id, space_view)| {
-                if space_view.data_blueprint.contains_entity(path) {
-                    Some(*space_view_id)
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-}
-
-/// State for the blueprint that persists across frames but otherwise
+/// State for the [`Viewport`] that persists across frames but otherwise
 /// is not saved.
 #[derive(Default)]
 pub struct ViewportState {
@@ -629,10 +26,6 @@ pub struct ViewportState {
 }
 
 impl ViewportState {
-    pub fn show_add_remove_entities_window(&mut self, space_view_id: SpaceViewId) {
-        self.space_view_entity_window = Some(SpaceViewEntityPicker { space_view_id });
-    }
-
     pub fn space_view_state_mut(
         &mut self,
         space_view_class_registry: &SpaceViewClassRegistry,
@@ -650,103 +43,108 @@ impl ViewportState {
     }
 }
 
-/// Show a single button (`add_content`), justified,
-/// and show a visibility button if the row is hovered.
-///
-/// Returns true if visibility changed.
-fn blueprint_row_with_buttons(
-    re_ui: &re_ui::ReUi,
-    ui: &mut egui::Ui,
-    enabled: bool,
-    visible: bool,
-    add_content: impl FnOnce(&mut egui::Ui) -> egui::Response,
-    add_on_hover_buttons: impl FnOnce(&re_ui::ReUi, &mut egui::Ui),
-) {
-    let where_to_add_hover_rect = ui.painter().add(egui::Shape::Noop);
+// ----------------------------------------------------------------------------
 
-    // Make the main button span the whole width to make it easier to click:
-    let main_button_response = ui
-        .with_layout(egui::Layout::top_down_justified(egui::Align::LEFT), |ui| {
-            ui.style_mut().wrap = Some(false);
+/// Defines the layout of the Viewport
+pub struct Viewport<'a, 'b> {
+    pub blueprint_db: &'a StoreDb,
 
-            // Turn off the background color of hovered buttons.
-            // Why? Because we add a manual hover-effect later.
-            // Why? Because we want that hover-effect even when only the visibility button is hovered.
-            let visuals = ui.visuals_mut();
-            visuals.widgets.hovered.weak_bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.hovered.bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.active.weak_bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.active.bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.open.weak_bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.open.bg_fill = egui::Color32::TRANSPARENT;
+    pub blueprint: ViewportBlueprint,
+    snapshot: ViewportBlueprint,
 
-            if ui
-                .interact(ui.max_rect(), ui.id(), egui::Sense::hover())
-                .hovered()
-            {
-                // Clip the main button so that the on-hover buttons have room to cover it.
-                // Ideally we would only clip the button _text_, not the button background, but that's not possible.
-                let mut clip_rect = ui.max_rect();
-                let on_hover_buttons_width = 36.0;
-                clip_rect.max.x -= on_hover_buttons_width;
-                ui.set_clip_rect(clip_rect);
-            }
-
-            if !visible || !enabled {
-                // Dim the appearance of things added by `add_content`:
-                let widget_visuals = &mut ui.visuals_mut().widgets;
-
-                fn dim_color(color: &mut egui::Color32) {
-                    *color = color.gamma_multiply(0.5);
-                }
-                dim_color(&mut widget_visuals.noninteractive.fg_stroke.color);
-                dim_color(&mut widget_visuals.inactive.fg_stroke.color);
-            }
-
-            add_content(ui)
-        })
-        .inner;
-
-    let main_button_rect = main_button_response.rect;
-
-    // We check the same rectangle as the main button,
-    // but we will also catch hovers on the visibility button (if any).
-    let button_hovered = ui
-        .interact(main_button_rect, ui.id(), egui::Sense::hover())
-        .hovered();
-    if button_hovered {
-        // Just put the buttons on top of the existing ui:
-        let mut ui = ui.child_ui(
-            ui.max_rect(),
-            egui::Layout::right_to_left(egui::Align::Center),
-        );
-        add_on_hover_buttons(re_ui, &mut ui);
-    }
-
-    // The main button might have been highlighted because what it was referring
-    // to was hovered somewhere else, and then we also want it highlighted here.
-    if button_hovered || main_button_response.highlighted() {
-        // Highlight the row:
-        let visuals = ui.visuals().widgets.hovered;
-        let hover_rect = main_button_rect.expand(visuals.expansion);
-        ui.painter().set(
-            where_to_add_hover_rect,
-            egui::Shape::rect_filled(hover_rect, visuals.rounding, visuals.bg_fill),
-        );
-    }
+    pub state: &'b mut ViewportState,
 }
 
-fn visibility_button_ui(
-    re_ui: &re_ui::ReUi,
-    ui: &mut egui::Ui,
-    enabled: bool,
-    visible: &mut bool,
-) -> egui::Response {
-    ui.set_enabled(enabled);
-    re_ui
-        .visibility_toggle_button(ui, visible)
-        .on_hover_text("Toggle visibility")
-        .on_disabled_hover_text("A parent is invisible")
+impl<'a, 'b> Viewport<'a, 'b> {
+    pub fn from_db(blueprint_db: &'a re_data_store::StoreDb, state: &'b mut ViewportState) -> Self {
+        re_tracing::profile_function!();
+
+        let blueprint = load_viewport_blueprint(blueprint_db);
+
+        Self {
+            blueprint_db,
+            blueprint: blueprint.clone(),
+            snapshot: blueprint,
+            state,
+        }
+    }
+
+    pub fn sync_blueprint_changes(&self, command_sender: &CommandSender) {
+        let mut deltas = vec![];
+
+        sync_viewport_blueprint(&mut deltas, &self.blueprint, &self.snapshot);
+
+        command_sender.send_system(SystemCommand::UpdateBlueprint(
+            self.blueprint_db.store_id().clone(),
+            deltas,
+        ));
+    }
+
+    pub fn show_add_remove_entities_window(&mut self, space_view_id: SpaceViewId) {
+        self.state.space_view_entity_window = Some(SpaceViewEntityPicker { space_view_id });
+    }
+
+    pub fn viewport_ui(&mut self, ui: &mut egui::Ui, ctx: &'a mut ViewerContext<'_>) {
+        let Viewport {
+            blueprint_db: _,
+            blueprint,
+            snapshot: _,
+            state,
+        } = self;
+
+        if let Some(window) = &mut state.space_view_entity_window {
+            if let Some(space_view) = blueprint.space_views.get_mut(&window.space_view_id) {
+                if !window.ui(ctx, ui, space_view) {
+                    state.space_view_entity_window = None;
+                }
+            } else {
+                // The space view no longer exist, close the window!
+                state.space_view_entity_window = None;
+            }
+        }
+
+        let is_zero_sized_viewport = ui.available_size().min_elem() <= 0.0;
+        if is_zero_sized_viewport {
+            return;
+        }
+
+        if let Some(space_view_id) = blueprint.maximized {
+            if !blueprint.space_views.contains_key(&space_view_id) {
+                blueprint.maximized = None; // protect against bad deserialized data
+            }
+        }
+
+        let mut maximized_tree;
+
+        let tree = if let Some(space_view_id) = blueprint.maximized {
+            let mut tiles = egui_tiles::Tiles::default();
+            let root = tiles.insert_pane(space_view_id);
+            maximized_tree = egui_tiles::Tree::new(root, tiles);
+            &mut maximized_tree
+        } else {
+            if blueprint.tree.is_empty() {
+                blueprint.tree = super::auto_layout::tree_from_space_views(
+                    ctx.space_view_class_registry,
+                    &blueprint.space_views,
+                );
+            }
+            &mut blueprint.tree
+        };
+
+        let mut tab_viewer = TabViewer {
+            viewport_state: state,
+            ctx,
+            space_views: &mut blueprint.space_views,
+            maximized: &mut blueprint.maximized,
+        };
+
+        ui.scope(|ui| {
+            ui.spacing_mut().item_spacing.x = re_ui::ReUi::view_padding();
+
+            re_tracing::profile_scope!("tree.ui");
+            tree.ui(&mut tab_viewer, ui);
+        });
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -926,13 +324,4 @@ fn space_view_ui(
     };
 
     space_view_blueprint.scene_ui(space_view_state, ctx, ui, latest_at, space_view_highlights);
-}
-
-// ----------------------------------------------------------------------------
-
-fn focus_tab(tree: &mut egui_tiles::Tree<SpaceViewId>, tab: &SpaceViewId) {
-    tree.make_active(|tile| match tile {
-        egui_tiles::Tile::Pane(space_view_id) => space_view_id == tab,
-        egui_tiles::Tile::Container(_) => false,
-    });
 }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -174,49 +174,6 @@ impl<'a> ViewportBlueprint<'a> {
         space_view_id
     }
 
-    pub fn on_frame_start(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        spaces_info: &SpaceInfoCollection,
-    ) {
-        re_tracing::profile_function!();
-
-        for space_view in self.space_views.values_mut() {
-            space_view.on_frame_start(ctx, spaces_info);
-        }
-
-        if self.auto_space_views {
-            for space_view_candidate in default_created_space_views(ctx, spaces_info) {
-                if self.should_auto_add_space_view(&space_view_candidate) {
-                    self.add_space_view(space_view_candidate);
-                }
-            }
-        }
-    }
-
-    fn should_auto_add_space_view(&self, space_view_candidate: &SpaceViewBlueprint) -> bool {
-        for existing_view in self.space_views.values() {
-            if existing_view.space_origin == space_view_candidate.space_origin {
-                if existing_view.entities_determined_by_user {
-                    // Since the user edited a space view with the same space path, we can't be sure our new one isn't redundant.
-                    // So let's skip that.
-                    return false;
-                }
-
-                if space_view_candidate
-                    .data_blueprint
-                    .entity_paths()
-                    .is_subset(existing_view.data_blueprint.entity_paths())
-                {
-                    // This space view wouldn't add anything we haven't already
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-
     pub fn space_views_containing_entity_path(&self, path: &EntityPath) -> Vec<SpaceViewId> {
         self.space_views
             .iter()

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -15,7 +15,7 @@ enum TreeAction {
     Remove,
 }
 
-impl ViewportBlueprint {
+impl ViewportBlueprint<'_> {
     /// Show the blueprint panel tree view.
     pub fn tree_ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         re_tracing::profile_function!();

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -1,0 +1,484 @@
+use itertools::Itertools;
+use re_data_ui::item_ui;
+use re_space_view::DataBlueprintGroup;
+use re_viewer_context::{DataBlueprintGroupHandle, Item, SpaceViewId, ViewerContext};
+
+use crate::{
+    space_view_heuristics::all_possible_space_views, SpaceInfoCollection, SpaceViewBlueprint,
+    ViewportBlueprint,
+};
+
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TreeAction {
+    Keep,
+    Remove,
+}
+
+impl ViewportBlueprint {
+    /// Show the blueprint panel tree view.
+    pub fn tree_ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
+        re_tracing::profile_function!();
+
+        egui::ScrollArea::both()
+            .auto_shrink([true, false])
+            .show(ui, |ui| {
+                if let Some(root) = self.tree.root() {
+                    match self.tile_ui(ctx, ui, root) == TreeAction::Remove {
+                        true => {
+                            self.tree.root = None;
+                        }
+                        false => (),
+                    }
+                }
+            });
+    }
+
+    /// If a group or spaceview has a total of this number of elements, show its subtree by default?
+    fn default_open_for_group(group: &DataBlueprintGroup) -> bool {
+        let num_children = group.children.len() + group.entities.len();
+        2 <= num_children && num_children <= 3
+    }
+
+    fn tile_ui(
+        &mut self,
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        tile_id: egui_tiles::TileId,
+    ) -> TreeAction {
+        // Temporarily remove the tile so we don't get borrow checker fights:
+        let Some(mut tile) = self.tree.tiles.remove(tile_id) else { return TreeAction::Remove; };
+
+        let action = match &mut tile {
+            egui_tiles::Tile::Container(container) => {
+                self.container_tree_ui(ctx, ui, tile_id, container)
+            }
+            egui_tiles::Tile::Pane(space_view_id) => {
+                // A space view
+                self.space_view_entry_ui(ctx, ui, tile_id, space_view_id)
+            }
+        };
+
+        self.tree.tiles.insert(tile_id, tile);
+
+        if action == TreeAction::Remove {
+            for tile in self.tree.tiles.remove_recursively(tile_id) {
+                if let egui_tiles::Tile::Pane(space_view_id) = tile {
+                    self.remove(&space_view_id);
+                }
+            }
+        }
+
+        action
+    }
+
+    fn container_tree_ui(
+        &mut self,
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        tile_id: egui_tiles::TileId,
+        container: &mut egui_tiles::Container,
+    ) -> TreeAction {
+        if let Some(child_id) = container.only_child() {
+            // Maybe a tab container with only one child - collapse it in the tree view to make it more easily understood.
+            // This means we won't be showing the visibility button of the parent container,
+            // so if the child is made invisible, we should do the same for the parent.
+            let child_is_visible = self.tree.is_visible(child_id);
+            self.tree.set_visible(tile_id, child_is_visible);
+            return self.tile_ui(ctx, ui, child_id);
+        }
+
+        let mut visibility_changed = false;
+        let mut action = TreeAction::Keep;
+        let mut visible = self.tree.is_visible(tile_id);
+
+        let default_open = true;
+        egui::collapsing_header::CollapsingState::load_with_default_open(
+            ui.ctx(),
+            egui::Id::new((tile_id, "tree")),
+            default_open,
+        )
+        .show_header(ui, |ui| {
+            blueprint_row_with_buttons(
+                ctx.re_ui,
+                ui,
+                true,
+                visible,
+                |ui| ui.label(format!("{:?}", container.kind())),
+                |re_ui, ui| {
+                    visibility_changed =
+                        visibility_button_ui(re_ui, ui, true, &mut visible).changed();
+                    if re_ui
+                        .small_icon_button(ui, &re_ui::icons::REMOVE)
+                        .on_hover_text("Remove container")
+                        .clicked()
+                    {
+                        action = TreeAction::Remove;
+                    }
+                },
+            );
+        })
+        .body(|ui| container.retain(|child| self.tile_ui(ctx, ui, child) == TreeAction::Keep));
+
+        if visibility_changed {
+            self.has_been_user_edited = true;
+            self.tree.set_visible(tile_id, visible);
+        }
+
+        action
+    }
+
+    fn space_view_entry_ui(
+        &mut self,
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        tile_id: egui_tiles::TileId,
+        space_view_id: &SpaceViewId,
+    ) -> TreeAction {
+        let Some(space_view) = self.space_views.get_mut(space_view_id) else {
+                re_log::warn_once!("Bug: asked to show a ui for a Space View that doesn't exist");
+                return TreeAction::Remove;
+            };
+        debug_assert_eq!(space_view.id, *space_view_id);
+
+        let mut visibility_changed = false;
+        let mut action = TreeAction::Keep;
+        let mut visible = self.tree.is_visible(tile_id);
+
+        let root_group = space_view.data_blueprint.root_group();
+        let default_open = Self::default_open_for_group(root_group);
+        let collapsing_header_id = ui.id().with(space_view.id);
+        egui::collapsing_header::CollapsingState::load_with_default_open(
+            ui.ctx(),
+            collapsing_header_id,
+            default_open,
+        )
+        .show_header(ui, |ui| {
+            blueprint_row_with_buttons(
+                ctx.re_ui,
+                ui,
+                true,
+                visible,
+                |ui| {
+                    let response = crate::item_ui::space_view_button(ctx, ui, space_view);
+                    if response.clicked() {
+                        focus_tab(&mut self.tree, space_view_id);
+                    }
+                    response
+                },
+                |re_ui, ui| {
+                    visibility_changed =
+                        visibility_button_ui(re_ui, ui, true, &mut visible).changed();
+                    if re_ui
+                        .small_icon_button(ui, &re_ui::icons::REMOVE)
+                        .on_hover_text("Remove Space View from the viewport.")
+                        .clicked()
+                    {
+                        action = TreeAction::Remove;
+                    }
+                },
+            );
+        })
+        .body(|ui| {
+            Self::data_blueprint_tree_ui(
+                ctx,
+                ui,
+                space_view.data_blueprint.root_handle(),
+                space_view,
+                visible,
+            );
+        });
+
+        if visibility_changed {
+            self.has_been_user_edited = true;
+            self.tree.set_visible(tile_id, visible);
+        }
+
+        if action == TreeAction::Remove {
+            self.remove(space_view_id);
+        }
+
+        action
+    }
+
+    fn data_blueprint_tree_ui(
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        group_handle: DataBlueprintGroupHandle,
+        space_view: &mut SpaceViewBlueprint,
+        space_view_visible: bool,
+    ) {
+        let Some(group) = space_view.data_blueprint.group(group_handle) else {
+                debug_assert!(false, "Invalid group handle in blueprint group tree");
+                return;
+            };
+
+        // TODO(andreas): These clones are workarounds against borrowing multiple times from data_blueprint_tree.
+        let children = group.children.clone();
+        let entities = group.entities.clone();
+        let group_name = group.display_name.clone();
+        let group_is_visible = group.properties_projected.visible && space_view_visible;
+
+        for entity_path in &entities {
+            if entity_path.is_root() {
+                continue;
+            }
+
+            ui.horizontal(|ui| {
+                let mut properties = space_view
+                    .data_blueprint
+                    .data_blueprints_individual()
+                    .get(entity_path);
+                blueprint_row_with_buttons(
+                    ctx.re_ui,
+                    ui,
+                    group_is_visible,
+                    properties.visible,
+                    |ui| {
+                        let name = entity_path.iter().last().unwrap().to_string();
+                        let label = format!("🔹 {name}");
+                        re_data_ui::item_ui::data_blueprint_button_to(
+                            ctx,
+                            ui,
+                            label,
+                            space_view.id,
+                            entity_path,
+                        )
+                    },
+                    |re_ui, ui| {
+                        if visibility_button_ui(
+                            re_ui,
+                            ui,
+                            group_is_visible,
+                            &mut properties.visible,
+                        )
+                        .changed()
+                        {
+                            space_view
+                                .data_blueprint
+                                .data_blueprints_individual()
+                                .set(entity_path.clone(), properties);
+                        }
+                        if re_ui
+                            .small_icon_button(ui, &re_ui::icons::REMOVE)
+                            .on_hover_text("Remove Entity from the space view.")
+                            .clicked()
+                        {
+                            space_view.data_blueprint.remove_entity(entity_path);
+                            space_view.entities_determined_by_user = true;
+                        }
+                    },
+                );
+            });
+        }
+
+        for child_group_handle in &children {
+            let Some(child_group) = space_view.data_blueprint.group_mut(*child_group_handle) else {
+                    debug_assert!(false, "Data blueprint group {group_name} has an invalid child");
+                    continue;
+                };
+
+            let mut remove_group = false;
+            let default_open = Self::default_open_for_group(child_group);
+            egui::collapsing_header::CollapsingState::load_with_default_open(
+                ui.ctx(),
+                ui.id().with(child_group_handle),
+                default_open,
+            )
+            .show_header(ui, |ui| {
+                blueprint_row_with_buttons(
+                    ctx.re_ui,
+                    ui,
+                    group_is_visible,
+                    child_group.properties_individual.visible,
+                    |ui| {
+                        item_ui::data_blueprint_group_button_to(
+                            ctx,
+                            ui,
+                            child_group.display_name.clone(),
+                            space_view.id,
+                            *child_group_handle,
+                        )
+                    },
+                    |re_ui, ui| {
+                        visibility_button_ui(
+                            re_ui,
+                            ui,
+                            group_is_visible,
+                            &mut child_group.properties_individual.visible,
+                        );
+                        if re_ui
+                            .small_icon_button(ui, &re_ui::icons::REMOVE)
+                            .on_hover_text("Remove group and all its children from the space view.")
+                            .clicked()
+                        {
+                            remove_group = true;
+                        }
+                    },
+                );
+            })
+            .body(|ui| {
+                Self::data_blueprint_tree_ui(
+                    ctx,
+                    ui,
+                    *child_group_handle,
+                    space_view,
+                    space_view_visible,
+                );
+            });
+            if remove_group {
+                space_view.data_blueprint.remove_group(*child_group_handle);
+                space_view.entities_determined_by_user = true;
+            }
+        }
+    }
+
+    pub fn add_new_spaceview_button_ui(
+        &mut self,
+        ctx: &mut ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        spaces_info: &SpaceInfoCollection,
+    ) {
+        #![allow(clippy::collapsible_if)]
+
+        let icon_image = ctx.re_ui.icon_image(&re_ui::icons::ADD);
+        let texture_id = icon_image.texture_id(ui.ctx());
+        ui.menu_image_button(texture_id, re_ui::ReUi::small_icon_size(), |ui| {
+            ui.style_mut().wrap = Some(false);
+
+            for space_view in all_possible_space_views(ctx, spaces_info)
+                .into_iter()
+                .sorted_by_key(|space_view| space_view.space_origin.to_string())
+            {
+                if ctx
+                    .re_ui
+                    .selectable_label_with_icon(
+                        ui,
+                        space_view.class(ctx.space_view_class_registry).icon(),
+                        if space_view.space_origin.is_root() {
+                            space_view.display_name.clone()
+                        } else {
+                            space_view.space_origin.to_string()
+                        },
+                        false,
+                    )
+                    .clicked()
+                {
+                    ui.close_menu();
+                    let new_space_view_id = self.add_space_view(space_view);
+                    ctx.set_single_selection(Item::SpaceView(new_space_view_id));
+                }
+            }
+        })
+        .response
+        .on_hover_text("Add new space view.");
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+fn focus_tab(tree: &mut egui_tiles::Tree<SpaceViewId>, tab: &SpaceViewId) {
+    tree.make_active(|tile| match tile {
+        egui_tiles::Tile::Pane(space_view_id) => space_view_id == tab,
+        egui_tiles::Tile::Container(_) => false,
+    });
+}
+
+/// Show a single button (`add_content`), justified,
+/// and show a visibility button if the row is hovered.
+///
+/// Returns true if visibility changed.
+fn blueprint_row_with_buttons(
+    re_ui: &re_ui::ReUi,
+    ui: &mut egui::Ui,
+    enabled: bool,
+    visible: bool,
+    add_content: impl FnOnce(&mut egui::Ui) -> egui::Response,
+    add_on_hover_buttons: impl FnOnce(&re_ui::ReUi, &mut egui::Ui),
+) {
+    let where_to_add_hover_rect = ui.painter().add(egui::Shape::Noop);
+
+    // Make the main button span the whole width to make it easier to click:
+    let main_button_response = ui
+        .with_layout(egui::Layout::top_down_justified(egui::Align::LEFT), |ui| {
+            ui.style_mut().wrap = Some(false);
+
+            // Turn off the background color of hovered buttons.
+            // Why? Because we add a manual hover-effect later.
+            // Why? Because we want that hover-effect even when only the visibility button is hovered.
+            let visuals = ui.visuals_mut();
+            visuals.widgets.hovered.weak_bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.hovered.bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.active.weak_bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.active.bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.open.weak_bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.open.bg_fill = egui::Color32::TRANSPARENT;
+
+            if ui
+                .interact(ui.max_rect(), ui.id(), egui::Sense::hover())
+                .hovered()
+            {
+                // Clip the main button so that the on-hover buttons have room to cover it.
+                // Ideally we would only clip the button _text_, not the button background, but that's not possible.
+                let mut clip_rect = ui.max_rect();
+                let on_hover_buttons_width = 36.0;
+                clip_rect.max.x -= on_hover_buttons_width;
+                ui.set_clip_rect(clip_rect);
+            }
+
+            if !visible || !enabled {
+                // Dim the appearance of things added by `add_content`:
+                let widget_visuals = &mut ui.visuals_mut().widgets;
+
+                fn dim_color(color: &mut egui::Color32) {
+                    *color = color.gamma_multiply(0.5);
+                }
+                dim_color(&mut widget_visuals.noninteractive.fg_stroke.color);
+                dim_color(&mut widget_visuals.inactive.fg_stroke.color);
+            }
+
+            add_content(ui)
+        })
+        .inner;
+
+    let main_button_rect = main_button_response.rect;
+
+    // We check the same rectangle as the main button,
+    // but we will also catch hovers on the visibility button (if any).
+    let button_hovered = ui
+        .interact(main_button_rect, ui.id(), egui::Sense::hover())
+        .hovered();
+    if button_hovered {
+        // Just put the buttons on top of the existing ui:
+        let mut ui = ui.child_ui(
+            ui.max_rect(),
+            egui::Layout::right_to_left(egui::Align::Center),
+        );
+        add_on_hover_buttons(re_ui, &mut ui);
+    }
+
+    // The main button might have been highlighted because what it was referring
+    // to was hovered somewhere else, and then we also want it highlighted here.
+    if button_hovered || main_button_response.highlighted() {
+        // Highlight the row:
+        let visuals = ui.visuals().widgets.hovered;
+        let hover_rect = main_button_rect.expand(visuals.expansion);
+        ui.painter().set(
+            where_to_add_hover_rect,
+            egui::Shape::rect_filled(hover_rect, visuals.rounding, visuals.bg_fill),
+        );
+    }
+}
+
+fn visibility_button_ui(
+    re_ui: &re_ui::ReUi,
+    ui: &mut egui::Ui,
+    enabled: bool,
+    visible: &mut bool,
+) -> egui::Response {
+    ui.set_enabled(enabled);
+    re_ui
+        .visibility_toggle_button(ui, visible)
+        .on_hover_text("Toggle visibility")
+        .on_disabled_hover_text("A parent is invisible")
+}


### PR DESCRIPTION
### What
In the process of plumbing new State through for things like auto-properties I found myself getting very mixed up with the organization and naming related to Viewport and Blueprint.

Previously ViewportBlueprint contained an internal "Viewport". This flips the naming to make Viewport the the top-level container, with separate internals members for `blueprint` and `state`:
```
pub struct Viewport<'a, 'b> {
    pub blueprint: ViewportBlueprint<'a>,
    pub state: &'b mut ViewportState,
}

...

let mut viewport = Viewport::from_db(store_context.blueprint, viewport_state);
```

The idea is the *Blueprint* represents the entity stored in the databse, while the *Viewport* represents the thing shown in the viewer, which users the blueprint as part of its display logic.

I also split the ui related functions for the blueprint into a separate `viewport_blueprint_ui.rs`.

Sadly, this diff ended up quite ugly since I both swapped the names of the structs and the corresponding files.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~ Refactor-only
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2595) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2595)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Fmore_viewport_refactor/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Fmore_viewport_refactor/examples)