### PR TITLE
Rust codegen: generate proper docstrings

### DIFF
--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -107,40 +107,17 @@ fn main() {
         "./definitions/rerun/archetypes.fbs",
     );
 
-    // NOTE: We're purposefully ignoring the error here.
-    //
-    // In the very unlikely chance that the user doesn't have the `fmt` component installed,
-    // there's still no good reason to fail the build.
-    //
-    // The CI will catch the unformatted file at PR time and complain appropriately anyhow.
-    cmd!(sh, "cargo fmt -p re_types").run().ok();
-    // RUN IT TWICE!!! `rustfmt` is __not__ idempotent until its second run!
-    //
-    // You can try it out yourself with e.g. this snippet:
-    // ```
-    // # [derive (Clone , Debug)]
-    //
-    // # [derive (Default , Copy , PartialEq , PartialOrd)]
-    // pub struct Vec2D (pub [f32 ; 2usize] ,) ;
-    // ```
-    //
-    // First run will take care of most things, but since `rustfmt` isn't recursive, it will also
-    // miss the opportunity to merge the two #derive clauses after it took care of removing the
-    // superfluous linefeeds:
-    // ```
-    // #[derive(Clone, Debug)]
-    // #[derive(Default, Copy, PartialEq, PartialOrd)]
-    // pub struct Vec2D(pub [f32; 2usize]);
-    // ```
-    //
-    // Now if you run it a second time on the other hand...:
-    // ```
-    // #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
-    // pub struct Vec2D(pub [f32; 2usize]);
-    // ```
-    //
-    // And finally things are idempotent, for real this time.
-    cmd!(sh, "cargo fmt -p re_types").run().ok();
+    // We need to run `cago fmt` several times because it is not idempotent!
+    // See https://github.com/rust-lang/rustfmt/issues/5824
+    for _ in 0..2 {
+        // NOTE: We're purposefully ignoring the error here.
+        //
+        // In the very unlikely chance that the user doesn't have the `fmt` component installed,
+        // there's still no good reason to fail the build.
+        //
+        // The CI will catch the unformatted file at PR time and complain appropriately anyhow.
+        cmd!(sh, "cargo fmt -p re_types").run().ok();
+    }
 
     re_types_builder::generate_python_code(
         DEFINITIONS_DIR_PATH,

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-9f57696c17798dfd38d903f4d28f68f0e5b2aa9af020bfcfc2847673e0b052dd
+73588bbdd10b7303d8d04bda573c315fd2acb3cd3edd2ee5244a926064c8dc46

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-478bc67049484da40beb2a0e8fa97aae5ffe1d0a29bd1e30024815ae844956be
+5df243acf7babdeed761c91003d1e302a1cf0ddfd849945d24d2fb0bd009a853

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-5df243acf7babdeed761c91003d1e302a1cf0ddfd849945d24d2fb0bd009a853
+1d133c59a94bd031a7f101824f6a23210278fe9a652c7a5c5579c3b503bda36d

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-1d133c59a94bd031a7f101824f6a23210278fe9a652c7a5c5579c3b503bda36d
+9f57696c17798dfd38d903f4d28f68f0e5b2aa9af020bfcfc2847673e0b052dd

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -26,13 +26,13 @@
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new(\"points\").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
 ///
-///    MsgSender::from_archetype(\"points\", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?
+///    MsgSender::from_archetype("points", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?
 ///        .send(&rec_stream)?;
 ///
 ///    // Log an extra rect to set the view bounds
-///    MsgSender::new(\"bounds\")
+///    MsgSender::new("bounds")
 ///        .with_component(&[Rect2D::XCYCWH(Vec4D([0.0, 0.0, 4.0, 3.0]))])?
 ///        .send(&rec_stream)?;
 ///

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -12,71 +12,71 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 2D point cloud with positions and optional colors, radii, labels, etc."]
-#[doc = ""]
-#[doc = "## Example"]
-#[doc = ""]
-#[doc = "```ignore"]
-#[doc = "//! Log some very simple points."]
-#[doc = ""]
-#[doc = "use rerun::{"]
-#[doc = "   components::{Rect2D, Vec4D},"]
-#[doc = "   experimental::archetypes::Points2D,"]
-#[doc = "   MsgSender, RecordingStreamBuilder,"]
-#[doc = "};"]
-#[doc = ""]
-#[doc = "fn main() -> Result<(), Box<dyn std::error::Error>> {"]
-#[doc = "   let (rec_stream, storage) = RecordingStreamBuilder::new(\"points\").memory()?;"]
-#[doc = ""]
-#[doc = "   MsgSender::from_archetype(\"points\", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?"]
-#[doc = "       .send(&rec_stream)?;"]
-#[doc = ""]
-#[doc = "   // Log an extra rect to set the view bounds"]
-#[doc = "   MsgSender::new(\"bounds\")"]
-#[doc = "       .with_component(&[Rect2D::XCYCWH(Vec4D([0.0, 0.0, 4.0, 3.0]))])?"]
-#[doc = "       .send(&rec_stream)?;"]
-#[doc = ""]
-#[doc = "   rerun::native_viewer::show(storage.take())?;"]
-#[doc = ""]
-#[doc = "   Ok(())"]
-#[doc = "}"]
-#[doc = "```"]
+/// A 2D point cloud with positions and optional colors, radii, labels, etc.
+///
+/// ## Example
+///
+/// ```ignore
+/// //! Log some very simple points.
+///
+/// use rerun::{
+///    components::{Rect2D, Vec4D},
+///    experimental::archetypes::Points2D,
+///    MsgSender, RecordingStreamBuilder,
+/// };
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(\"points\").memory()?;
+///
+///    MsgSender::from_archetype(\"points\", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?
+///        .send(&rec_stream)?;
+///
+///    // Log an extra rect to set the view bounds
+///    MsgSender::new(\"bounds\")
+///        .with_component(&[Rect2D::XCYCWH(Vec4D([0.0, 0.0, 4.0, 3.0]))])?
+///        .send(&rec_stream)?;
+///
+///    rerun::native_viewer::show(storage.take())?;
+///
+///    Ok(())
+/// }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Points2D {
-    #[doc = "All the actual 2D points that make up the point cloud."]
+    /// All the actual 2D points that make up the point cloud.
     pub points: Vec<crate::components::Point2D>,
 
-    #[doc = "Optional radii for the points, effectively turning them into circles."]
+    /// Optional radii for the points, effectively turning them into circles.
     pub radii: Option<Vec<crate::components::Radius>>,
 
-    #[doc = "Optional colors for the points."]
+    /// Optional colors for the points.
     pub colors: Option<Vec<crate::components::Color>>,
 
-    #[doc = "Optional text labels for the points."]
+    /// Optional text labels for the points.
     pub labels: Option<Vec<crate::components::Label>>,
 
-    #[doc = "An optional floating point value that specifies the 2D drawing order."]
-    #[doc = "Objects with higher values are drawn on top of those with lower values."]
-    #[doc = ""]
-    #[doc = "The default for 2D points is 30.0."]
+    /// An optional floating point value that specifies the 2D drawing order.
+    /// Objects with higher values are drawn on top of those with lower values.
+    ///
+    /// The default for 2D points is 30.0.
     pub draw_order: Option<crate::components::DrawOrder>,
 
-    #[doc = "Optional class Ids for the points."]
-    #[doc = ""]
-    #[doc = "The class ID provides colors and labels if not specified explicitly."]
+    /// Optional class Ids for the points.
+    ///
+    /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 
-    #[doc = "Optional keypoint IDs for the points, identifying them within a class."]
-    #[doc = ""]
-    #[doc = "If keypoint IDs are passed in but no class IDs were specified, the class ID will"]
-    #[doc = "default to 0."]
-    #[doc = "This is useful to identify points within a single classification (which is identified"]
-    #[doc = "with `class_id`)."]
-    #[doc = "E.g. the classification might be 'Person' and the keypoints refer to joints on a"]
-    #[doc = "detected skeleton."]
+    /// Optional keypoint IDs for the points, identifying them within a class.
+    ///
+    /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
+    /// default to 0.
+    /// This is useful to identify points within a single classification (which is identified
+    /// with `class_id`).
+    /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
+    /// detected skeleton.
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
 
-    #[doc = "Unique identifiers for each individual point in the batch."]
+    /// Unique identifiers for each individual point in the batch.
     pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -12,10 +12,10 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 3D transform"]
+/// A 3D transform
 #[derive(Clone, Debug)]
 pub struct Transform3D {
-    #[doc = "The transform"]
+    /// The transform
     pub transform: crate::components::Transform3D,
 }
 

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -12,9 +12,9 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 16-bit ID representing a type of semantic class."]
-#[doc = ""]
-#[doc = "Used to look up a `crate::components::ClassDescription` within the `crate::components::AnnotationContext`."]
+/// A 16-bit ID representing a type of semantic class.
+///
+/// Used to look up a `crate::components::ClassDescription` within the `crate::components::AnnotationContext`.
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassId(pub u16);
 

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha."]
+/// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
 #[derive(
     Clone,
     Debug,

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -12,13 +12,13 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "Draw order used for the display order of 2D elements."]
-#[doc = ""]
-#[doc = "Higher values are drawn on top of lower values."]
-#[doc = "An entity can have only a single draw order component."]
-#[doc = "Within an entity draw order is governed by the order of the components."]
-#[doc = ""]
-#[doc = "Draw order for entities with the same draw order is generally undefined."]
+/// Draw order used for the display order of 2D elements.
+///
+/// Higher values are drawn on top of lower values.
+/// An entity can have only a single draw order component.
+/// Within an entity draw order is governed by the order of the components.
+///
+/// Draw order for entities with the same draw order is generally undefined.
 #[derive(Clone, Debug, Copy)]
 #[repr(transparent)]
 pub struct DrawOrder(pub f32);

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A unique numeric identifier for each individual instance within a batch."]
+/// A unique numeric identifier for each individual instance within a batch.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InstanceKey(pub u64);
 

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -12,11 +12,11 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 16-bit ID representing a type of semantic keypoint within a class."]
-#[doc = ""]
-#[doc = "`KeypointId`s are only meaningful within the context of a `crate::components::ClassDescription`."]
-#[doc = ""]
-#[doc = "Used to look up an `crate::components::AnnotationInfo` for a Keypoint within the `crate::components::AnnotationContext`."]
+/// A 16-bit ID representing a type of semantic keypoint within a class.
+///
+/// `KeypointId`s are only meaningful within the context of a `crate::components::ClassDescription`.
+///
+/// Used to look up an `crate::components::AnnotationInfo` for a Keypoint within the `crate::components::AnnotationContext`.
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeypointId(pub u16);
 

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A String label component."]
+/// A String label component.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Label(pub String);

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A point in 2D space."]
+/// A point in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Point2D {
     pub xy: crate::datatypes::Point2D,

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A Radius component."]
+/// A Radius component.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Radius(pub f32);
 

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -12,10 +12,10 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "An affine transform between two 3D spaces, represented in a given direction."]
+/// An affine transform between two 3D spaces, represented in a given direction.
 #[derive(Clone, Debug)]
 pub struct Transform3D {
-    #[doc = "Representation of the transform."]
+    /// Representation of the transform.
     pub repr: crate::datatypes::Transform3D,
 }
 

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "Angle in either radians or degrees."]
+/// Angle in either radians or degrees.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Angle {
     Radians(f32),

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 3x3 column-major Matrix."]
+/// A 3x3 column-major Matrix.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Mat3x3(pub [f32; 9usize]);
 

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 4x4 column-major Matrix."]
+/// A 4x4 column-major Matrix.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Mat4x4(pub [f32; 16usize]);
 

