### PR TITLE
Fix `FixedSizeList` deserialization edge-case + trivial optimizations

### DIFF
--- a/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
+++ b/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
@@ -22,6 +22,10 @@ table SurprisinglyShallowScalar (transparent, order: 001) {
   value: FlattenedScalar (order: 100);
 }
 
+struct ArrayOfFloats (transparent, order: 001) {
+  values: [float: 3] (order: 100);
+}
+
 table AffixFuzzer1 (
   "attr.rust.derive": "PartialEq",
   order: 100
@@ -57,6 +61,7 @@ union AffixFuzzer3 (
   degrees: FlattenedScalar (transparent, order: 100),
   radians: FlattenedScalar (transparent, nullable, order: 101),
   craziness: __AffixFuzzer1Vec (transparent, order: 102),
+  fixed_size_shenanigans: ArrayOfFloats (transparent, order: 103),
 }
 
 table __AffixFuzzer3 (transparent, order: 0) {

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-934a605d9f5de40dea31cf0b9c34bac1fa4e0a6f0852251371faeb965511f6b3
+e313951ab9913cf900115d4925d6880f7552293ba4b680ee10d58fe9786a6d9a

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-e313951ab9913cf900115d4925d6880f7552293ba4b680ee10d58fe9786a6d9a
+478bc67049484da40beb2a0e8fa97aae5ffe1d0a29bd1e30024815ae844956be

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -1271,115 +1271,119 @@ impl crate::Component for AffixFuzzer7 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::ListArray<i32>>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
-                .into_iter()
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Struct(vec![
-                            Field {
-                                name: "single_float_optional".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_string_required".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "single_string_optional".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_floats_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = {
+                    let offsets = data.offsets();
+                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                };
+                let data = &**data.values();
+                let data = crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
+                    .into_iter()
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Struct(vec![
+                                Field {
+                                    name: "single_float_optional".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: true,
                                     metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_strings_required".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
+                                },
+                                Field {
+                                    name: "single_string_required".to_owned(),
                                     data_type: DataType::Utf8,
                                     is_nullable: false,
                                     metadata: [].into(),
-                                })),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "many_strings_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
-                                    name: "item".to_owned(),
+                                },
+                                Field {
+                                    name: "single_string_optional".to_owned(),
                                     data_type: DataType::Utf8,
                                     is_nullable: true,
                                     metadata: [].into(),
-                                })),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "flattened_scalar".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "almost_flattened_scalar".to_owned(),
-                                data_type: DataType::Struct(vec![Field {
-                                    name: "value".to_owned(),
+                                },
+                                Field {
+                                    name: "many_floats_optional".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_strings_required".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "many_strings_optional".to_owned(),
+                                    data_type: DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    })),
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "flattened_scalar".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,
                                     metadata: [].into(),
-                                }]),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            },
-                            Field {
-                                name: "from_parent".to_owned(),
-                                data_type: DataType::Boolean,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            },
-                        ]),
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
+                                },
+                                Field {
+                                    name: "almost_flattened_scalar".to_owned(),
+                                    data_type: DataType::Struct(vec![Field {
+                                        name: "value".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }]),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "from_parent".to_owned(),
+                                    data_type: DataType::Boolean,
+                                    is_nullable: true,
+                                    metadata: [].into(),
+                                },
+                            ]),
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                Ok(data
+                                    .get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec())
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(Ok)
         .map(|res| res.map(|many_optional| Some(Self { many_optional })))
@@ -1890,44 +1894,48 @@ impl crate::Component for AffixFuzzer11 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::ListArray<i32>>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.copied())
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Float32,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = {
+                    let offsets = data.offsets();
+                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                };
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.copied())
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Float32,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                Ok(data
+                                    .get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec())
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(Ok)
         .map(|res| {
@@ -2096,44 +2104,48 @@ impl crate::Component for AffixFuzzer12 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::ListArray<i32>>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Utf8Array<i32>>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.map(ToOwned::to_owned))
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Utf8,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = {
+                    let offsets = data.offsets();
+                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                };
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Utf8Array<i32>>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.map(ToOwned::to_owned))
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Utf8,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                Ok(data
+                                    .get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec())
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {
@@ -2308,44 +2320,48 @@ impl crate::Component for AffixFuzzer13 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::ListArray<i32>>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Utf8Array<i32>>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.map(ToOwned::to_owned))
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Utf8,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = {
+                    let offsets = data.offsets();
+                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                };
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Utf8Array<i32>>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.map(ToOwned::to_owned))
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Utf8,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                Ok(data
+                                    .get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec())
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(Ok)
         .map(|res| {
@@ -2485,6 +2501,20 @@ impl crate::Component for AffixFuzzer14 {
                         is_nullable: false,
                         metadata: [].into(),
                     })),
+                    is_nullable: false,
+                    metadata: [].into(),
+                },
+                Field {
+                    name: "fixed_size_shenanigans".to_owned(),
+                    data_type: DataType::FixedSizeList(
+                        Box::new(Field {
+                            name: "item".to_owned(),
+                            data_type: DataType::Float32,
+                            is_nullable: false,
+                            metadata: [].into(),
+                        }),
+                        3usize,
+                    ),
                     is_nullable: false,
                     metadata: [].into(),
                 },
@@ -2691,6 +2721,20 @@ impl crate::Component for AffixFuzzer16 {
                         is_nullable: false,
                         metadata: [].into(),
                     },
+                    Field {
+                        name: "fixed_size_shenanigans".to_owned(),
+                        data_type: DataType::FixedSizeList(
+                            Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Float32,
+                                is_nullable: false,
+                                metadata: [].into(),
+                            }),
+                            3usize,
+                        ),
+                        is_nullable: false,
+                        metadata: [].into(),
+                    },
                 ],
                 None,
                 UnionMode::Dense,
@@ -2858,6 +2902,20 @@ impl crate::Component for AffixFuzzer16 {
                                             is_nullable: false,
                                             metadata: [].into(),
                                         },
+                                        Field {
+                                            name: "fixed_size_shenanigans".to_owned(),
+                                            data_type: DataType::FixedSizeList(
+                                                Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                }),
+                                                3usize,
+                                            ),
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        },
                                     ],
                                     None,
                                     UnionMode::Dense,
@@ -2901,143 +2959,161 @@ impl crate::Component for AffixFuzzer16 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::ListArray<i32>>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
-                .into_iter()
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Union(
-                            vec![
-                                Field {
-                                    name: "degrees".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "radians".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "craziness".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Struct(vec![
-                                            Field {
-                                                name: "single_float_optional".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_required".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_optional".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_floats_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_required".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "flattened_scalar".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "almost_flattened_scalar".to_owned(),
-                                                data_type: DataType::Struct(vec![Field {
-                                                    name: "value".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                }]),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "from_parent".to_owned(),
-                                                data_type: DataType::Boolean,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                        ]),
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = {
+                    let offsets = data.offsets();
+                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                };
+                let data = &**data.values();
+                let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
+                    .into_iter()
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Union(
+                                vec![
+                                    Field {
+                                        name: "degrees".to_owned(),
+                                        data_type: DataType::Float32,
                                         is_nullable: false,
                                         metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ],
-                            None,
-                            UnionMode::Dense,
-                        ),
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
+                                    },
+                                    Field {
+                                        name: "radians".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "craziness".to_owned(),
+                                        data_type: DataType::List(Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Struct(vec![
+                                                Field {
+                                                    name: "single_float_optional".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "single_string_required".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "single_string_optional".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_floats_optional".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Float32,
+                                                        is_nullable: true,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_strings_required".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Utf8,
+                                                        is_nullable: false,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_strings_optional".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Utf8,
+                                                        is_nullable: true,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "flattened_scalar".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "almost_flattened_scalar".to_owned(),
+                                                    data_type: DataType::Struct(vec![Field {
+                                                        name: "value".to_owned(),
+                                                        data_type: DataType::Float32,
+                                                        is_nullable: false,
+                                                        metadata: [].into(),
+                                                    }]),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "from_parent".to_owned(),
+                                                    data_type: DataType::Boolean,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                            ]),
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                ],
+                                None,
+                                UnionMode::Dense,
+                            ),
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                Ok(data
+                                    .get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec())
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {
@@ -3183,6 +3259,20 @@ impl crate::Component for AffixFuzzer17 {
                             is_nullable: false,
                             metadata: [].into(),
                         })),
+                        is_nullable: false,
+                        metadata: [].into(),
+                    },
+                    Field {
+                        name: "fixed_size_shenanigans".to_owned(),
+                        data_type: DataType::FixedSizeList(
+                            Box::new(Field {
+                                name: "item".to_owned(),
+                                data_type: DataType::Float32,
+                                is_nullable: false,
+                                metadata: [].into(),
+                            }),
+                            3usize,
+                        ),
                         is_nullable: false,
                         metadata: [].into(),
                     },
@@ -3355,6 +3445,20 @@ impl crate::Component for AffixFuzzer17 {
                                             is_nullable: false,
                                             metadata: [].into(),
                                         },
+                                        Field {
+                                            name: "fixed_size_shenanigans".to_owned(),
+                                            data_type: DataType::FixedSizeList(
+                                                Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                }),
+                                                3usize,
+                                            ),
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        },
                                     ],
                                     None,
                                     UnionMode::Dense,
@@ -3398,143 +3502,161 @@ impl crate::Component for AffixFuzzer17 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::ListArray<i32>>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
-                .into_iter()
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Union(
-                            vec![
-                                Field {
-                                    name: "degrees".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "radians".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "craziness".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Struct(vec![
-                                            Field {
-                                                name: "single_float_optional".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_required".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "single_string_optional".to_owned(),
-                                                data_type: DataType::Utf8,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_floats_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_required".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "many_strings_optional".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Utf8,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "flattened_scalar".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "almost_flattened_scalar".to_owned(),
-                                                data_type: DataType::Struct(vec![Field {
-                                                    name: "value".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                }]),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "from_parent".to_owned(),
-                                                data_type: DataType::Boolean,
-                                                is_nullable: true,
-                                                metadata: [].into(),
-                                            },
-                                        ]),
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = {
+                    let offsets = data.offsets();
+                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                };
+                let data = &**data.values();
+                let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
+                    .into_iter()
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Union(
+                                vec![
+                                    Field {
+                                        name: "degrees".to_owned(),
+                                        data_type: DataType::Float32,
                                         is_nullable: false,
                                         metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ],
-                            None,
-                            UnionMode::Dense,
-                        ),
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
+                                    },
+                                    Field {
+                                        name: "radians".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "craziness".to_owned(),
+                                        data_type: DataType::List(Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Struct(vec![
+                                                Field {
+                                                    name: "single_float_optional".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "single_string_required".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "single_string_optional".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_floats_optional".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Float32,
+                                                        is_nullable: true,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_strings_required".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Utf8,
+                                                        is_nullable: false,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "many_strings_optional".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Utf8,
+                                                        is_nullable: true,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "flattened_scalar".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "almost_flattened_scalar".to_owned(),
+                                                    data_type: DataType::Struct(vec![Field {
+                                                        name: "value".to_owned(),
+                                                        data_type: DataType::Float32,
+                                                        is_nullable: false,
+                                                        metadata: [].into(),
+                                                    }]),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "from_parent".to_owned(),
+                                                    data_type: DataType::Boolean,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                },
+                                            ]),
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                ],
+                                None,
+                                UnionMode::Dense,
+                            ),
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                Ok(data
+                                    .get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec())
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(Ok)
         .map(|res| {
@@ -3683,6 +3805,20 @@ impl crate::Component for AffixFuzzer18 {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
+                                Field {
+                                    name: "fixed_size_shenanigans".to_owned(),
+                                    data_type: DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    ),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
                             ],
                             None,
                             UnionMode::Dense,
@@ -3791,6 +3927,20 @@ impl crate::Component for AffixFuzzer18 {
                                             is_nullable: false,
                                             metadata: [].into(),
                                         })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
                                         is_nullable: false,
                                         metadata: [].into(),
                                     },
@@ -3908,6 +4058,20 @@ impl crate::Component for AffixFuzzer18 {
                                         is_nullable: false,
                                         metadata: [].into(),
                                     },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
                                 ],
                                 None,
                                 UnionMode::Dense,
@@ -4008,6 +4172,10 @@ impl crate::Component for AffixFuzzer18 {
 
 )) , is_nullable : false , metadata : [] . into () , }
 
