### PR TITLE
Fix rust docs deploy

### DIFF
--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -119,14 +119,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "build-linux"
-          env-vars: RUSTFLAGS CARGO CC CFLAGS CXX CMAKE RUST CACHE_KEY
-          cache-targets: false
+          env-vars: CARGO CC CFLAGS CXX CMAKE RUST CACHE_KEY
           save-if: false
 
       # Sccache will cache everything else
       # See: https://github.com/marketplace/actions/sccache-action
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Delete existing /target/doc
+        run: rm -rf ./target/doc
 
       - name: cargo doc --document-private-items
         uses: actions-rs/cargo@v1

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -1,4 +1,4 @@
-name: 'Reusable Deploy Docs'
+name: "Reusable Deploy Docs"
 
 on:
   workflow_call:
@@ -33,8 +33,7 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-
-# ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
 
   py-deploy-docs:
     name: Python
@@ -90,8 +89,7 @@ jobs:
           git commit -m "Update docs for ${GITHUB_SHA}"
           git push origin gh-pages-orphan:gh-pages -f
 
-
-# ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
 
   rs-deploy-docs:
     name: Rust
@@ -121,7 +119,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "build-linux"
-          env-vars: CARGO CC CFLAGS CXX CMAKE RUST CACHE_KEY
+          env-vars: RUSTFLAGS CARGO CC CFLAGS CXX CMAKE RUST CACHE_KEY
+          cache-targets: false
           save-if: false
 
       # Sccache will cache everything else
@@ -156,3 +155,4 @@ jobs:
         run: |
           git fetch
           python3 -m ghp_import -n -p -x docs/rust/head target/doc/ -m "Update the rust docs"
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,12 @@
     },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
+    "files.exclude": {
+        "target_ra/**": true,
+        "target_wasm/**": true,
+        "target/**": true,
+        "venv/**": true,
+    },
     "files.autoGuessEncoding": true,
     "python.formatting.provider": "black",
     "python.formatting.blackArgs": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,12 +7,6 @@
     },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    "files.exclude": {
-        "target_ra/**": true,
-        "target_wasm/**": true,
-        "target/**": true,
-        "venv/**": true,
-    },
     "files.autoGuessEncoding": true,
     "python.formatting.provider": "black",
     "python.formatting.blackArgs": [


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Remove the `/target/doc` directory before building and deploying docs. This should fix the rust docs deploy issue, but it will be unconfirmed until we merge into main

Also removes the `files.exclude` vscode setting for already gitignored directories. I keep having to dig into target dirs and/or the venv and it's pretty annoying to keep this change around locally inbetween all the git checkouts. I don't see why we need it in the first place, it just removes the files from the explorer pane. That makes it a bit shorter, but not by a lot.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2615) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2615)
- [Docs preview](https://rerun.io/preview/pr%3Ajan%2Ffix-deploy-docs/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajan%2Ffix-deploy-docs/examples)