### PR TITLE
Use `camino` crate for UTF8 paths in `re_types_builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4534,6 +4534,7 @@ version = "0.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "arrow2",
+ "camino",
  "convert_case",
  "flatbuffers",
  "indent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ anyhow = "1.0"
 arrow2 = "0.17"
 arrow2_convert = "0.5.0"
 bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
+camino = "1.1"
 cfg-if = "1.0"
 clap = "4.0"
 comfy-table = { version = "6.1", default-features = false }

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-4ae47b009f4946234e8d7edd37ce7815ef9f77dd35cfdd83bf328be612b4d54e
+bfac745d1eadd1c774419b33ced26cb6cbf7404036e19725db1dfc4e767e791d

--- a/crates/re_types_builder/Cargo.toml
+++ b/crates/re_types_builder/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 # External
 anyhow.workspace = true
 arrow2.workspace = true
+camino.workspace = true
 convert_case = "0.6"
 flatbuffers = "23.0"
 indent = "0.1"

--- a/crates/re_types_builder/src/codegen/mod.rs
+++ b/crates/re_types_builder/src/codegen/mod.rs
@@ -7,7 +7,7 @@ pub trait CodeGenerator {
         &mut self,
         objs: &crate::Objects,
         arrow_registry: &crate::ArrowRegistry,
-    ) -> Vec<std::path::PathBuf>;
+    ) -> Vec<camino::Utf8PathBuf>;
 }
 
 // ---

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -159,7 +159,7 @@ pub const ATTR_RUST_TUPLE_STRUCT: &str = "attr.rust.tuple_struct";
 
 // --- Entrypoints ---
 
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path, Utf8PathBuf};
 
 /// Compiles binary reflection dumps from flatbuffers definitions.
 ///
@@ -180,13 +180,13 @@ use std::path::{Path, PathBuf};
 /// );
 /// ```
 pub fn compile_binary_schemas(
-    include_dir_path: impl AsRef<Path>,
-    output_dir_path: impl AsRef<Path>,
-    entrypoint_path: impl AsRef<Path>,
+    include_dir_path: impl AsRef<Utf8Path>,
+    output_dir_path: impl AsRef<Utf8Path>,
+    entrypoint_path: impl AsRef<Utf8Path>,
 ) {
-    let include_dir_path = include_dir_path.as_ref().to_str().unwrap();
-    let output_dir_path = output_dir_path.as_ref().to_str().unwrap();
-    let entrypoint_path = entrypoint_path.as_ref().to_str().unwrap();
+    let include_dir_path = include_dir_path.as_ref().as_str();
+    let output_dir_path = output_dir_path.as_ref().as_str();
+    let entrypoint_path = entrypoint_path.as_ref().as_str();
 
     use xshell::{cmd, Shell};
     let sh = Shell::new().unwrap();
@@ -206,33 +206,34 @@ pub fn compile_binary_schemas(
 /// 2. Run the semantic pass
 /// 3. Compute the Arrow registry
 fn generate_lang_agnostic(
-    include_dir_path: impl AsRef<Path>,
-    entrypoint_path: impl AsRef<Path>,
+    include_dir_path: impl AsRef<Utf8Path>,
+    entrypoint_path: impl AsRef<Utf8Path>,
 ) -> (Objects, ArrowRegistry) {
     use xshell::Shell;
 
     let sh = Shell::new().unwrap();
     let tmp = sh.create_temp_dir().unwrap();
+    let tmp_path = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
 
     let entrypoint_path = entrypoint_path.as_ref();
     let entrypoint_filename = entrypoint_path.file_name().unwrap();
 
     let include_dir_path = include_dir_path.as_ref();
     let include_dir_path = include_dir_path
-        .canonicalize()
+        .canonicalize_utf8()
         .with_context(|| format!("failed to canonicalize include path: {include_dir_path:?}"))
         .unwrap();
 
     // generate bfbs definitions
-    compile_binary_schemas(&include_dir_path, tmp.path(), entrypoint_path);
+    compile_binary_schemas(&include_dir_path, &tmp_path, entrypoint_path);
 
-    let mut binary_entrypoint_path = PathBuf::from(entrypoint_filename);
+    let mut binary_entrypoint_path = Utf8PathBuf::from(entrypoint_filename);
     binary_entrypoint_path.set_extension("bfbs");
 
     // semantic pass: high level objects from low-level reflection data
     let mut objects = Objects::from_buf(
         include_dir_path,
-        sh.read_binary_file(tmp.path().join(binary_entrypoint_path))
+        sh.read_binary_file(tmp_path.join(binary_entrypoint_path))
             .unwrap()
             .as_slice(),
     );
@@ -263,9 +264,9 @@ fn generate_lang_agnostic(
 /// );
 /// ```
 pub fn generate_rust_code(
-    include_dir_path: impl AsRef<Path>,
-    output_crate_path: impl AsRef<Path>,
-    entrypoint_path: impl AsRef<Path>,
+    include_dir_path: impl AsRef<Utf8Path>,
+    output_crate_path: impl AsRef<Utf8Path>,
+    entrypoint_path: impl AsRef<Utf8Path>,
 ) {
     // passes 1 through 3: bfbs, semantic, arrow registry
     let (objects, arrow_registry) = generate_lang_agnostic(include_dir_path, entrypoint_path);
@@ -291,9 +292,9 @@ pub fn generate_rust_code(
 /// );
 /// ```
 pub fn generate_python_code(
-    include_dir_path: impl AsRef<Path>,
-    output_pkg_path: impl AsRef<Path>,
-    entrypoint_path: impl AsRef<Path>,
+    include_dir_path: impl AsRef<Utf8Path>,
+    output_pkg_path: impl AsRef<Utf8Path>,
+    entrypoint_path: impl AsRef<Utf8Path>,
 ) {
     // passes 1 through 3: bfbs, semantic, arrow registry
     let (objects, arrow_registry) = generate_lang_agnostic(include_dir_path, entrypoint_path);


### PR DESCRIPTION
### What
TLDR: camino paths are a more ergonomic, since they implement `to_string`, `as_str` etc. I think we should use it in more places.

From [the docs of `camino`](https://crates.io/crates/camino):

#### Why camino?
`camino`'s `Utf8PathBuf` and `Utf8Path` types are like the standard library's `PathBuf` and `Path` types, except
they  are guaranteed to only contain UTF-8 encoded data. Therefore, they expose the ability to get their
contents as strings, they implement `Display`, etc.

The `std::path` types are not guaranteed to be valid UTF-8. This is the right decision for the standard library,
since it must be as general as possible. However, on all platforms, non-Unicode paths are vanishingly uncommon for a
number of reasons:
* Unicode won. There are still some legacy codebases that store paths in encodings like [Shift JIS], but most
  have been converted to Unicode at this point.
* Unicode is the common subset of supported paths across Windows and Unix platforms. (On Windows, Rust stores paths
  as [an extension to UTF-8](https://simonsapin.github.io/wtf-8/), and converts them to UTF-16 at Win32
  API boundaries.)
* There are already many systems, such as Cargo, that only support UTF-8 paths. If your own tool interacts with any such
  system, you can assume that paths are valid UTF-8 without creating any additional burdens on consumers.
* The ["makefile problem"](https://www.mercurial-scm.org/wiki/EncodingStrategy#The_.22makefile_problem.22) asks: given a
  Makefile or other metadata file (such as `Cargo.toml`) that lists the names of other files, how should the names in
  the Makefile be matched with the ones on disk? This has *no general, cross-platform solution* in systems that support
  non-UTF-8 paths. However, restricting paths to UTF-8 eliminates this problem.

[Shift JIS]: https://en.wikipedia.org/wiki/Shift_JIS

Therefore, many programs that want to manipulate paths *do* assume they contain UTF-8 data, and convert them to `str`s
as  necessary. However, because this invariant is not encoded in the `Path` type, conversions such as
`path.to_str().unwrap()` need to be repeated again and again, creating a frustrating experience.

Instead, `camino` allows you to check that your paths are UTF-8 *once*, and then manipulate them
as valid UTF-8 from there on, avoiding repeated lossy and confusing conversions.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2637) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2637)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fcamino/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fcamino/examples)