+ , Field { name : "fixed_size_shenanigans" . to_owned () , data_type : DataType :: FixedSizeList (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+) , 3usize) , is_nullable : false , metadata : [] . into () , }
+
  ,] , None , UnionMode :: Dense) , is_nullable : false , metadata : [] . into () , }
 
  , Field { name : "many_required" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Union (vec ! [Field { name : "degrees" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
@@ -4043,6 +4211,10 @@ impl crate::Component for AffixFuzzer18 {
  ,]) , is_nullable : false , metadata : [] . into () , }
 
 )) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "fixed_size_shenanigans" . to_owned () , data_type : DataType :: FixedSizeList (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+) , 3usize) , is_nullable : false , metadata : [] . into () , }
 
  ,] , None , UnionMode :: Dense) , is_nullable : false , metadata : [] . into () , }
 
@@ -4082,6 +4254,10 @@ impl crate::Component for AffixFuzzer18 {
 
 )) , is_nullable : false , metadata : [] . into () , }
 
+ , Field { name : "fixed_size_shenanigans" . to_owned () , data_type : DataType :: FixedSizeList (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+) , 3usize) , is_nullable : false , metadata : [] . into () , }
+
  ,] , None , UnionMode :: Dense) , is_nullable : true , metadata : [] . into () , }
 
 )) , is_nullable : false , metadata : [] . into () , }
@@ -4106,446 +4282,147 @@ impl crate::Component for AffixFuzzer18 {
     {
         use crate::{Component as _, Datatype as _};
         use ::arrow2::{array::*, datatypes::*};
-        Ok({
-            let datatype = data.data_type();
-            let data = data
-                .as_any()
-                .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = {
-                let offsets = data.offsets();
-                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-            };
-            let data = &**data.values();
-            let data = crate::datatypes::AffixFuzzer4::try_from_arrow_opt(data)?
-                .into_iter()
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Union(
-                            vec![
-                                Field {
-                                    name: "single_required".to_owned(),
-                                    data_type: DataType::Union(
-                                        vec![
-                                            Field {
-                                                name: "degrees".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "radians".to_owned(),
-                                                data_type: DataType::Float32,
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                            Field {
-                                                name: "craziness".to_owned(),
-                                                data_type: DataType::List(Box::new(Field {
-                                                    name: "item".to_owned(),
-                                                    data_type: DataType::Struct(vec![
-                                                        Field {
-                                                            name: "single_float_optional"
-                                                                .to_owned(),
-                                                            data_type: DataType::Float32,
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "single_string_required"
-                                                                .to_owned(),
-                                                            data_type: DataType::Utf8,
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "single_string_optional"
-                                                                .to_owned(),
-                                                            data_type: DataType::Utf8,
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "many_floats_optional".to_owned(),
-                                                            data_type: DataType::List(Box::new(
-                                                                Field {
-                                                                    name: "item".to_owned(),
-                                                                    data_type: DataType::Float32,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            )),
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "many_strings_required"
-                                                                .to_owned(),
-                                                            data_type: DataType::List(Box::new(
-                                                                Field {
-                                                                    name: "item".to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            )),
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "many_strings_optional"
-                                                                .to_owned(),
-                                                            data_type: DataType::List(Box::new(
-                                                                Field {
-                                                                    name: "item".to_owned(),
-                                                                    data_type: DataType::Utf8,
-                                                                    is_nullable: true,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            )),
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "flattened_scalar".to_owned(),
-                                                            data_type: DataType::Float32,
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "almost_flattened_scalar"
-                                                                .to_owned(),
-                                                            data_type: DataType::Struct(vec![
-                                                                Field {
-                                                                    name: "value".to_owned(),
-                                                                    data_type: DataType::Float32,
-                                                                    is_nullable: false,
-                                                                    metadata: [].into(),
-                                                                },
-                                                            ]),
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        },
-                                                        Field {
-                                                            name: "from_parent".to_owned(),
-                                                            data_type: DataType::Boolean,
-                                                            is_nullable: true,
-                                                            metadata: [].into(),
-                                                        },
-                                                    ]),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                })),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            },
-                                        ],
-                                        None,
-                                        UnionMode::Dense,
-                                    ),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_required".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Union(
-                                            vec![
-                                                Field {
-                                                    name: "degrees".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "radians".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "craziness".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Struct(vec![
-                                                            Field {
-                                                                name: "single_float_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Float32,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "single_string_required"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Utf8,
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "single_string_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Utf8,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_floats_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type:
-                                                                            DataType::Float32,
-                                                                        is_nullable: true,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_strings_required"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type: DataType::Utf8,
-                                                                        is_nullable: false,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_strings_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type: DataType::Utf8,
-                                                                        is_nullable: true,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "flattened_scalar".to_owned(),
-                                                                data_type: DataType::Float32,
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "almost_flattened_scalar"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Struct(vec![
-                                                                    Field {
-                                                                        name: "value".to_owned(),
-                                                                        data_type:
-                                                                            DataType::Float32,
-                                                                        is_nullable: false,
-                                                                        metadata: [].into(),
-                                                                    },
-                                                                ]),
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "from_parent".to_owned(),
-                                                                data_type: DataType::Boolean,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                        ]),
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                            ],
-                                            None,
-                                            UnionMode::Dense,
-                                        ),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "many_optional".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Union(
-                                            vec![
-                                                Field {
-                                                    name: "degrees".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "radians".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "craziness".to_owned(),
-                                                    data_type: DataType::List(Box::new(Field {
-                                                        name: "item".to_owned(),
-                                                        data_type: DataType::Struct(vec![
-                                                            Field {
-                                                                name: "single_float_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Float32,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "single_string_required"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Utf8,
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "single_string_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Utf8,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_floats_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type:
-                                                                            DataType::Float32,
-                                                                        is_nullable: true,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_strings_required"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type: DataType::Utf8,
-                                                                        is_nullable: false,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "many_strings_optional"
-                                                                    .to_owned(),
-                                                                data_type: DataType::List(
-                                                                    Box::new(Field {
-                                                                        name: "item".to_owned(),
-                                                                        data_type: DataType::Utf8,
-                                                                        is_nullable: true,
-                                                                        metadata: [].into(),
-                                                                    }),
-                                                                ),
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "flattened_scalar".to_owned(),
-                                                                data_type: DataType::Float32,
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "almost_flattened_scalar"
-                                                                    .to_owned(),
-                                                                data_type: DataType::Struct(vec![
-                                                                    Field {
-                                                                        name: "value".to_owned(),
-                                                                        data_type:
-                                                                            DataType::Float32,
-                                                                        is_nullable: false,
-                                                                        metadata: [].into(),
-                                                                    },
-                                                                ]),
-                                                                is_nullable: false,
-                                                                metadata: [].into(),
-                                                            },
-                                                            Field {
-                                                                name: "from_parent".to_owned(),
-                                                                data_type: DataType::Boolean,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                        ]),
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    })),
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                            ],
-                                            None,
-                                            UnionMode::Dense,
-                                        ),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ],
-                            None,
-                            UnionMode::Dense,
-                        ),
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            Ok(data
-                                .get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec())
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
-        }
-        .map(Ok)
-        .map(|res| {
-            res.map(|many_optional_unions| {
-                Some(Self {
-                    many_optional_unions,
-                })
-            })
-        })
-        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
+        Ok ({ let datatype = data . data_type () ; let data = data . as_any () . downcast_ref :: < :: arrow2 :: array :: ListArray < i32 >> () . unwrap () ; if data . is_empty () { Vec :: new () }
+
+ else { let bitmap = data . validity () . cloned () ; let offsets = { let offsets = data . offsets () ; offsets . iter () . copied () . zip (offsets . iter () . copied () . skip (1)) }
+
+ ; let data = & * * data . values () ; let data = crate :: datatypes :: AffixFuzzer4 :: try_from_arrow_opt (data) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { datatype : DataType :: Union (vec ! [Field { name : "single_required" . to_owned () , data_type : DataType :: Union (vec ! [Field { name : "degrees" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "radians" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "craziness" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Struct (vec ! [Field { name : "single_float_optional" . to_owned () , data_type : DataType :: Float32 , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "single_string_required" . to_owned () , data_type : DataType :: Utf8 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "single_string_optional" . to_owned () , data_type : DataType :: Utf8 , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "many_floats_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "many_strings_required" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Utf8 , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "many_strings_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Utf8 , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "flattened_scalar" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "almost_flattened_scalar" . to_owned () , data_type : DataType :: Struct (vec ! [Field { name : "value" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ ,]) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "from_parent" . to_owned () , data_type : DataType :: Boolean , is_nullable : true , metadata : [] . into () , }
+
+ ,]) , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "fixed_size_shenanigans" . to_owned () , data_type : DataType :: FixedSizeList (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+) , 3usize) , is_nullable : false , metadata : [] . into () , }
+
+ ,] , None , UnionMode :: Dense) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "many_required" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Union (vec ! [Field { name : "degrees" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "radians" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "craziness" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Struct (vec ! [Field { name : "single_float_optional" . to_owned () , data_type : DataType :: Float32 , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "single_string_required" . to_owned () , data_type : DataType :: Utf8 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "single_string_optional" . to_owned () , data_type : DataType :: Utf8 , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "many_floats_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "many_strings_required" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Utf8 , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "many_strings_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Utf8 , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "flattened_scalar" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "almost_flattened_scalar" . to_owned () , data_type : DataType :: Struct (vec ! [Field { name : "value" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ ,]) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "from_parent" . to_owned () , data_type : DataType :: Boolean , is_nullable : true , metadata : [] . into () , }
+
+ ,]) , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "fixed_size_shenanigans" . to_owned () , data_type : DataType :: FixedSizeList (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+) , 3usize) , is_nullable : false , metadata : [] . into () , }
+
+ ,] , None , UnionMode :: Dense) , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "many_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Union (vec ! [Field { name : "degrees" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "radians" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "craziness" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Struct (vec ! [Field { name : "single_float_optional" . to_owned () , data_type : DataType :: Float32 , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "single_string_required" . to_owned () , data_type : DataType :: Utf8 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "single_string_optional" . to_owned () , data_type : DataType :: Utf8 , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "many_floats_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "many_strings_required" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Utf8 , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "many_strings_optional" . to_owned () , data_type : DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Utf8 , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : true , metadata : [] . into () , }
+
+ , Field { name : "flattened_scalar" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "almost_flattened_scalar" . to_owned () , data_type : DataType :: Struct (vec ! [Field { name : "value" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+ ,]) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "from_parent" . to_owned () , data_type : DataType :: Boolean , is_nullable : true , metadata : [] . into () , }
+
+ ,]) , is_nullable : false , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ , Field { name : "fixed_size_shenanigans" . to_owned () , data_type : DataType :: FixedSizeList (Box :: new (Field { name : "item" . to_owned () , data_type : DataType :: Float32 , is_nullable : false , metadata : [] . into () , }
+
+) , 3usize) , is_nullable : false , metadata : [] . into () , }
+
+ ,] , None , UnionMode :: Dense) , is_nullable : true , metadata : [] . into () , }
+
+)) , is_nullable : false , metadata : [] . into () , }
+
+ ,] , None , UnionMode :: Dense) , }
+
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or_else (|| crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , datatype : datatype . clone () , }
+
+) ? . to_vec ()) }
+
+) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
+
+ . into_iter () }
+
+ . map (Ok) . map (| res | res . map (| many_optional_unions | Some (Self { many_optional_unions }
+
+))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ?)
     }
 }
 
