### PR TITLE
Cpp codegen to_arrow_data_type for unions

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,8 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-<<<<<<< HEAD
-70102e74a219445db03e9e5d914687f1756e85b35d93e187dd3346d87b99f806
-=======
-b4f2c2b3b6518fd5c5b8fe2255952c6986895efe58cbc6ae0b56b0384a9ad930
->>>>>>> origin/main
+94f7feacba1a7d75fee69d10294c77e2f4539106e4906f3d58a5db776e11c4be

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -393,44 +393,37 @@ impl QuotedObject {
             })
             .collect_vec();
 
-        let implicit_constructors = if are_types_disjoint(&obj.fields) {
+        let mut methods = Vec::new();
+
+        // Static constructors:
+        for obj_field in &obj.fields {
+            methods.push(static_constructor_for_enum_type(
+                objects,
+                &mut hpp_includes,
+                obj_field,
+                &pascal_case_ident,
+                &tag_typename,
+            ));
+        }
+
+        if are_types_disjoint(&obj.fields) {
             // Implicit construct from the different variant types:
-            obj.fields
-                .iter()
-                .map(|obj_field| {
-                    let snake_case_ident =
-                        format_ident!("{}", crate::to_snake_case(&obj_field.name));
-                    let docstring = quote_docstrings(&obj_field.docs);
-                    let param_declaration =
-                        quote_declaration(&mut hpp_includes, obj_field, &snake_case_ident);
-                    quote! {
-                        #docstring
-                        #pascal_case_ident(#param_declaration)
-                        {
-                            *this = #pascal_case_ident::#snake_case_ident(std::move(#snake_case_ident));
-                        }
-                    }
-                })
-                .collect_vec()
+            for obj_field in &obj.fields {
+                let snake_case_ident = format_ident!("{}", crate::to_snake_case(&obj_field.name));
+                let param_declaration =
+                    quote_declaration(&mut hpp_includes, obj_field, &snake_case_ident);
+
+                methods.push(Method {
+                    docs: obj_field.docs.clone().into(),
+                    declaration: MethodDeclaration::constructor(quote!(#pascal_case_ident(#param_declaration))),
+                    definition_body: quote!(*this = #pascal_case_ident::#snake_case_ident(std::move(#snake_case_ident));),
+                    inline: true,
+                });
+            }
         } else {
             // Cannot make implicit constructors, e.g. for
             // `enum Angle { Radians(f32), Degrees(f32) };`
-            vec![]
         };
-
-        let static_constructors = obj
-            .fields
-            .iter()
-            .map(|obj_field| {
-                quote_static_constructor_for_enum_type(
-                    objects,
-                    &mut hpp_includes,
-                    obj_field,
-                    &pascal_case_ident,
-                    &tag_typename,
-                )
-            })
-            .collect_vec();
 
         let destructor = if obj.has_default_destructor(objects) {
             // No destructor needed
@@ -496,6 +489,7 @@ impl QuotedObject {
         };
 
         hpp_includes.system.insert("cstring".to_owned()); // std::memcpy
+        let hpp_methods = methods.iter().map(|m| m.to_hpp_tokens());
 
         let swap_comment = comment("This bitwise swap would fail for self-referential types, but we don't have any of those.");
 
@@ -550,9 +544,7 @@ impl QuotedObject {
 
                         #destructor
 
-                        #(#static_constructors)*
-
-                        #(#implicit_constructors)*
+                        #(#hpp_methods)*
 
                         // This is useful for easily implementing the move constructor and move assignment operator:
                         void swap(#pascal_case_ident& other) noexcept {
@@ -588,7 +580,7 @@ fn arrow_data_type_method(
     let quoted_datatype = quote_arrow_data_type(datatype, cpp_includes, true);
 
     Method {
-        doc_string: "Returns the arrow data type this type corresponds to.".to_owned(),
+        docs: "Returns the arrow data type this type corresponds to.".into(),
         declaration: MethodDeclaration {
             is_static: true,
             return_type: quote! { std::shared_ptr<arrow::DataType> },
@@ -600,18 +592,23 @@ fn arrow_data_type_method(
 }
 
 /// e.g. `static Angle radians(float radians);` -> `auto angle = Angle::radians(radians);`
-fn quote_static_constructor_for_enum_type(
+fn static_constructor_for_enum_type(
     objects: &Objects,
     hpp_includes: &mut Includes,
     obj_field: &ObjectField,
     pascal_case_ident: &Ident,
     tag_typename: &Ident,
-) -> TokenStream {
+) -> Method {
     let tag_ident = format_ident!("{}", obj_field.name);
     let snake_case_ident = format_ident!("{}", crate::to_snake_case(&obj_field.name));
-    let docstring = quote_docstrings(&obj_field.docs);
+    let docs = obj_field.docs.clone().into();
 
     let param_declaration = quote_declaration(hpp_includes, obj_field, &snake_case_ident);
+    let declaration = MethodDeclaration {
+        is_static: true,
+        return_type: quote!(#pascal_case_ident),
+        name_and_parameters: quote!(#snake_case_ident(#param_declaration)),
+    };
 
     if let Type::Array { elem_type, length } = &obj_field.typ {
         // We need special casing for constructing arrays:
@@ -632,10 +629,10 @@ fn quote_static_constructor_for_enum_type(
 
         let elem_type = quote_element_type(hpp_includes, elem_type);
 
-        quote! {
-            #docstring
-            static #pascal_case_ident #snake_case_ident(#param_declaration)
-            {
+        Method {
+            docs,
+            declaration,
+            definition_body: quote! {
                 typedef #elem_type TypeAlias;
                 #pascal_case_ident self;
                 self._tag = detail::#tag_typename::#tag_ident;
@@ -643,35 +640,38 @@ fn quote_static_constructor_for_enum_type(
                     #element_assignment
                 }
                 return std::move(self);
-            }
+            },
+            inline: true,
         }
     } else if obj_field.typ.has_default_destructor(objects) {
         // Generate simpler code for simple types:
-        quote! {
-            #docstring
-            static #pascal_case_ident #snake_case_ident(#param_declaration)
-            {
+        Method {
+            docs,
+            declaration,
+            definition_body: quote! {
                 #pascal_case_ident self;
                 self._tag = detail::#tag_typename::#tag_ident;
                 self._data.#snake_case_ident = std::move(#snake_case_ident);
                 return std::move(self);
-            }
+            },
+            inline: true,
         }
     } else {
         // We need to use placement-new since the union is in an uninitialized state here:
         hpp_includes.system.insert("new".to_owned()); // placement-new
         let typedef_declaration =
             quote_declaration(hpp_includes, obj_field, &format_ident!("TypeAlias"));
-        quote! {
-            #docstring
-            static #pascal_case_ident #snake_case_ident(#param_declaration)
-            {
+        Method {
+            docs,
+            declaration,
+            definition_body: quote! {
                 typedef #typedef_declaration;
                 #pascal_case_ident self;
                 self._tag = detail::#tag_typename::#tag_ident;
                 new (&self._data.#snake_case_ident) TypeAlias(std::move(#snake_case_ident));
                 return std::move(self);
-            }
+            },
+            inline: true,
         }
     }
 }

--- a/rerun_cpp/src/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer14.cpp
@@ -3,29 +3,14 @@
 
 #include "affix_fuzzer14.hpp"
 
-#include "../datatypes/affix_fuzzer1.hpp"
+#include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
         std::shared_ptr<arrow::DataType> AffixFuzzer14::to_arrow_datatype() {
-            return arrow::dense_union({
-                arrow::field("_null_markers", arrow::null(), true, nullptr),
-                arrow::field("degrees", arrow::float32(), false, nullptr),
-                arrow::field("radians", arrow::float32(), false, nullptr),
-                arrow::field(
-                    "craziness",
-                    arrow::list(arrow::field(
-                        "item", rr::datatypes::AffixFuzzer1::to_arrow_datatype(), false, nullptr)),
-                    false,
-                    nullptr),
-                arrow::field("fixed_size_shenanigans",
-                             arrow::fixed_size_list(
-                                 arrow::field("item", arrow::float32(), false, nullptr), 3),
-                             false,
-                             nullptr),
-            });
+            return rr::datatypes::AffixFuzzer3::to_arrow_datatype();
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer15.cpp
@@ -3,29 +3,14 @@
 
 #include "affix_fuzzer15.hpp"
 
-#include "../datatypes/affix_fuzzer1.hpp"
+#include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
         std::shared_ptr<arrow::DataType> AffixFuzzer15::to_arrow_datatype() {
-            return arrow::dense_union({
-                arrow::field("_null_markers", arrow::null(), true, nullptr),
-                arrow::field("degrees", arrow::float32(), false, nullptr),
-                arrow::field("radians", arrow::float32(), false, nullptr),
-                arrow::field(
-                    "craziness",
-                    arrow::list(arrow::field(
-                        "item", rr::datatypes::AffixFuzzer1::to_arrow_datatype(), false, nullptr)),
-                    false,
-                    nullptr),
-                arrow::field("fixed_size_shenanigans",
-                             arrow::fixed_size_list(
-                                 arrow::field("item", arrow::float32(), false, nullptr), 3),
-                             false,
-                             nullptr),
-            });
+            return rr::datatypes::AffixFuzzer3::to_arrow_datatype();
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer16.cpp
@@ -3,7 +3,7 @@
 
 #include "affix_fuzzer16.hpp"
 
-#include "../datatypes/affix_fuzzer1.hpp"
+#include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/api.h>
 
@@ -11,27 +11,7 @@ namespace rr {
     namespace components {
         std::shared_ptr<arrow::DataType> AffixFuzzer16::to_arrow_datatype() {
             return arrow::list(arrow::field(
-                "item",
-                arrow::dense_union({
-                    arrow::field("_null_markers", arrow::null(), true, nullptr),
-                    arrow::field("degrees", arrow::float32(), false, nullptr),
-                    arrow::field("radians", arrow::float32(), false, nullptr),
-                    arrow::field(
-                        "craziness",
-                        arrow::list(arrow::field("item",
-                                                 rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                                 false,
-                                                 nullptr)),
-                        false,
-                        nullptr),
-                    arrow::field("fixed_size_shenanigans",
-                                 arrow::fixed_size_list(
-                                     arrow::field("item", arrow::float32(), false, nullptr), 3),
-                                 false,
-                                 nullptr),
-                }),
-                false,
-                nullptr));
+                "item", rr::datatypes::AffixFuzzer3::to_arrow_datatype(), false, nullptr));
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer17.cpp
@@ -3,7 +3,7 @@
 
 #include "affix_fuzzer17.hpp"
 
-#include "../datatypes/affix_fuzzer1.hpp"
+#include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/api.h>
 
@@ -11,27 +11,7 @@ namespace rr {
     namespace components {
         std::shared_ptr<arrow::DataType> AffixFuzzer17::to_arrow_datatype() {
             return arrow::list(arrow::field(
-                "item",
-                arrow::dense_union({
-                    arrow::field("_null_markers", arrow::null(), true, nullptr),
-                    arrow::field("degrees", arrow::float32(), false, nullptr),
-                    arrow::field("radians", arrow::float32(), false, nullptr),
-                    arrow::field(
-                        "craziness",
-                        arrow::list(arrow::field("item",
-                                                 rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                                 false,
-                                                 nullptr)),
-                        false,
-                        nullptr),
-                    arrow::field("fixed_size_shenanigans",
-                                 arrow::fixed_size_list(
-                                     arrow::field("item", arrow::float32(), false, nullptr), 3),
-                                 false,
-                                 nullptr),
-                }),
-                true,
-                nullptr));
+                "item", rr::datatypes::AffixFuzzer3::to_arrow_datatype(), true, nullptr));
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer18.cpp
@@ -3,7 +3,7 @@
 
 #include "affix_fuzzer18.hpp"
 
-#include "../datatypes/affix_fuzzer1.hpp"
+#include "../datatypes/affix_fuzzer4.hpp"
 
 #include <arrow/api.h>
 
@@ -11,89 +11,7 @@ namespace rr {
     namespace components {
         std::shared_ptr<arrow::DataType> AffixFuzzer18::to_arrow_datatype() {
             return arrow::list(arrow::field(
-                "item",
-                arrow::dense_union({
-                    arrow::field("_null_markers", arrow::null(), true, nullptr),
-                    arrow::field(
-                        "single_required",
-                        arrow::dense_union({
-                            arrow::field("_null_markers", arrow::null(), true, nullptr),
-                            arrow::field("degrees", arrow::float32(), false, nullptr),
-                            arrow::field("radians", arrow::float32(), false, nullptr),
-                            arrow::field("craziness",
-                                         arrow::list(arrow::field(
-                                             "item",
-                                             rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                             false,
-                                             nullptr)),
-                                         false,
-                                         nullptr),
-                            arrow::field(
-                                "fixed_size_shenanigans",
-                                arrow::fixed_size_list(
-                                    arrow::field("item", arrow::float32(), false, nullptr), 3),
-                                false,
-                                nullptr),
-                        }),
-                        false,
-                        nullptr),
-                    arrow::field(
-                        "many_required",
-                        arrow::list(arrow::field(
-                            "item",
-                            arrow::dense_union({
-                                arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                arrow::field("degrees", arrow::float32(), false, nullptr),
-                                arrow::field("radians", arrow::float32(), false, nullptr),
-                                arrow::field("craziness",
-                                             arrow::list(arrow::field(
-                                                 "item",
-                                                 rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                                 false,
-                                                 nullptr)),
-                                             false,
-                                             nullptr),
-                                arrow::field(
-                                    "fixed_size_shenanigans",
-                                    arrow::fixed_size_list(
-                                        arrow::field("item", arrow::float32(), false, nullptr), 3),
-                                    false,
-                                    nullptr),
-                            }),
-                            false,
-                            nullptr)),
-                        false,
-                        nullptr),
-                    arrow::field(
-                        "many_optional",
-                        arrow::list(arrow::field(
-                            "item",
-                            arrow::dense_union({
-                                arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                arrow::field("degrees", arrow::float32(), false, nullptr),
-                                arrow::field("radians", arrow::float32(), false, nullptr),
-                                arrow::field("craziness",
-                                             arrow::list(arrow::field(
-                                                 "item",
-                                                 rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                                 false,
-                                                 nullptr)),
-                                             false,
-                                             nullptr),
-                                arrow::field(
-                                    "fixed_size_shenanigans",
-                                    arrow::fixed_size_list(
-                                        arrow::field("item", arrow::float32(), false, nullptr), 3),
-                                    false,
-                                    nullptr),
-                            }),
-                            true,
-                            nullptr)),
-                        false,
-                        nullptr),
-                }),
-                true,
-                nullptr));
+                "item", rr::datatypes::AffixFuzzer4::to_arrow_datatype(), true, nullptr));
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/transform3d.cpp
+++ b/rerun_cpp/src/components/transform3d.cpp
@@ -3,25 +3,14 @@
 
 #include "transform3d.hpp"
 
-#include "../datatypes/translation_and_mat3x3.hpp"
-#include "../datatypes/translation_rotation_scale3d.hpp"
+#include "../datatypes/transform3d.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
         std::shared_ptr<arrow::DataType> Transform3D::to_arrow_datatype() {
-            return arrow::dense_union({
-                arrow::field("_null_markers", arrow::null(), true, nullptr),
-                arrow::field("TranslationAndMat3x3",
-                             rr::datatypes::TranslationAndMat3x3::to_arrow_datatype(),
-                             false,
-                             nullptr),
-                arrow::field("TranslationRotationScale",
-                             rr::datatypes::TranslationRotationScale3D::to_arrow_datatype(),
-                             false,
-                             nullptr),
-            });
+            return rr::datatypes::Transform3D::to_arrow_datatype();
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer3.cpp
@@ -2,3 +2,30 @@
 // Based on "crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs"
 
 #include "affix_fuzzer3.hpp"
+
+#include "../datatypes/affix_fuzzer1.hpp"
+
+#include <arrow/api.h>
+
+namespace rr {
+    namespace datatypes {
+        std::shared_ptr<arrow::DataType> AffixFuzzer3::to_arrow_datatype() {
+            return arrow::dense_union({
+                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                arrow::field("degrees", arrow::float32(), false, nullptr),
+                arrow::field("radians", arrow::float32(), false, nullptr),
+                arrow::field(
+                    "craziness",
+                    arrow::list(arrow::field(
+                        "item", rr::datatypes::AffixFuzzer1::to_arrow_datatype(), false, nullptr)),
+                    false,
+                    nullptr),
+                arrow::field("fixed_size_shenanigans",
+                             arrow::fixed_size_list(
+                                 arrow::field("item", arrow::float32(), false, nullptr), 3),
+                             false,
+                             nullptr),
+            });
+        }
+    } // namespace datatypes
+} // namespace rr

--- a/rerun_cpp/src/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer3.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <new>
 #include <optional>
 #include <utility>
@@ -120,6 +121,9 @@ namespace rr {
                 }
                 return std::move(self);
             }
+
+            /// Returns the arrow data type this type corresponds to.
+            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
 
             void swap(AffixFuzzer3& other) noexcept {
                 auto tag_temp = this->_tag;

--- a/rerun_cpp/src/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer4.cpp
@@ -2,3 +2,33 @@
 // Based on "crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs"
 
 #include "affix_fuzzer4.hpp"
+
+#include "../datatypes/affix_fuzzer3.hpp"
+
+#include <arrow/api.h>
+
+namespace rr {
+    namespace datatypes {
+        std::shared_ptr<arrow::DataType> AffixFuzzer4::to_arrow_datatype() {
+            return arrow::dense_union({
+                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                arrow::field("single_required",
+                             rr::datatypes::AffixFuzzer3::to_arrow_datatype(),
+                             false,
+                             nullptr),
+                arrow::field(
+                    "many_required",
+                    arrow::list(arrow::field(
+                        "item", rr::datatypes::AffixFuzzer3::to_arrow_datatype(), false, nullptr)),
+                    false,
+                    nullptr),
+                arrow::field(
+                    "many_optional",
+                    arrow::list(arrow::field(
+                        "item", rr::datatypes::AffixFuzzer3::to_arrow_datatype(), true, nullptr)),
+                    false,
+                    nullptr),
+            });
+        }
+    } // namespace datatypes
+} // namespace rr

--- a/rerun_cpp/src/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer4.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <new>
 #include <optional>
 #include <utility>
@@ -112,6 +113,9 @@ namespace rr {
                 new (&self._data.many_optional) TypeAlias(std::move(many_optional));
                 return std::move(self);
             }
+
+            /// Returns the arrow data type this type corresponds to.
+            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
 
             void swap(AffixFuzzer4& other) noexcept {
                 auto tag_temp = this->_tag;

--- a/rerun_cpp/src/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer5.cpp
@@ -3,7 +3,7 @@
 
 #include "affix_fuzzer5.hpp"
 
-#include "../datatypes/affix_fuzzer1.hpp"
+#include "../datatypes/affix_fuzzer4.hpp"
 
 #include <arrow/api.h>
 
@@ -11,94 +11,10 @@ namespace rr {
     namespace datatypes {
         std::shared_ptr<arrow::DataType> AffixFuzzer5::to_arrow_datatype() {
             return arrow::struct_({
-                arrow::field(
-                    "single_optional_union",
-                    arrow::dense_union({
-                        arrow::field("_null_markers", arrow::null(), true, nullptr),
-                        arrow::field(
-                            "single_required",
-                            arrow::dense_union({
-                                arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                arrow::field("degrees", arrow::float32(), false, nullptr),
-                                arrow::field("radians", arrow::float32(), false, nullptr),
-                                arrow::field("craziness",
-                                             arrow::list(arrow::field(
-                                                 "item",
-                                                 rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                                 false,
-                                                 nullptr)),
-                                             false,
-                                             nullptr),
-                                arrow::field(
-                                    "fixed_size_shenanigans",
-                                    arrow::fixed_size_list(
-                                        arrow::field("item", arrow::float32(), false, nullptr), 3),
-                                    false,
-                                    nullptr),
-                            }),
-                            false,
-                            nullptr),
-                        arrow::field(
-                            "many_required",
-                            arrow::list(arrow::field(
-                                "item",
-                                arrow::dense_union({
-                                    arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                    arrow::field("degrees", arrow::float32(), false, nullptr),
-                                    arrow::field("radians", arrow::float32(), false, nullptr),
-                                    arrow::field(
-                                        "craziness",
-                                        arrow::list(arrow::field(
-                                            "item",
-                                            rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                            false,
-                                            nullptr)),
-                                        false,
-                                        nullptr),
-                                    arrow::field(
-                                        "fixed_size_shenanigans",
-                                        arrow::fixed_size_list(
-                                            arrow::field("item", arrow::float32(), false, nullptr),
-                                            3),
-                                        false,
-                                        nullptr),
-                                }),
-                                false,
-                                nullptr)),
-                            false,
-                            nullptr),
-                        arrow::field(
-                            "many_optional",
-                            arrow::list(arrow::field(
-                                "item",
-                                arrow::dense_union({
-                                    arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                    arrow::field("degrees", arrow::float32(), false, nullptr),
-                                    arrow::field("radians", arrow::float32(), false, nullptr),
-                                    arrow::field(
-                                        "craziness",
-                                        arrow::list(arrow::field(
-                                            "item",
-                                            rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                                            false,
-                                            nullptr)),
-                                        false,
-                                        nullptr),
-                                    arrow::field(
-                                        "fixed_size_shenanigans",
-                                        arrow::fixed_size_list(
-                                            arrow::field("item", arrow::float32(), false, nullptr),
-                                            3),
-                                        false,
-                                        nullptr),
-                                }),
-                                true,
-                                nullptr)),
-                            false,
-                            nullptr),
-                    }),
-                    true,
-                    nullptr),
+                arrow::field("single_optional_union",
+                             rr::datatypes::AffixFuzzer4::to_arrow_datatype(),
+                             true,
+                             nullptr),
             });
         }
     } // namespace datatypes

--- a/rerun_cpp/src/datatypes/angle.cpp
+++ b/rerun_cpp/src/datatypes/angle.cpp
@@ -2,3 +2,17 @@
 // Based on "crates/re_types/definitions/rerun/datatypes/angle.fbs"
 
 #include "angle.hpp"
+
+#include <arrow/api.h>
+
+namespace rr {
+    namespace datatypes {
+        std::shared_ptr<arrow::DataType> Angle::to_arrow_datatype() {
+            return arrow::dense_union({
+                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                arrow::field("Radians", arrow::float32(), false, nullptr),
+                arrow::field("Degrees", arrow::float32(), false, nullptr),
+            });
+        }
+    } // namespace datatypes
+} // namespace rr

--- a/rerun_cpp/src/datatypes/angle.hpp
+++ b/rerun_cpp/src/datatypes/angle.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace rr {
@@ -70,6 +71,9 @@ namespace rr {
                 self._data.degrees = std::move(degrees);
                 return std::move(self);
             }
+
+            /// Returns the arrow data type this type corresponds to.
+            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
 
             void swap(Angle& other) noexcept {
                 auto tag_temp = this->_tag;

--- a/rerun_cpp/src/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/datatypes/rotation3d.cpp
@@ -2,3 +2,24 @@
 // Based on "crates/re_types/definitions/rerun/datatypes/rotation3d.fbs"
 
 #include "rotation3d.hpp"
+
+#include "../datatypes/quaternion.hpp"
+#include "../datatypes/rotation_axis_angle.hpp"
+
+#include <arrow/api.h>
+
+namespace rr {
+    namespace datatypes {
+        std::shared_ptr<arrow::DataType> Rotation3D::to_arrow_datatype() {
+            return arrow::dense_union({
+                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                arrow::field(
+                    "Quaternion", rr::datatypes::Quaternion::to_arrow_datatype(), false, nullptr),
+                arrow::field("AxisAngle",
+                             rr::datatypes::RotationAxisAngle::to_arrow_datatype(),
+                             false,
+                             nullptr),
+            });
+        }
+    } // namespace datatypes
+} // namespace rr

--- a/rerun_cpp/src/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/datatypes/rotation3d.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace rr {
@@ -87,6 +88,9 @@ namespace rr {
             Rotation3D(rr::datatypes::RotationAxisAngle axis_angle) {
                 *this = Rotation3D::axis_angle(std::move(axis_angle));
             }
+
+            /// Returns the arrow data type this type corresponds to.
+            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
 
             void swap(Rotation3D& other) noexcept {
                 auto tag_temp = this->_tag;

--- a/rerun_cpp/src/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/datatypes/rotation_axis_angle.cpp
@@ -3,6 +3,7 @@
 
 #include "rotation_axis_angle.hpp"
 
+#include "../datatypes/angle.hpp"
 #include "../datatypes/vec3d.hpp"
 
 #include <arrow/api.h>
@@ -12,14 +13,7 @@ namespace rr {
         std::shared_ptr<arrow::DataType> RotationAxisAngle::to_arrow_datatype() {
             return arrow::struct_({
                 arrow::field("axis", rr::datatypes::Vec3D::to_arrow_datatype(), false, nullptr),
-                arrow::field("angle",
-                             arrow::dense_union({
-                                 arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                 arrow::field("Radians", arrow::float32(), false, nullptr),
-                                 arrow::field("Degrees", arrow::float32(), false, nullptr),
-                             }),
-                             false,
-                             nullptr),
+                arrow::field("angle", rr::datatypes::Angle::to_arrow_datatype(), false, nullptr),
             });
         }
     } // namespace datatypes

--- a/rerun_cpp/src/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/datatypes/scale3d.cpp
@@ -2,3 +2,19 @@
 // Based on "crates/re_types/definitions/rerun/datatypes/scale3d.fbs"
 
 #include "scale3d.hpp"
+
+#include "../datatypes/vec3d.hpp"
+
+#include <arrow/api.h>
+
+namespace rr {
+    namespace datatypes {
+        std::shared_ptr<arrow::DataType> Scale3D::to_arrow_datatype() {
+            return arrow::dense_union({
+                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                arrow::field("ThreeD", rr::datatypes::Vec3D::to_arrow_datatype(), false, nullptr),
+                arrow::field("Uniform", arrow::float32(), false, nullptr),
+            });
+        }
+    } // namespace datatypes
+} // namespace rr

--- a/rerun_cpp/src/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/datatypes/scale3d.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace rr {
@@ -86,6 +87,9 @@ namespace rr {
             Scale3D(float uniform) {
                 *this = Scale3D::uniform(std::move(uniform));
             }
+
+            /// Returns the arrow data type this type corresponds to.
+            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
 
             void swap(Scale3D& other) noexcept {
                 auto tag_temp = this->_tag;

--- a/rerun_cpp/src/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/datatypes/transform3d.cpp
@@ -2,3 +2,26 @@
 // Based on "crates/re_types/definitions/rerun/datatypes/transform3d.fbs"
 
 #include "transform3d.hpp"
+
+#include "../datatypes/translation_and_mat3x3.hpp"
+#include "../datatypes/translation_rotation_scale3d.hpp"
+
+#include <arrow/api.h>
+
+namespace rr {
+    namespace datatypes {
+        std::shared_ptr<arrow::DataType> Transform3D::to_arrow_datatype() {
+            return arrow::dense_union({
+                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                arrow::field("TranslationAndMat3x3",
+                             rr::datatypes::TranslationAndMat3x3::to_arrow_datatype(),
+                             false,
+                             nullptr),
+                arrow::field("TranslationRotationScale",
+                             rr::datatypes::TranslationRotationScale3D::to_arrow_datatype(),
+                             false,
+                             nullptr),
+            });
+        }
+    } // namespace datatypes
+} // namespace rr

--- a/rerun_cpp/src/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/datatypes/transform3d.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace rr {
@@ -84,6 +85,9 @@ namespace rr {
                 *this =
                     Transform3D::translation_rotation_scale(std::move(translation_rotation_scale));
             }
+
+            /// Returns the arrow data type this type corresponds to.
+            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
 
             void swap(Transform3D& other) noexcept {
                 auto tag_temp = this->_tag;

--- a/rerun_cpp/src/datatypes/translation_rotation_scale3d.cpp
+++ b/rerun_cpp/src/datatypes/translation_rotation_scale3d.cpp
@@ -3,8 +3,8 @@
 
 #include "translation_rotation_scale3d.hpp"
 
-#include "../datatypes/quaternion.hpp"
-#include "../datatypes/rotation_axis_angle.hpp"
+#include "../datatypes/rotation3d.hpp"
+#include "../datatypes/scale3d.hpp"
 #include "../datatypes/vec3d.hpp"
 
 #include <arrow/api.h>
@@ -15,30 +15,9 @@ namespace rr {
             return arrow::struct_({
                 arrow::field(
                     "translation", rr::datatypes::Vec3D::to_arrow_datatype(), true, nullptr),
-                arrow::field("rotation",
-                             arrow::dense_union({
-                                 arrow::field("_null_markers", arrow::null(), true, nullptr),
-                                 arrow::field("Quaternion",
-                                              rr::datatypes::Quaternion::to_arrow_datatype(),
-                                              false,
-                                              nullptr),
-                                 arrow::field("AxisAngle",
-                                              rr::datatypes::RotationAxisAngle::to_arrow_datatype(),
-                                              false,
-                                              nullptr),
-                             }),
-                             true,
-                             nullptr),
                 arrow::field(
-                    "scale",
-                    arrow::dense_union({
-                        arrow::field("_null_markers", arrow::null(), true, nullptr),
-                        arrow::field(
-                            "ThreeD", rr::datatypes::Vec3D::to_arrow_datatype(), false, nullptr),
-                        arrow::field("Uniform", arrow::float32(), false, nullptr),
-                    }),
-                    true,
-                    nullptr),
+                    "rotation", rr::datatypes::Rotation3D::to_arrow_datatype(), true, nullptr),
+                arrow::field("scale", rr::datatypes::Scale3D::to_arrow_datatype(), true, nullptr),
                 arrow::field("from_parent", arrow::boolean(), false, nullptr),
             });
         }


### PR DESCRIPTION
* Part of #2647
* Next step after #2765

### What

implements 

Tested with `cargo codegen && ./examples/cpp/minimal/build_and_run.sh`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2765) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2765)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fdatatype-no-rec-cpp/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fdatatype-no-rec-cpp/examples)