--- a/crates/re_types/src/datatypes/point2d.rs
+++ b/crates/re_types/src/datatypes/point2d.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A point in 2D space."]
+/// A point in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Point2D {
     pub x: f32,

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A Quaternion represented by 4 real numbers."]
+/// A Quaternion represented by 4 real numbers.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Quaternion(pub [f32; 4usize]);
 

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -12,13 +12,13 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A 3D rotation."]
+/// A 3D rotation.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Rotation3D {
-    #[doc = "Rotation defined by a quaternion."]
+    /// Rotation defined by a quaternion.
     Quaternion(crate::datatypes::Quaternion),
 
-    #[doc = "Rotation defined with an axis and an angle."]
+    /// Rotation defined with an axis and an angle.
     AxisAngle(crate::datatypes::RotationAxisAngle),
 }
 

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -12,17 +12,17 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "3D rotation represented by a rotation around a given axis."]
+/// 3D rotation represented by a rotation around a given axis.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct RotationAxisAngle {
-    #[doc = "Axis to rotate around."]
-    #[doc = ""]
-    #[doc = "This is not required to be normalized."]
-    #[doc = "If normalization fails (typically because the vector is length zero), the rotation is silently"]
-    #[doc = "ignored."]
+    /// Axis to rotate around.
+    ///
+    /// This is not required to be normalized.
+    /// If normalization fails (typically because the vector is length zero), the rotation is silently
+    /// ignored.
     pub axis: crate::datatypes::Vec3D,
 