@@ -4684,6 +4561,20 @@ impl crate::Component for AffixFuzzer19 {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
+                                Field {
+                                    name: "fixed_size_shenanigans".to_owned(),
+                                    data_type: DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    ),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
                             ],
                             None,
                             UnionMode::Dense,
@@ -4792,6 +4683,20 @@ impl crate::Component for AffixFuzzer19 {
                                             is_nullable: false,
                                             metadata: [].into(),
                                         })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
                                         is_nullable: false,
                                         metadata: [].into(),
                                     },
@@ -4906,6 +4811,20 @@ impl crate::Component for AffixFuzzer19 {
                                             is_nullable: false,
                                             metadata: [].into(),
                                         })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
                                         is_nullable: false,
                                         metadata: [].into(),
                                     },

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -200,61 +200,65 @@ impl crate::Datatype for Angle {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_types, data_arrays, data_offsets) =
-                (data.types(), data.fields(), data.offsets().unwrap());
-            let radians = {
-                let data = &*data_arrays[0usize];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_types, data_arrays, data_offsets) =
+                    (data.types(), data.fields(), data.offsets().unwrap());
+                let radians = {
+                    let data = &*data_arrays[0usize];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-                    .collect::<Vec<_>>()
-            };
-            let degrees = {
-                let data = &*data_arrays[1usize];
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                        .collect::<Vec<_>>()
+                };
+                let degrees = {
+                    let data = &*data_arrays[1usize];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-                    .collect::<Vec<_>>()
-            };
-            data_types
-                .iter()
-                .enumerate()
-                .map(|(i, typ)| {
-                    let offset = data_offsets[i];
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                        .collect::<Vec<_>>()
+                };
+                data_types
+                    .iter()
+                    .enumerate()
+                    .map(|(i, typ)| {
+                        let offset = data_offsets[i];
 
-                    Ok(Some(match typ {
-                        0i8 => Angle::Radians(
-                            radians
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: radians.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        1i8 => Angle::Degrees(
-                            degrees
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: degrees.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        _ => unreachable!(),
-                    }))
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                        Ok(Some(match typ {
+                            0i8 => Angle::Radians(
+                                radians
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: radians.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            1i8 => Angle::Degrees(
+                                degrees
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: degrees.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            _ => unreachable!(),
+                        }))
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -131,39 +131,43 @@ impl crate::Datatype for FlattenedScalar {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let value = {
-                let data = &**arrays_by_name["value"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let value = {
+                    let data = &**arrays_by_name["value"];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-            };
-            ::itertools::izip!(value)
-                .enumerate()
-                .map(|(i, (value))| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                value: value.ok_or_else(|| {
-                                    crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    }
-                                })?,
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                };
+                ::itertools::izip!(value)
+                    .enumerate()
+                    .map(|(i, (value))| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    value: value.ok_or_else(|| {
+                                        crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        }
+                                    })?,
+                                })
                             })
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }
@@ -804,277 +808,293 @@ impl crate::Datatype for AffixFuzzer1 {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let single_float_optional = {
-                let data = &**arrays_by_name["single_float_optional"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let single_float_optional = {
+                    let data = &**arrays_by_name["single_float_optional"];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-            };
-            let single_string_required = {
-                let data = &**arrays_by_name["single_string_required"];
-
-                data.as_any()
-                    .downcast_ref::<Utf8Array<i32>>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.map(ToOwned::to_owned))
-            };
-            let single_string_optional = {
-                let data = &**arrays_by_name["single_string_optional"];
-
-                data.as_any()
-                    .downcast_ref::<Utf8Array<i32>>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.map(ToOwned::to_owned))
-            };
-            let many_floats_optional = {
-                let data = &**arrays_by_name["many_floats_optional"];
-
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = {
-                        let offsets = data.offsets();
-                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                    };
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
+                    data.as_any()
                         .downcast_ref::<Float32Array>()
                         .unwrap()
                         .into_iter()
                         .map(|v| v.copied())
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Float32,
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    Ok(data
-                                        .get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec())
-                                })
-                                .transpose()
-                        })
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-            };
-            let many_strings_required = {
-                let data = &**arrays_by_name["many_strings_required"];
+                };
+                let single_string_required = {
+                    let data = &**arrays_by_name["single_string_required"];
 
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = {
-                        let offsets = data.offsets();
-                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                    };
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
+                    data.as_any()
                         .downcast_ref::<Utf8Array<i32>>()
                         .unwrap()
                         .into_iter()
                         .map(|v| v.map(ToOwned::to_owned))
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Utf8,
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    Ok(data
-                                        .get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec())
-                                })
-                                .transpose()
-                        })
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-            };
-            let many_strings_optional = {
-                let data = &**arrays_by_name["many_strings_optional"];
+                };
+                let single_string_optional = {
+                    let data = &**arrays_by_name["single_string_optional"];
 
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = {
-                        let offsets = data.offsets();
-                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                    };
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
+                    data.as_any()
                         .downcast_ref::<Utf8Array<i32>>()
                         .unwrap()
                         .into_iter()
                         .map(|v| v.map(ToOwned::to_owned))
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Utf8,
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    Ok(data
-                                        .get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec())
+                };
+                let many_floats_optional = {
+                    let data = &**arrays_by_name["many_floats_optional"];
+
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::ListArray<i32>>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Float32Array>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.copied())
+                                .map(|v| {
+                                    v.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: DataType::Float32,
+                                    })
                                 })
-                                .transpose()
-                        })
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            Ok(data
+                                                .get(start as usize..end as usize)
+                                                .ok_or_else(|| {
+                                                    crate::DeserializationError::OffsetsMismatch {
+                                                        bounds: (start as usize, end as usize),
+                                                        len: data.len(),
+                                                        datatype: datatype.clone(),
+                                                    }
+                                                })?
+                                                .to_vec())
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
                         .into_iter()
-                }
-            };
-            let flattened_scalar = {
-                let data = &**arrays_by_name["flattened_scalar"];
+                    }
+                };
+                let many_strings_required = {
+                    let data = &**arrays_by_name["many_strings_required"];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-            };
-            let almost_flattened_scalar = {
-                let data = &**arrays_by_name["almost_flattened_scalar"];
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::ListArray<i32>>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Utf8Array<i32>>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.map(ToOwned::to_owned))
+                                .map(|v| {
+                                    v.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: DataType::Utf8,
+                                    })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            Ok(data
+                                                .get(start as usize..end as usize)
+                                                .ok_or_else(|| {
+                                                    crate::DeserializationError::OffsetsMismatch {
+                                                        bounds: (start as usize, end as usize),
+                                                        len: data.len(),
+                                                        datatype: datatype.clone(),
+                                                    }
+                                                })?
+                                                .to_vec())
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                        .into_iter()
+                    }
+                };
+                let many_strings_optional = {
+                    let data = &**arrays_by_name["many_strings_optional"];
 
-                crate::datatypes::FlattenedScalar::try_from_arrow_opt(data)?.into_iter()
-            };
-            let from_parent = {
-                let data = &**arrays_by_name["from_parent"];
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::ListArray<i32>>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Utf8Array<i32>>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.map(ToOwned::to_owned))
+                                .map(|v| {
+                                    v.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: DataType::Utf8,
+                                    })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            Ok(data
+                                                .get(start as usize..end as usize)
+                                                .ok_or_else(|| {
+                                                    crate::DeserializationError::OffsetsMismatch {
+                                                        bounds: (start as usize, end as usize),
+                                                        len: data.len(),
+                                                        datatype: datatype.clone(),
+                                                    }
+                                                })?
+                                                .to_vec())
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                        .into_iter()
+                    }
+                };
+                let flattened_scalar = {
+                    let data = &**arrays_by_name["flattened_scalar"];
 
-                data.as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .unwrap()
-                    .into_iter()
-            };
-            ::itertools::izip!(
-                single_float_optional,
-                single_string_required,
-                single_string_optional,
-                many_floats_optional,
-                many_strings_required,
-                many_strings_optional,
-                flattened_scalar,
-                almost_flattened_scalar,
-                from_parent
-            )
-            .enumerate()
-            .map(
-                |(
-                    i,
-                    (
-                        single_float_optional,
-                        single_string_required,
-                        single_string_optional,
-                        many_floats_optional,
-                        many_strings_required,
-                        many_strings_optional,
-                        flattened_scalar,
-                        almost_flattened_scalar,
-                        from_parent,
-                    ),
-                )| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                single_float_optional,
-                                single_string_required: single_string_required.ok_or_else(
-                                    || crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    },
-                                )?,
-                                single_string_optional,
-                                many_floats_optional,
-                                many_strings_required: many_strings_required.ok_or_else(|| {
-                                    crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    }
-                                })?,
-                                many_strings_optional,
-                                flattened_scalar: flattened_scalar.ok_or_else(|| {
-                                    crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    }
-                                })?,
-                                almost_flattened_scalar: almost_flattened_scalar.ok_or_else(
-                                    || crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    },
-                                )?,
-                                from_parent,
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                };
+                let almost_flattened_scalar = {
+                    let data = &**arrays_by_name["almost_flattened_scalar"];
+
+                    crate::datatypes::FlattenedScalar::try_from_arrow_opt(data)?.into_iter()
+                };
+                let from_parent = {
+                    let data = &**arrays_by_name["from_parent"];
+
+                    data.as_any()
+                        .downcast_ref::<BooleanArray>()
+                        .unwrap()
+                        .into_iter()
+                };
+                ::itertools::izip!(
+                    single_float_optional,
+                    single_string_required,
+                    single_string_optional,
+                    many_floats_optional,
+                    many_strings_required,
+                    many_strings_optional,
+                    flattened_scalar,
+                    almost_flattened_scalar,
+                    from_parent
+                )
+                .enumerate()
+                .map(
+                    |(
+                        i,
+                        (
+                            single_float_optional,
+                            single_string_required,
+                            single_string_optional,
+                            many_floats_optional,
+                            many_strings_required,
+                            many_strings_optional,
+                            flattened_scalar,
+                            almost_flattened_scalar,
+                            from_parent,
+                        ),
+                    )| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    single_float_optional,
+                                    single_string_required: single_string_required.ok_or_else(
+                                        || crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        },
+                                    )?,
+                                    single_string_optional,
+                                    many_floats_optional,
+                                    many_strings_required: many_strings_required.ok_or_else(
+                                        || crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        },
+                                    )?,
+                                    many_strings_optional,
+                                    flattened_scalar: flattened_scalar.ok_or_else(|| {
+                                        crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        }
+                                    })?,
+                                    almost_flattened_scalar: almost_flattened_scalar.ok_or_else(
+                                        || crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        },
+                                    )?,
+                                    from_parent,
+                                })
                             })
-                        })
-                        .transpose()
-                },
-            )
-            .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    },
+                )
+                .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }
@@ -1181,6 +1201,7 @@ pub enum AffixFuzzer3 {
     Degrees(f32),
     Radians(Option<f32>),
     Craziness(Vec<crate::datatypes::AffixFuzzer1>),
+    FixedSizeShenanigans([f32; 3usize]),
 }
 
 impl<'a> From<AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
@@ -1307,6 +1328,20 @@ impl crate::Datatype for AffixFuzzer3 {
                     is_nullable: false,
                     metadata: [].into(),
                 },
+                Field {
+                    name: "fixed_size_shenanigans".to_owned(),
+                    data_type: DataType::FixedSizeList(
+                        Box::new(Field {
+                            name: "item".to_owned(),
+                            data_type: DataType::Float32,
+                            is_nullable: false,
+                            metadata: [].into(),
+                        }),
+                        3usize,
+                    ),
+                    is_nullable: false,
+                    metadata: [].into(),
+                },
             ],
             None,
             UnionMode::Dense,
@@ -1350,6 +1385,7 @@ impl crate::Datatype for AffixFuzzer3 {
                             AffixFuzzer3::Degrees(_) => 0i8,
                             AffixFuzzer3::Radians(_) => 1i8,
                             AffixFuzzer3::Craziness(_) => 2i8,
+                            AffixFuzzer3::FixedSizeShenanigans(_) => 3i8,
                         })
                         .collect()
                 },
