### PR TITLE
End-to-end cross-language roundtrip tests for our archetypes

### DIFF
--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -276,8 +276,11 @@ jobs:
       - name: Run e2e roundtrip tests
         if: needs.set-config.outputs.RUN_TESTS == 'true'
         shell: bash
+        # --release so we can inherit from some of the artifacts that maturin has just built before
+        # --target x86_64-unknown-linux-gnu because otherwise cargo loses the target cache... even though this is the target anyhow...
+        # --no-build because rerun-sdk is already built and installed
         # NOTE: run with --release so we can reuse some of the "Build Wheel"'s job artifacts, hopefully
-        run: RUST_LOG=debug scripts/ci/run_e2e_roundtrip_tests.py --release --no-build # rerun-sdk is already built and installed
+        run: RUST_LOG=debug scripts/ci/run_e2e_roundtrip_tests.py --release --target x86_64-unknown-linux-gnu --no-build 
 
       - name: Cache RRD dataset
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -276,7 +276,8 @@ jobs:
       - name: Run e2e roundtrip tests
         if: needs.set-config.outputs.RUN_TESTS == 'true'
         shell: bash
-        run: RUST_LOG=debug scripts/ci/run_e2e_roundtrip_tests.py --no-build # rerun-sdk is already built and installed
+        # NOTE: run with --release so we can reuse some of the "Build Wheel"'s job artifacts, hopefully
+        run: RUST_LOG=debug scripts/ci/run_e2e_roundtrip_tests.py --release --no-build # rerun-sdk is already built and installed
 
       - name: Cache RRD dataset
         if: needs.set-config.outputs.RUN_TESTS == 'true'

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -273,6 +273,11 @@ jobs:
         shell: bash
         run: RUST_LOG=debug scripts/run_python_e2e_test.py --no-build # rerun-sdk is already built and installed
 
+      - name: Run e2e roundtrip tests
+        if: needs.set-config.outputs.RUN_TESTS == 'true'
+        shell: bash
+        run: RUST_LOG=debug scripts/ci/run_e2e_roundtrip_tests.py --no-build # rerun-sdk is already built and installed
+
       - name: Cache RRD dataset
         if: needs.set-config.outputs.RUN_TESTS == 'true'
         id: dataset

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ screenshot*.png
 web_demo
 
 .nox/
+out.rrd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4944,6 +4944,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roundtrip_points2d"
+version = "0.8.0-alpha.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rerun",
+]
+
+[[package]]
 name = "run_wasm"
 version = "0.8.0-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "rerun_py",
   "run_wasm",
   "tests/rust/test_*",
+  "tests/rust/roundtrips/points2d",
 ]
 
 [workspace.package]

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ cpp-format:
 
 ### Python
 
-py_folders := "examples rerun_py scripts docs/code-examples"
+py_folders := "docs/code-examples examples rerun_py scripts tests"
 
 # Set up a Pythonvirtual environment for development
 py-dev-env:

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -34,7 +34,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print("Building rerun-sdk…")
         start_time = time.time()
-        subprocess.Popen(["just", "py-build", "--quiet"], env=build_env).wait()
+        subprocess.Popen(["just", "py-build"], env=build_env).wait()
         elapsed = time.time() - start_time
         print(f"rerun-sdk built in {elapsed:.1f} seconds")
         print("")
@@ -58,8 +58,8 @@ def run_roundtrip_python(arch: str) -> str:
         python_executable = "python3"
 
     cmd = [python_executable, main_path, "--save", output_path]
-    roundtrip_process = subprocess.Popen(cmd)
     print(cmd)
+    roundtrip_process = subprocess.Popen(cmd)
     returncode = roundtrip_process.wait(timeout=600)
     assert returncode == 0, f"python roundtrip process exited with error code {returncode}"
 
@@ -70,19 +70,19 @@ def run_roundtrip_rust(arch: str) -> str:
     project_name = f"roundtrip_{arch}"
     output_path = f"tests/rust/roundtrips/{arch}/out.rrd"
 
-    cmd = ["cargo", "r", "--quiet", "-p", project_name, "--", "--save", output_path]
-    roundtrip_process = subprocess.Popen(cmd)
+    cmd = ["cargo", "r", "-p", project_name, "--", "--save", output_path]
     print(cmd)