-    #[doc = "How much to rotate around the axis."]
+    /// How much to rotate around the axis.
     pub angle: crate::datatypes::Angle,
 }
 

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -12,13 +12,13 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "3D scaling factor, part of a transform representation."]
+/// 3D scaling factor, part of a transform representation.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Scale3D {
-    #[doc = "Individual scaling factors for each axis, distorting the original object."]
+    /// Individual scaling factors for each axis, distorting the original object.
     ThreeD(crate::datatypes::Vec3D),
 
-    #[doc = "Uniform scaling factor along all axis."]
+    /// Uniform scaling factor along all axis.
     Uniform(f32),
 }
 

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -12,10 +12,10 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "Representation of a 3D affine transform."]
-#[doc = ""]
-#[doc = "Rarely used directly, prefer using the underlying representation classes and pass them"]
-#[doc = "directly to `Transform3D::child_from_parent` or `Transform3D::parent_from_child`."]
+/// Representation of a 3D affine transform.
+///
+/// Rarely used directly, prefer using the underlying representation classes and pass them
+/// directly to `Transform3D::child_from_parent` or `Transform3D::parent_from_child`.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Transform3D {
     TranslationAndMat3X3(crate::datatypes::TranslationAndMat3x3),

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -12,19 +12,19 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "Representation of an affine transform via a 3x3 affine matrix paired with a translation."]
-#[doc = ""]
-#[doc = "First applies the matrix, then the translation."]
+/// Representation of an affine transform via a 3x3 affine matrix paired with a translation.
+///
+/// First applies the matrix, then the translation.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct TranslationAndMat3x3 {
-    #[doc = "3D translation, applied after the matrix."]
+    /// 3D translation, applied after the matrix.
     pub translation: Option<crate::datatypes::Vec3D>,
 