@@ -1544,11 +1580,75 @@ impl crate::Datatype for AffixFuzzer3 {
                             .boxed()
                         }
                     },
+                    {
+                        let (somes, fixed_size_shenanigans): (Vec<_>, Vec<_>) = data
+                            .iter()
+                            .flatten()
+                            .filter(|datum| {
+                                matches!(***datum, AffixFuzzer3::FixedSizeShenanigans(_))
+                            })
+                            .map(|datum| {
+                                let datum = match &**datum {
+                                    AffixFuzzer3::FixedSizeShenanigans(v) => Some(v.clone()),
+                                    _ => None,
+                                };
+                                (datum.is_some(), datum)
+                            })
+                            .unzip();
+                        let fixed_size_shenanigans_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+                            let any_nones = somes.iter().any(|some| !*some);
+                            any_nones.then(|| somes.into())
+                        };
+                        {
+                            use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
+                            let fixed_size_shenanigans_inner_data: Vec<_> = fixed_size_shenanigans
+                                .iter()
+                                .flatten()
+                                .flatten()
+                                .map(ToOwned::to_owned)
+                                .map(Some)
+                                .collect();
+                            let fixed_size_shenanigans_inner_bitmap: Option<
+                                ::arrow2::bitmap::Bitmap,
+                            > = None;
+                            FixedSizeListArray::new(
+                                {
+                                    _ = extension_wrapper;
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
+                                },
+                                PrimitiveArray::new(
+                                    {
+                                        _ = extension_wrapper;
+                                        DataType::Float32.to_logical_type().clone()
+                                    },
+                                    fixed_size_shenanigans_inner_data
+                                        .into_iter()
+                                        .map(|v| v.unwrap_or_default())
+                                        .collect(),
+                                    fixed_size_shenanigans_inner_bitmap,
+                                )
+                                .boxed(),
+                                fixed_size_shenanigans_bitmap,
+                            )
+                            .boxed()
+                        }
+                    },
                 ],
                 Some({
                     let mut degrees_offset = 0;
                     let mut radians_offset = 0;
                     let mut craziness_offset = 0;
+                    let mut fixed_size_shenanigans_offset = 0;
                     data.iter()
                         .flatten()
                         .map(|v| match **v {
@@ -1567,6 +1667,12 @@ impl crate::Datatype for AffixFuzzer3 {
                             AffixFuzzer3::Craziness(_) => {
                                 let offset = craziness_offset;
                                 craziness_offset += 1;
+                                offset
+                            }
+
+                            AffixFuzzer3::FixedSizeShenanigans(_) => {
+                                let offset = fixed_size_shenanigans_offset;
+                                fixed_size_shenanigans_offset += 1;
                                 offset
                             }
                         })
@@ -1594,194 +1700,232 @@ impl crate::Datatype for AffixFuzzer3 {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_types, data_arrays, data_offsets) =
-                (data.types(), data.fields(), data.offsets().unwrap());
-            let degrees = {
-                let data = &*data_arrays[0usize];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_types, data_arrays, data_offsets) =
+                    (data.types(), data.fields(), data.offsets().unwrap());
+                let degrees = {
+                    let data = &*data_arrays[0usize];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-                    .collect::<Vec<_>>()
-            };
-            let radians = {
-                let data = &*data_arrays[1usize];
-
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-                    .collect::<Vec<_>>()
-            };
-            let craziness = {
-                let data = &*data_arrays[2usize];
-
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = {
-                        let offsets = data.offsets();
-                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                    };
-                    let data = &**data.values();
-                    let data = crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
                         .into_iter()
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Struct(vec![
-                                    Field {
-                                        name: "single_float_optional".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "single_string_required".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "single_string_optional".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_floats_optional".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_strings_required".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "many_strings_optional".to_owned(),
-                                        data_type: DataType::List(Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Utf8,
-                                            is_nullable: true,
-                                            metadata: [].into(),
-                                        })),
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "flattened_scalar".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "almost_flattened_scalar".to_owned(),
-                                        data_type: DataType::Struct(vec![Field {
-                                            name: "value".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }]),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "from_parent".to_owned(),
-                                        data_type: DataType::Boolean,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                ]),
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    Ok(data
-                                        .get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec())
+                        .map(|v| v.copied())
+                        .collect::<Vec<_>>()
+                };
+                let radians = {
+                    let data = &*data_arrays[1usize];
+
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                        .collect::<Vec<_>>()
+                };
+                let craziness = {
+                    let data = &*data_arrays[2usize];
+
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::ListArray<i32>>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
+                                .into_iter()
+                                .map(|v| {
+                                    v.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: DataType::Struct(vec![
+                                            Field {
+                                                name: "single_float_optional".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "single_string_required".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "single_string_optional".to_owned(),
+                                                data_type: DataType::Utf8,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_floats_optional".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                })),
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_strings_required".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                })),
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "many_strings_optional".to_owned(),
+                                                data_type: DataType::List(Box::new(Field {
+                                                    name: "item".to_owned(),
+                                                    data_type: DataType::Utf8,
+                                                    is_nullable: true,
+                                                    metadata: [].into(),
+                                                })),
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "flattened_scalar".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "almost_flattened_scalar".to_owned(),
+                                                data_type: DataType::Struct(vec![Field {
+                                                    name: "value".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                }]),
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            },
+                                            Field {
+                                                name: "from_parent".to_owned(),
+                                                data_type: DataType::Boolean,
+                                                is_nullable: true,
+                                                metadata: [].into(),
+                                            },
+                                        ]),
+                                    })
                                 })
-                                .transpose()
-                        })
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            Ok(data
+                                                .get(start as usize..end as usize)
+                                                .ok_or_else(|| {
+                                                    crate::DeserializationError::OffsetsMismatch {
+                                                        bounds: (start as usize, end as usize),
+                                                        len: data.len(),
+                                                        datatype: datatype.clone(),
+                                                    }
+                                                })?
+                                                .to_vec())
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
                         .into_iter()
-                }
-                .collect::<Vec<_>>()
-            };
-            data_types
-                .iter()
-                .enumerate()
-                .map(|(i, typ)| {
-                    let offset = data_offsets[i];
+                    }
+                    .collect::<Vec<_>>()
+                };
+                let fixed_size_shenanigans = {
+                    let data = &*data_arrays[3usize];
 
-                    Ok(Some(match typ {
-                        0i8 => AffixFuzzer3::Degrees(
-                            degrees
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: degrees.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        1i8 => AffixFuzzer3::Radians(
-                            radians
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: radians.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone(),
-                        ),
-                        2i8 => AffixFuzzer3::Craziness(
-                            craziness
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: craziness.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        _ => unreachable!(),
-                    }))
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                    { let datatype = data . data_type () ; let data = data . as_any () . downcast_ref :: < :: arrow2 :: array :: FixedSizeListArray > () . unwrap () ; if data . is_empty () { Vec :: new () }
+
+ else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { datatype : DataType :: Float32 , }
+
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or_else (|| crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , datatype : datatype . clone () , }
+
+) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , datatype : datatype . clone () , }
+
+) }
+
+) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
+
+ . into_iter () }
+
+ . collect :: < Vec < _ >> ()
+                };
+                data_types
+                    .iter()
+                    .enumerate()
+                    .map(|(i, typ)| {
+                        let offset = data_offsets[i];
+
+                        Ok(Some(match typ {
+                            0i8 => AffixFuzzer3::Degrees(
+                                degrees
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: degrees.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            1i8 => AffixFuzzer3::Radians(
+                                radians
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: radians.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone(),
+                            ),
+                            2i8 => AffixFuzzer3::Craziness(
+                                craziness
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: craziness.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            3i8 => AffixFuzzer3::FixedSizeShenanigans(
+                                fixed_size_shenanigans
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: fixed_size_shenanigans.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            _ => unreachable!(),
+                        }))
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }
@@ -1921,6 +2065,20 @@ impl crate::Datatype for AffixFuzzer4 {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
+                            Field {
+                                name: "fixed_size_shenanigans".to_owned(),
+                                data_type: DataType::FixedSizeList(
+                                    Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }),
+                                    3usize,
+                                ),
+                                is_nullable: false,
+                                metadata: [].into(),
+                            },
                         ],
                         None,
                         UnionMode::Dense,
@@ -2029,6 +2187,20 @@ impl crate::Datatype for AffixFuzzer4 {
                                         is_nullable: false,
                                         metadata: [].into(),
                                     })),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "fixed_size_shenanigans".to_owned(),
+                                    data_type: DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    ),
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
@@ -2143,6 +2315,20 @@ impl crate::Datatype for AffixFuzzer4 {
                                         is_nullable: false,
                                         metadata: [].into(),
                                     })),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
+                                Field {
+                                    name: "fixed_size_shenanigans".to_owned(),
+                                    data_type: DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    ),
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
@@ -2385,6 +2571,20 @@ impl crate::Datatype for AffixFuzzer4 {
                                                     is_nullable: false,
                                                     metadata: [].into(),
                                                 },
+                                                Field {
+                                                    name: "fixed_size_shenanigans".to_owned(),
+                                                    data_type: DataType::FixedSizeList(
+                                                        Box::new(Field {
+                                                            name: "item".to_owned(),
+                                                            data_type: DataType::Float32,
+                                                            is_nullable: false,
+                                                            metadata: [].into(),
+                                                        }),
+                                                        3usize,
+                                                    ),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
                                             ],
                                             None,
                                             UnionMode::Dense,
@@ -2566,6 +2766,20 @@ impl crate::Datatype for AffixFuzzer4 {
                                                     is_nullable: false,
                                                     metadata: [].into(),
                                                 },
+                                                Field {
+                                                    name: "fixed_size_shenanigans".to_owned(),
+                                                    data_type: DataType::FixedSizeList(
+                                                        Box::new(Field {
+                                                            name: "item".to_owned(),
+                                                            data_type: DataType::Float32,
+                                                            is_nullable: false,
+                                                            metadata: [].into(),
+                                                        }),
+                                                        3usize,
+                                                    ),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
                                             ],
                                             None,
                                             UnionMode::Dense,
