### PR TITLE
Make `Datatype` & `Component` both inherit from `Loggable`

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-73588bbdd10b7303d8d04bda573c315fd2acb3cd3edd2ee5244a926064c8dc46
+d86ab89fae71ae9a5f145017617c8bdb8f1f65355e5788eff6b2c88ee3a9081b

--- a/crates/re_types/src/archetypes/fuzzy.rs
+++ b/crates/re_types/src/archetypes/fuzzy.rs
@@ -263,7 +263,7 @@ impl crate::Archetype for AffixFuzzer1 {
     ) -> crate::SerializationResult<
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
-        use crate::Component as _;
+        use crate::Loggable as _;
         Ok([
             {
                 Some({
@@ -1592,7 +1592,7 @@ impl crate::Archetype for AffixFuzzer1 {
     fn try_from_arrow(
         data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     ) -> crate::DeserializationResult<Self> {
-        use crate::Component as _;
+        use crate::Loggable as _;
         let arrays_by_name: ::std::collections::HashMap<_, _> = data
             .into_iter()
             .map(|(field, array)| (field.name, array))

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -136,7 +136,7 @@ impl crate::Archetype for Points2D {
     ) -> crate::SerializationResult<
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
-        use crate::Component as _;
+        use crate::Loggable as _;
         Ok([
             {
                 Some({
@@ -301,7 +301,7 @@ impl crate::Archetype for Points2D {
     fn try_from_arrow(
         data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     ) -> crate::DeserializationResult<Self> {
-        use crate::Component as _;
+        use crate::Loggable as _;
         let arrays_by_name: ::std::collections::HashMap<_, _> = data
             .into_iter()
             .map(|(field, array)| (field.name, array))

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -61,7 +61,7 @@ impl crate::Archetype for Transform3D {
     ) -> crate::SerializationResult<
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
-        use crate::Component as _;
+        use crate::Loggable as _;
         Ok([{
             Some({
                 let array = <crate::components::Transform3D>::try_to_arrow([&self.transform], None);
@@ -88,7 +88,7 @@ impl crate::Archetype for Transform3D {
     fn try_from_arrow(
         data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     ) -> crate::DeserializationResult<Self> {
-        use crate::Component as _;
+        use crate::Loggable as _;
         let arrays_by_name: ::std::collections::HashMap<_, _> = data
             .into_iter()
             .map(|(field, array)| (field.name, array))

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -32,9 +32,10 @@ impl<'a> From<&'a ClassId> for ::std::borrow::Cow<'a, ClassId> {
     }
 }
 
-impl crate::Component for ClassId {
+impl crate::Loggable for ClassId {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.class_id")
     }
 
@@ -53,7 +54,7 @@ impl crate::Component for ClassId {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -96,7 +97,7 @@ impl crate::Component for ClassId {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -113,3 +114,5 @@ impl crate::Component for ClassId {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for ClassId {}

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -42,9 +42,10 @@ impl<'a> From<&'a Color> for ::std::borrow::Cow<'a, Color> {
     }
 }
 
-impl crate::Component for Color {
+impl crate::Loggable for Color {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.colorrgba")
     }
 
@@ -63,7 +64,7 @@ impl crate::Component for Color {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -106,7 +107,7 @@ impl crate::Component for Color {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -123,3 +124,5 @@ impl crate::Component for Color {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for Color {}

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -37,9 +37,10 @@ impl<'a> From<&'a DrawOrder> for ::std::borrow::Cow<'a, DrawOrder> {
     }
 }
 
-impl crate::Component for DrawOrder {
+impl crate::Loggable for DrawOrder {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.draw_order")
     }
 
@@ -58,7 +59,7 @@ impl crate::Component for DrawOrder {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -101,7 +102,7 @@ impl crate::Component for DrawOrder {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -118,3 +119,5 @@ impl crate::Component for DrawOrder {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for DrawOrder {}

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -31,9 +31,10 @@ impl<'a> From<&'a AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
     }
 }
 
-impl crate::Component for AffixFuzzer1 {
+impl crate::Loggable for AffixFuzzer1 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer1")
     }
 
@@ -127,7 +128,7 @@ impl crate::Component for AffixFuzzer1 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_required): (Vec<_>, Vec<_>) = data
@@ -163,7 +164,7 @@ impl crate::Component for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
             .into_iter()
@@ -176,6 +177,8 @@ impl crate::Component for AffixFuzzer1 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer1 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer2(pub crate::datatypes::AffixFuzzer1);
@@ -194,9 +197,10 @@ impl<'a> From<&'a AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
     }
 }
 
-impl crate::Component for AffixFuzzer2 {
+impl crate::Loggable for AffixFuzzer2 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer2")
     }
 
@@ -290,7 +294,7 @@ impl crate::Component for AffixFuzzer2 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -326,7 +330,7 @@ impl crate::Component for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
             .into_iter()
@@ -339,6 +343,8 @@ impl crate::Component for AffixFuzzer2 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer2 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer3 {
@@ -359,9 +365,10 @@ impl<'a> From<&'a AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
     }
 }
 
-impl crate::Component for AffixFuzzer3 {
+impl crate::Loggable for AffixFuzzer3 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer3")
     }
 
@@ -455,7 +462,7 @@ impl crate::Component for AffixFuzzer3 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_required): (Vec<_>, Vec<_>) = data
@@ -491,7 +498,7 @@ impl crate::Component for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
             .into_iter()
@@ -504,6 +511,8 @@ impl crate::Component for AffixFuzzer3 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer3 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer4 {
@@ -524,9 +533,10 @@ impl<'a> From<&'a AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
     }
 }
 
-impl crate::Component for AffixFuzzer4 {
+impl crate::Loggable for AffixFuzzer4 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer4")
     }
 
@@ -620,7 +630,7 @@ impl crate::Component for AffixFuzzer4 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_optional): (Vec<_>, Vec<_>) = data
@@ -658,7 +668,7 @@ impl crate::Component for AffixFuzzer4 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
             .into_iter()
@@ -667,6 +677,8 @@ impl crate::Component for AffixFuzzer4 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer4 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer5(pub Option<crate::datatypes::AffixFuzzer1>);
@@ -685,9 +697,10 @@ impl<'a> From<&'a AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
     }
 }
 
-impl crate::Component for AffixFuzzer5 {
+impl crate::Loggable for AffixFuzzer5 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer5")
     }
 
@@ -781,7 +794,7 @@ impl crate::Component for AffixFuzzer5 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -819,7 +832,7 @@ impl crate::Component for AffixFuzzer5 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
             .into_iter()
@@ -828,6 +841,8 @@ impl crate::Component for AffixFuzzer5 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer5 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer6 {
@@ -848,9 +863,10 @@ impl<'a> From<&'a AffixFuzzer6> for ::std::borrow::Cow<'a, AffixFuzzer6> {
     }
 }
 
-impl crate::Component for AffixFuzzer6 {
+impl crate::Loggable for AffixFuzzer6 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer6")
     }
 
@@ -944,7 +960,7 @@ impl crate::Component for AffixFuzzer6 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_optional): (Vec<_>, Vec<_>) = data
@@ -982,7 +998,7 @@ impl crate::Component for AffixFuzzer6 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer1::try_from_arrow_opt(data)?
             .into_iter()
@@ -991,6 +1007,8 @@ impl crate::Component for AffixFuzzer6 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer6 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer7 {
@@ -1011,9 +1029,10 @@ impl<'a> From<&'a AffixFuzzer7> for ::std::borrow::Cow<'a, AffixFuzzer7> {
     }
 }
 
-impl crate::Component for AffixFuzzer7 {
+impl crate::Loggable for AffixFuzzer7 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer7")
     }
 
@@ -1112,7 +1131,7 @@ impl crate::Component for AffixFuzzer7 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_optional): (Vec<_>, Vec<_>) = data
@@ -1263,7 +1282,7 @@ impl crate::Component for AffixFuzzer7 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -1391,6 +1410,8 @@ impl crate::Component for AffixFuzzer7 {
     }
 }
 
+impl crate::Component for AffixFuzzer7 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer8 {
     pub single_float_optional: Option<f32>,
@@ -1410,9 +1431,10 @@ impl<'a> From<&'a AffixFuzzer8> for ::std::borrow::Cow<'a, AffixFuzzer8> {
     }
 }
 
-impl crate::Component for AffixFuzzer8 {
+impl crate::Loggable for AffixFuzzer8 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer8")
     }
 
@@ -1431,7 +1453,7 @@ impl crate::Component for AffixFuzzer8 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_float_optional): (Vec<_>, Vec<_>) = data
@@ -1481,7 +1503,7 @@ impl crate::Component for AffixFuzzer8 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -1500,6 +1522,8 @@ impl crate::Component for AffixFuzzer8 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer8 {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AffixFuzzer9 {
@@ -1520,9 +1544,10 @@ impl<'a> From<&'a AffixFuzzer9> for ::std::borrow::Cow<'a, AffixFuzzer9> {
     }
 }
 
-impl crate::Component for AffixFuzzer9 {
+impl crate::Loggable for AffixFuzzer9 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer9")
     }
 
@@ -1541,7 +1566,7 @@ impl crate::Component for AffixFuzzer9 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_string_required): (Vec<_>, Vec<_>) = data
@@ -1604,7 +1629,7 @@ impl crate::Component for AffixFuzzer9 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -1628,6 +1653,8 @@ impl crate::Component for AffixFuzzer9 {
     }
 }
 
+impl crate::Component for AffixFuzzer9 {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AffixFuzzer10 {
     pub single_string_optional: Option<String>,
@@ -1647,9 +1674,10 @@ impl<'a> From<&'a AffixFuzzer10> for ::std::borrow::Cow<'a, AffixFuzzer10> {
     }
 }
 
-impl crate::Component for AffixFuzzer10 {
+impl crate::Loggable for AffixFuzzer10 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer10")
     }
 
@@ -1668,7 +1696,7 @@ impl crate::Component for AffixFuzzer10 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_string_optional): (Vec<_>, Vec<_>) = data
@@ -1733,7 +1761,7 @@ impl crate::Component for AffixFuzzer10 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -1752,6 +1780,8 @@ impl crate::Component for AffixFuzzer10 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer10 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer11 {
@@ -1772,9 +1802,10 @@ impl<'a> From<&'a AffixFuzzer11> for ::std::borrow::Cow<'a, AffixFuzzer11> {
     }
 }
 
-impl crate::Component for AffixFuzzer11 {
+impl crate::Loggable for AffixFuzzer11 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer11")
     }
 
@@ -1798,7 +1829,7 @@ impl crate::Component for AffixFuzzer11 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_floats_optional): (Vec<_>, Vec<_>) = data
@@ -1886,7 +1917,7 @@ impl crate::Component for AffixFuzzer11 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -1949,6 +1980,8 @@ impl crate::Component for AffixFuzzer11 {
     }
 }
 
+impl crate::Component for AffixFuzzer11 {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AffixFuzzer12 {
     pub many_strings_required: Vec<String>,
@@ -1968,9 +2001,10 @@ impl<'a> From<&'a AffixFuzzer12> for ::std::borrow::Cow<'a, AffixFuzzer12> {
     }
 }
 
-impl crate::Component for AffixFuzzer12 {
+impl crate::Loggable for AffixFuzzer12 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer12")
     }
 
@@ -1994,7 +2028,7 @@ impl crate::Component for AffixFuzzer12 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_strings_required): (Vec<_>, Vec<_>) = data
@@ -2096,7 +2130,7 @@ impl crate::Component for AffixFuzzer12 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -2163,6 +2197,8 @@ impl crate::Component for AffixFuzzer12 {
     }
 }
 
+impl crate::Component for AffixFuzzer12 {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AffixFuzzer13 {
     pub many_strings_optional: Option<Vec<String>>,
@@ -2182,9 +2218,10 @@ impl<'a> From<&'a AffixFuzzer13> for ::std::borrow::Cow<'a, AffixFuzzer13> {
     }
 }
 
-impl crate::Component for AffixFuzzer13 {
+impl crate::Loggable for AffixFuzzer13 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer13")
     }
 
@@ -2208,7 +2245,7 @@ impl crate::Component for AffixFuzzer13 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_strings_optional): (Vec<_>, Vec<_>) = data
@@ -2312,7 +2349,7 @@ impl crate::Component for AffixFuzzer13 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -2375,6 +2412,8 @@ impl crate::Component for AffixFuzzer13 {
     }
 }
 