-    #[doc = "3x3 matrix for scale, rotation & shear."]
+    /// 3x3 matrix for scale, rotation & shear.
     pub matrix: Option<crate::datatypes::Mat3x3>,
 
-    #[doc = "If true, the transform maps from the parent space to the space where the transform was logged."]
-    #[doc = "Otherwise, the transform maps from the space to its parent."]
+    /// If true, the transform maps from the parent space to the space where the transform was logged.
+    /// Otherwise, the transform maps from the space to its parent.
     pub from_parent: Option<bool>,
 }
 

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -12,20 +12,20 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "Representation of an affine transform via separate translation, rotation & scale."]
+/// Representation of an affine transform via separate translation, rotation & scale.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct TranslationRotationScale3D {
-    #[doc = "3D translation vector, applied last."]
+    /// 3D translation vector, applied last.
     pub translation: Option<crate::datatypes::Vec3D>,
 
-    #[doc = "3D rotation, applied second."]
+    /// 3D rotation, applied second.
     pub rotation: Option<crate::datatypes::Rotation3D>,
 
-    #[doc = "3D scale, applied first."]
+    /// 3D scale, applied first.
     pub scale: Option<crate::datatypes::Scale3D>,
 
-    #[doc = "If true, the transform maps from the parent space to the space where the transform was logged."]
-    #[doc = "Otherwise, the transform maps from the space to its parent."]
+    /// If true, the transform maps from the parent space to the space where the transform was logged.
+    /// Otherwise, the transform maps from the space to its parent.
     pub from_parent: Option<bool>,
 }
 

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A vector in 2D space."]
+/// A vector in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Vec2D(pub [f32; 2usize]);
 

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A vector in 3D space."]
+/// A vector in 3D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Vec3D(pub [f32; 3usize]);
 

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-#[doc = "A vector in 4D space."]
+/// A vector in 4D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Vec4D(pub [f32; 4usize]);
 