@@ -2640,372 +2854,434 @@ impl crate::Datatype for AffixFuzzer4 {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_types, data_arrays, data_offsets) =
-                (data.types(), data.fields(), data.offsets().unwrap());
-            let single_required = {
-                let data = &*data_arrays[0usize];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_types, data_arrays, data_offsets) =
+                    (data.types(), data.fields(), data.offsets().unwrap());
+                let single_required = {
+                    let data = &*data_arrays[0usize];
 
-                crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
-                    .into_iter()
+                    crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                };
+                let many_required = {
+                    let data = &*data_arrays[1usize];
+
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::ListArray<i32>>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
+                                .into_iter()
+                                .map(|v| {
+                                    v.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: DataType::Union(
+                                            vec![
+                                                Field {
+                                                    name: "degrees".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "radians".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "craziness".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Struct(vec![
+                                                            Field {
+                                                                name: "single_float_optional"
+                                                                    .to_owned(),
+                                                                data_type: DataType::Float32,
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "single_string_required"
+                                                                    .to_owned(),
+                                                                data_type: DataType::Utf8,
+                                                                is_nullable: false,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "single_string_optional"
+                                                                    .to_owned(),
+                                                                data_type: DataType::Utf8,
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "many_floats_optional"
+                                                                    .to_owned(),
+                                                                data_type: DataType::List(
+                                                                    Box::new(Field {
+                                                                        name: "item".to_owned(),
+                                                                        data_type:
+                                                                            DataType::Float32,
+                                                                        is_nullable: true,
+                                                                        metadata: [].into(),
+                                                                    }),
+                                                                ),
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "many_strings_required"
+                                                                    .to_owned(),
+                                                                data_type: DataType::List(
+                                                                    Box::new(Field {
+                                                                        name: "item".to_owned(),
+                                                                        data_type: DataType::Utf8,
+                                                                        is_nullable: false,
+                                                                        metadata: [].into(),
+                                                                    }),
+                                                                ),
+                                                                is_nullable: false,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "many_strings_optional"
+                                                                    .to_owned(),
+                                                                data_type: DataType::List(
+                                                                    Box::new(Field {
+                                                                        name: "item".to_owned(),
+                                                                        data_type: DataType::Utf8,
+                                                                        is_nullable: true,
+                                                                        metadata: [].into(),
+                                                                    }),
+                                                                ),
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "flattened_scalar".to_owned(),
+                                                                data_type: DataType::Float32,
+                                                                is_nullable: false,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "almost_flattened_scalar"
+                                                                    .to_owned(),
+                                                                data_type: DataType::Struct(vec![
+                                                                    Field {
+                                                                        name: "value".to_owned(),
+                                                                        data_type:
+                                                                            DataType::Float32,
+                                                                        is_nullable: false,
+                                                                        metadata: [].into(),
+                                                                    },
+                                                                ]),
+                                                                is_nullable: false,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "from_parent".to_owned(),
+                                                                data_type: DataType::Boolean,
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                        ]),
+                                                        is_nullable: false,
+                                                        metadata: [].into(),
+                                                    })),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "fixed_size_shenanigans".to_owned(),
+                                                    data_type: DataType::FixedSizeList(
+                                                        Box::new(Field {
+                                                            name: "item".to_owned(),
+                                                            data_type: DataType::Float32,
+                                                            is_nullable: false,
+                                                            metadata: [].into(),
+                                                        }),
+                                                        3usize,
+                                                    ),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                            ],
+                                            None,
+                                            UnionMode::Dense,
+                                        ),
+                                    })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            Ok(data
+                                                .get(start as usize..end as usize)
+                                                .ok_or_else(|| {
+                                                    crate::DeserializationError::OffsetsMismatch {
+                                                        bounds: (start as usize, end as usize),
+                                                        len: data.len(),
+                                                        datatype: datatype.clone(),
+                                                    }
+                                                })?
+                                                .to_vec())
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                        .into_iter()
+                    }
                     .collect::<Vec<_>>()
-            };
-            let many_required = {
-                let data = &*data_arrays[1usize];
+                };
+                let many_optional = {
+                    let data = &*data_arrays[2usize];
 
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = {
-                        let offsets = data.offsets();
-                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                    };
-                    let data = &**data.values();
-                    let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
-                        .into_iter()
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Union(
-                                    vec![
-                                        Field {
-                                            name: "degrees".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "radians".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "craziness".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Struct(vec![
-                                                    Field {
-                                                        name: "single_float_optional".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "single_string_required".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "single_string_optional".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "many_floats_optional".to_owned(),
-                                                        data_type: DataType::List(Box::new(
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::ListArray<i32>>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
+                                .into_iter()
+                                .map(|v| {
+                                    v.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: DataType::Union(
+                                            vec![
+                                                Field {
+                                                    name: "degrees".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "radians".to_owned(),
+                                                    data_type: DataType::Float32,
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "craziness".to_owned(),
+                                                    data_type: DataType::List(Box::new(Field {
+                                                        name: "item".to_owned(),
+                                                        data_type: DataType::Struct(vec![
                                                             Field {
-                                                                name: "item".to_owned(),
+                                                                name: "single_float_optional"
+                                                                    .to_owned(),
                                                                 data_type: DataType::Float32,
                                                                 is_nullable: true,
                                                                 metadata: [].into(),
                                                             },
-                                                        )),
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "many_strings_required".to_owned(),
-                                                        data_type: DataType::List(Box::new(
                                                             Field {
-                                                                name: "item".to_owned(),
+                                                                name: "single_string_required"
+                                                                    .to_owned(),
                                                                 data_type: DataType::Utf8,
                                                                 is_nullable: false,
                                                                 metadata: [].into(),
                                                             },
-                                                        )),
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "many_strings_optional".to_owned(),
-                                                        data_type: DataType::List(Box::new(
                                                             Field {
-                                                                name: "item".to_owned(),
+                                                                name: "single_string_optional"
+                                                                    .to_owned(),
                                                                 data_type: DataType::Utf8,
                                                                 is_nullable: true,
                                                                 metadata: [].into(),
                                                             },
-                                                        )),
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "flattened_scalar".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "almost_flattened_scalar".to_owned(),
-                                                        data_type: DataType::Struct(vec![Field {
-                                                            name: "value".to_owned(),
-                                                            data_type: DataType::Float32,
-                                                            is_nullable: false,
-                                                            metadata: [].into(),
-                                                        }]),
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "from_parent".to_owned(),
-                                                        data_type: DataType::Boolean,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                ]),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                    ],
-                                    None,
-                                    UnionMode::Dense,
-                                ),
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    Ok(data
-                                        .get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec())
-                                })
-                                .transpose()
-                        })
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-                .collect::<Vec<_>>()
-            };
-            let many_optional = {
-                let data = &*data_arrays[2usize];
-
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::ListArray<i32>>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = {
-                        let offsets = data.offsets();
-                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                    };
-                    let data = &**data.values();
-                    let data = crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
-                        .into_iter()
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Union(
-                                    vec![
-                                        Field {
-                                            name: "degrees".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "radians".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                        Field {
-                                            name: "craziness".to_owned(),
-                                            data_type: DataType::List(Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: DataType::Struct(vec![
-                                                    Field {
-                                                        name: "single_float_optional".to_owned(),
-                                                        data_type: DataType::Float32,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "single_string_required".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "single_string_optional".to_owned(),
-                                                        data_type: DataType::Utf8,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "many_floats_optional".to_owned(),
-                                                        data_type: DataType::List(Box::new(
                                                             Field {
-                                                                name: "item".to_owned(),
+                                                                name: "many_floats_optional"
+                                                                    .to_owned(),
+                                                                data_type: DataType::List(
+                                                                    Box::new(Field {
+                                                                        name: "item".to_owned(),
+                                                                        data_type:
+                                                                            DataType::Float32,
+                                                                        is_nullable: true,
+                                                                        metadata: [].into(),
+                                                                    }),
+                                                                ),
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "many_strings_required"
+                                                                    .to_owned(),
+                                                                data_type: DataType::List(
+                                                                    Box::new(Field {
+                                                                        name: "item".to_owned(),
+                                                                        data_type: DataType::Utf8,
+                                                                        is_nullable: false,
+                                                                        metadata: [].into(),
+                                                                    }),
+                                                                ),
+                                                                is_nullable: false,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "many_strings_optional"
+                                                                    .to_owned(),
+                                                                data_type: DataType::List(
+                                                                    Box::new(Field {
+                                                                        name: "item".to_owned(),
+                                                                        data_type: DataType::Utf8,
+                                                                        is_nullable: true,
+                                                                        metadata: [].into(),
+                                                                    }),
+                                                                ),
+                                                                is_nullable: true,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "flattened_scalar".to_owned(),
                                                                 data_type: DataType::Float32,
-                                                                is_nullable: true,
-                                                                metadata: [].into(),
-                                                            },
-                                                        )),
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "many_strings_required".to_owned(),
-                                                        data_type: DataType::List(Box::new(
-                                                            Field {
-                                                                name: "item".to_owned(),
-                                                                data_type: DataType::Utf8,
                                                                 is_nullable: false,
                                                                 metadata: [].into(),
                                                             },
-                                                        )),
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "many_strings_optional".to_owned(),
-                                                        data_type: DataType::List(Box::new(
                                                             Field {
-                                                                name: "item".to_owned(),
-                                                                data_type: DataType::Utf8,
+                                                                name: "almost_flattened_scalar"
+                                                                    .to_owned(),
+                                                                data_type: DataType::Struct(vec![
+                                                                    Field {
+                                                                        name: "value".to_owned(),
+                                                                        data_type:
+                                                                            DataType::Float32,
+                                                                        is_nullable: false,
+                                                                        metadata: [].into(),
+                                                                    },
+                                                                ]),
+                                                                is_nullable: false,
+                                                                metadata: [].into(),
+                                                            },
+                                                            Field {
+                                                                name: "from_parent".to_owned(),
+                                                                data_type: DataType::Boolean,
                                                                 is_nullable: true,
                                                                 metadata: [].into(),
                                                             },
-                                                        )),
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "flattened_scalar".to_owned(),
-                                                        data_type: DataType::Float32,
+                                                        ]),
                                                         is_nullable: false,
                                                         metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "almost_flattened_scalar".to_owned(),
-                                                        data_type: DataType::Struct(vec![Field {
-                                                            name: "value".to_owned(),
+                                                    })),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                                Field {
+                                                    name: "fixed_size_shenanigans".to_owned(),
+                                                    data_type: DataType::FixedSizeList(
+                                                        Box::new(Field {
+                                                            name: "item".to_owned(),
                                                             data_type: DataType::Float32,
                                                             is_nullable: false,
                                                             metadata: [].into(),
-                                                        }]),
-                                                        is_nullable: false,
-                                                        metadata: [].into(),
-                                                    },
-                                                    Field {
-                                                        name: "from_parent".to_owned(),
-                                                        data_type: DataType::Boolean,
-                                                        is_nullable: true,
-                                                        metadata: [].into(),
-                                                    },
-                                                ]),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            })),
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        },
-                                    ],
-                                    None,
-                                    UnionMode::Dense,
-                                ),
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    Ok(data
-                                        .get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec())
+                                                        }),
+                                                        3usize,
+                                                    ),
+                                                    is_nullable: false,
+                                                    metadata: [].into(),
+                                                },
+                                            ],
+                                            None,
+                                            UnionMode::Dense,
+                                        ),
+                                    })
                                 })
-                                .transpose()
-                        })
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            Ok(data
+                                                .get(start as usize..end as usize)
+                                                .ok_or_else(|| {
+                                                    crate::DeserializationError::OffsetsMismatch {
+                                                        bounds: (start as usize, end as usize),
+                                                        len: data.len(),
+                                                        datatype: datatype.clone(),
+                                                    }
+                                                })?
+                                                .to_vec())
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
                         .into_iter()
-                }
-                .collect::<Vec<_>>()
-            };
-            data_types
-                .iter()
-                .enumerate()
-                .map(|(i, typ)| {
-                    let offset = data_offsets[i];
+                    }
+                    .collect::<Vec<_>>()
+                };
+                data_types
+                    .iter()
+                    .enumerate()
+                    .map(|(i, typ)| {
+                        let offset = data_offsets[i];
 
-                    Ok(Some(match typ {
-                        0i8 => AffixFuzzer4::SingleRequired(
-                            single_required
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: single_required.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        1i8 => AffixFuzzer4::ManyRequired(
-                            many_required
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: many_required.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        2i8 => AffixFuzzer4::ManyOptional(
-                            many_optional
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: many_optional.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone(),
-                        ),
-                        _ => unreachable!(),
-                    }))
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                        Ok(Some(match typ {
+                            0i8 => AffixFuzzer4::SingleRequired(
+                                single_required
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: single_required.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            1i8 => AffixFuzzer4::ManyRequired(
+                                many_required
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: many_required.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            2i8 => AffixFuzzer4::ManyOptional(
+                                many_optional
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: many_optional.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone(),
+                            ),
+                            _ => unreachable!(),
+                        }))
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }
@@ -3145,6 +3421,20 @@ impl crate::Datatype for AffixFuzzer5 {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
+                                Field {
+                                    name: "fixed_size_shenanigans".to_owned(),
+                                    data_type: DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    ),
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                },
                             ],
                             None,
                             UnionMode::Dense,
@@ -3253,6 +3543,20 @@ impl crate::Datatype for AffixFuzzer5 {
                                             is_nullable: false,
                                             metadata: [].into(),
                                         })),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
                                         is_nullable: false,
                                         metadata: [].into(),
                                     },
@@ -3370,6 +3674,20 @@ impl crate::Datatype for AffixFuzzer5 {
                                         is_nullable: false,
                                         metadata: [].into(),
                                     },
+                                    Field {
+                                        name: "fixed_size_shenanigans".to_owned(),
+                                        data_type: DataType::FixedSizeList(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: DataType::Float32,
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                            3usize,
+                                        ),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    },
                                 ],
                                 None,
                                 UnionMode::Dense,