+impl crate::Component for AffixFuzzer13 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer14 {
     pub single_required_union: crate::datatypes::AffixFuzzer3,
@@ -2394,9 +2433,10 @@ impl<'a> From<&'a AffixFuzzer14> for ::std::borrow::Cow<'a, AffixFuzzer14> {
     }
 }
 
-impl crate::Component for AffixFuzzer14 {
+impl crate::Loggable for AffixFuzzer14 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer14")
     }
 
@@ -2532,7 +2572,7 @@ impl crate::Component for AffixFuzzer14 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, single_required_union): (Vec<_>, Vec<_>) = data
@@ -2570,7 +2610,7 @@ impl crate::Component for AffixFuzzer14 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer3::try_from_arrow_opt(data)?
             .into_iter()
@@ -2589,6 +2629,8 @@ impl crate::Component for AffixFuzzer14 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer14 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer16 {
@@ -2609,9 +2651,10 @@ impl<'a> From<&'a AffixFuzzer16> for ::std::borrow::Cow<'a, AffixFuzzer16> {
     }
 }
 
-impl crate::Component for AffixFuzzer16 {
+impl crate::Loggable for AffixFuzzer16 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer16")
     }
 
@@ -2752,7 +2795,7 @@ impl crate::Component for AffixFuzzer16 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_required_unions): (Vec<_>, Vec<_>) = data
@@ -2951,7 +2994,7 @@ impl crate::Component for AffixFuzzer16 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -3131,6 +3174,8 @@ impl crate::Component for AffixFuzzer16 {
     }
 }
 
