### PR TITLE
Update egui_tiles to fix crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.1.0"
-source = "git+https://github.com/rerun-io/egui_tiles.git?rev=3fff2b01310aa3569e29d2dd3ee97b2e62c45870#3fff2b01310aa3569e29d2dd3ee97b2e62c45870"
+source = "git+https://github.com/rerun-io/egui_tiles.git?rev=cc97c9c977270108d9d644c0d425cd6bead3beb7#cc97c9c977270108d9d644c0d425cd6bead3beb7"
 dependencies = [
  "ahash 0.8.3",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,4 +145,4 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "3fff2b01310aa3569e29d2dd3ee97b2e62c45870" } # 2023-06-29: drag-and-drop fixes
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "cc97c9c977270108d9d644c0d425cd6bead3beb7" } # 2023-07-04: visibility toggle crash fix

--- a/Cranky.toml
+++ b/Cranky.toml
@@ -15,6 +15,7 @@ warn = [
   "clippy::bool_to_int_with_if",
   "clippy::char_lit_as_u8",
   "clippy::checked_conversions",
+  "clippy::cloned_instead_of_copied",
   "clippy::dbg_macro",
   "clippy::debug_assert_with_mut_call",
   "clippy::derive_partial_eq_without_eq",


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2593
* https://github.com/rerun-io/rerun/issues/2593

This is what is new:
* https://github.com/rerun-io/egui_tiles/pull/8

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2598) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2598)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fbump-egui-tiles/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fbump-egui-tiles/examples)