### PR TITLE
Support any `dtype` for depth images

### DIFF
--- a/crates/re_analytics/src/sink_native.rs
+++ b/crates/re_analytics/src/sink_native.rs
@@ -85,7 +85,10 @@ impl PostHogSink {
             .collect::<Vec<_>>();
         let batch = PostHogBatch::from_events(&events);
 
-        re_log::debug!("{}", serde_json::to_string_pretty(&batch)?);
+        re_log::trace!(
+            "Sending analytics: {}",
+            serde_json::to_string_pretty(&batch)?
+        );
         self.agent.post(resolved_url).send_json(&batch)?;
         Ok(())
     }

--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -82,7 +82,7 @@ impl DataStore {
                 let num_bytes_to_drop = initial_num_bytes * p;
                 let target_num_bytes = initial_num_bytes - num_bytes_to_drop;
 
-                re_log::debug!(
+                re_log::trace!(
                     kind = "gc",
                     id = self.gc_id,
                     %target,
@@ -106,7 +106,7 @@ impl DataStore {
         let new_num_bytes =
             (stats_after.temporal.num_bytes + stats_after.metadata_registry.num_bytes) as f64;
 
-        re_log::debug!(
+        re_log::trace!(
             kind = "gc",
             id = self.gc_id,
             %target,

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -298,10 +298,12 @@ impl EntityTree {
             components: fields,
         } = self;
 
-        for (timeline, histogram) in &mut prefix_times.0 {
+        {
             re_tracing::profile_scope!("prefix_times");
-            if let Some(cutoff_time) = cutoff_times.get(timeline) {
-                histogram.remove(..cutoff_time.as_i64());
+            for (timeline, histogram) in &mut prefix_times.0 {
+                if let Some(cutoff_time) = cutoff_times.get(timeline) {
+                    histogram.remove(..cutoff_time.as_i64());
+                }
             }
         }
         {

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -339,7 +339,7 @@ impl StoreDb {
         let (drop_row_ids, stats_diff) = self.entity_db.data_store.gc(
             re_arrow_store::GarbageCollectionTarget::DropAtLeastFraction(fraction_to_purge as _),
         );
-        re_log::debug!(
+        re_log::trace!(
             num_row_ids_dropped = drop_row_ids.len(),
             size_bytes_dropped = re_format::format_bytes(stats_diff.total.num_bytes as _),
             "purged datastore"

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -13,8 +13,13 @@
 
 // ---
 
-/// Keep in sync with `DepthCloudInfoUBO` in `depth_cloud.rs`.
-///
+// Keep in sync with `DepthCloudInfoUBO` in `depth_cloud.rs`.
+
+// Which texture to read from?
+const SAMPLE_TYPE_FLOAT = 1u;
+const SAMPLE_TYPE_SINT  = 2u;
+const SAMPLE_TYPE_UINT  = 3u;
+
 /// Same for all draw-phases.
 struct DepthCloudInfo {
     /// The extrinsincs of the camera used for the projection.
@@ -43,6 +48,9 @@ struct DepthCloudInfo {
     /// Configures color mapping mode, see `colormap.wgsl`.
     colormap: u32,
 
+    /// Which texture sample to use
+    sample_type: u32,
+
     /// Changes between the opaque and outline draw-phases.
     radius_boost_in_ui_points: f32,
 };
@@ -51,7 +59,13 @@ struct DepthCloudInfo {
 var<uniform> depth_cloud_info: DepthCloudInfo;
 
 @group(1) @binding(1)
-var depth_texture: texture_2d<f32>;
+var texture_float: texture_2d<f32>;
+
+@group(1) @binding(2)
+var texture_sint: texture_2d<i32>;
+
+@group(1) @binding(3)
+var texture_uint: texture_2d<u32>;
 
 struct VertexOut {
     @builtin(position)
@@ -83,11 +97,24 @@ struct PointData {
 
 // Backprojects the depth texture using the intrinsics passed in the uniform buffer.
 fn compute_point_data(quad_idx: u32) -> PointData {
-    let wh = textureDimensions(depth_texture);
-    let texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+    var texcoords: UVec2;
+    var texture_value = 0.0;
+    if depth_cloud_info.sample_type == SAMPLE_TYPE_FLOAT {
+        let wh = textureDimensions(texture_float);
+        texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+        texture_value = textureLoad(texture_float, texcoords, 0).x;
+    } else if depth_cloud_info.sample_type == SAMPLE_TYPE_SINT {
+        let wh = textureDimensions(texture_sint);
+        texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+        texture_value = f32(textureLoad(texture_sint, texcoords, 0).x);
+    } else {
+        let wh = textureDimensions(texture_uint);
+        texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+        texture_value = f32(textureLoad(texture_uint, texcoords, 0).x);
+    }
 
     // TODO(cmc): expose knobs to linearize/normalize/flip/cam-to-plane depth.
-    let world_space_depth = depth_cloud_info.world_depth_from_texture_value * textureLoad(depth_texture, texcoords, 0).x;
+    let world_space_depth = depth_cloud_info.world_depth_from_texture_value * texture_value;
 
     var data: PointData;
 

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -62,21 +62,18 @@ struct UniformBuffer {
 var<uniform> rect_info: UniformBuffer;
 
 @group(1) @binding(1)
-var texture_sampler: sampler;
-
-@group(1) @binding(2)
 var texture_float: texture_2d<f32>;
 
-@group(1) @binding(3)
+@group(1) @binding(2)
 var texture_sint: texture_2d<i32>;
 
-@group(1) @binding(4)
+@group(1) @binding(3)
 var texture_uint: texture_2d<u32>;
 
-@group(1) @binding(5)
+@group(1) @binding(4)
 var colormap_texture: texture_2d<f32>;
 
-@group(1) @binding(6)
+@group(1) @binding(5)
 var texture_float_filterable: texture_2d<f32>;
 
 struct VertexOut {

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -22,7 +22,7 @@ use crate::{
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
-        GpuRenderPipelineHandle, PipelineLayoutDesc, RenderPipelineDesc, SamplerDesc,
+        GpuRenderPipelineHandle, PipelineLayoutDesc, RenderPipelineDesc,
     },
     Colormap, OutlineMaskPreference, PickingLayerProcessor, Rgba,
 };
@@ -390,30 +390,6 @@ impl RectangleDrawData {
 
         let mut instances = Vec::with_capacity(rectangles.len());
         for (rectangle, uniform_buffer) in izip!(rectangles, uniform_buffer_bindings) {
-            let options = &rectangle.options;
-            let sampler = ctx.gpu_resources.samplers.get_or_create(
-                &ctx.device,
-                &SamplerDesc {
-                    label: format!(
-                        "rectangle sampler mag {:?} min {:?}",
-                        options.texture_filter_magnification, options.texture_filter_minification
-                    )
-                    .into(),
-                    mag_filter: match options.texture_filter_magnification {
-                        TextureFilterMag::Linear => wgpu::FilterMode::Linear,
-                        TextureFilterMag::Nearest => wgpu::FilterMode::Nearest,
-                    },
-                    min_filter: match options.texture_filter_minification {
-                        TextureFilterMin::Linear => wgpu::FilterMode::Linear,
-                        TextureFilterMin::Nearest => wgpu::FilterMode::Nearest,
-                    },
-                    mipmap_filter: wgpu::FilterMode::Nearest,
-                    address_mode_u: wgpu::AddressMode::ClampToEdge,
-                    address_mode_v: wgpu::AddressMode::ClampToEdge,
-                    ..Default::default()
-                },
-            );
-
             let texture = &rectangle.colormapped_texture.texture;
             let texture_format = texture.creation_desc.format;
             if texture_format.required_features() != Default::default() {
@@ -463,7 +439,6 @@ impl RectangleDrawData {
                         label: "RectangleInstance::bind_group".into(),
                         entries: smallvec![
                             uniform_buffer,
-                            BindGroupEntry::Sampler(sampler),
                             BindGroupEntry::DefaultTextureView(texture_float),
                             BindGroupEntry::DefaultTextureView(texture_sint),
                             BindGroupEntry::DefaultTextureView(texture_uint),
@@ -518,16 +493,9 @@ impl Renderer for RectangleRenderer {
                         },
                         count: None,
                     },
-                    // float sampler:
+                    // float texture:
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                        count: None,
-                    },
-                    // float textures without filtering (e.g. R32Float):
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             sample_type: wgpu::TextureSampleType::Float { filterable: false },
@@ -538,7 +506,7 @@ impl Renderer for RectangleRenderer {
                     },
                     // sint texture:
                     wgpu::BindGroupLayoutEntry {
-                        binding: 3,
+                        binding: 2,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             sample_type: wgpu::TextureSampleType::Sint,
@@ -549,7 +517,7 @@ impl Renderer for RectangleRenderer {
                     },
                     // uint texture:
                     wgpu::BindGroupLayoutEntry {
-                        binding: 4,
+                        binding: 3,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             sample_type: wgpu::TextureSampleType::Uint,
@@ -560,10 +528,10 @@ impl Renderer for RectangleRenderer {
                     },
                     // colormap texture:
                     wgpu::BindGroupLayoutEntry {
-                        binding: 5,
+                        binding: 4,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            sample_type: wgpu::TextureSampleType::Float { filterable: false },
                             view_dimension: wgpu::TextureViewDimension::D2,
                             multisampled: false,
                         },

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -168,10 +168,8 @@ pub enum RectangleError {
     #[error("Texture required special features: {0:?}")]
     SpecialFeatures(wgpu::Features),
 
-    // There's really no need for users to be able to sample depth textures.
-    // We don't get filtering of depth textures any way.
-    #[error("Depth textures not supported - use float or integer textures instead.")]
-    DepthTexturesNotSupported,
+    #[error("Texture format not supported: {0:?} - use float or integer textures instead.")]
+    TextureFormatNotSupported(wgpu::TextureFormat),
 
     #[error("Color mapping is being applied to a four-component RGBA texture")]
     ColormappingRgbaTexture,
@@ -278,7 +276,7 @@ mod gpu_data {
                 Some(wgpu::TextureSampleType::Sint) => SAMPLE_TYPE_SINT,
                 Some(wgpu::TextureSampleType::Uint) => SAMPLE_TYPE_UINT,
                 _ => {
-                    return Err(RectangleError::DepthTexturesNotSupported);
+                    return Err(RectangleError::TextureFormatNotSupported(texture_format));
                 }
             };
 
@@ -440,7 +438,7 @@ impl RectangleDrawData {
                     texture_uint = texture.handle;
                 }
                 _ => {
-                    return Err(RectangleError::DepthTexturesNotSupported);
+                    return Err(RectangleError::TextureFormatNotSupported(texture_format));
                 }
             }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -664,17 +664,17 @@ impl App {
         if let Some(minimum_fraction_to_purge) = limit.is_exceeded_by(&mem_use_before) {
             let fraction_to_purge = (minimum_fraction_to_purge + 0.2).clamp(0.25, 1.0);
 
-            re_log::debug!("RAM limit: {}", format_limit(limit.limit));
+            re_log::trace!("RAM limit: {}", format_limit(limit.limit));
             if let Some(resident) = mem_use_before.resident {
-                re_log::debug!("Resident: {}", format_bytes(resident as _),);
+                re_log::trace!("Resident: {}", format_bytes(resident as _),);
             }
             if let Some(counted) = mem_use_before.counted {
-                re_log::debug!("Counted: {}", format_bytes(counted as _));
+                re_log::trace!("Counted: {}", format_bytes(counted as _));
             }
 
             re_tracing::profile_scope!("pruning");
             if let Some(counted) = mem_use_before.counted {
-                re_log::debug!(
+                re_log::trace!(
                     "Attempting to purge {:.1}% of used RAM ({})…",
                     100.0 * fraction_to_purge,
                     format_bytes(counted as f64 * fraction_to_purge as f64)

--- a/crates/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/mod.rs
@@ -1,7 +1,7 @@
 //! Bridge to `re_renderer`
 
 mod tensor_to_gpu;
-pub use tensor_to_gpu::tensor_to_gpu;
+pub use tensor_to_gpu::{depth_tensor_to_gpu, tensor_to_gpu};
 
 use crate::TensorStats;
 

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -211,7 +211,7 @@ fn class_id_tensor_to_gpu(
 // ----------------------------------------------------------------------------
 // Depth textures:
 
-fn depth_tensor_to_gpu(
+pub fn depth_tensor_to_gpu(
     render_ctx: &RenderContext,
     debug_name: &str,
     tensor: &DecodedTensor,

--- a/crates/re_viewer_context/src/tensor/tensor_decode_cache.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_decode_cache.rs
@@ -92,7 +92,7 @@ impl Cache for TensorDecodeCache {
             retain
         });
 
-        re_log::debug!(
+        re_log::trace!(
             "Flushed tensor decode cache. Before: {:.2} GB. After: {:.2} GB",
             before as f64 / 1e9,
             self.memory_used as f64 / 1e9,

--- a/examples/python/live_depth_sensor/requirements.txt
+++ b/examples/python/live_depth_sensor/requirements.txt
@@ -1,3 +1,4 @@
 numpy
-pyrealsense2
+pyrealsense2-mac; sys_platform == 'darwin'
+pyrealsense2; sys_platform != 'darwin'
 rerun-sdk

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -11,7 +11,7 @@ import os
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import cv2
 import numpy as np
@@ -38,26 +38,26 @@ def camera_for_image(h: float, w: float) -> tuple[float, float, float]:
     return (w / 2, h / 2, 0.7 * w)
 
 
-def camera_intrinsics(image: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
+def camera_intrinsics(image: npt.NDArray[Any]) -> npt.NDArray[Any]:
     """Create reasonable camera intrinsics given the resolution."""
     (h, w) = image.shape
     (u_center, v_center, focal_length) = camera_for_image(h, w)
     return np.array(((focal_length, 0, u_center), (0, focal_length, v_center), (0, 0, 1)))
 
 
-def read_image_rgb(buf: bytes) -> npt.NDArray[np.uint8]:
+def read_image_rgb(buf: bytes) -> npt.NDArray[Any]:
     """Decode an image provided in `buf`, and interpret it as RGB data."""
     np_buf: npt.NDArray[np.uint8] = np.ndarray(shape=(1, len(buf)), dtype=np.uint8, buffer=buf)
     # OpenCV reads images in BGR rather than RGB format
     img_bgr = cv2.imdecode(np_buf, cv2.IMREAD_COLOR)
-    img_rgb: npt.NDArray[np.uint8] = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+    img_rgb: npt.NDArray[Any] = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
     return img_rgb
 
 
-def read_image(buf: bytes) -> npt.NDArray[np.uint8]:
+def read_depth_image(buf: bytes) -> npt.NDArray[Any]:
     """Decode an image provided in `buf`."""
     np_buf: npt.NDArray[np.uint8] = np.ndarray(shape=(1, len(buf)), dtype=np.uint8, buffer=buf)
-    img: npt.NDArray[np.uint8] = cv2.imdecode(np_buf, cv2.IMREAD_UNCHANGED)
+    img: npt.NDArray[Any] = cv2.imdecode(np_buf, cv2.IMREAD_UNCHANGED)
     return img
 
 
@@ -88,7 +88,7 @@ def log_nyud_data(recording_path: Path, subset_idx: int = 0) -> None:
 
             elif f.filename.endswith(".pgm"):
                 buf = archive.read(f)
-                img_depth = read_image(buf)
+                img_depth = read_depth_image(buf)
 
                 # Log the camera transforms:
                 rr.log_view_coordinates("world/camera", xyz="RDF")  # X=Right, Y=Down, Z=Forward

--- a/rerun_py/rerun_sdk/rerun/log/image.py
+++ b/rerun_py/rerun_sdk/rerun/log/image.py
@@ -141,7 +141,7 @@ def log_depth_image(
 
     Supported dtypes
     ----------------
-    uint16, float32, float64
+    float16, float32, float64, uint8, uint16, uint32, uint64, int8, int16, int32, int64
 
     Parameters
     ----------


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2550
* https://github.com/rerun-io/rerun/issues/2550

### What
Support any `dtype` for depth images. Previously only `uint16` and `float32` were supported.

This also unifies the textures used for depth cloud projection and for displaying images ("rectangle" shader). This means less time spent uploading data to the GPU, half the GPU memory used, and less room for bugs and inconsistencies.

I also took an unrelated pass at reducing log spam when running with `RUST_LOG=debug`.

Example of using `float16`:
![image](https://github.com/rerun-io/rerun/assets/1148717/579b61af-6554-4c8c-b894-81b134a34d5c)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2602) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2602)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fgeneralize-depth-texture/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fgeneralize-depth-texture/examples)