### PR TITLE
Format python with: black, ruff, black

### DIFF
--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -154,12 +154,6 @@ fn main() {
 }
 
 fn call_black(sh: &Shell, pyproject_path: &String) {
-    // NOTE: This requires both `black` and `ruff` to be in $PATH, but only for contributors,
-    // not end users.
-    // Even for contributors, `black` and `ruff` won't be needed unless they edit some of the
-    // .fbs files... and even then, this won't crash if they are missing, it will just fail to pass
-    // the CI!
-
     // NOTE: We're purposefully ignoring the error here.
     //
     // If the user doesn't have `black` in their $PATH, there's still no good reason to fail

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -144,7 +144,7 @@ fn main() {
     //
     // 1) Call black, which among others things fixes line-length
     // 2) Call ruff, which requires line-lengths to be correct
-    // 3) Call black again to cleanup some whitespace issues
+    // 3) Call black again to cleanup some whitespace issues ruff might introduce
 
     call_black(&sh, &pyproject_path);
     call_ruff(&sh, &pyproject_path);

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -133,19 +133,27 @@ fn main() {
         .to_string_lossy()
         .to_string();
 
-    // NOTE: We're purposefully ignoring the error here.
+    // NOTE: This requires both `black` and `ruff` to be in $PATH, but only for contributors,
+    // not end users.
+    // Even for contributors, `black` and `ruff` won't be needed unless they edit some of the
+    // .fbs files... and even then, this won't crash if they are missing, it will just fail to pass
+    // the CI!
     //
-    // If the user doesn't have `ruff` in their $PATH, there's still no good reason to fail
-    // the build.
+    // The order below is important and sadly we need to call black twice. Ruff does not yet
+    // fix line-length (See: https://github.com/astral-sh/ruff/issues/1904).
     //
-    // The CI will catch the unformatted files at PR time and complain appropriately anyhow.
-    cmd!(
-        sh,
-        "ruff --config {pyproject_path} --fix {PYTHON_OUTPUT_DIR_PATH}"
-    )
-    .run()
-    .ok();
+    // 1) Call black, which among others things fixes line-length
+    // 2) Call ruff, which requires line-lengths to be correct
+    // 3) Call black again to cleanup some whitespace issues
 
+    call_black(&sh, &pyproject_path);
+    call_ruff(&sh, &pyproject_path);
+    call_black(&sh, &pyproject_path);
+
+    write_versioning_hash(SOURCE_HASH_PATH, new_hash);
+}
+
+fn call_black(sh: &Shell, pyproject_path: &String) {
     // NOTE: This requires both `black` and `ruff` to be in $PATH, but only for contributors,
     // not end users.
     // Even for contributors, `black` and `ruff` won't be needed unless they edit some of the
@@ -164,6 +172,19 @@ fn main() {
     )
     .run()
     .ok();
+}
 
-    write_versioning_hash(SOURCE_HASH_PATH, new_hash);
+fn call_ruff(sh: &Shell, pyproject_path: &String) {
+    // NOTE: We're purposefully ignoring the error here.
+    //
+    // If the user doesn't have `ruff` in their $PATH, there's still no good reason to fail
+    // the build.
+    //
+    // The CI will catch the unformatted files at PR time and complain appropriately anyhow.
+    cmd!(
+        sh,
+        "ruff --config {pyproject_path} --fix {PYTHON_OUTPUT_DIR_PATH}"
+    )
+    .run()
+    .ok();
 }

--- a/justfile
+++ b/justfile
@@ -75,6 +75,12 @@ py-format:
     # Note: proto.py relies on old-style annotation to work, and pyupgrade is too opinionated to be disabled from comments
     # See https://github.com/rerun-io/rerun/pull/2559 for details
     pyupgrade --py38-plus `find {{py_folders}} -name "*.py" -type f ! -path "examples/python/objectron/proto/objectron/proto.py"`
+    # The order below is important and sadly we need to call black twice. Ruff does not yet
+    # fix line-length (See: https://github.com/astral-sh/ruff/issues/1904).
+    #
+    # 1) Call black, which among others things fixes line-length
+    # 2) Call ruff, which requires line-lengths to be correct
+    # 3) Call black again to cleanup some whitespace issues ruff might introduce
     black --config rerun_py/pyproject.toml {{py_folders}}
     ruff --fix --config rerun_py/pyproject.toml  {{py_folders}}
     black --config rerun_py/pyproject.toml {{py_folders}}

--- a/justfile
+++ b/justfile
@@ -75,6 +75,7 @@ py-format:
     # Note: proto.py relies on old-style annotation to work, and pyupgrade is too opinionated to be disabled from comments
     # See https://github.com/rerun-io/rerun/pull/2559 for details
     pyupgrade --py38-plus `find {{py_folders}} -name "*.py" -type f ! -path "examples/python/objectron/proto/objectron/proto.py"`
+    black --config rerun_py/pyproject.toml {{py_folders}}
     ruff --fix --config rerun_py/pyproject.toml  {{py_folders}}
     black --config rerun_py/pyproject.toml {{py_folders}}
     blackdoc {{py_folders}}


### PR DESCRIPTION
### What
The previous PR: https://github.com/rerun-io/rerun/pull/2681 turned out not to handle all edge-cases.

Ruff does not currently format line-lengths which causes ruff to fail if black hasn't been run first. For now we just need to call black twice.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2686) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2686)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Fblack_ruff_black/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Fblack_ruff_black/examples)