--- a/crates/re_types_builder/src/codegen/mod.rs
+++ b/crates/re_types_builder/src/codegen/mod.rs
@@ -7,7 +7,7 @@ pub trait CodeGenerator {
         &mut self,
         objs: &crate::Objects,
         arrow_registry: &crate::ArrowRegistry,
-    ) -> Vec<camino::Utf8PathBuf>;
+    ) -> std::collections::BTreeSet<camino::Utf8PathBuf>;
 }
 
 // ---

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -243,7 +243,7 @@ fn replace_doc_attrb_with_doc_comment(code: &String) -> String {
                 let content_end = content_start + off;
                 new_code.push_str(&code[i..doc_start]);
                 new_code.push_str("/// ");
-                new_code.push_str(&code[content_start..content_end]);
+                unescape_string_into(&code[content_start..content_end], &mut new_code);
                 new_code.push('\n');
 
                 i = content_end + end_pattern.len();
@@ -260,6 +260,27 @@ fn replace_doc_attrb_with_doc_comment(code: &String) -> String {
         break;
     }
     new_code
+}
+
+fn unescape_string_into(input: &str, output: &mut String) {
+    let mut chars = input.chars();
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            let c = chars.next().expect("Trailing backslash");
+            match c {
+                'n' => output.push('\n'),
+                'r' => output.push('\r'),
+                't' => output.push('\t'),
+                '\\' => output.push('\\'),
+                '"' => output.push('"'),
+                '\'' => output.push('\''),
+                _ => panic!("Unknown escape sequence: \\{c}"),
+            }
+        } else {
+            output.push(c);
+        }
+    }
 }
 
 // --- Codegen core loop ---

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -254,7 +254,7 @@ fn replace_doc_attrb_with_doc_comment(code: &String) -> String {
                 new_code.push('\n');
 
                 i = content_end + end_pattern.len();
-                // Skip trailing shitespace (extra newlines)
+                // Skip trailing whitespace (extra newlines)
                 while matches!(code.as_bytes().get(i), Some(b'\n' | b' ')) {
                     i += 1;
                 }

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -226,6 +226,12 @@ fn replace_doc_attrb_with_doc_comment(code: &String) -> String {
     let start_pattern = "# [doc = \"";
     let end_pattern = "\"]"; // assues there is no escaped quote followed by a bracket
 
+    let problematic = r#"\"]"#;
+    assert!(
+        !code.contains(problematic),
+        "The codegen cannot handle the string {problematic} yet"
+    );
+
     let mut new_code = String::new();
 
     let mut i = 0;

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -205,7 +205,12 @@ pub fn compile_binary_schemas(
 /// 1. Generate binary reflection dumps for our definitions.
 /// 2. Run the semantic pass
 /// 3. Compute the Arrow registry
-fn generate_lang_agnostic(
+///
+/// Panics on error.
+///
+/// - `include_dir_path`: path to the root directory of the fbs definition tree.
+/// - `entrypoint_path`: path to the root file of the fbs definition tree.
+pub fn generate_lang_agnostic(
     include_dir_path: impl AsRef<Utf8Path>,
     entrypoint_path: impl AsRef<Utf8Path>,
 ) -> (Objects, ArrowRegistry) {
@@ -247,59 +252,56 @@ fn generate_lang_agnostic(
     (objects, arrow_registry)
 }
 
-/// Generates Rust code from a set of flatbuffers definitions.
+/// Generates Rust code.
 ///
 /// Panics on error.
 ///
-/// - `include_dir_path`: path to the root directory of the fbs definition tree.
 /// - `output_crate_path`: path to the root of the output crate.
-/// - `entrypoint_path`: path to the root file of the fbs definition tree.
 ///
 /// E.g.:
 /// ```no_run
-/// re_types_builder::generate_rust_code(
+/// let (object, arrow_registry) = re_types_builder::generate_lang_agnostic(
 ///     "./definitions",
-///     ".",
 ///     "./definitions/rerun/archetypes.fbs",
+/// );
+/// re_types_builder::generate_rust_code(
+///     ".",
+///     &objects,
+///     &arrow_registry,
 /// );
 /// ```
 pub fn generate_rust_code(
-    include_dir_path: impl AsRef<Utf8Path>,
     output_crate_path: impl AsRef<Utf8Path>,
-    entrypoint_path: impl AsRef<Utf8Path>,
+    objects: &Objects,
+    arrow_registry: &ArrowRegistry,
 ) {
-    // passes 1 through 3: bfbs, semantic, arrow registry
-    let (objects, arrow_registry) = generate_lang_agnostic(include_dir_path, entrypoint_path);
-
     let mut gen = RustCodeGenerator::new(output_crate_path.as_ref());
-    let _filepaths = gen.generate(&objects, &arrow_registry);
+    let _filepaths = gen.generate(objects, arrow_registry);
 }
 
-/// Generates Python code from a set of flatbuffers definitions.
+/// Generates Python code.
 ///
 /// Panics on error.
 ///
-/// - `include_dir_path`: path to the root directory of the fbs definition tree.
 /// - `output_pkg_path`: path to the root of the output package.
-/// - `entrypoint_path`: path to the root file of the fbs definition tree.
 ///
 /// E.g.:
 /// ```no_run
-/// re_types_builder::generate_python_code(
+/// let (object, arrow_registry) = re_types_builder::generate_lang_agnostic(
 ///     "./definitions",
-///     "./rerun_py",
 ///     "./definitions/rerun/archetypes.fbs",
+/// );
+/// re_types_builder::generate_python_code(
+///     "./rerun_py",
+///     &objects,
+///     &arrow_registry,
 /// );
 /// ```
 pub fn generate_python_code(
-    include_dir_path: impl AsRef<Utf8Path>,
     output_pkg_path: impl AsRef<Utf8Path>,
-    entrypoint_path: impl AsRef<Utf8Path>,
+    objects: &Objects,
+    arrow_registry: &ArrowRegistry,
 ) {
-    // passes 1 through 3: bfbs, semantic, arrow registry
-    let (objects, arrow_registry) = generate_lang_agnostic(include_dir_path, entrypoint_path);
-
-    // generate python code
     let mut gen = PythonCodeGenerator::new(output_pkg_path.as_ref());
-    let _filepaths = gen.generate(&objects, &arrow_registry);
+    let _filepaths = gen.generate(objects, arrow_registry);
 }

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -260,7 +260,7 @@ pub fn generate_lang_agnostic(
 ///
 /// E.g.:
 /// ```no_run
-/// let (object, arrow_registry) = re_types_builder::generate_lang_agnostic(
+/// let (objects, arrow_registry) = re_types_builder::generate_lang_agnostic(
 ///     "./definitions",
 ///     "./definitions/rerun/archetypes.fbs",
 /// );
@@ -287,7 +287,7 @@ pub fn generate_rust_code(
 ///
 /// E.g.:
 /// ```no_run
-/// let (object, arrow_registry) = re_types_builder::generate_lang_agnostic(
+/// let (objects, arrow_registry) = re_types_builder::generate_lang_agnostic(
 ///     "./definitions",
 ///     "./definitions/rerun/archetypes.fbs",
 /// );

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -265,7 +265,7 @@ impl Docs {
                 .with_context(|| format!("couldn't parse included path: {raw_path:?}"))
                 .unwrap();
 
-            let path = filepath.join(path);
+            let path = filepath.parent().unwrap().join(path);
 
             included_files
                 .entry(path.clone())
@@ -416,7 +416,13 @@ impl Object {
             .map(ToOwned::to_owned)
             .with_context(|| format!("no declaration_file found for {fqname}"))
             .unwrap();
+        assert!(virtpath.ends_with(".fbs"), "Bad virtpath: {virtpath:?}");
+
         let filepath = filepath_from_declaration_file(include_dir_path, &virtpath);
+        assert!(
+            filepath.to_string().ends_with(".fbs"),
+            "Bad filepath: {filepath:?}"
+        );
 
         let docs = Docs::from_raw_docs(&filepath, obj.documentation());
         let kind = ObjectKind::from_pkg_name(&pkg_name);
@@ -1075,8 +1081,6 @@ fn filepath_from_declaration_file(
 ) -> Utf8PathBuf {
     include_dir_path.as_ref().join("rerun").join(
         Utf8PathBuf::from(declaration_file.as_ref())
-            .parent()
-            .unwrap() // NOTE: safe, this _must_ be a file
             .to_string()
             .replace("//", ""),
     )


### PR DESCRIPTION
### What
Replace `#[doc = "…"]` with `/// …`. This is so that the generated code is easier to read, which is nice for us, and nice for our users.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2668) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2668)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fcodegen-docstrings/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fcodegen-docstrings/examples)