### PR TITLE
Cleanup internal data-structures when process has been forked

### DIFF
--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -38,6 +38,38 @@ thread_local! {
     static LOCAL_BLUEPRINT_RECORDING: RefCell<Option<RecordingStream>> = RefCell::new(None);
 }
 
+/// Check whether a fork has happened since creating the recording streams.
+/// If so, then we forget our globals.
+pub fn cleanup_if_forked() {
+    if let Some(global_recording) = RecordingStream::global(StoreKind::Recording) {
+        if global_recording.has_forked() {
+            re_log::debug!("Fork detected. Forgetting global Recording");
+            RecordingStream::forget_global(StoreKind::Recording);
+        }
+    }
+
+    if let Some(global_blueprint) = RecordingStream::global(StoreKind::Blueprint) {
+        if global_blueprint.has_forked() {
+            re_log::debug!("Fork detected. Forgetting global Blueprint");
+            RecordingStream::forget_global(StoreKind::Recording);
+        }
+    }
+
+    if let Some(thread_recording) = RecordingStream::thread_local(StoreKind::Recording) {
+        if thread_recording.has_forked() {
+            re_log::debug!("Fork detected. Forgetting thread-local Recording");
+            RecordingStream::forget_thread_local(StoreKind::Recording);
+        }
+    }
+
+    if let Some(thread_blueprint) = RecordingStream::thread_local(StoreKind::Blueprint) {
+        if thread_blueprint.has_forked() {
+            re_log::debug!("Fork detected. Forgetting thread-local Blueprint");
+            RecordingStream::forget_thread_local(StoreKind::Blueprint);
+        }
+    }
+}
+
 impl RecordingStream {
     /// Returns `overrides` if it exists, otherwise returns the most appropriate active recording
     /// of the specified type (i.e. thread-local first, then global scope), if any.
@@ -106,6 +138,15 @@ impl RecordingStream {
         Self::set_any(RecordingScope::Global, kind, rec)
     }
 
+    /// Forgets the currently active recording of the specified type in the global scope.
+    ///
+    /// WARNING: this intentionally bypasses any drop/flush logic. This should only ever be used in
+    /// cases where you know the batcher/sink threads have been lost such as in a forked process.
+    #[inline]
+    pub fn forget_global(kind: StoreKind) {
+        Self::forget_any(RecordingScope::Global, kind);
+    }
+
     // --- Thread local ---
 
     /// Returns the currently active recording of the specified type in the thread-local scope,
@@ -123,6 +164,15 @@ impl RecordingStream {
         rec: Option<RecordingStream>,
     ) -> Option<RecordingStream> {
         Self::set_any(RecordingScope::ThreadLocal, kind, rec)
+    }
+
+    /// Forgets the currently active recording of the specified type in the thread-local scope.
+    ///
+    /// WARNING: this intentionally bypasses any drop/flush logic. This should only ever be used in
+    /// cases where you know the batcher/sink threads have been lost such as in a forked process.
+    #[inline]
+    pub fn forget_thread_local(kind: StoreKind) {
+        Self::forget_any(RecordingScope::ThreadLocal, kind);
     }
 
     // --- Internal helpers ---
@@ -176,6 +226,35 @@ impl RecordingStream {
                 RecordingScope::ThreadLocal => LOCAL_BLUEPRINT_RECORDING.with(|cell| {
                     let mut cell = cell.borrow_mut();
                     std::mem::replace(&mut *cell, rec)
+                }),
+            },
+        }
+    }
+
+    fn forget_any(scope: RecordingScope, kind: StoreKind) {
+        match kind {
+            StoreKind::Recording => match scope {
+                RecordingScope::Global => {
+                    if let Some(global) = GLOBAL_DATA_RECORDING.get() {
+                        std::mem::forget(global.write().take());
+                    }
+                }
+                RecordingScope::ThreadLocal => LOCAL_DATA_RECORDING.with(|cell| {
+                    if let Some(cell) = cell.take() {
+                        std::mem::forget(cell);
+                    }
+                }),
+            },
+            StoreKind::Blueprint => match scope {
+                RecordingScope::Global => {
+                    if let Some(global) = GLOBAL_BLUEPRINT_RECORDING.get() {
+                        std::mem::forget(global.write().take());
+                    }
+                }
+                RecordingScope::ThreadLocal => LOCAL_BLUEPRINT_RECORDING.with(|cell| {
+                    if let Some(cell) = cell.take() {
+                        std::mem::forget(cell);
+                    }
                 }),
             },
         }

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -26,6 +26,8 @@ pub use re_log_types::{
     ApplicationId, Component, ComponentName, EntityPath, SerializableComponent, StoreId, StoreKind,
 };
 
+pub use global::cleanup_if_forked;
+
 #[cfg(not(target_arch = "wasm32"))]
 impl crate::sink::LogSink for re_log_encoding::FileSink {
     fn send(&self, msg: re_log_types::LogMsg) {

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -26,7 +26,7 @@ pub use re_log_types::{
     ApplicationId, Component, ComponentName, EntityPath, SerializableComponent, StoreId, StoreKind,
 };
 
-pub use global::cleanup_if_forked;
+pub use global::cleanup_if_forked_child;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl crate::sink::LogSink for re_log_encoding::FileSink {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -356,7 +356,7 @@ struct RecordingStreamInner {
 impl Drop for RecordingStreamInner {
     fn drop(&mut self) {
         if self.has_forked() {
-            re_log::warn_once!("Process-id mismatch while dropping RecordingStreamInner. Likely forked without calling cleanup_if_forked().");
+            re_log::error_once!("Fork detected while dropping RecordingStreamInner. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
             return;
         }
 
@@ -763,7 +763,7 @@ impl RecordingStream {
     /// See [`RecordingStream`] docs for ordering semantics and multithreading guarantees.
     pub fn flush_blocking(&self) {
         if self.has_forked() {
-            re_log::warn_once!("Fork detected - call to flush_blocking() ignored. Likely forked without calling cleanup_if_forked().");
+            re_log::error_once!("Fork detected during flush. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
             return;
         }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -608,7 +608,7 @@ impl RecordingStream {
     /// Determine whether a fork has happened since creating this `RecordingStream`. In general, this means our
     /// batcher/sink threads are gone and all data logged since the fork has been dropped.
     ///
-    /// It is essential that [`crate::cleanup_if_forked`] be called after forking the process. SDK-implementations
+    /// It is essential that [`crate::cleanup_if_forked_child`] be called after forking the process. SDK-implementations
     /// should do this during their initialization phase.
     #[inline]
     pub fn is_forked_child(&self) -> bool {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -355,7 +355,7 @@ struct RecordingStreamInner {
 
 impl Drop for RecordingStreamInner {
     fn drop(&mut self) {
-        if self.has_forked() {
+        if self.is_forked_child() {
             re_log::error_once!("Fork detected while dropping RecordingStreamInner. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
             return;
         }
@@ -422,7 +422,7 @@ impl RecordingStreamInner {
     }
 
     #[inline]
-    pub fn has_forked(&self) -> bool {
+    pub fn is_forked_child(&self) -> bool {
         self.pid_at_creation != std::process::id()
     }
 }
@@ -611,10 +611,10 @@ impl RecordingStream {
     /// It is essential that [`crate::cleanup_if_forked`] be called after forking the process. SDK-implementations
     /// should do this during their initialization phase.
     #[inline]
-    pub fn has_forked(&self) -> bool {
+    pub fn is_forked_child(&self) -> bool {
         (*self.inner)
             .as_ref()
-            .map_or(false, |inner| inner.has_forked())
+            .map_or(false, |inner| inner.is_forked_child())
     }
 }
 
@@ -762,7 +762,7 @@ impl RecordingStream {
     ///
     /// See [`RecordingStream`] docs for ordering semantics and multithreading guarantees.
     pub fn flush_blocking(&self) {
-        if self.has_forked() {
+        if self.is_forked_child() {
             re_log::error_once!("Fork detected during flush. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
             return;
         }

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -15,10 +15,12 @@ import rerun as rr  # pip install rerun-sdk
 # decorator to ensure data is flushed when the task completes.
 @rr.shutdown_at_exit
 def task(child_index: int) -> None:
-    # All processes spawned with `multiprocessing` will automatically
-    # be assigned the same default recording_id.
-    # We just need to connect each process to the the rerun viewer:
+    # In the new process, we always need to call init with the same application id.
+    # The internal recording-id is carried over from the parent process, so all
+    # of these processes will have their log data merged in the viewer.
     rr.init("multiprocessing")
+
+    # We then have to connect to the viewer instance.
     rr.connect()
 
     title = f"task {child_index}"

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -15,9 +15,11 @@ import rerun as rr  # pip install rerun-sdk
 # decorator to ensure data is flushed when the task completes.
 @rr.shutdown_at_exit
 def task(child_index: int) -> None:
-    # In the new process, we always need to call init with the same application id.
-    # The internal recording-id is carried over from the parent process, so all
-    # of these processes will have their log data merged in the viewer.
+    # In the new process, we always need to call init with the same `application_id`.
+    # By default, the `recording_id`` will match the `recording_id`` of the parent process,
+    # so all of these processes will have their log data merged in the viewer.
+    # Caution: if you manually specified `recording_id` in the parent, you also must
+    # pass the same `recording_id` here.
     rr.init("multiprocessing")
 
     # We then have to connect to the viewer instance.

--- a/examples/python/multiprocessing/main.py
+++ b/examples/python/multiprocessing/main.py
@@ -10,6 +10,10 @@ import threading
 import rerun as rr  # pip install rerun-sdk
 
 
+# Python does not guarantee that the normal atexit-handlers will be called at the
+# termination of a multiprocessing.Process. Explicitly add the `shutdown_at_exit`
+# decorator to ensure data is flushed when the task completes.
+@rr.shutdown_at_exit
 def task(child_index: int) -> None:
     # All processes spawned with `multiprocessing` will automatically
     # be assigned the same default recording_id.
@@ -36,11 +40,6 @@ def main() -> None:
     rr.spawn(connect=False)  # this is the viewer that each child process will connect to
 
     task(0)
-
-    # Using multiprocessing with "fork" results in a hang on shutdown so
-    # always use "spawn"
-    # TODO(https://github.com/rerun-io/rerun/issues/1921)
-    multiprocessing.set_start_method("spawn")
 
     for i in [1, 2, 3]:
         p = multiprocessing.Process(target=task, args=(i,))

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -158,9 +158,9 @@ def init(
     global _strict_mode
     _strict_mode = strict
 
-    # Always check for fork when calling init.  This should have happened via `_register_on_fork`
-    # but it's worth being conservative.
-    cleanup_if_forked()
+    # Always check whether we are a forked child when calling init.  This should have happened
+    # via `_register_on_fork` but it's worth being conservative.
+    cleanup_if_forked_child()
 
     if init_logging:
         new_recording(
@@ -318,8 +318,8 @@ def unregister_shutdown() -> None:
     atexit.unregister(rerun_shutdown)
 
 
-def cleanup_if_forked() -> None:
-    bindings.cleanup_if_forked()
+def cleanup_if_forked_child() -> None:
+    bindings.cleanup_if_forked_child()
 
 
 def _register_on_fork() -> None:
@@ -327,7 +327,7 @@ def _register_on_fork() -> None:
     try:
         import os
 
-        os.register_at_fork(after_in_child=cleanup_if_forked)
+        os.register_at_fork(after_in_child=cleanup_if_forked_child)
     except NotImplementedError:
         pass
 

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -155,6 +155,10 @@ def init(
     global _strict_mode
     _strict_mode = strict
 
+    # Always check for fork when calling init.  This should have happened via `_register_on_fork`
+    # but it's worth being conservative.
+    # cleanup_if_forked()
+
     if init_logging:
         new_recording(
             application_id,
@@ -310,6 +314,22 @@ def unregister_shutdown() -> None:
 
     atexit.unregister(rerun_shutdown)
 
+
+def cleanup_if_forked() -> None:
+    bindings.cleanup_if_forked()
+
+
+def _register_on_fork() -> None:
+    # Only relevant on Linux
+    try:
+        import os
+
+        os.register_at_fork(after_in_child=cleanup_if_forked)
+    except NotImplementedError:
+        pass
+
+
+_register_on_fork()
 
 # ---
 

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -160,7 +160,7 @@ def init(
 
     # Always check for fork when calling init.  This should have happened via `_register_on_fork`
     # but it's worth being conservative.
-    # cleanup_if_forked()
+    cleanup_if_forked()
 
     if init_logging:
         new_recording(

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -119,6 +119,7 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(new_recording, m)?)?;
     m.add_function(wrap_pyfunction!(new_blueprint, m)?)?;
     m.add_function(wrap_pyfunction!(shutdown, m)?)?;
+    m.add_function(wrap_pyfunction!(cleanup_if_forked, m)?)?;
 
     // recordings
     m.add_function(wrap_pyfunction!(get_application_id, m)?)?;
@@ -347,6 +348,12 @@ fn get_data_recording(recording: Option<&PyRecordingStream>) -> Option<PyRecordi
 #[pyfunction]
 fn get_global_data_recording() -> Option<PyRecordingStream> {
     RecordingStream::global(rerun::StoreKind::Recording).map(PyRecordingStream)
+}
+
+/// Cleans up internal state if the process was forked
+#[pyfunction]
+fn cleanup_if_forked() {
+    rerun::cleanup_if_forked();
 }
 
 /// Replaces the currently active recording in the global scope with the specified one.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -119,7 +119,7 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(new_recording, m)?)?;
     m.add_function(wrap_pyfunction!(new_blueprint, m)?)?;
     m.add_function(wrap_pyfunction!(shutdown, m)?)?;
-    m.add_function(wrap_pyfunction!(cleanup_if_forked, m)?)?;
+    m.add_function(wrap_pyfunction!(cleanup_if_forked_child, m)?)?;
 
     // recordings
     m.add_function(wrap_pyfunction!(get_application_id, m)?)?;
@@ -350,10 +350,10 @@ fn get_global_data_recording() -> Option<PyRecordingStream> {
     RecordingStream::global(rerun::StoreKind::Recording).map(PyRecordingStream)
 }
 
-/// Cleans up internal state if the process was forked
+/// Cleans up internal state if this is the child of a forked process.
 #[pyfunction]
-fn cleanup_if_forked() {
-    rerun::cleanup_if_forked();
+fn cleanup_if_forked_child() {
+    rerun::cleanup_if_forked_child();
 }
 
 /// Replaces the currently active recording in the global scope with the specified one.


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/1921

### What

The crux of the problem is the following:
> The child process is created with a single thread—the one that called fork().  The entire virtual address space of the parent is replicated in the child, ...

The major consequence of this is that our global `RecordingStream` context is duplicated into the child memory space but none of the threads (batcher, tcp-sender, dropper, etc.) are duplicated.  When we go to call `connect()` inside the forked process, we try to replace the global recording-stream, which subsequently tries to call drop on the forked copy of `RecordingStreamInner` . However, without any existing threads to process the flush, things just hang inside that flush call.

We take a few actions to alleviate this problem:
1. Introduce a new SDK function: `cleanup_if_forked` which compares the process-ids on existing globals and forgets them as necessary.
1. In python, use `os.register_at_fork` to proactively call `cleanup_if_forked` in any forked child processes.
1. Also add a call to `cleanup_if_forked` inside of init() in case we're forking through a more exotic mechanism.
1. Check for the forked state anywhere we potentially flush to avoid deadlocks and produce a visible user-error.

Additionally, it turns out that forked processes bypass the normal python `atexit` handler which means we don't get proper shutdown/flush behavior when the forked processes terminate.  To help users workaround this, we introduce a `@shutdown_at_exit` decorator which can be used to decorate functions launched via multiprocessing.

### Testing

On linux:
```
$ python examples/python/multiprocessing/main.py
```
observe demo exits cleanly and all data shows in viewer.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2676) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2676)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Fcleanup_if_forked/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Fcleanup_if_forked/examples)