### PR TITLE
Rename _typos.toml to .typos.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,7 +4,7 @@
 
 [files]
 extend-exclude = [
-  "_typos.toml",
+  ".typos.toml",
   "crates/re_ui/data/design_tokens.json",
   "crates/re_ui/src/design_tokens.rs",
 ]


### PR DESCRIPTION
This is how we name other config files

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2655) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2655)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Frename-typos-file/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Frename-typos-file/examples)