@@ -3476,31 +3794,35 @@ impl crate::Datatype for AffixFuzzer5 {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let single_optional_union = {
-                let data = &**arrays_by_name["single_optional_union"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let single_optional_union = {
+                    let data = &**arrays_by_name["single_optional_union"];
 
-                crate::datatypes::AffixFuzzer4::try_from_arrow_opt(data)?.into_iter()
-            };
-            ::itertools::izip!(single_optional_union)
-                .enumerate()
-                .map(|(i, (single_optional_union))| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                single_optional_union,
+                    crate::datatypes::AffixFuzzer4::try_from_arrow_opt(data)?.into_iter()
+                };
+                ::itertools::izip!(single_optional_union)
+                    .enumerate()
+                    .map(|(i, (single_optional_union))| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    single_optional_union,
+                                })
                             })
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -146,46 +146,54 @@ impl crate::Datatype for Mat3x3 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = (0..).step_by(9usize).zip((9usize..).step_by(9usize));
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.copied())
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Float32,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            data.get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec()
-                                .try_into()
-                                .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
-                                    expected: 9usize,
-                                    got: (end - start) as usize,
-                                    datatype: datatype.clone(),
-                                })
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = (0..)
+                    .step_by(9usize)
+                    .zip((9usize..).step_by(9usize).take(data.len()));
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.copied())
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Float32,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                data.get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec()
+                                    .try_into()
+                                    .map_err(|_err| {
+                                        crate::DeserializationError::ArrayLengthMismatch {
+                                            expected: 9usize,
+                                            got: (end - start) as usize,
+                                            datatype: datatype.clone(),
+                                        }
+                                    })
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -146,46 +146,54 @@ impl crate::Datatype for Mat4x4 {
                 .as_any()
                 .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = (0..).step_by(16usize).zip((16usize..).step_by(16usize));
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.copied())
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Float32,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            data.get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec()
-                                .try_into()
-                                .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
-                                    expected: 16usize,
-                                    got: (end - start) as usize,
-                                    datatype: datatype.clone(),
-                                })
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = (0..)
+                    .step_by(16usize)
+                    .zip((16usize..).step_by(16usize).take(data.len()));
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.copied())
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Float32,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                data.get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec()
+                                    .try_into()
+                                    .map_err(|_err| {
+                                        crate::DeserializationError::ArrayLengthMismatch {
+                                            expected: 16usize,
+                                            got: (end - start) as usize,
+                                            datatype: datatype.clone(),
+                                        }
+                                    })
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {

--- a/crates/re_types/src/datatypes/point2d.rs
+++ b/crates/re_types/src/datatypes/point2d.rs
@@ -168,49 +168,53 @@ impl crate::Datatype for Point2D {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let x = {
-                let data = &**arrays_by_name["x"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let x = {
+                    let data = &**arrays_by_name["x"];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-            };
-            let y = {
-                let data = &**arrays_by_name["y"];
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                };
+                let y = {
+                    let data = &**arrays_by_name["y"];
 
-                data.as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap()
-                    .into_iter()
-                    .map(|v| v.copied())
-            };
-            ::itertools::izip!(x, y)
-                .enumerate()
-                .map(|(i, (x, y))| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                x: x.ok_or_else(|| crate::DeserializationError::MissingData {
-                                    datatype: data.data_type().clone(),
-                                })?,
-                                y: y.ok_or_else(|| crate::DeserializationError::MissingData {
-                                    datatype: data.data_type().clone(),
-                                })?,
+                    data.as_any()
+                        .downcast_ref::<Float32Array>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|v| v.copied())
+                };
+                ::itertools::izip!(x, y)
+                    .enumerate()
+                    .map(|(i, (x, y))| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    x: x.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: data.data_type().clone(),
+                                    })?,
+                                    y: y.ok_or_else(|| crate::DeserializationError::MissingData {
+                                        datatype: data.data_type().clone(),
+                                    })?,
+                                })
                             })
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -146,46 +146,54 @@ impl crate::Datatype for Quaternion {
                 .as_any()
                 .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = (0..).step_by(4usize).zip((4usize..).step_by(4usize));
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.copied())
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Float32,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            data.get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec()
-                                .try_into()
-                                .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
-                                    expected: 4usize,
-                                    got: (end - start) as usize,
-                                    datatype: datatype.clone(),
-                                })
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = (0..)
+                    .step_by(4usize)
+                    .zip((4usize..).step_by(4usize).take(data.len()));
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.copied())
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Float32,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                data.get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec()
+                                    .try_into()
+                                    .map_err(|_err| {
+                                        crate::DeserializationError::ArrayLengthMismatch {
+                                            expected: 4usize,
+                                            got: (end - start) as usize,
+                                            datatype: datatype.clone(),
+                                        }
+                                    })
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -232,96 +232,68 @@ impl crate::Datatype for RotationAxisAngle {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let axis = {
-                let data = &**arrays_by_name["axis"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let axis = {
+                    let data = &**arrays_by_name["axis"];
 
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = (0..).step_by(3usize).zip((3usize..).step_by(3usize));
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .unwrap()
-                        .into_iter()
-                        .map(|v| v.copied())
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Float32,
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    data.get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec()
-                                        .try_into()
-                                        .map_err(|_err| {
-                                            crate::DeserializationError::ArrayLengthMismatch {
-                                                expected: 3usize,
-                                                got: (end - start) as usize,
-                                                datatype: datatype.clone(),
-                                            }
-                                        })
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::FixedSizeListArray>()
+                            .unwrap();
+                        if data . is_empty () { Vec :: new () }
+
+ else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { datatype : DataType :: Float32 , }
+
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or_else (|| crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , datatype : datatype . clone () , }
+
+) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , datatype : datatype . clone () , }
+
+) }
+
+) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
+
+ . into_iter ()
+                    }
+                };
+                let angle = {
+                    let data = &**arrays_by_name["angle"];
+
+                    crate::datatypes::Angle::try_from_arrow_opt(data)?.into_iter()
+                };
+                ::itertools::izip!(axis, angle)
+                    .enumerate()
+                    .map(|(i, (axis, angle))| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    axis: axis.ok_or_else(|| {
+                                        crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        }
+                                    })?,
+                                    angle: angle.ok_or_else(|| {
+                                        crate::DeserializationError::MissingData {
+                                            datatype: data.data_type().clone(),
+                                        }
+                                    })?,
                                 })
-                                .transpose()
-                        })
-                        .map(|res| res.map(|opt| opt.map(|v| crate::datatypes::Vec3D(v))))
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-            };
-            let angle = {
-                let data = &**arrays_by_name["angle"];
-
-                crate::datatypes::Angle::try_from_arrow_opt(data)?.into_iter()
-            };
-            ::itertools::izip!(axis, angle)
-                .enumerate()
-                .map(|(i, (axis, angle))| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                axis: axis.ok_or_else(|| {
-                                    crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    }
-                                })?,
-                                angle: angle.ok_or_else(|| {
-                                    crate::DeserializationError::MissingData {
-                                        datatype: data.data_type().clone(),
-                                    }
-                                })?,
                             })
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -361,55 +361,59 @@ impl crate::Datatype for Transform3D {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_types, data_arrays, data_offsets) =
-                (data.types(), data.fields(), data.offsets().unwrap());
-            let translation_and_mat_3_x_3 = {
-                let data = &*data_arrays[0usize];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_types, data_arrays, data_offsets) =
+                    (data.types(), data.fields(), data.offsets().unwrap());
+                let translation_and_mat_3_x_3 = {
+                    let data = &*data_arrays[0usize];
 
-                crate::datatypes::TranslationAndMat3x3::try_from_arrow_opt(data)?
-                    .into_iter()
-                    .collect::<Vec<_>>()
-            };
-            let translation_rotation_scale = {
-                let data = &*data_arrays[1usize];
+                    crate::datatypes::TranslationAndMat3x3::try_from_arrow_opt(data)?
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                };
+                let translation_rotation_scale = {
+                    let data = &*data_arrays[1usize];
 
-                crate::datatypes::TranslationRotationScale3D::try_from_arrow_opt(data)?
-                    .into_iter()
-                    .collect::<Vec<_>>()
-            };
-            data_types
-                .iter()
-                .enumerate()
-                .map(|(i, typ)| {
-                    let offset = data_offsets[i];
+                    crate::datatypes::TranslationRotationScale3D::try_from_arrow_opt(data)?
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                };
+                data_types
+                    .iter()
+                    .enumerate()
+                    .map(|(i, typ)| {
+                        let offset = data_offsets[i];
 
-                    Ok(Some(match typ {
-                        0i8 => Transform3D::TranslationAndMat3X3(
-                            translation_and_mat_3_x_3
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: translation_and_mat_3_x_3.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        1i8 => Transform3D::TranslationRotationScale(
-                            translation_rotation_scale
-                                .get(offset as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (offset as usize, offset as usize),
-                                    len: translation_rotation_scale.len(),
-                                    datatype: data.data_type().clone(),
-                                })?
-                                .clone()
-                                .unwrap(),
-                        ),
-                        _ => unreachable!(),
-                    }))
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                        Ok(Some(match typ {
+                            0i8 => Transform3D::TranslationAndMat3X3(
+                                translation_and_mat_3_x_3
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: translation_and_mat_3_x_3.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            1i8 => Transform3D::TranslationRotationScale(
+                                translation_rotation_scale
+                                    .get(offset as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (offset as usize, offset as usize),
+                                        len: translation_rotation_scale.len(),
+                                        datatype: data.data_type().clone(),
+                                    })?
+                                    .clone()
+                                    .unwrap(),
+                            ),
+                            _ => unreachable!(),
+                        }))
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -308,148 +308,88 @@ impl crate::Datatype for TranslationAndMat3x3 {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let translation = {
-                let data = &**arrays_by_name["translation"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let translation = {
+                    let data = &**arrays_by_name["translation"];
 
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = (0..).step_by(3usize).zip((3usize..).step_by(3usize));
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::FixedSizeListArray>()
+                            .unwrap();
+                        if data . is_empty () { Vec :: new () }
+
+ else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { datatype : DataType :: Float32 , }
+
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or_else (|| crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , datatype : datatype . clone () , }
+
+) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , datatype : datatype . clone () , }
+
+) }
+
+) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
+
+ . into_iter ()
+                    }
+                };
+                let matrix = {
+                    let data = &**arrays_by_name["matrix"];
+
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::FixedSizeListArray>()
+                            .unwrap();
+                        if data . is_empty () { Vec :: new () }
+
+ else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (9usize) . zip ((9usize ..) . step_by (9usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { datatype : DataType :: Float32 , }
+
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or_else (|| crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , datatype : datatype . clone () , }
+
+) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 9usize , got : (end - start) as usize , datatype : datatype . clone () , }
+
+) }
+
+) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Mat3x3 (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
+
+ . into_iter ()
+                    }
+                };
+                let from_parent = {
+                    let data = &**arrays_by_name["from_parent"];
+
+                    data.as_any()
+                        .downcast_ref::<BooleanArray>()
                         .unwrap()
                         .into_iter()
-                        .map(|v| v.copied())
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Float32,
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    data.get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec()
-                                        .try_into()
-                                        .map_err(|_err| {
-                                            crate::DeserializationError::ArrayLengthMismatch {
-                                                expected: 3usize,
-                                                got: (end - start) as usize,
-                                                datatype: datatype.clone(),
-                                            }
-                                        })
+                };
+                ::itertools::izip!(translation, matrix, from_parent)
+                    .enumerate()
+                    .map(|(i, (translation, matrix, from_parent))| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    translation,
+                                    matrix,
+                                    from_parent,
                                 })