+impl crate::Component for AffixFuzzer16 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer17 {
     pub many_optional_unions: Option<Vec<crate::datatypes::AffixFuzzer3>>,
@@ -3150,9 +3195,10 @@ impl<'a> From<&'a AffixFuzzer17> for ::std::borrow::Cow<'a, AffixFuzzer17> {
     }
 }
 
-impl crate::Component for AffixFuzzer17 {
+impl crate::Loggable for AffixFuzzer17 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer17")
     }
 
@@ -3293,7 +3339,7 @@ impl crate::Component for AffixFuzzer17 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_optional_unions): (Vec<_>, Vec<_>) = data
@@ -3494,7 +3540,7 @@ impl crate::Component for AffixFuzzer17 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -3670,6 +3716,8 @@ impl crate::Component for AffixFuzzer17 {
     }
 }
 
+impl crate::Component for AffixFuzzer17 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer18 {
     pub many_optional_unions: Option<Vec<crate::datatypes::AffixFuzzer4>>,
@@ -3689,9 +3737,10 @@ impl<'a> From<&'a AffixFuzzer18> for ::std::borrow::Cow<'a, AffixFuzzer18> {
     }
 }
 
-impl crate::Component for AffixFuzzer18 {
+impl crate::Loggable for AffixFuzzer18 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer18")
     }
 
@@ -4099,7 +4148,7 @@ impl crate::Component for AffixFuzzer18 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, many_optional_unions): (Vec<_>, Vec<_>) = data
@@ -4280,7 +4329,7 @@ impl crate::Component for AffixFuzzer18 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok ({ let datatype = data . data_type () ; let data = data . as_any () . downcast_ref :: < :: arrow2 :: array :: ListArray < i32 >> () . unwrap () ; if data . is_empty () { Vec :: new () }
 
@@ -4426,6 +4475,8 @@ impl crate::Component for AffixFuzzer18 {
     }
 }
 
+impl crate::Component for AffixFuzzer18 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer19 {
     pub just_a_table_nothing_shady: crate::datatypes::AffixFuzzer5,
@@ -4445,9 +4496,10 @@ impl<'a> From<&'a AffixFuzzer19> for ::std::borrow::Cow<'a, AffixFuzzer19> {
     }
 }
 
-impl crate::Component for AffixFuzzer19 {
+impl crate::Loggable for AffixFuzzer19 {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.testing.components.AffixFuzzer19")
     }
 
@@ -4855,7 +4907,7 @@ impl crate::Component for AffixFuzzer19 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, just_a_table_nothing_shady): (Vec<_>, Vec<_>) = data
@@ -4893,7 +4945,7 @@ impl crate::Component for AffixFuzzer19 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::AffixFuzzer5::try_from_arrow_opt(data)?
             .into_iter()
@@ -4912,3 +4964,5 @@ impl crate::Component for AffixFuzzer19 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for AffixFuzzer19 {}

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a InstanceKey> for ::std::borrow::Cow<'a, InstanceKey> {
     }
 }
 