-    returncode = roundtrip_process.wait(timeout=600)
+    roundtrip_process = subprocess.Popen(cmd)
+    returncode = roundtrip_process.wait(timeout=6000)
     assert returncode == 0, f"rust roundtrip process exited with error code {returncode}"
 
     return output_path
 
 
 def run_comparison(python_output_path: str, rust_output_path: str):
-    cmd = ["cargo", "r", "-p", "rerun-cli", "--quiet", "--", "compare", python_output_path, rust_output_path]
-    roundtrip_process = subprocess.Popen(cmd)
+    cmd = ["cargo", "r", "-p", "rerun-cli", "--", "compare", python_output_path, rust_output_path]
     print(cmd)
+    roundtrip_process = subprocess.Popen(cmd)
     returncode = roundtrip_process.wait(timeout=600)
     assert returncode == 0, f"comparison process exited with error code {returncode}"
 

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -23,6 +23,7 @@ ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run our end-to-end cross-language roundtrip tests for all SDK")
     parser.add_argument("--no-build", action="store_true", help="Skip building rerun-sdk")
+    parser.add_argument("--release", action="store_true", help="Run cargo invocations with --release")
     parser.add_argument("--target-dir", type=str, default=None, help="Target directory used for cargo invocations")
 
     args = parser.parse_args()
@@ -47,7 +48,7 @@ def main() -> None:
 
     for arch in archetypes:
         python_output_path = run_roundtrip_python(arch)
-        rust_output_path = run_roundtrip_rust(arch, args.target_dir)
+        rust_output_path = run_roundtrip_rust(arch, args.release, args.target_dir)
         run_comparison(python_output_path, rust_output_path)
 
 
@@ -69,14 +70,20 @@ def run_roundtrip_python(arch: str) -> str:
     return output_path
 
 
-def run_roundtrip_rust(arch: str, target_dir: str | None) -> str:
+def run_roundtrip_rust(arch: str, release: bool, target_dir: str | None) -> str:
     project_name = f"roundtrip_{arch}"
     output_path = f"tests/rust/roundtrips/{arch}/out.rrd"
 
+    cmd = ["cargo", "r", "-p", project_name]
+
     if target_dir is not None:
-        cmd = ["cargo", "r", "-p", project_name, "--target-dir", target_dir, "--", "--save", output_path]
-    else:
-        cmd = ["cargo", "r", "-p", project_name, "--", "--save", output_path]
+        cmd += ["--target-dir", target_dir] 
+
+    if release:
+        cmd += ["--release"]
+
+    cmd += ["--", "--save", output_path]
+
     print(cmd)
     roundtrip_process = subprocess.Popen(cmd)
     returncode = roundtrip_process.wait(timeout=12000)

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -60,7 +60,7 @@ def run_roundtrip_python(arch: str) -> str:
     cmd = [python_executable, main_path, "--save", output_path]
     roundtrip_process = subprocess.Popen(cmd)
     print(cmd)
-    returncode = roundtrip_process.wait(timeout=30)
+    returncode = roundtrip_process.wait(timeout=600)
     assert returncode == 0, f"python roundtrip process exited with error code {returncode}"
 
     return output_path
@@ -73,7 +73,7 @@ def run_roundtrip_rust(arch: str) -> str:
     cmd = ["cargo", "r", "--quiet", "-p", project_name, "--", "--save", output_path]
     roundtrip_process = subprocess.Popen(cmd)
     print(cmd)
-    returncode = roundtrip_process.wait(timeout=30)
+    returncode = roundtrip_process.wait(timeout=600)
     assert returncode == 0, f"rust roundtrip process exited with error code {returncode}"
 
     return output_path
@@ -83,7 +83,7 @@ def run_comparison(python_output_path: str, rust_output_path: str):
     cmd = ["cargo", "r", "-p", "rerun-cli", "--quiet", "--", "compare", python_output_path, rust_output_path]
     roundtrip_process = subprocess.Popen(cmd)
     print(cmd)
-    returncode = roundtrip_process.wait(timeout=30)
+    returncode = roundtrip_process.wait(timeout=600)
     assert returncode == 0, f"comparison process exited with error code {returncode}"
 
 

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-This runs our end-to-end cross-language roundtrip tests for all SDKs.
+Run our end-to-end cross-language roundtrip tests for all SDKs.
 
 The list of archetypes is read directly from `crates/re_types/definitions/rerun/archetypes`.
 If you create a new archetype definition without end-to-end tests, this will fail.
