### PR TITLE
test_api: set different app_id based on what test is run

### DIFF
--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -421,6 +421,7 @@ def spawn_test(test: Callable[[], None], rec: rr.RecordingStream) -> None:
 
 def main() -> None:
     tests = {
+        "2d_layering": run_2d_layering,
         "2d_lines": run_2d_lines,
         "3d_points": run_3d_points,
         "bbox": run_bounding_box,
@@ -432,9 +433,8 @@ def main() -> None:
         "segmentation": run_segmentation,
         "small_image": small_image,
         "text": run_text_logs,
-        "transforms_rigid_3d": transforms_rigid_3d,
         "transform_test": transform_test,
-        "2d_layering": run_2d_layering,
+        "transforms_rigid_3d": transforms_rigid_3d,
     }
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
@@ -458,7 +458,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if not args.split_recordings:
-        rec = rr.script_setup(args, "test_api")
+        rec = rr.script_setup(args, f"test_api_{args.test}")
 
     if args.test in ["most", "all"]:
         print(f"Running {args.test} tests…")


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1125
* https://github.com/rerun-io/rerun/issues/1125

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
