### PR TITLE
Run ruff before black when formatting python code

### DIFF
--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -133,6 +133,19 @@ fn main() {
         .to_string_lossy()
         .to_string();
 
+    // NOTE: We're purposefully ignoring the error here.
+    //
+    // If the user doesn't have `ruff` in their $PATH, there's still no good reason to fail
+    // the build.
+    //
+    // The CI will catch the unformatted files at PR time and complain appropriately anyhow.
+    cmd!(
+        sh,
+        "ruff --config {pyproject_path} --fix {PYTHON_OUTPUT_DIR_PATH}"
+    )
+    .run()
+    .ok();
+
     // NOTE: This requires both `black` and `ruff` to be in $PATH, but only for contributors,
     // not end users.
     // Even for contributors, `black` and `ruff` won't be needed unless they edit some of the
@@ -148,19 +161,6 @@ fn main() {
     cmd!(
         sh,
         "black --config {pyproject_path} {PYTHON_OUTPUT_DIR_PATH}"
-    )
-    .run()
-    .ok();
-
-    // NOTE: We're purposefully ignoring the error here.
-    //
-    // If the user doesn't have `ruff` in their $PATH, there's still no good reason to fail
-    // the build.
-    //
-    // The CI will catch the unformatted files at PR time and complain appropriately anyhow.
-    cmd!(
-        sh,
-        "ruff --config {pyproject_path} --fix {PYTHON_OUTPUT_DIR_PATH}"
     )
     .run()
     .ok();

--- a/justfile
+++ b/justfile
@@ -72,12 +72,12 @@ py-build *ARGS:
 py-format:
     #!/usr/bin/env bash
     set -euxo pipefail
-    black --config rerun_py/pyproject.toml {{py_folders}}
-    blackdoc {{py_folders}}
     # Note: proto.py relies on old-style annotation to work, and pyupgrade is too opinionated to be disabled from comments
     # See https://github.com/rerun-io/rerun/pull/2559 for details
     pyupgrade --py38-plus `find {{py_folders}} -name "*.py" -type f ! -path "examples/python/objectron/proto/objectron/proto.py"`
     ruff --fix --config rerun_py/pyproject.toml  {{py_folders}}
+    black --config rerun_py/pyproject.toml {{py_folders}}
+    blackdoc {{py_folders}}
 
 # Check that all the requirements.txt files for all the examples are correct
 py-requirements:
@@ -89,9 +89,9 @@ py-requirements:
 py-lint:
     #!/usr/bin/env bash
     set -euxo pipefail
+    ruff check --config rerun_py/pyproject.toml  {{py_folders}}
     black --check --config rerun_py/pyproject.toml --diff {{py_folders}}
     blackdoc --check {{py_folders}}
-    ruff check --config rerun_py/pyproject.toml  {{py_folders}}
     mypy --no-warn-unused-ignore
 
 # Run fast unittests


### PR DESCRIPTION
### What
There are some edge cases where ruff code-modifications are subsequently formatted by black.

Running ruff first seems to make sense.  Really hoping to avoid needing to loop over both multiple times.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2681) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2681)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Flinting_order/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Flinting_order/examples)