### PR TITLE
Fix wrong path being `rerun_if_changed()` in `compute_dir_hash`

### DIFF
--- a/crates/re_build_tools/src/hashing.rs
+++ b/crates/re_build_tools/src/hashing.rs
@@ -90,7 +90,7 @@ pub fn compute_dir_hash<'a>(path: impl AsRef<Path>, extensions: Option<&'a [&'a 
             .with_context(|| format!("couldn't copy from {filepath:?}"))
             .unwrap();
 
-        rerun_if_changed(path);
+        rerun_if_changed(filepath);
     }
 
     encode_hex(hasher.finalize().as_slice())

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-57a9b0fe0f20a438034beaa8924a121cc02d6f527d155b8675b182ab3a84acb3
+fe95d42267d6803af40c31b57c2fe5fc59b898b7bb718e2b461400bd83fd16d6


### PR DESCRIPTION
Randomly noticed that `compute_dir_hash` was passing the directory's path to `rerun_if_changed` rather than the filepath!

<details>
  <summary>Before:</summary>

```
  cargo:rerun-if-env-changed=IS_IN_RERUN_WORKSPACE
  cargo:rerun-if-env-changed=RERUN_IS_PUBLISHING
  cargo:rerun-if-changed=./source_hash.txt
  cargo:rerun-if-changed=./definitions/arrow/attributes.fbs
  cargo:rerun-if-changed=./definitions/fbs/attributes.fbs
  cargo:rerun-if-changed=./definitions/fbs/scalars.fbs
  cargo:rerun-if-changed=./definitions/python/attributes.fbs
  cargo:rerun-if-changed=./definitions/rerun/archetypes/points2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/archetypes.fbs
  cargo:rerun-if-changed=./definitions/rerun/attributes.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/class_id.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/color.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/draw_order.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/instance_key.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/keypoint_id.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/label.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/point2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/radius.fbs
  cargo:rerun-if-changed=./definitions/rerun/components.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes/point2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes/vec2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/archetypes/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/components/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/datatypes/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rust/attributes.fbs
  cargo:rerun-if-changed=./source_hash.txt
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/Cargo.toml
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/src/hashing.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/src/lib.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/src/rebuild_detector.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/Cargo.toml
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/build.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/arrow_registry.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/common.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/mod.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/python.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/rust.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/lib.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/objects.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/reflection.rs
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=./definitions
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../docs/code-examples
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/archetypes/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides
```

</details>

<details>
  <summary>After:</summary>

