### PR TITLE
Weekly crates.io release

### DIFF
--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -1,0 +1,53 @@
+name: Release a branch or target with the given version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * MON"
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: "write"
+
+jobs:
+  create-release:
+    name: "Create Release"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -r scripts/ci/requirements.txt
+
+      - name: Update crate versions
+        run: |
+          python3 scripts/ci/crates.py version prerelease
+
+      - name: Get version
+        run: |
+          CRATE_VERSION=$(python3 scripts/ci/crates.py get-version)
+          echo "CRATE_VERSION=$CRATE_VERSION" >> "$GITHUB_ENV"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          commit-message: "[weekly-release] ${{ env.CRATE_VERSION }}"
+
+  publish-crates:
+    name: "Publish Crates"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.event.head_commit.message, '[weekly-release]')
+    steps:
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -r scripts/ci/requirements.txt
+
+      - name: Publish
+        run: |
+          python3 scripts/ci/crates.py release --token ${{ secrets.CRATES_IO_TOKEN }}
+

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -1,4 +1,4 @@
-name: Release a branch or target with the given version
+name: Weekly release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -3,7 +3,7 @@ name: Release a branch or target with the given version
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * MON"
+    - cron: "0 14 * * MON"
   push:
     branches: [main]
 

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -22,6 +22,7 @@ import argparse
 import os.path
 import shutil
 import subprocess
+import sys
 from enum import Enum
 from glob import glob
 from pathlib import Path
@@ -333,6 +334,14 @@ def publish(dry_run: bool, token: str) -> None:
                 sleep((1 - elapsed_s))
 
 
+def get_version() -> None:
+    root: dict[str, Any] = tomlkit.parse(Path("Cargo.toml").read_text())
+    current_version = VersionInfo.parse(root["workspace"]["package"]["version"])
+
+    sys.stdout.write(str(current_version))
+    sys.stdout.flush()
+
+
 def main() -> None:
     colorama_init()
     parser = argparse.ArgumentParser(description="Generate a PR summary page")
@@ -344,8 +353,11 @@ def main() -> None:
     publish_parser.add_argument("--token", type=str, help="crates.io token")
     publish_parser.add_argument("--dry-run", action="store_true", help="Display the execution plan")
     publish_parser.add_argument("--allow-dirty", action="store_true", help="Allow uncommitted changes")
+    cmds_parser.add_parser("get-version", help="Get the current crate version")
     args = parser.parse_args()
 
+    if args.cmd == "get-version":
+        get_version()
     if args.cmd == "version":
         version(args.dry_run, args.bump)
     if args.cmd == "publish":

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import os.path
+import shutil
 import subprocess
 from enum import Enum
 from glob import glob
@@ -33,9 +34,11 @@ from colorama import Fore
 from colorama import init as colorama_init
 from semver import VersionInfo
 
+CARGO_PATH = shutil.which("cargo") or "cargo"
+
 
 def cargo(args: str, cwd: str | Path | None = None, env: dict[str, Any] = {}) -> Any:
-    subprocess.check_output(["cargo"] + args.split(), cwd=cwd, env=env)
+    subprocess.check_output([CARGO_PATH] + args.split(), cwd=cwd, env=env)
 
 
 class Crate:


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Part of https://github.com/rerun-io/rerun/issues/1343

- Adds `get-version` command to `scripts/ci/crates.py`, which can be used to query the current version specified in the root `Cargo.toml`
- Adds the `weekly_release` workflow, which runs at 2 PM every monday. It will:
  - Bump the crate versions, and create a pull request
  - Once the pull request is merged, it will release all crates

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2710) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2710)
- [Docs preview](https://rerun.io/preview/pr%3Ajan%2Frelease-crates-weekly/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajan%2Frelease-crates-weekly/examples)