-                                .transpose()
-                        })
-                        .map(|res| res.map(|opt| opt.map(|v| crate::datatypes::Vec3D(v))))
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-            };
-            let matrix = {
-                let data = &**arrays_by_name["matrix"];
-
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = (0..).step_by(9usize).zip((9usize..).step_by(9usize));
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .unwrap()
-                        .into_iter()
-                        .map(|v| v.copied())
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Float32,
                             })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    data.get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec()
-                                        .try_into()
-                                        .map_err(|_err| {
-                                            crate::DeserializationError::ArrayLengthMismatch {
-                                                expected: 9usize,
-                                                got: (end - start) as usize,
-                                                datatype: datatype.clone(),
-                                            }
-                                        })
-                                })
-                                .transpose()
-                        })
-                        .map(|res| res.map(|opt| opt.map(|v| crate::datatypes::Mat3x3(v))))
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-            };
-            let from_parent = {
-                let data = &**arrays_by_name["from_parent"];
-
-                data.as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .unwrap()
-                    .into_iter()
-            };
-            ::itertools::izip!(translation, matrix, from_parent)
-                .enumerate()
-                .map(|(i, (translation, matrix, from_parent))| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                translation,
-                                matrix,
-                                from_parent,
-                            })
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -383,103 +383,75 @@ impl crate::Datatype for TranslationRotationScale3D {
                     expected: data.data_type().clone(),
                     got: data.data_type().clone(),
                 })?;
-            let (data_fields, data_arrays, data_bitmap) =
-                (data.fields(), data.values(), data.validity());
-            let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
-            let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
-                .iter()
-                .map(|field| field.name.as_str())
-                .zip(data_arrays)
-                .collect();
-            let translation = {
-                let data = &**arrays_by_name["translation"];
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let (data_fields, data_arrays, data_bitmap) =
+                    (data.fields(), data.values(), data.validity());
+                let is_valid = |i| data_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                let arrays_by_name: ::std::collections::HashMap<_, _> = data_fields
+                    .iter()
+                    .map(|field| field.name.as_str())
+                    .zip(data_arrays)
+                    .collect();
+                let translation = {
+                    let data = &**arrays_by_name["translation"];
 
-                {
-                    let datatype = data.data_type();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                        .unwrap();
-                    let bitmap = data.validity().cloned();
-                    let offsets = (0..).step_by(3usize).zip((3usize..).step_by(3usize));
-                    let data = &**data.values();
-                    let data = data
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
+                    {
+                        let datatype = data.data_type();
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::FixedSizeListArray>()
+                            .unwrap();
+                        if data . is_empty () { Vec :: new () }
+
+ else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { datatype : DataType :: Float32 , }
+
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or_else (|| crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , datatype : datatype . clone () , }
+
+) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , datatype : datatype . clone () , }
+
+) }
+
+) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
+
+ . into_iter ()
+                    }
+                };
+                let rotation = {
+                    let data = &**arrays_by_name["rotation"];
+
+                    crate::datatypes::Rotation3D::try_from_arrow_opt(data)?.into_iter()
+                };
+                let scale = {
+                    let data = &**arrays_by_name["scale"];
+
+                    crate::datatypes::Scale3D::try_from_arrow_opt(data)?.into_iter()
+                };
+                let from_parent = {
+                    let data = &**arrays_by_name["from_parent"];
+
+                    data.as_any()
+                        .downcast_ref::<BooleanArray>()
                         .unwrap()
                         .into_iter()
-                        .map(|v| v.copied())
-                        .map(|v| {
-                            v.ok_or_else(|| crate::DeserializationError::MissingData {
-                                datatype: DataType::Float32,
-                            })
-                        })
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
-                    offsets
-                        .enumerate()
-                        .map(move |(i, (start, end))| {
-                            bitmap
-                                .as_ref()
-                                .map_or(true, |bitmap| bitmap.get_bit(i))
-                                .then(|| {
-                                    data.get(start as usize..end as usize)
-                                        .ok_or_else(|| {
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                datatype: datatype.clone(),
-                                            }
-                                        })?
-                                        .to_vec()
-                                        .try_into()
-                                        .map_err(|_err| {
-                                            crate::DeserializationError::ArrayLengthMismatch {
-                                                expected: 3usize,
-                                                got: (end - start) as usize,
-                                                datatype: datatype.clone(),
-                                            }
-                                        })
+                };
+                ::itertools::izip!(translation, rotation, scale, from_parent)
+                    .enumerate()
+                    .map(|(i, (translation, rotation, scale, from_parent))| {
+                        is_valid(i)
+                            .then(|| {
+                                Ok(Self {
+                                    translation,
+                                    rotation,
+                                    scale,
+                                    from_parent,
                                 })
-                                .transpose()
-                        })
-                        .map(|res| res.map(|opt| opt.map(|v| crate::datatypes::Vec3D(v))))
-                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                        .into_iter()
-                }
-            };
-            let rotation = {
-                let data = &**arrays_by_name["rotation"];
-
-                crate::datatypes::Rotation3D::try_from_arrow_opt(data)?.into_iter()
-            };
-            let scale = {
-                let data = &**arrays_by_name["scale"];
-
-                crate::datatypes::Scale3D::try_from_arrow_opt(data)?.into_iter()
-            };
-            let from_parent = {
-                let data = &**arrays_by_name["from_parent"];
-
-                data.as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .unwrap()
-                    .into_iter()
-            };
-            ::itertools::izip!(translation, rotation, scale, from_parent)
-                .enumerate()
-                .map(|(i, (translation, rotation, scale, from_parent))| {
-                    is_valid(i)
-                        .then(|| {
-                            Ok(Self {
-                                translation,
-                                rotation,
-                                scale,
-                                from_parent,
                             })
-                        })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?
+            }
         })
     }
 }

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -146,46 +146,54 @@ impl crate::Datatype for Vec2D {
                 .as_any()
                 .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = (0..).step_by(2usize).zip((2usize..).step_by(2usize));
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.copied())
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Float32,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            data.get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec()
-                                .try_into()
-                                .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
-                                    expected: 2usize,
-                                    got: (end - start) as usize,
-                                    datatype: datatype.clone(),
-                                })
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = (0..)
+                    .step_by(2usize)
+                    .zip((2usize..).step_by(2usize).take(data.len()));
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.copied())
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Float32,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                data.get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec()
+                                    .try_into()
+                                    .map_err(|_err| {
+                                        crate::DeserializationError::ArrayLengthMismatch {
+                                            expected: 2usize,
+                                            got: (end - start) as usize,
+                                            datatype: datatype.clone(),
+                                        }
+                                    })
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -146,46 +146,54 @@ impl crate::Datatype for Vec3D {
                 .as_any()
                 .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                 .unwrap();
-            let bitmap = data.validity().cloned();
-            let offsets = (0..).step_by(3usize).zip((3usize..).step_by(3usize));
-            let data = &**data.values();
-            let data = data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .unwrap()
-                .into_iter()
-                .map(|v| v.copied())
-                .map(|v| {
-                    v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: DataType::Float32,
-                    })
-                })
-                .collect::<crate::DeserializationResult<Vec<_>>>()?;
-            offsets
-                .enumerate()
-                .map(move |(i, (start, end))| {
-                    bitmap
-                        .as_ref()
-                        .map_or(true, |bitmap| bitmap.get_bit(i))
-                        .then(|| {
-                            data.get(start as usize..end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec()
-                                .try_into()
-                                .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
-                                    expected: 3usize,
-                                    got: (end - start) as usize,
-                                    datatype: datatype.clone(),
-                                })
+            if data.is_empty() {
+                Vec::new()
+            } else {
+                let bitmap = data.validity().cloned();
+                let offsets = (0..)
+                    .step_by(3usize)
+                    .zip((3usize..).step_by(3usize).take(data.len()));
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.copied())
+                    .map(|v| {
+                        v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: DataType::Float32,
                         })
-                        .transpose()
-                })
-                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                .into_iter()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                offsets
+                    .enumerate()
+                    .map(move |(i, (start, end))| {
+                        bitmap
+                            .as_ref()
+                            .map_or(true, |bitmap| bitmap.get_bit(i))
+                            .then(|| {
+                                data.get(start as usize..end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec()
+                                    .try_into()
+                                    .map_err(|_err| {
+                                        crate::DeserializationError::ArrayLengthMismatch {
+                                            expected: 3usize,
+                                            got: (end - start) as usize,
+                                            datatype: datatype.clone(),
+                                        }
+                                    })
+                            })
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+            }
+            .into_iter()
         }
         .map(|v| {
             v.ok_or_else(|| crate::DeserializationError::MissingData {

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -1867,7 +1867,7 @@ fn quote_arrow_field_deserializer(
                     .unwrap(); // safe
 
                 let bitmap = #data_src.validity().cloned();
-                let offsets = (0..).step_by(#length).zip((#length..).step_by(#length));
+                let offsets = (0..).step_by(#length).zip((#length..).step_by(#length).take(#data_src.len()));
 
                 let #data_src = &**#data_src.values();
 

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -1660,26 +1660,30 @@ fn quote_arrow_deserializer(
                             got: #data_src.data_type().clone(),
                         })?;
 
-                    let (#data_src_fields, #data_src_arrays, #data_src_bitmap) =
-                        (#data_src.fields(), #data_src.values(), #data_src.validity());
+                    if #data_src.is_empty() {
+                        Vec::new()
+                    } else {
+                        let (#data_src_fields, #data_src_arrays, #data_src_bitmap) =
+                            (#data_src.fields(), #data_src.values(), #data_src.validity());
 
-                    let is_valid = |i| #data_src_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
+                        let is_valid = |i| #data_src_bitmap.map_or(true, |bitmap| bitmap.get_bit(i));
 
-                    let arrays_by_name: ::std::collections::HashMap<_, _> = #data_src_fields
-                        .iter()
-                        .map(|field| field.name.as_str())
-                        .zip(#data_src_arrays)
-                        .collect();
+                        let arrays_by_name: ::std::collections::HashMap<_, _> = #data_src_fields
+                            .iter()
+                            .map(|field| field.name.as_str())
+                            .zip(#data_src_arrays)
+                            .collect();
 
-                    #(#quoted_field_deserializers;)*
+                        #(#quoted_field_deserializers;)*
 
-                    ::itertools::izip!(#(#quoted_field_names),*)
-                        .enumerate()
-                        .map(|(i, (#(#quoted_field_names),*))| is_valid(i).then(|| Ok(Self {
-                            #(#quoted_unwrappings,)*
-                        })).transpose())
-                        // NOTE: implicit Vec<Result> to Result<Vec>
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?
+                        ::itertools::izip!(#(#quoted_field_names),*)
+                            .enumerate()
+                            .map(|(i, (#(#quoted_field_names),*))| is_valid(i).then(|| Ok(Self {
+                                #(#quoted_unwrappings,)*
+                            })).transpose())
+                            // NOTE: implicit Vec<Result> to Result<Vec>
+                            .collect::<crate::DeserializationResult<Vec<_>>>()?
+                    }
                 }}
             }
 
@@ -1745,25 +1749,29 @@ fn quote_arrow_deserializer(
                             got: #data_src.data_type().clone(),
                         })?;
 
-                    let (#data_src_types, #data_src_arrays, #data_src_offsets) =
-                        // NOTE: unwrapping of offsets is safe because this is a dense union
-                        (#data_src.types(), #data_src.fields(), #data_src.offsets().unwrap());
+                    if #data_src.is_empty() {
+                        Vec::new()
+                    } else {
+                        let (#data_src_types, #data_src_arrays, #data_src_offsets) =
+                            // NOTE: unwrapping of offsets is safe because this is a dense union
+                            (#data_src.types(), #data_src.fields(), #data_src.offsets().unwrap());
 
-                    #(#quoted_field_deserializers;)*
+                        #(#quoted_field_deserializers;)*
 
-                    #data_src_types
-                        .iter()
-                        .enumerate()
-                        .map(|(i, typ)| {
-                            let offset = #data_src_offsets[i];
+                        #data_src_types
+                            .iter()
+                            .enumerate()
+                            .map(|(i, typ)| {
+                                let offset = #data_src_offsets[i];
 
-                            Ok(Some(match typ {
-                                #(#quoted_branches,)*
-                                _ => unreachable!(),
-                            }))
-                        })
-                        // NOTE: implicit Vec<Result> to Result<Vec>
-                        .collect::<crate::DeserializationResult<Vec<_>>>()?
+                                Ok(Some(match typ {
+                                    #(#quoted_branches,)*
+                                    _ => unreachable!(),
+                                }))
+                            })
+                            // NOTE: implicit Vec<Result> to Result<Vec>
+                            .collect::<crate::DeserializationResult<Vec<_>>>()?
+                    }
                 }}
             }
 
@@ -1866,40 +1874,44 @@ fn quote_arrow_field_deserializer(
                     .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .unwrap(); // safe
 
-                let bitmap = #data_src.validity().cloned();
-                let offsets = (0..).step_by(#length).zip((#length..).step_by(#length).take(#data_src.len()));
+                if #data_src.is_empty() {
+                    Vec::new()
+                } else {
+                    let bitmap = #data_src.validity().cloned();
+                    let offsets = (0..).step_by(#length).zip((#length..).step_by(#length).take(#data_src.len()));
 
-                let #data_src = &**#data_src.values();
+                    let #data_src = &**#data_src.values();
 
-                let data = #quoted_inner
-                    .map(|v| v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: #quoted_inner_datatype,
-                    }))
-                    // NOTE: implicit Vec<Result> to Result<Vec>
-                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                    let data = #quoted_inner
+                        .map(|v| v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: #quoted_inner_datatype,
+                        }))
+                        // NOTE: implicit Vec<Result> to Result<Vec>
+                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
 
-                offsets
-                    .enumerate()
-                    .map(move |(i, (start, end))| bitmap.as_ref().map_or(true, |bitmap| bitmap.get_bit(i)).then(|| {
-                        data.get(start as usize .. end as usize)
-                            .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                bounds: (start as usize, end as usize),
-                                len: data.len(),
-                                datatype: datatype.clone(),
-                            })?
-                            .to_vec()
-                            .try_into()
-                            .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
-                                expected: #length,
-                                got: (end - start) as usize,
-                                datatype: datatype.clone(),
-                            })
-                        }).transpose()
-                    )
-                    #quoted_transparent_unmapping
-                    // NOTE: implicit Vec<Result> to Result<Vec>
-                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                    .into_iter()
+                    offsets
+                        .enumerate()
+                        .map(move |(i, (start, end))| bitmap.as_ref().map_or(true, |bitmap| bitmap.get_bit(i)).then(|| {
+                            data.get(start as usize .. end as usize)
+                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                    bounds: (start as usize, end as usize),
+                                    len: data.len(),
+                                    datatype: datatype.clone(),
+                                })?
+                                .to_vec()
+                                .try_into()
+                                .map_err(|_err| crate::DeserializationError::ArrayLengthMismatch {
+                                    expected: #length,
+                                    got: (end - start) as usize,
+                                    datatype: datatype.clone(),
+                                })
+                            }).transpose()
+                        )
+                        #quoted_transparent_unmapping
+                        // NOTE: implicit Vec<Result> to Result<Vec>
+                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                }
+                .into_iter()
             }}
         }
 