```
  cargo:rerun-if-env-changed=IS_IN_RERUN_WORKSPACE
  cargo:rerun-if-env-changed=RERUN_IS_PUBLISHING
  cargo:rerun-if-changed=./source_hash.txt
  cargo:rerun-if-changed=./definitions/arrow/attributes.fbs
  cargo:rerun-if-changed=./definitions/fbs/attributes.fbs
  cargo:rerun-if-changed=./definitions/fbs/scalars.fbs
  cargo:rerun-if-changed=./definitions/python/attributes.fbs
  cargo:rerun-if-changed=./definitions/rerun/archetypes/points2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/archetypes.fbs
  cargo:rerun-if-changed=./definitions/rerun/attributes.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/class_id.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/color.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/draw_order.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/instance_key.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/keypoint_id.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/label.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/point2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/radius.fbs
  cargo:rerun-if-changed=./definitions/rerun/components.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes/point2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes/vec2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/archetypes/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/components/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/datatypes/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rust/attributes.fbs
  cargo:rerun-if-changed=./source_hash.txt
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/Cargo.toml
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/src/hashing.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/src/lib.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_build_tools/src/rebuild_detector.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/Cargo.toml
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/build.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/arrow_registry.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/common.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/mod.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/python.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/rust.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/lib.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/objects.rs
  cargo:rerun-if-changed=/home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/reflection.rs
  cargo:rerun-if-changed=./definitions/arrow/attributes.fbs
  cargo:rerun-if-changed=./definitions/fbs/attributes.fbs
  cargo:rerun-if-changed=./definitions/fbs/scalars.fbs
  cargo:rerun-if-changed=./definitions/python/attributes.fbs
  cargo:rerun-if-changed=./definitions/rerun/archetypes/points2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/archetypes.fbs
  cargo:rerun-if-changed=./definitions/rerun/attributes.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/class_id.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/color.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/draw_order.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/instance_key.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/keypoint_id.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/label.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/point2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/components/radius.fbs
  cargo:rerun-if-changed=./definitions/rerun/components.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes/point2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes/vec2d.fbs
  cargo:rerun-if-changed=./definitions/rerun/datatypes.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/archetypes/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/components/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rerun/testing/datatypes/fuzzy.fbs
  cargo:rerun-if-changed=./definitions/rust/attributes.fbs
  cargo:rerun-if-changed=../../docs/code-examples/annotation-context/example.py
  cargo:rerun-if-changed=../../docs/code-examples/annotation-context/example.rs
  cargo:rerun-if-changed=../../docs/code-examples/annotation_context_connections.py
  cargo:rerun-if-changed=../../docs/code-examples/annotation_context_connections.rs
  cargo:rerun-if-changed=../../docs/code-examples/annotation_context_rects.py
  cargo:rerun-if-changed=../../docs/code-examples/annotation_context_rects.rs
  cargo:rerun-if-changed=../../docs/code-examples/annotation_context_segmentation.py
  cargo:rerun-if-changed=../../docs/code-examples/annotation_context_segmentation.rs
  cargo:rerun-if-changed=../../docs/code-examples/arrow3d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/arrow3d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/box3d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/box3d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/default-off-session/example.py
  cargo:rerun-if-changed=../../docs/code-examples/default-off-session/example.rs
  cargo:rerun-if-changed=../../docs/code-examples/depth_image_3d.py
  cargo:rerun-if-changed=../../docs/code-examples/depth_image_3d.rs
  cargo:rerun-if-changed=../../docs/code-examples/depth_image_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/depth_image_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/extension-components/example.py
  cargo:rerun-if-changed=../../docs/code-examples/extension-components/example.rs
  cargo:rerun-if-changed=../../docs/code-examples/image_advanced.py
  cargo:rerun-if-changed=../../docs/code-examples/image_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/image_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/line_segments2d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/line_segments2d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/line_segments3d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/line_segments3d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/line_strip2d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/line_strip2d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/line_strip3d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/line_strip3d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/mesh_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/mesh_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/pinhole_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/pinhole_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/point2d_random.py
  cargo:rerun-if-changed=../../docs/code-examples/point2d_random.rs
  cargo:rerun-if-changed=../../docs/code-examples/point2d_random_v2.py
  cargo:rerun-if-changed=../../docs/code-examples/point2d_random_v2.rs
  cargo:rerun-if-changed=../../docs/code-examples/point2d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/point2d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/point2d_simple_v2.py
  cargo:rerun-if-changed=../../docs/code-examples/point2d_simple_v2.rs
  cargo:rerun-if-changed=../../docs/code-examples/point3d_random.py
  cargo:rerun-if-changed=../../docs/code-examples/point3d_random.rs
  cargo:rerun-if-changed=../../docs/code-examples/point3d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/point3d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/rect2d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/rect2d_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/scalar_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/scalar_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/segmentation_image_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/segmentation_image_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/tensor_one_dim.py
  cargo:rerun-if-changed=../../docs/code-examples/tensor_one_dim.rs
  cargo:rerun-if-changed=../../docs/code-examples/tensor_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/tensor_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/text_entry_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/text_entry_simple.rs
  cargo:rerun-if-changed=../../docs/code-examples/transform3d_simple.py
  cargo:rerun-if-changed=../../docs/code-examples/transform3d_simple.rs
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/archetypes/_overrides/__init__.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/__init__.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/class_id.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/color.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/draw_order.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/instance_key.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/keypoint_id.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/label.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/radius.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/__init__.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/point2d.py
  cargo:rerun-if-changed=../../rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/vec2d.py
```

</details>

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2612) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2612)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Frerun_if_changed_shenanigans/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Frerun_if_changed_shenanigans/examples)