-impl crate::Component for InstanceKey {
+impl crate::Loggable for InstanceKey {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.instance_key")
     }
 
@@ -51,7 +52,7 @@ impl crate::Component for InstanceKey {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -94,7 +95,7 @@ impl crate::Component for InstanceKey {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -111,3 +112,5 @@ impl crate::Component for InstanceKey {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for InstanceKey {}

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -34,9 +34,10 @@ impl<'a> From<&'a KeypointId> for ::std::borrow::Cow<'a, KeypointId> {
     }
 }
 
-impl crate::Component for KeypointId {
+impl crate::Loggable for KeypointId {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.keypoint_id")
     }
 
@@ -55,7 +56,7 @@ impl crate::Component for KeypointId {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -98,7 +99,7 @@ impl crate::Component for KeypointId {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -115,3 +116,5 @@ impl crate::Component for KeypointId {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for KeypointId {}

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -31,9 +31,10 @@ impl<'a> From<&'a Label> for ::std::borrow::Cow<'a, Label> {
     }
 }
 
-impl crate::Component for Label {
+impl crate::Loggable for Label {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.label")
     }
 
@@ -52,7 +53,7 @@ impl crate::Component for Label {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -110,7 +111,7 @@ impl crate::Component for Label {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -127,3 +128,5 @@ impl crate::Component for Label {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for Label {}

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -32,9 +32,10 @@ impl<'a> From<&'a Point2D> for ::std::borrow::Cow<'a, Point2D> {
     }
 }
 
-impl crate::Component for Point2D {
+impl crate::Loggable for Point2D {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.point2d")
     }
 
@@ -66,7 +67,7 @@ impl crate::Component for Point2D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, xy): (Vec<_>, Vec<_>) = data
@@ -99,7 +100,7 @@ impl crate::Component for Point2D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::Point2D::try_from_arrow_opt(data)?
             .into_iter()
@@ -112,3 +113,5 @@ impl crate::Component for Point2D {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for Point2D {}

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Radius> for ::std::borrow::Cow<'a, Radius> {
     }
 }
 
-impl crate::Component for Radius {
+impl crate::Loggable for Radius {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.radius")
     }
 
@@ -51,7 +52,7 @@ impl crate::Component for Radius {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -94,7 +95,7 @@ impl crate::Component for Radius {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -111,3 +112,5 @@ impl crate::Component for Radius {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for Radius {}

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -33,9 +33,10 @@ impl<'a> From<&'a Transform3D> for ::std::borrow::Cow<'a, Transform3D> {
     }
 }
 
-impl crate::Component for Transform3D {
+impl crate::Loggable for Transform3D {
+    type Name = crate::ComponentName;
     #[inline]
-    fn name() -> crate::ComponentName {
+    fn name() -> Self::Name {
         crate::ComponentName::Borrowed("rerun.components.Transform3D")
     }
 
@@ -227,7 +228,7 @@ impl crate::Component for Transform3D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, repr): (Vec<_>, Vec<_>) = data
@@ -263,7 +264,7 @@ impl crate::Component for Transform3D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(crate::datatypes::Transform3D::try_from_arrow_opt(data)?
             .into_iter()
@@ -276,3 +277,5 @@ impl crate::Component for Transform3D {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Component for Transform3D {}

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -33,9 +33,10 @@ impl<'a> From<&'a Angle> for ::std::borrow::Cow<'a, Angle> {
     }
 }
 
-impl crate::Datatype for Angle {
+impl crate::Loggable for Angle {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Angle")
     }
 
@@ -71,7 +72,7 @@ impl crate::Datatype for Angle {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data: Vec<_> = data
@@ -190,7 +191,7 @@ impl crate::Datatype for Angle {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -262,3 +263,5 @@ impl crate::Datatype for Angle {
         })
     }
 }
+
+impl crate::Datatype for Angle {}

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -31,9 +31,10 @@ impl<'a> From<&'a FlattenedScalar> for ::std::borrow::Cow<'a, FlattenedScalar> {
     }
 }
 
-impl crate::Datatype for FlattenedScalar {
+impl crate::Loggable for FlattenedScalar {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.testing.datatypes.FlattenedScalar")
     }
 
@@ -57,7 +58,7 @@ impl crate::Datatype for FlattenedScalar {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -121,7 +122,7 @@ impl crate::Datatype for FlattenedScalar {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -172,6 +173,8 @@ impl crate::Datatype for FlattenedScalar {
     }
 }
 
+impl crate::Datatype for FlattenedScalar {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer1 {
     pub single_float_optional: Option<f32>,
@@ -199,9 +202,10 @@ impl<'a> From<&'a AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
     }
 }
 
-impl crate::Datatype for AffixFuzzer1 {
+impl crate::Loggable for AffixFuzzer1 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.testing.datatypes.AffixFuzzer1")
     }
 
@@ -295,7 +299,7 @@ impl crate::Datatype for AffixFuzzer1 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -798,7 +802,7 @@ impl crate::Datatype for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -1099,6 +1103,8 @@ impl crate::Datatype for AffixFuzzer1 {
     }
 }
 
+impl crate::Datatype for AffixFuzzer1 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer2(pub Option<f32>);
 
@@ -1116,9 +1122,10 @@ impl<'a> From<&'a AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
     }
 }
 
-impl crate::Datatype for AffixFuzzer2 {
+impl crate::Loggable for AffixFuzzer2 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.testing.datatypes.AffixFuzzer2")
     }
 
@@ -1137,7 +1144,7 @@ impl crate::Datatype for AffixFuzzer2 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -1182,7 +1189,7 @@ impl crate::Datatype for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok(data
             .as_any()
@@ -1195,6 +1202,8 @@ impl crate::Datatype for AffixFuzzer2 {
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for AffixFuzzer2 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AffixFuzzer3 {
@@ -1218,9 +1227,10 @@ impl<'a> From<&'a AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
     }
 }
 
-impl crate::Datatype for AffixFuzzer3 {
+impl crate::Loggable for AffixFuzzer3 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.testing.datatypes.AffixFuzzer3")
     }
 
@@ -1356,7 +1366,7 @@ impl crate::Datatype for AffixFuzzer3 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data: Vec<_> = data
@@ -1690,7 +1700,7 @@ impl crate::Datatype for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -1930,6 +1940,8 @@ impl crate::Datatype for AffixFuzzer3 {
     }
 }
 
+impl crate::Datatype for AffixFuzzer3 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum AffixFuzzer4 {
     SingleRequired(crate::datatypes::AffixFuzzer3),
@@ -1951,9 +1963,10 @@ impl<'a> From<&'a AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
     }
 }
 
-impl crate::Datatype for AffixFuzzer4 {
+impl crate::Loggable for AffixFuzzer4 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.testing.datatypes.AffixFuzzer4")
     }
 
@@ -2356,7 +2369,7 @@ impl crate::Datatype for AffixFuzzer4 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data: Vec<_> = data
@@ -2844,7 +2857,7 @@ impl crate::Datatype for AffixFuzzer4 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -3286,6 +3299,8 @@ impl crate::Datatype for AffixFuzzer4 {
     }
 }
 
+impl crate::Datatype for AffixFuzzer4 {}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer5 {
     pub single_optional_union: Option<crate::datatypes::AffixFuzzer4>,
@@ -3305,9 +3320,10 @@ impl<'a> From<&'a AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
     }
 }
 
-impl crate::Datatype for AffixFuzzer5 {
+impl crate::Loggable for AffixFuzzer5 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.testing.datatypes.AffixFuzzer5")
     }
 
@@ -3715,7 +3731,7 @@ impl crate::Datatype for AffixFuzzer5 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -3784,7 +3800,7 @@ impl crate::Datatype for AffixFuzzer5 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -3826,3 +3842,5 @@ impl crate::Datatype for AffixFuzzer5 {
         })
     }
 }