@@ -21,7 +21,7 @@ ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Runs end-to-end tests of select python example.")
+    parser = argparse.ArgumentParser(description="Run our end-to-end cross-language roundtrip tests for all SDK")
     parser.add_argument("--no-build", action="store_true", help="Skip building rerun-sdk")
 
     if parser.parse_args().no_build:

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -60,7 +60,7 @@ def run_roundtrip_python(arch: str) -> str:
     cmd = [python_executable, main_path, "--save", output_path]
     print(cmd)
     roundtrip_process = subprocess.Popen(cmd)
-    returncode = roundtrip_process.wait(timeout=600)
+    returncode = roundtrip_process.wait(timeout=30)
     assert returncode == 0, f"python roundtrip process exited with error code {returncode}"
 
     return output_path
@@ -73,17 +73,17 @@ def run_roundtrip_rust(arch: str) -> str:
     cmd = ["cargo", "r", "-p", project_name, "--", "--save", output_path]
     print(cmd)
     roundtrip_process = subprocess.Popen(cmd)
-    returncode = roundtrip_process.wait(timeout=6000)
+    returncode = roundtrip_process.wait(timeout=12000)
     assert returncode == 0, f"rust roundtrip process exited with error code {returncode}"
 
     return output_path
 
 
 def run_comparison(python_output_path: str, rust_output_path: str):
-    cmd = ["cargo", "r", "-p", "rerun-cli", "--", "compare", python_output_path, rust_output_path]
+    cmd = ["rerun", "compare", python_output_path, rust_output_path]
     print(cmd)
     roundtrip_process = subprocess.Popen(cmd)
-    returncode = roundtrip_process.wait(timeout=600)
+    returncode = roundtrip_process.wait(timeout=30)
     assert returncode == 0, f"comparison process exited with error code {returncode}"
 
 

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -24,6 +24,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run our end-to-end cross-language roundtrip tests for all SDK")
     parser.add_argument("--no-build", action="store_true", help="Skip building rerun-sdk")
     parser.add_argument("--release", action="store_true", help="Run cargo invocations with --release")
+    parser.add_argument("--target", type=str, default=None, help="Target used for cargo invocations")
     parser.add_argument("--target-dir", type=str, default=None, help="Target directory used for cargo invocations")
 
     args = parser.parse_args()
@@ -48,7 +49,7 @@ def main() -> None:
 
     for arch in archetypes:
         python_output_path = run_roundtrip_python(arch)
-        rust_output_path = run_roundtrip_rust(arch, args.release, args.target_dir)
+        rust_output_path = run_roundtrip_rust(arch, args.release, args.target, args.target_dir)
         run_comparison(python_output_path, rust_output_path)
 
 
@@ -70,11 +71,14 @@ def run_roundtrip_python(arch: str) -> str:
     return output_path
 
 
-def run_roundtrip_rust(arch: str, release: bool, target_dir: str | None) -> str:
+def run_roundtrip_rust(arch: str, release: bool, target: str | None, target_dir: str | None) -> str:
     project_name = f"roundtrip_{arch}"
     output_path = f"tests/rust/roundtrips/{arch}/out.rrd"
 
     cmd = ["cargo", "r", "-p", project_name]
