### PR TITLE
Fix flickering of orbit camera indicator

### DIFF
--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -52,7 +52,8 @@ pub struct View3DState {
     pub show_axes: bool,
     pub show_bbox: bool,
 
-    last_eye_interact_time: f64,
+    eye_interact_fade_in: bool,
+    eye_interact_fade_change_time: f64,
 }
 
 impl Default for View3DState {
@@ -65,7 +66,8 @@ impl Default for View3DState {
             spin: false,
             show_axes: false,
             show_bbox: false,
-            last_eye_interact_time: f64::NEG_INFINITY,
+            eye_interact_fade_in: false,
+            eye_interact_fade_change_time: f64::NEG_INFINITY,
         }
     }
 }
@@ -313,7 +315,6 @@ pub fn view_3d(
     let eye = orbit_eye.to_eye();
 
     if did_interact_with_eye {
-        state.state_3d.last_eye_interact_time = ui.input(|i| i.time);
         state.state_3d.eye_interpolation = None;
         state.state_3d.tracked_camera = None;
         state.state_3d.camera_before_tracked_camera = None;
@@ -477,24 +478,46 @@ pub fn view_3d(
         }
     }
 
+    // Show center of orbit camera when interacting with camera (it's quite helpful).
     {
-        let orbit_center_alpha = egui::remap_clamp(
-            ui.input(|i| i.time) - state.state_3d.last_eye_interact_time,
-            0.0..=0.4,
-            1.0..=0.0,
-        ) as f32;
+        const FADE_DURATION: f32 = 0.1;
+        const FADE_OUT_DELAY: f64 = 0.4; // Need a relatively high delay, otherwise interaction from mouse wheel looks pretty bad.
 
-        if orbit_center_alpha > 0.0 {
-            // Show center of orbit camera when interacting with camera (it's quite helpful).
+        let ui_time = ui.input(|i| i.time);
+
+        if did_interact_with_eye && !state.state_3d.eye_interact_fade_in {
+            // Any interaction immediately causes fade in to start if it's not already on.
+            state.state_3d.eye_interact_fade_change_time = ui_time;
+            state.state_3d.eye_interact_fade_in = true;
+        } else if state.state_3d.eye_interact_fade_in
+            && !ui.input(|i| i.pointer.any_down())
+            && ui_time - state.state_3d.eye_interact_fade_change_time > FADE_OUT_DELAY
+        {
+            // Fade out on the other hand only happens if no mouse cursor is pressed and a bit of time has passed.
+            state.state_3d.eye_interact_fade_change_time = ui_time;
+            state.state_3d.eye_interact_fade_in = false;
+        }
+
+        pub fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+            let t = f32::clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+            t * t * (3.0 - t * 2.0)
+        }
+
+        // Compute smooth fade.
+        let time_since_fade_change =
+            (ui_time - state.state_3d.eye_interact_fade_change_time) as f32;
+        let orbit_center_fade = if state.state_3d.eye_interact_fade_in {
+            // Fade in.
+            smoothstep(0.0, FADE_DURATION, time_since_fade_change)
+        } else {
+            // Fade out.
+            smoothstep(FADE_DURATION, 0.0, time_since_fade_change)
+        };
+
+        if orbit_center_fade > 0.001 {
             let half_line_length = orbit_eye.orbit_radius * 0.03;
 
-            // We can't fade via alpha yet, but we can do so by making it smaller.
-            // Do so very quickly at the end of time we display "show period".
-            pub fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
-                let t = f32::clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
-                t * t * (3.0 - t * 2.0)
-            }
-            let half_line_length = half_line_length * smoothstep(0.0, 0.2, orbit_center_alpha);
+            let half_line_length = half_line_length * orbit_center_fade;
 
             line_builder
                 .batch("center orbit orientation help")

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -481,19 +481,21 @@ pub fn view_3d(
     // Show center of orbit camera when interacting with camera (it's quite helpful).
     {
         const FADE_DURATION: f32 = 0.1;
-        const FADE_OUT_DELAY: f64 = 0.4; // Need a relatively high delay, otherwise interaction from mouse wheel looks pretty bad.
 
         let ui_time = ui.input(|i| i.time);
+        let any_mouse_button_down = ui.input(|i| i.pointer.any_down());
 
-        if did_interact_with_eye && !state.state_3d.eye_interact_fade_in {
+        // Don't show for merely scrolling.
+        // Scroll events from a mouse wheel often happen with some pause between meaning we either need a long delay for the center to show
+        // or live with the flickering.
+        let should_show_center_of_orbit_camera = did_interact_with_eye && any_mouse_button_down;
+
+        if should_show_center_of_orbit_camera && !state.state_3d.eye_interact_fade_in {
             // Any interaction immediately causes fade in to start if it's not already on.
             state.state_3d.eye_interact_fade_change_time = ui_time;
             state.state_3d.eye_interact_fade_in = true;
-        } else if state.state_3d.eye_interact_fade_in
-            && !ui.input(|i| i.pointer.any_down())
-            && ui_time - state.state_3d.eye_interact_fade_change_time > FADE_OUT_DELAY
-        {
-            // Fade out on the other hand only happens if no mouse cursor is pressed and a bit of time has passed.
+        } else if state.state_3d.eye_interact_fade_in && !any_mouse_button_down {
+            // Fade out on the other hand only happens if no mouse cursor is pressed.
             state.state_3d.eye_interact_fade_change_time = ui_time;
             state.state_3d.eye_interact_fade_in = false;
         }

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -481,12 +481,20 @@ pub fn view_3d(
         let orbit_center_alpha = egui::remap_clamp(
             ui.input(|i| i.time) - state.state_3d.last_eye_interact_time,
             0.0..=0.4,
-            0.7..=0.0,
+            1.0..=0.0,
         ) as f32;
 
         if orbit_center_alpha > 0.0 {
             // Show center of orbit camera when interacting with camera (it's quite helpful).
             let half_line_length = orbit_eye.orbit_radius * 0.03;
+
+            // We can't fade via alpha yet, but we can do so by making it smaller.
+            // Do so very quickly at the end of time we display "show period".
+            pub fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+                let t = f32::clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+                t * t * (3.0 - t * 2.0)
+            }
+            let half_line_length = half_line_length * smoothstep(0.0, 0.2, orbit_center_alpha);
 
             line_builder
                 .batch("center orbit orientation help")


### PR DESCRIPTION
and make it disappear more smoothly by collapsing inwards

Fixes #2201
* #2201

Stressing it a bit by holding the mouse still and moving just when it disappears again:
https://github.com/rerun-io/rerun/assets/1220815/5d53dd1b-a7bb-4846-8ad5-fd422fe7ed2d
But I think this works out now fine enough.




### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2746) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2746)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-flickering-orbit-center/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-flickering-orbit-center/examples)