+
+impl crate::Datatype for AffixFuzzer5 {}

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Mat3x3> for ::std::borrow::Cow<'a, Mat3x3> {
     }
 }
 
-impl crate::Datatype for Mat3x3 {
+impl crate::Loggable for Mat3x3 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Mat3x3")
     }
 
@@ -59,7 +60,7 @@ impl crate::Datatype for Mat3x3 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -138,7 +139,7 @@ impl crate::Datatype for Mat3x3 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -204,3 +205,5 @@ impl crate::Datatype for Mat3x3 {
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for Mat3x3 {}

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Mat4x4> for ::std::borrow::Cow<'a, Mat4x4> {
     }
 }
 
-impl crate::Datatype for Mat4x4 {
+impl crate::Loggable for Mat4x4 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Mat4x4")
     }
 
@@ -59,7 +60,7 @@ impl crate::Datatype for Mat4x4 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -138,7 +139,7 @@ impl crate::Datatype for Mat4x4 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -204,3 +205,5 @@ impl crate::Datatype for Mat4x4 {
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for Mat4x4 {}

--- a/crates/re_types/src/datatypes/point2d.rs
+++ b/crates/re_types/src/datatypes/point2d.rs
@@ -33,9 +33,10 @@ impl<'a> From<&'a Point2D> for ::std::borrow::Cow<'a, Point2D> {
     }
 }
 
-impl crate::Datatype for Point2D {
+impl crate::Loggable for Point2D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Point2D")
     }
 
@@ -67,7 +68,7 @@ impl crate::Datatype for Point2D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -158,7 +159,7 @@ impl crate::Datatype for Point2D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -218,3 +219,5 @@ impl crate::Datatype for Point2D {
         })
     }
 }
+
+impl crate::Datatype for Point2D {}

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Quaternion> for ::std::borrow::Cow<'a, Quaternion> {
     }
 }
 
-impl crate::Datatype for Quaternion {
+impl crate::Loggable for Quaternion {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Quaternion")
     }
 
@@ -59,7 +60,7 @@ impl crate::Datatype for Quaternion {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -138,7 +139,7 @@ impl crate::Datatype for Quaternion {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -204,3 +205,5 @@ impl crate::Datatype for Quaternion {
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for Quaternion {}

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -36,9 +36,10 @@ impl<'a> From<&'a Rotation3D> for ::std::borrow::Cow<'a, Rotation3D> {
     }
 }
 
-impl crate::Datatype for Rotation3D {
+impl crate::Loggable for Rotation3D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Rotation3D")
     }
 
@@ -120,7 +121,7 @@ impl crate::Datatype for Rotation3D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data: Vec<_> = data
@@ -274,7 +275,7 @@ impl crate::Datatype for Rotation3D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -352,3 +353,5 @@ impl crate::Datatype for Rotation3D {
         })
     }
 }
+
+impl crate::Datatype for Rotation3D {}

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -40,9 +40,10 @@ impl<'a> From<&'a RotationAxisAngle> for ::std::borrow::Cow<'a, RotationAxisAngl
     }
 }
 
-impl crate::Datatype for RotationAxisAngle {
+impl crate::Loggable for RotationAxisAngle {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.RotationAxisAngle")
     }
 
@@ -99,7 +100,7 @@ impl crate::Datatype for RotationAxisAngle {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -222,7 +223,7 @@ impl crate::Datatype for RotationAxisAngle {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -297,3 +298,5 @@ impl crate::Datatype for RotationAxisAngle {
         })
     }
 }
+
+impl crate::Datatype for RotationAxisAngle {}

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -36,9 +36,10 @@ impl<'a> From<&'a Scale3D> for ::std::borrow::Cow<'a, Scale3D> {
     }
 }
 
-impl crate::Datatype for Scale3D {
+impl crate::Loggable for Scale3D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Scale3D")
     }
 
@@ -82,7 +83,7 @@ impl crate::Datatype for Scale3D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data: Vec<_> = data
@@ -237,7 +238,7 @@ impl crate::Datatype for Scale3D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -318,3 +319,5 @@ impl crate::Datatype for Scale3D {
         })
     }
 }
+
+impl crate::Datatype for Scale3D {}

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -36,9 +36,10 @@ impl<'a> From<&'a Transform3D> for ::std::borrow::Cow<'a, Transform3D> {
     }
 }
 
-impl crate::Datatype for Transform3D {
+impl crate::Loggable for Transform3D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Transform3D")
     }
 
@@ -230,7 +231,7 @@ impl crate::Datatype for Transform3D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data: Vec<_> = data
@@ -351,7 +352,7 @@ impl crate::Datatype for Transform3D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -417,3 +418,5 @@ impl crate::Datatype for Transform3D {
         })
     }
 }
+
+impl crate::Datatype for Transform3D {}

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -42,9 +42,10 @@ impl<'a> From<&'a TranslationAndMat3x3> for ::std::borrow::Cow<'a, TranslationAn
     }
 }
 
-impl crate::Datatype for TranslationAndMat3x3 {
+impl crate::Loggable for TranslationAndMat3x3 {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.TranslationAndMat3x3")
     }
 
@@ -98,7 +99,7 @@ impl crate::Datatype for TranslationAndMat3x3 {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -298,7 +299,7 @@ impl crate::Datatype for TranslationAndMat3x3 {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -393,3 +394,5 @@ impl crate::Datatype for TranslationAndMat3x3 {
         })
     }
 }
+
+impl crate::Datatype for TranslationAndMat3x3 {}

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -45,9 +45,10 @@ impl<'a> From<&'a TranslationRotationScale3D>
     }
 }
 
-impl crate::Datatype for TranslationRotationScale3D {
+impl crate::Loggable for TranslationRotationScale3D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.TranslationRotationScale3D")
     }
 
@@ -187,7 +188,7 @@ impl crate::Datatype for TranslationRotationScale3D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
@@ -373,7 +374,7 @@ impl crate::Datatype for TranslationRotationScale3D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let data = data
@@ -455,3 +456,5 @@ impl crate::Datatype for TranslationRotationScale3D {
         })
     }
 }