@@ -1921,37 +1933,41 @@ fn quote_arrow_field_deserializer(
                     .downcast_ref::<::arrow2::array::ListArray<i32>>()
                     .unwrap(); // safe
 
-                let bitmap = #data_src.validity().cloned();
-                let offsets = {
-                    let offsets = #data_src.offsets();
-                    offsets.iter().copied().zip(offsets.iter().copied().skip(1))
-                };
+                if #data_src.is_empty() {
+                    Vec::new()
+                } else {
+                    let bitmap = #data_src.validity().cloned();
+                    let offsets = {
+                        let offsets = #data_src.offsets();
+                        offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                    };
 
-                let #data_src = &**#data_src.values();
+                    let #data_src = &**#data_src.values();
 
-                let data = #quoted_inner
-                    .map(|v| v.ok_or_else(|| crate::DeserializationError::MissingData {
-                        datatype: #quoted_inner_datatype,
-                    }))
-                    // NOTE: implicit Vec<Result> to Result<Vec>
-                    .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                    let data = #quoted_inner
+                        .map(|v| v.ok_or_else(|| crate::DeserializationError::MissingData {
+                            datatype: #quoted_inner_datatype,
+                        }))
+                        // NOTE: implicit Vec<Result> to Result<Vec>
+                        .collect::<crate::DeserializationResult<Vec<_>>>()?;
 
-                offsets
-                    .enumerate()
-                    .map(move |(i, (start, end))| bitmap.as_ref().map_or(true, |bitmap| bitmap.get_bit(i)).then(|| {
-                            Ok(data.get(start as usize .. end as usize)
-                                .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
-                                    bounds: (start as usize, end as usize),
-                                    len: data.len(),
-                                    datatype: datatype.clone(),
-                                })?
-                                .to_vec()
-                            )
-                        }).transpose()
-                    )
-                    // NOTE: implicit Vec<Result> to Result<Vec>
-                    .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
-                    .into_iter()
+                    offsets
+                        .enumerate()
+                        .map(move |(i, (start, end))| bitmap.as_ref().map_or(true, |bitmap| bitmap.get_bit(i)).then(|| {
+                                Ok(data.get(start as usize .. end as usize)
+                                    .ok_or_else(|| crate::DeserializationError::OffsetsMismatch {
+                                        bounds: (start as usize, end as usize),
+                                        len: data.len(),
+                                        datatype: datatype.clone(),
+                                    })?
+                                    .to_vec()
+                                )
+                            }).transpose()
+                        )
+                        // NOTE: implicit Vec<Result> to Result<Vec>
+                        .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                }
+                .into_iter()
             }}
         }
 

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -1661,6 +1661,10 @@ fn quote_arrow_deserializer(
                         })?;
 
                     if #data_src.is_empty() {
+                        // NOTE: The outer container is empty and so we already know that the end result
+                        // is also going to be an empty vec.
+                        // Early out right now rather than waste time computing possibly many empty
+                        // datastructures for all of our children.
                         Vec::new()
                     } else {
                         let (#data_src_fields, #data_src_arrays, #data_src_bitmap) =
@@ -1750,6 +1754,10 @@ fn quote_arrow_deserializer(
                         })?;
 
                     if #data_src.is_empty() {
+                        // NOTE: The outer container is empty and so we already know that the end result
+                        // is also going to be an empty vec.
+                        // Early out right now rather than waste time computing possibly many empty
+                        // datastructures for all of our children.
                         Vec::new()
                     } else {
                         let (#data_src_types, #data_src_arrays, #data_src_offsets) =
@@ -1875,6 +1883,10 @@ fn quote_arrow_field_deserializer(
                     .unwrap(); // safe
 
                 if #data_src.is_empty() {
+                    // NOTE: The outer container is empty and so we already know that the end result
+                    // is also going to be an empty vec.
+                    // Early out right now rather than waste time computing possibly many empty
+                    // datastructures for all of our children.
                     Vec::new()
                 } else {
                     let bitmap = #data_src.validity().cloned();
@@ -1934,6 +1946,10 @@ fn quote_arrow_field_deserializer(
                     .unwrap(); // safe
 
                 if #data_src.is_empty() {
+                    // NOTE: The outer container is empty and so we already know that the end result
+                    // is also going to be an empty vec.
+                    // Early out right now rather than waste time computing possibly many empty
+                    // datastructures for all of our children.
                     Vec::new()
                 } else {
                     let bitmap = #data_src.validity().cloned();

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/fuzzy.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/fuzzy.py
@@ -614,6 +614,12 @@ class AffixFuzzer16Type(BaseExtensionType):
                                 False,
                                 {},
                             ),
+                            pa.field(
+                                "fixed_size_shenanigans",
+                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
+                                False,
+                                {},
+                            ),
                         ]
                     ),
                     False,
@@ -712,6 +718,12 @@ class AffixFuzzer17Type(BaseExtensionType):
                                         {},
                                     )
                                 ),
+                                False,
+                                {},
+                            ),
+                            pa.field(
+                                "fixed_size_shenanigans",
+                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                 False,
                                 {},
                             ),
@@ -820,6 +832,12 @@ class AffixFuzzer18Type(BaseExtensionType):
                                             False,
                                             {},
                                         ),
+                                        pa.field(
+                                            "fixed_size_shenanigans",
+                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
+                                            False,
+                                            {},
+                                        ),
                                     ]
                                 ),
                                 False,
@@ -890,6 +908,12 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                             {},
                                                         )
                                                     ),
+                                                    False,
+                                                    {},
+                                                ),
+                                                pa.field(
+                                                    "fixed_size_shenanigans",
+                                                    pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                                     False,
                                                     {},
                                                 ),
@@ -967,6 +991,12 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                             {},
                                                         )
                                                     ),
+                                                    False,
+                                                    {},
+                                                ),
+                                                pa.field(
+                                                    "fixed_size_shenanigans",
+                                                    pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                                     False,
                                                     {},
                                                 ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/fuzzy.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/fuzzy.py
@@ -214,6 +214,7 @@ class AffixFuzzer3:
     degrees: float | None = None
     radians: float | None = None
     craziness: list[datatypes.AffixFuzzer1] | None = None
+    fixed_size_shenanigans: npt.NDArray[np.float32] | None = None
 
 
 if TYPE_CHECKING:
@@ -283,6 +284,9 @@ class AffixFuzzer3Type(BaseExtensionType):
                         ),
                         False,
                         {},
+                    ),
+                    pa.field(
+                        "fixed_size_shenanigans", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {}
                     ),
                 ]
             ),
@@ -384,6 +388,12 @@ class AffixFuzzer4Type(BaseExtensionType):
                                     False,
                                     {},
                                 ),
+                                pa.field(
+                                    "fixed_size_shenanigans",
+                                    pa.list_(pa.field("item", pa.float32(), False, {}), 3),
+                                    False,
+                                    {},
+                                ),
                             ]
                         ),
                         False,
@@ -440,6 +450,12 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                     {},
                                                 )
                                             ),
+                                            False,
+                                            {},
+                                        ),
+                                        pa.field(
+                                            "fixed_size_shenanigans",
+                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                             False,
                                             {},
                                         ),
@@ -503,6 +519,12 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                     {},
                                                 )
                                             ),
+                                            False,
+                                            {},
+                                        ),
+                                        pa.field(
+                                            "fixed_size_shenanigans",
+                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                             False,
                                             {},
                                         ),
@@ -623,6 +645,12 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                 False,
                                                 {},
                                             ),
+                                            pa.field(
+                                                "fixed_size_shenanigans",
+                                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
+                                                False,
+                                                {},
+                                            ),
                                         ]
                                     ),
                                     False,
@@ -708,6 +736,12 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                 {},
                                                             )
                                                         ),
+                                                        False,
+                                                        {},
+                                                    ),
+                                                    pa.field(
+                                                        "fixed_size_shenanigans",
+                                                        pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                                         False,
                                                         {},
                                                     ),
@@ -800,6 +834,12 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                 {},
                                                             )
                                                         ),
+                                                        False,
+                                                        {},
+                                                    ),
+                                                    pa.field(
+                                                        "fixed_size_shenanigans",
+                                                        pa.list_(pa.field("item", pa.float32(), False, {}), 3),
                                                         False,
                                                         {},
                                                     ),


### PR DESCRIPTION
Deserializing a `FixedSizeList` itself contained within an empty list would fail; a situation that actually occurs all the time when using the transform types.

The fix is trivial, and also added a few early out in there to optimize that path.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2673) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2673)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Ffixed_size_list_deser_bug/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Ffixed_size_list_deser_bug/examples)