+
+    if target is not None:
+        cmd += ["--target", target]
 
     if target_dir is not None:
         cmd += ["--target-dir", target_dir]

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+"""
+This runs our end-to-end cross-language roundtrip tests for all SDKs.
+
+The list of archetypes is read directly from `crates/re_types/definitions/rerun/archetypes`.
+If you create a new archetype definition without end-to-end tests, this will fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from os import listdir
+from os.path import isfile, join
+
+ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Runs end-to-end tests of select python example.")
+    parser.add_argument("--no-build", action="store_true", help="Skip building rerun-sdk")
+
+    if parser.parse_args().no_build:
+        print("Skipping building rerun-sdk - assuming it is already built and up-to-date!")
+    else:
+        build_env = os.environ.copy()
+        if "RUST_LOG" in build_env:
+            del build_env["RUST_LOG"]  # The user likely only meant it for the actual tests; not the setup
+
+        print("----------------------------------------------------------")
+        print("Building rerun-sdk…")
+        start_time = time.time()
+        subprocess.Popen(["just", "py-build", "--quiet"], env=build_env).wait()
+        elapsed = time.time() - start_time
+        print(f"rerun-sdk built in {elapsed:.1f} seconds")
+        print("")
+
+    files = [f for f in listdir(ARCHETYPES_PATH) if isfile(join(ARCHETYPES_PATH, f))]
+    archetypes = [filename for filename, extension in [os.path.splitext(file) for file in files] if extension == ".fbs"]
+
+    for arch in archetypes:
+        python_output_path = run_roundtrip_python(arch)
+        rust_output_path = run_roundtrip_rust(arch)
+        run_comparison(python_output_path, rust_output_path)
+
+
+def run_roundtrip_python(arch: str) -> str:
+    main_path = f"tests/python/roundtrips/{arch}/main.py"
+    output_path = f"tests/python/roundtrips/{arch}/out.rrd"
+
+    # sys.executable: the absolute path of the executable binary for the Python interpreter
+    python_executable = sys.executable
+    if python_executable is None:
+        python_executable = "python3"
+
+    cmd = [python_executable, main_path, "--save", output_path]
+    roundtrip_process = subprocess.Popen(cmd)
+    print(cmd)
+    returncode = roundtrip_process.wait(timeout=30)
+    assert returncode == 0, f"python roundtrip process exited with error code {returncode}"
+
+    return output_path
+
+
+def run_roundtrip_rust(arch: str) -> str:
+    project_name = f"roundtrip_{arch}"
+    output_path = f"tests/rust/roundtrips/{arch}/out.rrd"
+
+    cmd = ["cargo", "r", "--quiet", "-p", project_name, "--", "--save", output_path]
+    roundtrip_process = subprocess.Popen(cmd)
+    print(cmd)
+    returncode = roundtrip_process.wait(timeout=30)
+    assert returncode == 0, f"rust roundtrip process exited with error code {returncode}"
+
+    return output_path
+
+
+def run_comparison(python_output_path: str, rust_output_path: str):
+    cmd = ["cargo", "r", "-p", "rerun-cli", "--quiet", "--", "compare", python_output_path, rust_output_path]
+    roundtrip_process = subprocess.Popen(cmd)
+    print(cmd)
+    returncode = roundtrip_process.wait(timeout=30)
+    assert returncode == 0, f"comparison process exited with error code {returncode}"
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -77,7 +77,7 @@ def run_roundtrip_rust(arch: str, release: bool, target_dir: str | None) -> str:
     cmd = ["cargo", "r", "-p", project_name]
 
     if target_dir is not None:
-        cmd += ["--target-dir", target_dir] 
+        cmd += ["--target-dir", target_dir]
 
     if release:
         cmd += ["--release"]

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import itertools
+
+import numpy as np
+import rerun as rr
+from rerun._rerun2 import components as rrc
+
+
+def main() -> None:
+    points = np.array([1, 2, 3, 4], dtype=np.float32)
+    radii = np.array([0.42, 0.43], dtype=np.float32)
+    colors = np.array(
+        [
+            0xAA0000CC,
+            0x00BB00DD,
+        ],
+        dtype=np.uint32,
+    )
+    labels = ["hello", "friend"]
+    draw_order = 300
+    class_ids = np.array([126, 127], dtype=np.uint64)
+    keypoint_ids = np.array([2, 3], dtype=np.uint64)
+    instance_keys = np.array([66, 666], dtype=np.uint64)
+
+    points2d = rr.Points2D(
+        points,  # type: ignore[arg-type]
+        radii=radii,  # type: ignore[arg-type]
+        colors=colors,  # type: ignore[arg-type]
+        labels=labels,  # type: ignore[arg-type]
+        draw_order=draw_order,  # type: ignore[arg-type]
+        class_ids=class_ids,  # type: ignore[arg-type]
+        keypoint_ids=keypoint_ids,  # type: ignore[arg-type]
+        instance_keys=instance_keys,  # type: ignore[arg-type]
+    )
+
+    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+
+    rr.script_setup(args, "roundtrip_points2d")
+
+    rr.log_any("points2d", points2d)
+    # Hack to establish 2d view bounds
+    rr.log_rect("rect", [0, 0, 4, 6])
+
+    rr.script_teardown(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -1,3 +1,5 @@
+"""Logs a `Points2D` archetype for roundtrip checks."""
+
 #!/usr/bin/env python3
 
 from __future__ import annotations

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -16,7 +16,7 @@ def main() -> None:
     colors = np.array(
         [
             0xAA0000CC,
-            0x00BB00DE,
+            0x00BB00DD,
         ],
         dtype=np.uint32,
     )

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import argparse
-import itertools
 
 import numpy as np
 import rerun as rr
-from rerun._rerun2 import components as rrc
 
 
 def main() -> None:

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -16,7 +16,7 @@ def main() -> None:
     colors = np.array(
         [
             0xAA0000CC,
-            0x00BB00DD,
+            0x00BB00DE,
         ],
         dtype=np.uint32,
     )

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -32,7 +32,7 @@ def main() -> None:
         colors=colors,
         labels=labels,
         draw_order=draw_order,
-        class_ids=class_ids, 
+        class_ids=class_ids,
         keypoint_ids=keypoint_ids,
         instance_keys=instance_keys,
     )

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -27,14 +27,14 @@ def main() -> None:
     instance_keys = np.array([66, 666], dtype=np.uint64)
 
     points2d = rr.Points2D(
-        points,  # type: ignore[arg-type]
-        radii=radii,  # type: ignore[arg-type]
-        colors=colors,  # type: ignore[arg-type]
-        labels=labels,  # type: ignore[arg-type]
-        draw_order=draw_order,  # type: ignore[arg-type]
-        class_ids=class_ids,  # type: ignore[arg-type]
-        keypoint_ids=keypoint_ids,  # type: ignore[arg-type]
-        instance_keys=instance_keys,  # type: ignore[arg-type]
+        points,
+        radii=radii,
+        colors=colors,
+        labels=labels,
+        draw_order=draw_order,
+        class_ids=class_ids, 
+        keypoint_ids=keypoint_ids,
+        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/rust/roundtrips/points2d/Cargo.toml
+++ b/tests/rust/roundtrips/points2d/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_api"
+name = "roundtrip_points2d"
 edition.workspace = true
 license.workspace = true
 publish = false
@@ -7,15 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-glam = "0.22"
-itertools = "0.11"
-ndarray = "0.15"
-ndarray-rand = "0.14"
-rand = "0.8"

--- a/tests/rust/roundtrips/points2d/src/main.rs
+++ b/tests/rust/roundtrips/points2d/src/main.rs
@@ -1,0 +1,47 @@
+use rerun::{
+    components::Rect2D, experimental::archetypes::Points2D, external::re_log, MsgSender,
+    RecordingStream,
+};
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[command(flatten)]
+    rerun: rerun::clap::RerunArgs,
+}
+
+fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
+    MsgSender::from_archetype(
+        "points2d",
+        &Points2D::new([(1.0, 2.0), (3.0, 4.0)])
+            .with_radii([0.42, 0.43])
+            .with_colors([0xAA0000CC, 0x00BB00DD])
+            .with_labels(["hello", "friend"])
+            .with_draw_order(300.0)
+            .with_class_ids([126, 127])
+            .with_keypoint_ids([2, 3])
+            .with_instance_keys([66, 666]),
+    )?
+    .send(rec_stream)?;
+
+    // Hack to establish 2d view bounds
+    MsgSender::new("rect")
+        .with_component(&[Rect2D::from_xywh(0.0, 0.0, 4.0, 6.0)])?
+        .send(rec_stream)?;
+
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    re_log::setup_native_logging();
+
+    use clap::Parser as _;
+    let args = Args::parse();
+
+    let default_enabled = true;
+    args.rerun
+        .clone()
+        .run("roundtrip_points2d", default_enabled, move |rec_stream| {
+            run(&rec_stream, &args).unwrap();
+        })
+}

--- a/tests/rust/roundtrips/points2d/src/main.rs
+++ b/tests/rust/roundtrips/points2d/src/main.rs
@@ -1,3 +1,5 @@
+//! Logs a `Points2D` archetype for roundtrip checks.
+
 use rerun::{
     components::Rect2D, experimental::archetypes::Points2D, external::re_log, MsgSender,
     RecordingStream,


### PR DESCRIPTION
With this PR, the CI will now compare the results of logging our archetypes across all of our SDKs.

You can run it locally with:
```
./scripts/ci/run_e2e_roundtrip_tests.py --no-build
```

E.g.:
![image](https://github.com/rerun-io/rerun/assets/2910679/38f1541e-20ef-4ebd-8d55-ee6215fefd3c)


Requires #2597 

Fixes #2383 
Fixes #2384 
Fixes #2386 

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2601) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2601)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fend_to_end_roundtrips_ci/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fend_to_end_roundtrips_ci/examples)