+
+impl crate::Datatype for TranslationRotationScale3D {}

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Vec2D> for ::std::borrow::Cow<'a, Vec2D> {
     }
 }
 
-impl crate::Datatype for Vec2D {
+impl crate::Loggable for Vec2D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Vec2D")
     }
 
@@ -59,7 +60,7 @@ impl crate::Datatype for Vec2D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -138,7 +139,7 @@ impl crate::Datatype for Vec2D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -204,3 +205,5 @@ impl crate::Datatype for Vec2D {
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for Vec2D {}

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Vec3D> for ::std::borrow::Cow<'a, Vec3D> {
     }
 }
 
-impl crate::Datatype for Vec3D {
+impl crate::Loggable for Vec3D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Vec3D")
     }
 
@@ -59,7 +60,7 @@ impl crate::Datatype for Vec3D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -138,7 +139,7 @@ impl crate::Datatype for Vec3D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -204,3 +205,5 @@ impl crate::Datatype for Vec3D {
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for Vec3D {}

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -30,9 +30,10 @@ impl<'a> From<&'a Vec4D> for ::std::borrow::Cow<'a, Vec4D> {
     }
 }
 
-impl crate::Datatype for Vec4D {
+impl crate::Loggable for Vec4D {
+    type Name = crate::DatatypeName;
     #[inline]
-    fn name() -> crate::DatatypeName {
+    fn name() -> Self::Name {
         crate::DatatypeName::Borrowed("rerun.datatypes.Vec4D")
     }
 
@@ -59,7 +60,7 @@ impl crate::Datatype for Vec4D {
     where
         Self: Clone + 'a,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let (somes, data0): (Vec<_>, Vec<_>) = data
@@ -138,7 +139,7 @@ impl crate::Datatype for Vec4D {
     where
         Self: Sized,
     {
-        use crate::{Component as _, Datatype as _};
+        use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
             let datatype = data.data_type();
@@ -204,3 +205,5 @@ impl crate::Datatype for Vec4D {
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?)
     }
 }
+
+impl crate::Datatype for Vec4D {}

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -76,290 +76,160 @@
 
 // ---
 
+/// Anything that can be serialized to and deserialized from Arrow data.
+pub trait Loggable {
+    type Name;
+
+    /// The fully-qualified name of this loggable, e.g. `rerun.datatypes.Vec2D`.
+    fn name() -> Self::Name;
+
+    /// The underlying [`arrow2::datatypes::DataType`].
+    fn to_arrow_datatype() -> arrow2::datatypes::DataType;
+
+    // ---
+
+    /// Given an iterator of owned or reference values to the current [`Loggable`], serializes
+    /// them into an Arrow array.
+    /// The Arrow array's datatype will match [`Loggable::to_arrow_datatype`].
+    ///
+    /// Panics on failure.
+    /// This will _never_ fail for Rerun's builtin [`Loggable`]s.
+    ///
+    /// For the fallible version, see [`Loggable::try_to_arrow`].
+    #[inline]
+    fn to_arrow<'a>(
+        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+        extension_wrapper: Option<&str>,
+    ) -> Box<dyn ::arrow2::array::Array>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper).unwrap()
+    }
+
+    /// Given an iterator of owned or reference values to the current [`Loggable`], serializes
+    /// them into an Arrow array.
+    /// The Arrow array's datatype will match [`Loggable::to_arrow_datatype`].
+    ///
+    /// This will _never_ fail for Rerun's builtin [`Loggable`].
+    /// For the non-fallible version, see [`Loggable::to_arrow`].
+    #[inline]
+    fn try_to_arrow<'a>(
+        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
+        extension_wrapper: Option<&str>,
+    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper)
+    }
+
+    /// Given an iterator of options of owned or reference values to the current
+    /// [`Loggable`], serializes them into an Arrow array.
+    /// The Arrow array's datatype will match [`Loggable::to_arrow_datatype`].
+    ///
+    /// Panics on failure.
+    /// This will _never_ fail for Rerun's builtin [`Loggable`].
+    ///
+    /// For the fallible version, see [`Loggable::try_to_arrow_opt`].
+    #[inline]
+    fn to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
+    ) -> Box<dyn ::arrow2::array::Array>
+    where
+        Self: Clone + 'a,
+    {
+        Self::try_to_arrow_opt(data, extension_wrapper).unwrap()
+    }
+
+    /// Given an iterator of options of owned or reference values to the current
+    /// [`Loggable`], serializes them into an Arrow array.
+    /// The Arrow array's datatype will match [`Loggable::to_arrow_datatype`].
+    ///
+    /// This will _never_ fail for Rerun's builtin [`Loggable`].
+    /// For the non-fallible version, see [`Loggable::to_arrow_opt`].
+    fn try_to_arrow_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+        extension_wrapper: Option<&str>,
+    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
+    where
+        Self: Clone + 'a;
+
+    // ---
+
+    /// Given an Arrow array, deserializes it into a collection of [`Loggable`]s.
+    ///
+    /// Panics if the data schema doesn't match, or if optional entries were missing at runtime.
+    /// For the non-fallible version, see [`Loggable::try_from_arrow`].
+    #[inline]
+    fn from_arrow(data: &dyn ::arrow2::array::Array) -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        Self::from_arrow_opt(data)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect()
+    }
+
+    /// Given an Arrow array, deserializes it into a collection of optional [`Loggable`]s.
+    ///
+    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
+    /// [`Loggable::to_arrow_datatype`].
+    /// For the non-fallible version, see [`Loggable::from_arrow_opt`].
+    #[inline]
+    fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        Self::try_from_arrow_opt(data)?
+            .into_iter()
+            .map(|v| {
+                v.ok_or_else(|| DeserializationError::MissingData {
+                    datatype: data.data_type().clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Given an Arrow array, deserializes it into a collection of optional [`Loggable`]s.
+    ///
+    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
+    /// [`Loggable::to_arrow_datatype`].
+    /// For the fallible version, see [`Loggable::try_from_arrow_opt`].
+    #[inline]
+    fn from_arrow_opt(data: &dyn ::arrow2::array::Array) -> Vec<Option<Self>>
+    where
+        Self: Sized,
+    {
+        Self::try_from_arrow_opt(data).unwrap()
+    }
+
+    /// Given an Arrow array, deserializes it into a collection of optional [`Loggable`]s.
+    ///
+    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
+    /// [`Loggable::to_arrow_datatype`].
+    /// For the non-fallible version, see [`Loggable::from_arrow_opt`].
+    fn try_from_arrow_opt(
+        data: &dyn ::arrow2::array::Array,
+    ) -> DeserializationResult<Vec<Option<Self>>>
+    where
+        Self: Sized;
+}
+
 /// The fully-qualified name of a [`Datatype`], e.g. `rerun.datatypes.Vec2D`.
 pub type DatatypeName = ::std::borrow::Cow<'static, str>;
 
 /// A [`Datatype`] describes plain old data that can be used by any number of [`Component`].
-pub trait Datatype {
-    /// The fully-qualified name of this datatype, e.g. `rerun.datatypes.Vec2D`.
-    fn name() -> DatatypeName;
-
-    /// The underlying [`arrow2::datatypes::DataType`].
-    fn to_arrow_datatype() -> arrow2::datatypes::DataType;
-
-    // ---
-
-    /// Given an iterator of owned or reference values to the current [`Datatype`], serializes
-    /// them into an Arrow array.
-    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
-    ///
-    /// Panics on failure.
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    ///
-    /// For the fallible version, see [`Datatype::try_to_arrow`].
-    #[inline]
-    fn to_arrow<'a>(
-        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
-        extension_wrapper: Option<&str>,
-    ) -> Box<dyn ::arrow2::array::Array>
-    where
-        Self: Clone + 'a,
-    {
-        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper).unwrap()
-    }
-
-    /// Given an iterator of owned or reference values to the current [`Datatype`], serializes
-    /// them into an Arrow array.
-    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
-    ///
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    /// For the non-fallible version, see [`Datatype::to_arrow`].
-    #[inline]
-    fn try_to_arrow<'a>(
-        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
-        extension_wrapper: Option<&str>,
-    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
-    where
-        Self: Clone + 'a,
-    {
-        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper)
-    }
-
-    /// Given an iterator of options of owned or reference values to the current
-    /// [`Datatype`], serializes them into an Arrow array.
-    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
-    ///
-    /// Panics on failure.
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    ///
-    /// For the fallible version, see [`Datatype::try_to_arrow_opt`].
-    #[inline]
-    fn to_arrow_opt<'a>(
-        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
-        extension_wrapper: Option<&str>,
-    ) -> Box<dyn ::arrow2::array::Array>
-    where
-        Self: Clone + 'a,
-    {
-        Self::try_to_arrow_opt(data, extension_wrapper).unwrap()
-    }
-
-    /// Given an iterator of options of owned or reference values to the current
-    /// [`Datatype`], serializes them into an Arrow array.
-    /// The Arrow array's datatype will match [`Datatype::to_arrow_datatype`].
-    ///
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    /// For the non-fallible version, see [`Datatype::to_arrow_opt`].
-    fn try_to_arrow_opt<'a>(
-        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
-        extension_wrapper: Option<&str>,
-    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
-    where
-        Self: Clone + 'a;
-
-    // ---
-
-    /// Given an Arrow array, deserializes it into a collection of [`Datatype`]s.
-    ///
-    /// Panics if the data schema doesn't match, or if optional entries were missing at runtime.
-    /// For the non-fallible version, see [`Datatype::try_from_arrow`].
-    #[inline]
-    fn from_arrow(data: &dyn ::arrow2::array::Array) -> Vec<Self>
-    where
-        Self: Sized,
-    {
-        Self::from_arrow_opt(data)
-            .into_iter()
-            .map(Option::unwrap)
-            .collect()
-    }
-
-    /// Given an Arrow array, deserializes it into a collection of optional [`Datatype`]s.
-    ///
-    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
-    /// [`Datatype::to_arrow_datatype`].
-    /// For the non-fallible version, see [`Datatype::from_arrow_opt`].
-    #[inline]
-    fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> DeserializationResult<Vec<Self>>
-    where
-        Self: Sized,
-    {
-        Self::try_from_arrow_opt(data)?
-            .into_iter()
-            .map(|v| {
-                v.ok_or_else(|| DeserializationError::MissingData {
-                    datatype: data.data_type().clone(),
-                })
-            })
-            .collect()
-    }
-
-    /// Given an Arrow array, deserializes it into a collection of optional [`Datatype`]s.
-    ///
-    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
-    /// [`Datatype::to_arrow_datatype`].
-    /// For the fallible version, see [`Datatype::try_from_arrow_opt`].
-    #[inline]
-    fn from_arrow_opt(data: &dyn ::arrow2::array::Array) -> Vec<Option<Self>>
-    where
-        Self: Sized,
-    {
-        Self::try_from_arrow_opt(data).unwrap()
-    }
-
-    /// Given an Arrow array, deserializes it into a collection of optional [`Datatype`]s.
-    ///
-    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
-    /// [`Datatype::to_arrow_datatype`].
-    /// For the non-fallible version, see [`Datatype::from_arrow_opt`].
-    fn try_from_arrow_opt(
-        data: &dyn ::arrow2::array::Array,
-    ) -> DeserializationResult<Vec<Option<Self>>>
-    where
-        Self: Sized;
-}
+pub trait Datatype: Loggable {}
 
 /// The fully-qualified name of a [`Component`], e.g. `rerun.components.Point2D`.
 pub type ComponentName = ::std::borrow::Cow<'static, str>;
 
