### PR TITLE
Bump all `py-lint`-related package versions

### DIFF
--- a/rerun_py/requirements-lint.txt
+++ b/rerun_py/requirements-lint.txt
@@ -1,7 +1,7 @@
 black==23.3.0
 blackdoc==0.3.8
 mypy==1.4.1
-numpy==1.25 # For mypy plugin
+numpy>=1.24 # For mypy plugin
 pip-check-reqs==2.4.4 # Checks for missing deps in requirements.txt files
 pyupgrade==3.8.0
 ruff==0.0.276

--- a/rerun_py/requirements-lint.txt
+++ b/rerun_py/requirements-lint.txt
@@ -1,9 +1,9 @@
-black==23.1.0
-blackdoc==0.3.6
-mypy==1.0.1
-numpy==1.23 # For mypy plugin
-pip-check-reqs==2.4.3 # Checks for missing deps in requirements.txt files
-pyupgrade==2.37.3
-ruff==0.0.251
-types-Deprecated==1.2.9
+black==23.3.0
+blackdoc==0.3.8
+mypy==1.4.1
+numpy==1.25 # For mypy plugin
+pip-check-reqs==2.4.4 # Checks for missing deps in requirements.txt files
+pyupgrade==3.8.0
+ruff==0.0.276
+types-Deprecated==1.2.9.2
 types-requests>=2.31,<3


### PR DESCRIPTION
### What

Most `py-lint`-related package are hard-pinned in `requirements-lint.txt`, and some are quite behind (in particular `mypy`). This PR bumps them all to their last version as of today.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2600) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2600)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fbump-py-lint-versions/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fbump-py-lint-versions/examples)