-pub trait Component {
-    /// The fully-qualified name of this component, e.g. `rerun.components.Point2D`.
-    fn name() -> ComponentName;
+pub trait Component: Loggable {}
 
-    /// The underlying [`arrow2::datatypes::DataType`].
-    fn to_arrow_datatype() -> arrow2::datatypes::DataType;
-
-    // ---
-
-    /// Given an iterator of owned or reference values to the current [`Component`], serializes
-    /// them into an Arrow array.
-    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
-    ///
-    /// Panics on failure.
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    ///
-    /// For the fallible version, see [`Component::try_to_arrow`].
-    #[inline]
-    fn to_arrow<'a>(
-        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
-        extension_wrapper: Option<&str>,
-    ) -> Box<dyn ::arrow2::array::Array>
-    where
-        Self: Clone + 'a,
-    {
-        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper).unwrap()
-    }
-
-    /// Given an iterator of owned or reference values to the current [`Component`], serializes
-    /// them into an Arrow array.
-    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
-    ///
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    /// For the non-fallible version, see [`Component::to_arrow`].
-    #[inline]
-    fn try_to_arrow<'a>(
-        data: impl IntoIterator<Item = impl Into<::std::borrow::Cow<'a, Self>>>,
-        extension_wrapper: Option<&str>,
-    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
-    where
-        Self: Clone + 'a,
-    {
-        Self::try_to_arrow_opt(data.into_iter().map(Some), extension_wrapper)
-    }
-
-    /// Given an iterator of options of owned or reference values to the current
-    /// [`Component`], serializes them into an Arrow array.
-    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
-    ///
-    /// Panics on failure.
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    ///
-    /// For the fallible version, see [`Component::try_to_arrow_opt`].
-    #[inline]
-    fn to_arrow_opt<'a>(
-        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
-        extension_wrapper: Option<&str>,
-    ) -> Box<dyn ::arrow2::array::Array>
-    where
-        Self: Clone + 'a,
-    {
-        Self::try_to_arrow_opt(data, extension_wrapper).unwrap()
-    }
-
-    /// Given an iterator of options of owned or reference values to the current
-    /// [`Component`], serializes them into an Arrow array.
-    /// The Arrow array's datatype will match [`Component::to_arrow_datatype`].
-    ///
-    /// This will _never_ fail for Rerun's builtin [`Datatype`].
-    /// For the non-fallible version, see [`Component::to_arrow_opt`].
-    fn try_to_arrow_opt<'a>(
-        data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
-        extension_wrapper: Option<&str>,
-    ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
-    where
-        Self: Clone + 'a;
-
-    // ---
-
-    /// Given an Arrow array, deserializes it into a collection of [`Component`]s.
-    ///
-    /// Panics if the data schema doesn't match, or if optional entries were missing at runtime.
-    /// For the non-fallible version, see [`Component::try_from_arrow`].
-    #[inline]
-    fn from_arrow(data: &dyn ::arrow2::array::Array) -> Vec<Self>
-    where
-        Self: Sized,
-    {
-        Self::from_arrow_opt(data)
-            .into_iter()
-            .map(Option::unwrap)
-            .collect()
-    }
-
-    /// Given an Arrow array, deserializes it into a collection of optional [`Component`]s.
-    ///
-    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
-    /// [`Component::to_arrow_datatype`].
-    /// For the non-fallible version, see [`Component::from_arrow_opt`].
-    #[inline]
-    fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> DeserializationResult<Vec<Self>>
-    where
-        Self: Sized,
-    {
-        Self::try_from_arrow_opt(data)?
-            .into_iter()
-            .map(|v| {
-                v.ok_or_else(|| DeserializationError::MissingData {
-                    datatype: data.data_type().clone(),
-                })
-            })
-            .collect()
-    }
-
-    /// Given an Arrow array, deserializes it into a collection of optional [`Component`]s.
-    ///
-    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
-    /// [`Component::to_arrow_datatype`].
-    /// For the fallible version, see [`Component::try_from_arrow_opt`].
-    #[inline]
-    fn from_arrow_opt(data: &dyn ::arrow2::array::Array) -> Vec<Option<Self>>
-    where
-        Self: Sized,
-    {
-        Self::try_from_arrow_opt(data).unwrap()
-    }
-
-    /// Given an Arrow array, deserializes it into a collection of optional [`Component`]s.
-    ///
-    /// This will _never_ fail for if the Arrow array's datatype matches the one returned by
-    /// [`Component::to_arrow_datatype`].
-    /// For the non-fallible version, see [`Component::from_arrow_opt`].
-    fn try_from_arrow_opt(
-        data: &dyn ::arrow2::array::Array,
-    ) -> DeserializationResult<Vec<Option<Self>>>
-    where
-        Self: Sized;
-}
+// ---
 
 /// The fully-qualified name of an [`Archetype`], e.g. `rerun.archetypes.Points2D`.
 pub type ArchetypeName = ::std::borrow::Cow<'static, str>;

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -664,9 +664,11 @@ fn quote_trait_impls_from_obj(
             quote! {
                 #into_cow
 
-                impl crate::#kind for #name {
+                impl crate::Loggable for #name {
+                    type Name = crate::#kind_name;
+
                     #[inline]
-                    fn name() -> crate::#kind_name {
+                    fn name() -> Self::Name {
                         crate::#kind_name::Borrowed(#legacy_fqname)
                     }
 
@@ -687,7 +689,7 @@ fn quote_trait_impls_from_obj(
                         Self: Clone + 'a
                     {
                         use ::arrow2::{datatypes::*, array::*};
-                        use crate::{Component as _, Datatype as _};
+                        use crate::Loggable as _;
                         Ok(#quoted_serializer)
                     }
 
@@ -697,10 +699,12 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Sized {
                         use ::arrow2::{datatypes::*, array::*};
-                        use crate::{Component as _, Datatype as _};
+                        use crate::Loggable as _;
                         Ok(#quoted_deserializer)
                     }
                 }
+
+                impl crate::#kind for #name {}
             }
         }
         ObjectKind::Archetype => {
@@ -888,7 +892,7 @@ fn quote_trait_impls_from_obj(
                     fn try_to_arrow(
                         &self,
                     ) -> crate::SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>> {
-                        use crate::Component as _;
+                        use crate::Loggable as _;
                         Ok([ #({ #all_serializers },)* ].into_iter().flatten().collect())
                     }
 
@@ -896,7 +900,7 @@ fn quote_trait_impls_from_obj(
                     fn try_from_arrow(
                         data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn::arrow2::array::Array>)>,
                     ) -> crate::DeserializationResult<Self> {
-                        use crate::Component as _;
+                        use crate::Loggable as _;
 
                         let arrays_by_name: ::std::collections::HashMap<_, _> = data
                             .into_iter()


### PR DESCRIPTION
**commit by commit!**

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2677) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2677)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fdatatype_component_are_one_and_the_sanme/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fdatatype_component_are_one_and_the_sanme/examples)