### PR TITLE
Automatically derive `tuple_struct` attr and trivial `From` impls where possible

### DIFF
--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -58,7 +58,7 @@ impl Points2DPart {
                     (point, Some(label)) => Some(UiLabel {
                         text: label,
                         color: *color,
-                        target: UiLabelTarget::Point2D(egui::pos2(point.xy.x, point.xy.y)),
+                        target: UiLabelTarget::Point2D(egui::pos2(point.x(), point.y())),
                         labeled_instance: *labeled_instance,
                     }),
                     _ => None,

--- a/crates/re_types/definitions/rerun/components/class_id.fbs
+++ b/crates/re_types/definitions/rerun/components/class_id.fbs
@@ -16,7 +16,6 @@ struct ClassId (
   "attr.python.array_aliases": "int, npt.NDArray[np.uint8], npt.NDArray[np.uint16], npt.NDArray[np.uint32], npt.NDArray[np.uint64]",
   "attr.rerun.legacy_fqname": "rerun.class_id",
   "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash",
-  "attr.rust.tuple_struct",
   order: 100
 ) {
   id: ushort (order: 100);

--- a/crates/re_types/definitions/rerun/components/color.fbs
+++ b/crates/re_types/definitions/rerun/components/color.fbs
@@ -20,7 +20,6 @@ struct Color (
   "attr.rerun.legacy_fqname": "rerun.colorrgba",
   "attr.rust.derive": "Default, Copy, PartialEq, Eq, PartialOrd, Ord, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
   order: 100
 ) {
   rgba: uint (order: 100);

--- a/crates/re_types/definitions/rerun/components/draw_order.fbs
+++ b/crates/re_types/definitions/rerun/components/draw_order.fbs
@@ -22,7 +22,6 @@ struct DrawOrder (
   "attr.rerun.legacy_fqname": "rerun.draw_order",
   "attr.rust.derive": "Copy",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
   order: 100
 ) {
    value: float (order: 100);

--- a/crates/re_types/definitions/rerun/components/instance_key.fbs
+++ b/crates/re_types/definitions/rerun/components/instance_key.fbs
@@ -14,7 +14,6 @@ struct InstanceKey (
   "attr.python.aliases": "int",
   "attr.python.array_aliases": "int, npt.NDArray[np.uint64]",
   "attr.rerun.legacy_fqname": "rerun.instance_key",
-  "attr.rust.tuple_struct",
   "attr.rust.derive": "Copy, Hash, PartialEq, Eq, PartialOrd, Ord",
   order: 100
 ) {

--- a/crates/re_types/definitions/rerun/components/keypoint_id.fbs
+++ b/crates/re_types/definitions/rerun/components/keypoint_id.fbs
@@ -23,7 +23,6 @@ struct KeypointId (
   "attr.python.array_aliases": "float, npt.NDArray[np.uint8], npt.NDArray[np.uint16], npt.NDArray[np.uint32]",
   "attr.rerun.legacy_fqname": "rerun.keypoint_id",
   "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash",
-  "attr.rust.tuple_struct",
   order: 200
 ) {
   id: ushort (order: 100);

--- a/crates/re_types/definitions/rerun/components/label.fbs
+++ b/crates/re_types/definitions/rerun/components/label.fbs
@@ -16,7 +16,6 @@ table Label (
   "attr.rerun.legacy_fqname": "rerun.label",
   "attr.rust.derive": "PartialEq, Eq, PartialOrd, Ord",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
   order: 100
 ) {
   value: string (order: 100);

--- a/crates/re_types/definitions/rerun/components/point2d.fbs
+++ b/crates/re_types/definitions/rerun/components/point2d.fbs
@@ -10,7 +10,6 @@ namespace rerun.components;
 // ---
 
 /// A point in 2D space.
-// TODO(cmc): bring back attr.rust.tuple_struct
 struct Point2D (
   "attr.python.aliases": "npt.NDArray[np.float32], Sequence[float], Tuple[float, float]",
   "attr.python.array_aliases": "npt.NDArray[np.float32], Sequence[float]",

--- a/crates/re_types/definitions/rerun/components/radius.fbs
+++ b/crates/re_types/definitions/rerun/components/radius.fbs
@@ -14,7 +14,6 @@ struct Radius (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float32]",
   "attr.rerun.legacy_fqname": "rerun.radius",
-  "attr.rust.tuple_struct",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
   order: 100
 ) {

--- a/crates/re_types/definitions/rerun/components/transform3d.fbs
+++ b/crates/re_types/definitions/rerun/components/transform3d.fbs
@@ -13,7 +13,6 @@ table Transform3D (
   // wrong schema for this component.
   //"attr.rerun.legacy_fqname": "rerun.transform3d",
   "attr.rust.derive": "PartialEq",
-  "attr.rust.tuple_struct",
   order: 100
 ) {
   /// Representation of the transform.

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-f1318b60e35827911eba3ea1e06ddd6aa5cf9d40ccbaae463caebc4cec62789b
+b4f2c2b3b6518fd5c5b8fe2255952c6986895efe58cbc6ae0b56b0384a9ad930

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-5c0babb259da736c35b9789c62319596f23b1444ef5cdc40e789fdda695faf27
+f1318b60e35827911eba3ea1e06ddd6aa5cf9d40ccbaae463caebc4cec62789b

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-4e7bff9578be94c0d8e42808d39c49e58b03a4b6dd5dd571dbf87ed7640fcca4
+5c0babb259da736c35b9789c62319596f23b1444ef5cdc40e789fdda695faf27

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -540,8 +540,8 @@ impl crate::Component for AffixFuzzer3 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer4(pub Option<crate::datatypes::AffixFuzzer1>);
 
-impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer4 {
-    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+impl From<Option<crate::datatypes::AffixFuzzer1>> for AffixFuzzer4 {
+    fn from(v: Option<crate::datatypes::AffixFuzzer1>) -> Self {
         Self(v)
     }
 }
@@ -713,8 +713,8 @@ impl crate::Component for AffixFuzzer4 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer5(pub Option<crate::datatypes::AffixFuzzer1>);
 
-impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer5 {
-    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+impl From<Option<crate::datatypes::AffixFuzzer1>> for AffixFuzzer5 {
+    fn from(v: Option<crate::datatypes::AffixFuzzer1>) -> Self {
         Self(v)
     }
 }
@@ -886,8 +886,8 @@ impl crate::Component for AffixFuzzer5 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer6(pub Option<crate::datatypes::AffixFuzzer1>);
 
-impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer6 {
-    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+impl From<Option<crate::datatypes::AffixFuzzer1>> for AffixFuzzer6 {
+    fn from(v: Option<crate::datatypes::AffixFuzzer1>) -> Self {
         Self(v)
     }
 }
@@ -1059,8 +1059,8 @@ impl crate::Component for AffixFuzzer6 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer7(pub Option<Vec<crate::datatypes::AffixFuzzer1>>);
 
-impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer7 {
-    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+impl From<Option<Vec<crate::datatypes::AffixFuzzer1>>> for AffixFuzzer7 {
+    fn from(v: Option<Vec<crate::datatypes::AffixFuzzer1>>) -> Self {
         Self(v)
     }
 }
@@ -2352,8 +2352,8 @@ impl crate::Component for AffixFuzzer14 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer15(pub Option<crate::datatypes::AffixFuzzer3>);
 
-impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer15 {
-    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+impl From<Option<crate::datatypes::AffixFuzzer3>> for AffixFuzzer15 {
+    fn from(v: Option<crate::datatypes::AffixFuzzer3>) -> Self {
         Self(v)
     }
 }
@@ -2503,8 +2503,8 @@ impl crate::Component for AffixFuzzer15 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer16(pub Vec<crate::datatypes::AffixFuzzer3>);
 
-impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer16 {
-    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+impl From<Vec<crate::datatypes::AffixFuzzer3>> for AffixFuzzer16 {
+    fn from(v: Vec<crate::datatypes::AffixFuzzer3>) -> Self {
         Self(v)
     }
 }
@@ -2694,8 +2694,8 @@ impl crate::Component for AffixFuzzer16 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer17(pub Option<Vec<crate::datatypes::AffixFuzzer3>>);
 
-impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer17 {
-    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+impl From<Option<Vec<crate::datatypes::AffixFuzzer3>>> for AffixFuzzer17 {
+    fn from(v: Option<Vec<crate::datatypes::AffixFuzzer3>>) -> Self {
         Self(v)
     }
 }
@@ -2883,8 +2883,8 @@ impl crate::Component for AffixFuzzer17 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer18(pub Option<Vec<crate::datatypes::AffixFuzzer4>>);
 
-impl From<crate::datatypes::AffixFuzzer4> for AffixFuzzer18 {
-    fn from(v: crate::datatypes::AffixFuzzer4) -> Self {
+impl From<Option<Vec<crate::datatypes::AffixFuzzer4>>> for AffixFuzzer18 {
+    fn from(v: Option<Vec<crate::datatypes::AffixFuzzer4>>) -> Self {
         Self(v)
     }
 }

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -15,6 +15,12 @@
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer1(pub crate::datatypes::AffixFuzzer1);
 
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer1 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
     #[inline]
     fn from(value: AffixFuzzer1) -> Self {
@@ -183,6 +189,12 @@ impl crate::Component for AffixFuzzer1 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer2(pub crate::datatypes::AffixFuzzer1);
+
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer2 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
 
 impl<'a> From<AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
     #[inline]
@@ -353,6 +365,12 @@ impl crate::Component for AffixFuzzer2 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer3(pub crate::datatypes::AffixFuzzer1);
 
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer3 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
     #[inline]
     fn from(value: AffixFuzzer3) -> Self {
@@ -522,6 +540,12 @@ impl crate::Component for AffixFuzzer3 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer4(pub Option<crate::datatypes::AffixFuzzer1>);
 
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer4 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
     #[inline]
     fn from(value: AffixFuzzer4) -> Self {
@@ -688,6 +712,12 @@ impl crate::Component for AffixFuzzer4 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer5(pub Option<crate::datatypes::AffixFuzzer1>);
+
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer5 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
 
 impl<'a> From<AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
     #[inline]
@@ -856,6 +886,12 @@ impl crate::Component for AffixFuzzer5 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer6(pub Option<crate::datatypes::AffixFuzzer1>);
 
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer6 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer6> for ::std::borrow::Cow<'a, AffixFuzzer6> {
     #[inline]
     fn from(value: AffixFuzzer6) -> Self {
@@ -1022,6 +1058,12 @@ impl crate::Component for AffixFuzzer6 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer7(pub Option<Vec<crate::datatypes::AffixFuzzer1>>);
+
+impl From<crate::datatypes::AffixFuzzer1> for AffixFuzzer7 {
+    fn from(v: crate::datatypes::AffixFuzzer1) -> Self {
+        Self(v)
+    }
+}
 
 impl<'a> From<AffixFuzzer7> for ::std::borrow::Cow<'a, AffixFuzzer7> {
     #[inline]
@@ -2157,6 +2199,12 @@ impl crate::Component for AffixFuzzer13 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer14(pub crate::datatypes::AffixFuzzer3);
 
+impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer14 {
+    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer14> for ::std::borrow::Cow<'a, AffixFuzzer14> {
     #[inline]
     fn from(value: AffixFuzzer14) -> Self {
@@ -2304,6 +2352,12 @@ impl crate::Component for AffixFuzzer14 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer15(pub Option<crate::datatypes::AffixFuzzer3>);
 
+impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer15 {
+    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer15> for ::std::borrow::Cow<'a, AffixFuzzer15> {
     #[inline]
     fn from(value: AffixFuzzer15) -> Self {
@@ -2448,6 +2502,12 @@ impl crate::Component for AffixFuzzer15 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer16(pub Vec<crate::datatypes::AffixFuzzer3>);
+
+impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer16 {
+    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+        Self(v)
+    }
+}
 
 impl<'a> From<AffixFuzzer16> for ::std::borrow::Cow<'a, AffixFuzzer16> {
     #[inline]
@@ -2634,6 +2694,12 @@ impl crate::Component for AffixFuzzer16 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer17(pub Option<Vec<crate::datatypes::AffixFuzzer3>>);
 
+impl From<crate::datatypes::AffixFuzzer3> for AffixFuzzer17 {
+    fn from(v: crate::datatypes::AffixFuzzer3) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer17> for ::std::borrow::Cow<'a, AffixFuzzer17> {
     #[inline]
     fn from(value: AffixFuzzer17) -> Self {
@@ -2817,6 +2883,12 @@ impl crate::Component for AffixFuzzer17 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer18(pub Option<Vec<crate::datatypes::AffixFuzzer4>>);
 
+impl From<crate::datatypes::AffixFuzzer4> for AffixFuzzer18 {
+    fn from(v: crate::datatypes::AffixFuzzer4) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer18> for ::std::borrow::Cow<'a, AffixFuzzer18> {
     #[inline]
     fn from(value: AffixFuzzer18) -> Self {
@@ -2999,6 +3071,12 @@ impl crate::Component for AffixFuzzer18 {}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer19(pub crate::datatypes::AffixFuzzer5);
+
+impl From<crate::datatypes::AffixFuzzer5> for AffixFuzzer19 {
+    fn from(v: crate::datatypes::AffixFuzzer5) -> Self {
+        Self(v)
+    }
+}
 
 impl<'a> From<AffixFuzzer19> for ::std::borrow::Cow<'a, AffixFuzzer19> {
     #[inline]

--- a/crates/re_types/src/components/fuzzy.rs
+++ b/crates/re_types/src/components/fuzzy.rs
@@ -13,9 +13,7 @@
 #![allow(clippy::unnecessary_cast)]
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer1 {
-    pub single_required: crate::datatypes::AffixFuzzer1,
-}
+pub struct AffixFuzzer1(pub crate::datatypes::AffixFuzzer1);
 
 impl<'a> From<AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
     #[inline]
@@ -126,26 +124,26 @@ impl crate::Loggable for AffixFuzzer1 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_required): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self { single_required } = datum.into_owned();
-                        single_required
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = single_required_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
-                    single_required,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer1"),
                 )?
             }
@@ -172,7 +170,7 @@ impl crate::Loggable for AffixFuzzer1 {
                     backtrace: ::backtrace::Backtrace::new_unresolved(),
                 })
             })
-            .map(|res| res.map(|single_required| Some(Self { single_required })))
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer1#single_required".into(),
@@ -353,9 +351,7 @@ impl crate::Loggable for AffixFuzzer2 {
 impl crate::Component for AffixFuzzer2 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer3 {
-    pub single_required: crate::datatypes::AffixFuzzer1,
-}
+pub struct AffixFuzzer3(pub crate::datatypes::AffixFuzzer1);
 
 impl<'a> From<AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
     #[inline]
@@ -466,26 +462,26 @@ impl crate::Loggable for AffixFuzzer3 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_required): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self { single_required } = datum.into_owned();
-                        single_required
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = single_required_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
-                    single_required,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer3"),
                 )?
             }
@@ -512,7 +508,7 @@ impl crate::Loggable for AffixFuzzer3 {
                     backtrace: ::backtrace::Backtrace::new_unresolved(),
                 })
             })
-            .map(|res| res.map(|single_required| Some(Self { single_required })))
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer3#single_required".into(),
@@ -524,9 +520,7 @@ impl crate::Loggable for AffixFuzzer3 {
 impl crate::Component for AffixFuzzer3 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer4 {
-    pub single_optional: Option<crate::datatypes::AffixFuzzer1>,
-}
+pub struct AffixFuzzer4(pub Option<crate::datatypes::AffixFuzzer1>);
 
 impl<'a> From<AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
     #[inline]
@@ -637,28 +631,28 @@ impl crate::Loggable for AffixFuzzer4 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self { single_optional } = datum.into_owned();
-                            single_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = single_optional_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
-                    single_optional,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer4"),
                 )?
             }
@@ -681,7 +675,7 @@ impl crate::Loggable for AffixFuzzer4 {
             })?
             .into_iter()
             .map(Ok)
-            .map(|res| res.map(|single_optional| Some(Self { single_optional })))
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer4#single_optional".into(),
@@ -860,9 +854,7 @@ impl crate::Loggable for AffixFuzzer5 {
 impl crate::Component for AffixFuzzer5 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer6 {
-    pub single_optional: Option<crate::datatypes::AffixFuzzer1>,
-}
+pub struct AffixFuzzer6(pub Option<crate::datatypes::AffixFuzzer1>);
 
 impl<'a> From<AffixFuzzer6> for ::std::borrow::Cow<'a, AffixFuzzer6> {
     #[inline]
@@ -973,28 +965,28 @@ impl crate::Loggable for AffixFuzzer6 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self { single_optional } = datum.into_owned();
-                            single_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = single_optional_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
-                    single_optional,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer6"),
                 )?
             }
@@ -1017,7 +1009,7 @@ impl crate::Loggable for AffixFuzzer6 {
             })?
             .into_iter()
             .map(Ok)
-            .map(|res| res.map(|single_optional| Some(Self { single_optional })))
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer6#single_optional".into(),
@@ -1029,9 +1021,7 @@ impl crate::Loggable for AffixFuzzer6 {
 impl crate::Component for AffixFuzzer6 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer7 {
-    pub many_optional: Option<Vec<crate::datatypes::AffixFuzzer1>>,
-}
+pub struct AffixFuzzer7(pub Option<Vec<crate::datatypes::AffixFuzzer1>>);
 
 impl<'a> From<AffixFuzzer7> for ::std::borrow::Cow<'a, AffixFuzzer7> {
     #[inline]
@@ -1077,35 +1067,35 @@ impl crate::Loggable for AffixFuzzer7 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self { many_optional } = datum.into_owned();
-                            many_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_optional_inner_data: Vec<_> = many_optional
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_optional_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_optional
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -1129,14 +1119,14 @@ impl crate::Loggable for AffixFuzzer7 {
                     },
                     offsets,
                     {
-                        _ = many_optional_inner_bitmap;
+                        _ = data0_inner_bitmap;
                         _ = extension_wrapper;
                         crate::datatypes::AffixFuzzer1::try_to_arrow_opt(
-                            many_optional_inner_data,
+                            data0_inner_data,
                             Some("rerun.testing.components.AffixFuzzer7"),
                         )?
                     },
-                    many_optional_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -1201,7 +1191,7 @@ impl crate::Loggable for AffixFuzzer7 {
             .into_iter()
         }
         .map(Ok)
-        .map(|res| res.map(|many_optional| Some(Self { many_optional })))
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer7#many_optional".into(),
@@ -1213,9 +1203,7 @@ impl crate::Loggable for AffixFuzzer7 {
 impl crate::Component for AffixFuzzer7 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer8 {
-    pub single_float_optional: Option<f32>,
-}
+pub struct AffixFuzzer8(pub Option<f32>);
 
 impl<'a> From<AffixFuzzer8> for ::std::borrow::Cow<'a, AffixFuzzer8> {
     #[inline]
@@ -1256,22 +1244,20 @@ impl crate::Loggable for AffixFuzzer8 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_float_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                single_float_optional,
-                            } = datum.into_owned();
-                            single_float_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_float_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
@@ -1286,11 +1272,8 @@ impl crate::Loggable for AffixFuzzer8 {
                     .to_logical_type()
                     .clone()
                 },
-                single_float_optional
-                    .into_iter()
-                    .map(|v| v.unwrap_or_default())
-                    .collect(),
-                single_float_optional_bitmap,
+                data0.into_iter().map(|v| v.unwrap_or_default()).collect(),
+                data0_bitmap,
             )
             .boxed()
         })
@@ -1312,13 +1295,7 @@ impl crate::Loggable for AffixFuzzer8 {
             .into_iter()
             .map(|v| v.copied())
             .map(Ok)
-            .map(|res| {
-                res.map(|single_float_optional| {
-                    Some(Self {
-                        single_float_optional,
-                    })
-                })
-            })
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer8#single_float_optional".into(),
@@ -1330,9 +1307,7 @@ impl crate::Loggable for AffixFuzzer8 {
 impl crate::Component for AffixFuzzer8 {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AffixFuzzer9 {
-    pub single_string_required: String,
-}
+pub struct AffixFuzzer9(pub String);
 
 impl<'a> From<AffixFuzzer9> for ::std::borrow::Cow<'a, AffixFuzzer9> {
     #[inline]
@@ -1373,31 +1348,26 @@ impl crate::Loggable for AffixFuzzer9 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_string_required): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self {
-                            single_string_required,
-                        } = datum.into_owned();
-                        single_string_required
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_string_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                let inner_data: ::arrow2::buffer::Buffer<u8> = single_string_required
-                    .iter()
-                    .flatten()
-                    .flat_map(|s| s.bytes())
-                    .collect();
+                let inner_data: ::arrow2::buffer::Buffer<u8> =
+                    data0.iter().flatten().flat_map(|s| s.bytes()).collect();
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    single_string_required
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -1418,7 +1388,7 @@ impl crate::Loggable for AffixFuzzer9 {
                         },
                         offsets,
                         inner_data,
-                        single_string_required_bitmap,
+                        data0_bitmap,
                     )
                 }
                 .boxed()
@@ -1446,13 +1416,7 @@ impl crate::Loggable for AffixFuzzer9 {
                     backtrace: ::backtrace::Backtrace::new_unresolved(),
                 })
             })
-            .map(|res| {
-                res.map(|single_string_required| {
-                    Some(Self {
-                        single_string_required,
-                    })
-                })
-            })
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer9#single_string_required".into(),
@@ -1464,9 +1428,7 @@ impl crate::Loggable for AffixFuzzer9 {
 impl crate::Component for AffixFuzzer9 {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AffixFuzzer10 {
-    pub single_string_optional: Option<String>,
-}
+pub struct AffixFuzzer10(pub Option<String>);
 
 impl<'a> From<AffixFuzzer10> for ::std::borrow::Cow<'a, AffixFuzzer10> {
     #[inline]
@@ -1507,33 +1469,28 @@ impl crate::Loggable for AffixFuzzer10 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_string_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                single_string_optional,
-                            } = datum.into_owned();
-                            single_string_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_string_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                let inner_data: ::arrow2::buffer::Buffer<u8> = single_string_optional
-                    .iter()
-                    .flatten()
-                    .flat_map(|s| s.bytes())
-                    .collect();
+                let inner_data: ::arrow2::buffer::Buffer<u8> =
+                    data0.iter().flatten().flat_map(|s| s.bytes()).collect();
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    single_string_optional
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -1554,7 +1511,7 @@ impl crate::Loggable for AffixFuzzer10 {
                         },
                         offsets,
                         inner_data,
-                        single_string_optional_bitmap,
+                        data0_bitmap,
                     )
                 }
                 .boxed()
@@ -1578,13 +1535,7 @@ impl crate::Loggable for AffixFuzzer10 {
             .into_iter()
             .map(|v| v.map(ToOwned::to_owned))
             .map(Ok)
-            .map(|res| {
-                res.map(|single_string_optional| {
-                    Some(Self {
-                        single_string_optional,
-                    })
-                })
-            })
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer10#single_string_optional".into(),
@@ -1596,9 +1547,7 @@ impl crate::Loggable for AffixFuzzer10 {
 impl crate::Component for AffixFuzzer10 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer11 {
-    pub many_floats_optional: Option<Vec<f32>>,
-}
+pub struct AffixFuzzer11(pub Option<Vec<f32>>);
 
 impl<'a> From<AffixFuzzer11> for ::std::borrow::Cow<'a, AffixFuzzer11> {
     #[inline]
@@ -1644,37 +1593,35 @@ impl crate::Loggable for AffixFuzzer11 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_floats_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                many_floats_optional,
-                            } = datum.into_owned();
-                            many_floats_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_floats_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_floats_optional_inner_data: Vec<_> = many_floats_optional
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_floats_optional_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_floats_optional
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -1708,14 +1655,14 @@ impl crate::Loggable for AffixFuzzer11 {
                             .to_logical_type()
                             .clone()
                         },
-                        many_floats_optional_inner_data
+                        data0_inner_data
                             .into_iter()
                             .map(|v| v.unwrap_or_default())
                             .collect(),
-                        many_floats_optional_inner_bitmap,
+                        data0_inner_bitmap,
                     )
                     .boxed(),
-                    many_floats_optional_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -1780,13 +1727,7 @@ impl crate::Loggable for AffixFuzzer11 {
             .into_iter()
         }
         .map(Ok)
-        .map(|res| {
-            res.map(|many_floats_optional| {
-                Some(Self {
-                    many_floats_optional,
-                })
-            })
-        })
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer11#many_floats_optional".into(),
@@ -1798,9 +1739,7 @@ impl crate::Loggable for AffixFuzzer11 {
 impl crate::Component for AffixFuzzer11 {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AffixFuzzer12 {
-    pub many_strings_required: Vec<String>,
-}
+pub struct AffixFuzzer12(pub Vec<String>);
 
 impl<'a> From<AffixFuzzer12> for ::std::borrow::Cow<'a, AffixFuzzer12> {
     #[inline]
@@ -1846,35 +1785,33 @@ impl crate::Loggable for AffixFuzzer12 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_strings_required): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self {
-                            many_strings_required,
-                        } = datum.into_owned();
-                        many_strings_required
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_strings_required_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_strings_required_inner_data: Vec<_> = many_strings_required
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_strings_required_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_strings_required
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -1898,14 +1835,13 @@ impl crate::Loggable for AffixFuzzer12 {
                     },
                     offsets,
                     {
-                        let inner_data: ::arrow2::buffer::Buffer<u8> =
-                            many_strings_required_inner_data
-                                .iter()
-                                .flatten()
-                                .flat_map(|s| s.bytes())
-                                .collect();
+                        let inner_data: ::arrow2::buffer::Buffer<u8> = data0_inner_data
+                            .iter()
+                            .flatten()
+                            .flat_map(|s| s.bytes())
+                            .collect();
                         let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            many_strings_required_inner_data.iter().map(|opt| {
+                            data0_inner_data.iter().map(|opt| {
                                 opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
                             }),
                         )
@@ -1926,12 +1862,12 @@ impl crate::Loggable for AffixFuzzer12 {
                                 },
                                 offsets,
                                 inner_data,
-                                many_strings_required_inner_bitmap,
+                                data0_inner_bitmap,
                             )
                         }
                         .boxed()
                     },
-                    many_strings_required_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -2000,13 +1936,7 @@ impl crate::Loggable for AffixFuzzer12 {
                 backtrace: ::backtrace::Backtrace::new_unresolved(),
             })
         })
-        .map(|res| {
-            res.map(|many_strings_required| {
-                Some(Self {
-                    many_strings_required,
-                })
-            })
-        })
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer12#many_strings_required".into(),
@@ -2018,9 +1948,7 @@ impl crate::Loggable for AffixFuzzer12 {
 impl crate::Component for AffixFuzzer12 {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AffixFuzzer13 {
-    pub many_strings_optional: Option<Vec<String>>,
-}
+pub struct AffixFuzzer13(pub Option<Vec<String>>);
 
 impl<'a> From<AffixFuzzer13> for ::std::borrow::Cow<'a, AffixFuzzer13> {
     #[inline]
@@ -2066,37 +1994,35 @@ impl crate::Loggable for AffixFuzzer13 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_strings_optional): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                many_strings_optional,
-                            } = datum.into_owned();
-                            many_strings_optional
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_strings_optional_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_strings_optional_inner_data: Vec<_> = many_strings_optional
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_strings_optional_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_strings_optional
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -2120,14 +2046,13 @@ impl crate::Loggable for AffixFuzzer13 {
                     },
                     offsets,
                     {
-                        let inner_data: ::arrow2::buffer::Buffer<u8> =
-                            many_strings_optional_inner_data
-                                .iter()
-                                .flatten()
-                                .flat_map(|s| s.bytes())
-                                .collect();
+                        let inner_data: ::arrow2::buffer::Buffer<u8> = data0_inner_data
+                            .iter()
+                            .flatten()
+                            .flat_map(|s| s.bytes())
+                            .collect();
                         let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            many_strings_optional_inner_data.iter().map(|opt| {
+                            data0_inner_data.iter().map(|opt| {
                                 opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
                             }),
                         )
@@ -2148,12 +2073,12 @@ impl crate::Loggable for AffixFuzzer13 {
                                 },
                                 offsets,
                                 inner_data,
-                                many_strings_optional_inner_bitmap,
+                                data0_inner_bitmap,
                             )
                         }
                         .boxed()
                     },
-                    many_strings_optional_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -2218,13 +2143,7 @@ impl crate::Loggable for AffixFuzzer13 {
             .into_iter()
         }
         .map(Ok)
-        .map(|res| {
-            res.map(|many_strings_optional| {
-                Some(Self {
-                    many_strings_optional,
-                })
-            })
-        })
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer13#many_strings_optional".into(),
@@ -2236,9 +2155,7 @@ impl crate::Loggable for AffixFuzzer13 {
 impl crate::Component for AffixFuzzer13 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer14 {
-    pub single_required_union: crate::datatypes::AffixFuzzer3,
-}
+pub struct AffixFuzzer14(pub crate::datatypes::AffixFuzzer3);
 
 impl<'a> From<AffixFuzzer14> for ::std::borrow::Cow<'a, AffixFuzzer14> {
     #[inline]
@@ -2327,28 +2244,26 @@ impl crate::Loggable for AffixFuzzer14 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_required_union): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self {
-                            single_required_union,
-                        } = datum.into_owned();
-                        single_required_union
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_required_union_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = single_required_union_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer3::try_to_arrow_opt(
-                    single_required_union,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer14"),
                 )?
             }
@@ -2375,13 +2290,7 @@ impl crate::Loggable for AffixFuzzer14 {
                     backtrace: ::backtrace::Backtrace::new_unresolved(),
                 })
             })
-            .map(|res| {
-                res.map(|single_required_union| {
-                    Some(Self {
-                        single_required_union,
-                    })
-                })
-            })
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer14#single_required_union".into(),
@@ -2393,9 +2302,7 @@ impl crate::Loggable for AffixFuzzer14 {
 impl crate::Component for AffixFuzzer14 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer15 {
-    pub single_optional_union: Option<crate::datatypes::AffixFuzzer3>,
-}
+pub struct AffixFuzzer15(pub Option<crate::datatypes::AffixFuzzer3>);
 
 impl<'a> From<AffixFuzzer15> for ::std::borrow::Cow<'a, AffixFuzzer15> {
     #[inline]
@@ -2484,30 +2391,28 @@ impl crate::Loggable for AffixFuzzer15 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, single_optional_union): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                single_optional_union,
-                            } = datum.into_owned();
-                            single_optional_union
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let single_optional_union_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = single_optional_union_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer3::try_to_arrow_opt(
-                    single_optional_union,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer15"),
                 )?
             }
@@ -2530,13 +2435,7 @@ impl crate::Loggable for AffixFuzzer15 {
             })?
             .into_iter()
             .map(Ok)
-            .map(|res| {
-                res.map(|single_optional_union| {
-                    Some(Self {
-                        single_optional_union,
-                    })
-                })
-            })
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer15#single_optional_union".into(),
@@ -2548,9 +2447,7 @@ impl crate::Loggable for AffixFuzzer15 {
 impl crate::Component for AffixFuzzer15 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer16 {
-    pub many_required_unions: Vec<crate::datatypes::AffixFuzzer3>,
-}
+pub struct AffixFuzzer16(pub Vec<crate::datatypes::AffixFuzzer3>);
 
 impl<'a> From<AffixFuzzer16> for ::std::borrow::Cow<'a, AffixFuzzer16> {
     #[inline]
@@ -2596,35 +2493,33 @@ impl crate::Loggable for AffixFuzzer16 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_required_unions): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self {
-                            many_required_unions,
-                        } = datum.into_owned();
-                        many_required_unions
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_required_unions_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_required_unions_inner_data: Vec<_> = many_required_unions
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_required_unions_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_required_unions
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -2648,14 +2543,14 @@ impl crate::Loggable for AffixFuzzer16 {
                     },
                     offsets,
                     {
-                        _ = many_required_unions_inner_bitmap;
+                        _ = data0_inner_bitmap;
                         _ = extension_wrapper;
                         crate::datatypes::AffixFuzzer3::try_to_arrow_opt(
-                            many_required_unions_inner_data,
+                            data0_inner_data,
                             Some("rerun.testing.components.AffixFuzzer16"),
                         )?
                     },
-                    many_required_unions_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -2725,13 +2620,7 @@ impl crate::Loggable for AffixFuzzer16 {
                 backtrace: ::backtrace::Backtrace::new_unresolved(),
             })
         })
-        .map(|res| {
-            res.map(|many_required_unions| {
-                Some(Self {
-                    many_required_unions,
-                })
-            })
-        })
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer16#many_required_unions".into(),
@@ -2743,9 +2632,7 @@ impl crate::Loggable for AffixFuzzer16 {
 impl crate::Component for AffixFuzzer16 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer17 {
-    pub many_optional_unions: Option<Vec<crate::datatypes::AffixFuzzer3>>,
-}
+pub struct AffixFuzzer17(pub Option<Vec<crate::datatypes::AffixFuzzer3>>);
 
 impl<'a> From<AffixFuzzer17> for ::std::borrow::Cow<'a, AffixFuzzer17> {
     #[inline]
@@ -2791,37 +2678,35 @@ impl crate::Loggable for AffixFuzzer17 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_optional_unions): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                many_optional_unions,
-                            } = datum.into_owned();
-                            many_optional_unions
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_optional_unions_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_optional_unions_inner_data: Vec<_> = many_optional_unions
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_optional_unions_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_optional_unions
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -2845,14 +2730,14 @@ impl crate::Loggable for AffixFuzzer17 {
                     },
                     offsets,
                     {
-                        _ = many_optional_unions_inner_bitmap;
+                        _ = data0_inner_bitmap;
                         _ = extension_wrapper;
                         crate::datatypes::AffixFuzzer3::try_to_arrow_opt(
-                            many_optional_unions_inner_data,
+                            data0_inner_data,
                             Some("rerun.testing.components.AffixFuzzer17"),
                         )?
                     },
-                    many_optional_unions_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -2918,13 +2803,7 @@ impl crate::Loggable for AffixFuzzer17 {
             .into_iter()
         }
         .map(Ok)
-        .map(|res| {
-            res.map(|many_optional_unions| {
-                Some(Self {
-                    many_optional_unions,
-                })
-            })
-        })
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer17#many_optional_unions".into(),
@@ -2936,9 +2815,7 @@ impl crate::Loggable for AffixFuzzer17 {
 impl crate::Component for AffixFuzzer17 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer18 {
-    pub many_optional_unions: Option<Vec<crate::datatypes::AffixFuzzer4>>,
-}
+pub struct AffixFuzzer18(pub Option<Vec<crate::datatypes::AffixFuzzer4>>);
 
 impl<'a> From<AffixFuzzer18> for ::std::borrow::Cow<'a, AffixFuzzer18> {
     #[inline]
@@ -2984,37 +2861,35 @@ impl crate::Loggable for AffixFuzzer18 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, many_optional_unions): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum
                         .map(|datum| {
-                            let Self {
-                                many_optional_unions,
-                            } = datum.into_owned();
-                            many_optional_unions
+                            let Self(data0) = datum.into_owned();
+                            data0
                         })
                         .flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let many_optional_unions_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let many_optional_unions_inner_data: Vec<_> = many_optional_unions
+                let data0_inner_data: Vec<_> = data0
                     .iter()
                     .flatten()
                     .flatten()
                     .cloned()
                     .map(Some)
                     .collect();
-                let many_optional_unions_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
                 let offsets = ::arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    many_optional_unions
+                    data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
@@ -3038,14 +2913,14 @@ impl crate::Loggable for AffixFuzzer18 {
                     },
                     offsets,
                     {
-                        _ = many_optional_unions_inner_bitmap;
+                        _ = data0_inner_bitmap;
                         _ = extension_wrapper;
                         crate::datatypes::AffixFuzzer4::try_to_arrow_opt(
-                            many_optional_unions_inner_data,
+                            data0_inner_data,
                             Some("rerun.testing.components.AffixFuzzer18"),
                         )?
                     },
-                    many_optional_unions_bitmap,
+                    data0_bitmap,
                 )
                 .boxed()
             }
@@ -3111,13 +2986,7 @@ impl crate::Loggable for AffixFuzzer18 {
             .into_iter()
         }
         .map(Ok)
-        .map(|res| {
-            res.map(|many_optional_unions| {
-                Some(Self {
-                    many_optional_unions,
-                })
-            })
-        })
+        .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
             location: "rerun.testing.components.AffixFuzzer18#many_optional_unions".into(),
@@ -3129,9 +2998,7 @@ impl crate::Loggable for AffixFuzzer18 {
 impl crate::Component for AffixFuzzer18 {}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct AffixFuzzer19 {
-    pub just_a_table_nothing_shady: crate::datatypes::AffixFuzzer5,
-}
+pub struct AffixFuzzer19(pub crate::datatypes::AffixFuzzer5);
 
 impl<'a> From<AffixFuzzer19> for ::std::borrow::Cow<'a, AffixFuzzer19> {
     #[inline]
@@ -3177,28 +3044,26 @@ impl crate::Loggable for AffixFuzzer19 {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, just_a_table_nothing_shady): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self {
-                            just_a_table_nothing_shady,
-                        } = datum.into_owned();
-                        just_a_table_nothing_shady
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let just_a_table_nothing_shady_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = just_a_table_nothing_shady_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
                 crate::datatypes::AffixFuzzer5::try_to_arrow_opt(
-                    just_a_table_nothing_shady,
+                    data0,
                     Some("rerun.testing.components.AffixFuzzer19"),
                 )?
             }
@@ -3226,13 +3091,7 @@ impl crate::Loggable for AffixFuzzer19 {
                     backtrace: ::backtrace::Backtrace::new_unresolved(),
                 })
             })
-            .map(|res| {
-                res.map(|just_a_table_nothing_shady| {
-                    Some(Self {
-                        just_a_table_nothing_shady,
-                    })
-                })
-            })
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.testing.components.AffixFuzzer19#just_a_table_nothing_shady"

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -14,9 +14,7 @@
 
 /// A point in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
-pub struct Point2D {
-    pub xy: crate::datatypes::Point2D,
-}
+pub struct Point2D(pub crate::datatypes::Point2D);
 
 impl<'a> From<Point2D> for ::std::borrow::Cow<'a, Point2D> {
     #[inline]
@@ -70,25 +68,28 @@ impl crate::Loggable for Point2D {
         use crate::Loggable as _;
         use ::arrow2::{array::*, datatypes::*};
         Ok({
-            let (somes, xy): (Vec<_>, Vec<_>) = data
+            let (somes, data0): (Vec<_>, Vec<_>) = data
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
                     let datum = datum.map(|datum| {
-                        let Self { xy } = datum.into_owned();
-                        xy
+                        let Self(data0) = datum.into_owned();
+                        data0
                     });
                     (datum.is_some(), datum)
                 })
                 .unzip();
-            let xy_bitmap: Option<::arrow2::bitmap::Bitmap> = {
+            let data0_bitmap: Option<::arrow2::bitmap::Bitmap> = {
                 let any_nones = somes.iter().any(|some| !*some);
                 any_nones.then(|| somes.into())
             };
             {
-                _ = xy_bitmap;
+                _ = data0_bitmap;
                 _ = extension_wrapper;
-                crate::datatypes::Point2D::try_to_arrow_opt(xy, Some("rerun.components.Point2D"))?
+                crate::datatypes::Point2D::try_to_arrow_opt(
+                    data0,
+                    Some("rerun.components.Point2D"),
+                )?
             }
         })
     }
@@ -113,7 +114,7 @@ impl crate::Loggable for Point2D {
                     backtrace: ::backtrace::Backtrace::new_unresolved(),
                 })
             })
-            .map(|res| res.map(|xy| Some(Self { xy })))
+            .map(|res| res.map(|v| Some(Self(v))))
             .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
             .map_err(|err| crate::DeserializationError::Context {
                 location: "rerun.components.Point2D#xy".into(),

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -16,6 +16,12 @@
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Point2D(pub crate::datatypes::Point2D);
 
+impl From<crate::datatypes::Point2D> for Point2D {
+    fn from(v: crate::datatypes::Point2D) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<Point2D> for ::std::borrow::Cow<'a, Point2D> {
     #[inline]
     fn from(value: Point2D) -> Self {

--- a/crates/re_types/src/components/point2d_ext.rs
+++ b/crates/re_types/src/components/point2d_ext.rs
@@ -8,19 +8,17 @@ impl Point2D {
 
     #[inline]
     pub const fn new(x: f32, y: f32) -> Self {
-        Self {
-            xy: crate::datatypes::Point2D::new(x, y),
-        }
+        Self(crate::datatypes::Point2D::new(x, y))
     }
 
     #[inline]
     pub fn x(&self) -> f32 {
-        self.xy.x
+        self.0.x
     }
 
     #[inline]
     pub fn y(&self) -> f32 {
-        self.xy.y
+        self.0.y
     }
 }
 

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -19,6 +19,12 @@ pub struct Transform3D(
     pub crate::datatypes::Transform3D,
 );
 
+impl From<crate::datatypes::Transform3D> for Transform3D {
+    fn from(v: crate::datatypes::Transform3D) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<Transform3D> for ::std::borrow::Cow<'a, Transform3D> {
     #[inline]
     fn from(value: Transform3D) -> Self {

--- a/crates/re_types/src/components/transform3d_ext.rs
+++ b/crates/re_types/src/components/transform3d_ext.rs
@@ -38,12 +38,6 @@ impl Transform3D {
     }
 }
 
-impl From<Transform3DRepr> for Transform3D {
-    fn from(value: Transform3DRepr) -> Self {
-        Self(value)
-    }
-}
-
 impl From<RotationAxisAngle> for Transform3D {
     fn from(value: RotationAxisAngle) -> Self {
         Self(value.into())

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -1996,9 +1996,11 @@ pub struct AffixFuzzer5 {
     pub single_optional_union: Option<crate::datatypes::AffixFuzzer4>,
 }
 
-impl From<crate::datatypes::AffixFuzzer4> for AffixFuzzer5 {
-    fn from(v: crate::datatypes::AffixFuzzer4) -> Self {
-        Self(v)
+impl From<Option<crate::datatypes::AffixFuzzer4>> for AffixFuzzer5 {
+    fn from(v: Option<crate::datatypes::AffixFuzzer4>) -> Self {
+        Self {
+            single_optional_union: v,
+        }
     }
 }
 

--- a/crates/re_types/src/datatypes/fuzzy.rs
+++ b/crates/re_types/src/datatypes/fuzzy.rs
@@ -1996,6 +1996,12 @@ pub struct AffixFuzzer5 {
     pub single_optional_union: Option<crate::datatypes::AffixFuzzer4>,
 }
 
+impl From<crate::datatypes::AffixFuzzer4> for AffixFuzzer5 {
+    fn from(v: crate::datatypes::AffixFuzzer4) -> Self {
+        Self(v)
+    }
+}
+
 impl<'a> From<AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
     #[inline]
     fn from(value: AffixFuzzer5) -> Self {

--- a/crates/re_types/tests/fuzzy.rs
+++ b/crates/re_types/tests/fuzzy.rs
@@ -6,19 +6,17 @@ use re_types::{archetypes::AffixFuzzer1, Archetype as _};
 
 #[test]
 fn roundtrip() {
-    let fuzzy1 = re_types::components::AffixFuzzer1 {
-        single_required: re_types::datatypes::AffixFuzzer1 {
-            single_float_optional: Some(1.0),
-            single_string_required: "a".into(),
-            single_string_optional: Some("a".into()),
-            many_floats_optional: Some(vec![1.0, 10.0, 100.0]),
-            many_strings_required: vec!["1".into(), "2".into()],
-            many_strings_optional: Some(vec!["10".into(), "20".into()]),
-            flattened_scalar: 42.0,
-            almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 42.0 },
-            from_parent: Some(true),
-        },
-    };
+    let fuzzy1 = re_types::components::AffixFuzzer1(re_types::datatypes::AffixFuzzer1 {
+        single_float_optional: Some(1.0),
+        single_string_required: "a".into(),
+        single_string_optional: Some("a".into()),
+        many_floats_optional: Some(vec![1.0, 10.0, 100.0]),
+        many_strings_required: vec!["1".into(), "2".into()],
+        many_strings_optional: Some(vec!["10".into(), "20".into()]),
+        flattened_scalar: 42.0,
+        almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 42.0 },
+        from_parent: Some(true),
+    });
 
     let fuzzy2 = re_types::components::AffixFuzzer2(re_types::datatypes::AffixFuzzer1 {
         single_float_optional: None,
@@ -32,33 +30,29 @@ fn roundtrip() {
         from_parent: Some(false),
     });
 
-    let fuzzy3 = re_types::components::AffixFuzzer3 {
-        single_required: re_types::datatypes::AffixFuzzer1 {
-            single_float_optional: Some(3.0),
-            single_string_required: "c".into(),
-            single_string_optional: Some("c".into()),
-            many_floats_optional: Some(vec![3.0, 30.0, 300.0]),
-            many_strings_required: vec!["5".into(), "6".into()],
-            many_strings_optional: Some(vec!["50".into(), "60".into()]),
-            flattened_scalar: 44.0,
-            almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 44.0 },
-            from_parent: None,
-        },
-    };
+    let fuzzy3 = re_types::components::AffixFuzzer3(re_types::datatypes::AffixFuzzer1 {
+        single_float_optional: Some(3.0),
+        single_string_required: "c".into(),
+        single_string_optional: Some("c".into()),
+        many_floats_optional: Some(vec![3.0, 30.0, 300.0]),
+        many_strings_required: vec!["5".into(), "6".into()],
+        many_strings_optional: Some(vec!["50".into(), "60".into()]),
+        flattened_scalar: 44.0,
+        almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 44.0 },
+        from_parent: None,
+    });
 
-    let fuzzy4 = re_types::components::AffixFuzzer4 {
-        single_optional: Some(re_types::datatypes::AffixFuzzer1 {
-            single_float_optional: None,
-            single_string_required: "d".into(),
-            single_string_optional: None,
-            many_floats_optional: Some(vec![4.0, 40.0, 400.0]),
-            many_strings_required: vec!["7".into(), "8".into()],
-            many_strings_optional: None,
-            flattened_scalar: 45.0,
-            almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 45.0 },
-            from_parent: None,
-        }),
-    };
+    let fuzzy4 = re_types::components::AffixFuzzer4(Some(re_types::datatypes::AffixFuzzer1 {
+        single_float_optional: None,
+        single_string_required: "d".into(),
+        single_string_optional: None,
+        many_floats_optional: Some(vec![4.0, 40.0, 400.0]),
+        many_strings_required: vec!["7".into(), "8".into()],
+        many_strings_optional: None,
+        flattened_scalar: 45.0,
+        almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 45.0 },
+        from_parent: None,
+    }));
 
     let fuzzy5 = re_types::components::AffixFuzzer5(None);
     // let fuzzy5 = re_types::components::AffixFuzzer5(Some(re_types::datatypes::AffixFuzzer1 {
@@ -70,9 +64,7 @@ fn roundtrip() {
     //     many_strings_optional: None,
     // }));
 
-    let fuzzy6 = re_types::components::AffixFuzzer6 {
-        single_optional: None,
-    };
+    let fuzzy6 = re_types::components::AffixFuzzer6(None);
     // let fuzzy6 = re_types::components::AffixFuzzer6 {
     //     single_optional: Some(re_types::datatypes::AffixFuzzer1 {
     //         // single_float_optional: None,
@@ -84,11 +76,9 @@ fn roundtrip() {
     //     }),
     // };
 
-    let fuzzy7_1 = re_types::components::AffixFuzzer7 {
-        many_optional: None,
-    };
-    let fuzzy7_2 = re_types::components::AffixFuzzer7 {
-        many_optional: Some(vec![re_types::datatypes::AffixFuzzer1 {
+    let fuzzy7_1 = re_types::components::AffixFuzzer7(None);
+    let fuzzy7_2 =
+        re_types::components::AffixFuzzer7(Some(vec![re_types::datatypes::AffixFuzzer1 {
             single_float_optional: None,
             single_string_required: "d".into(),
             single_string_optional: None,
@@ -98,182 +88,125 @@ fn roundtrip() {
             flattened_scalar: 46.0,
             almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 46.0 },
             from_parent: Some(false),
-        }]),
-    };
+        }]));
 
-    let fuzzy8_1 = re_types::components::AffixFuzzer8 {
-        single_float_optional: None,
-    };
-    let fuzzy8_2 = re_types::components::AffixFuzzer8 {
-        single_float_optional: Some(1.0),
-    };
+    let fuzzy8_1 = re_types::components::AffixFuzzer8(None);
+    let fuzzy8_2 = re_types::components::AffixFuzzer8(Some(1.0));
 
-    let fuzzy9_1 = re_types::components::AffixFuzzer9 {
-        single_string_required: "b".into(),
-    };
-    let fuzzy9_2 = re_types::components::AffixFuzzer9 {
-        single_string_required: "a".into(),
-    };
+    let fuzzy9_1 = re_types::components::AffixFuzzer9("b".into());
+    let fuzzy9_2 = re_types::components::AffixFuzzer9("a".into());
 
-    let fuzzy10_1 = re_types::components::AffixFuzzer10 {
-        single_string_optional: None,
-    };
-    let fuzzy10_2 = re_types::components::AffixFuzzer10 {
-        single_string_optional: Some("a".into()),
-    };
+    let fuzzy10_1 = re_types::components::AffixFuzzer10(None);
+    let fuzzy10_2 = re_types::components::AffixFuzzer10(Some("a".into()));
 
-    let fuzzy11_1 = re_types::components::AffixFuzzer11 {
-        many_floats_optional: Some(vec![1.0, 10.0]),
-    };
-    let fuzzy11_2 = re_types::components::AffixFuzzer11 {
-        many_floats_optional: Some(vec![2.0, 20.0, 200.0]),
-    };
+    let fuzzy11_1 = re_types::components::AffixFuzzer11(Some(vec![1.0, 10.0]));
+    let fuzzy11_2 = re_types::components::AffixFuzzer11(Some(vec![2.0, 20.0, 200.0]));
 
-    let fuzzy12_1 = re_types::components::AffixFuzzer12 {
-        many_strings_required: vec!["1".into(), "10".into()],
-    };
-    let fuzzy12_2 = re_types::components::AffixFuzzer12 {
-        many_strings_required: vec!["20".into(), "200".into(), "2000".into()],
-    };
+    let fuzzy12_1 = re_types::components::AffixFuzzer12(vec!["1".into(), "10".into()]);
+    let fuzzy12_2 =
+        re_types::components::AffixFuzzer12(vec!["20".into(), "200".into(), "2000".into()]);
 
-    let fuzzy13_1 = re_types::components::AffixFuzzer13 {
-        many_strings_optional: None,
-    };
-    let fuzzy13_2 = re_types::components::AffixFuzzer13 {
-        many_strings_optional: Some(vec![
-            "30".into(),
-            "300".into(),
-            "3000".into(),
-            "30000".into(),
-        ]),
-    };
+    let fuzzy13_1 = re_types::components::AffixFuzzer13(None);
+    let fuzzy13_2 = re_types::components::AffixFuzzer13(Some(vec![
+        "30".into(),
+        "300".into(),
+        "3000".into(),
+        "30000".into(),
+    ]));
 
-    let fuzzy14_1 = re_types::components::AffixFuzzer14 {
-        single_required_union: re_types::datatypes::AffixFuzzer3::Degrees(90.0),
-    };
-    let fuzzy14_2 = re_types::components::AffixFuzzer14 {
-        single_required_union: re_types::datatypes::AffixFuzzer3::Radians(Some(PI)),
-    };
-    let fuzzy14_3 = re_types::components::AffixFuzzer14 {
-        single_required_union: re_types::datatypes::AffixFuzzer3::Radians(None),
-    };
+    let fuzzy14_1 =
+        re_types::components::AffixFuzzer14(re_types::datatypes::AffixFuzzer3::Degrees(90.0));
+    let fuzzy14_2 =
+        re_types::components::AffixFuzzer14(re_types::datatypes::AffixFuzzer3::Radians(Some(PI)));
+    let fuzzy14_3 =
+        re_types::components::AffixFuzzer14(re_types::datatypes::AffixFuzzer3::Radians(None));
 
-    let fuzzy15_1 = re_types::components::AffixFuzzer15 {
-        single_optional_union: None,
-    };
-    let fuzzy15_2 = re_types::components::AffixFuzzer15 {
-        single_optional_union: Some(re_types::datatypes::AffixFuzzer3::Radians(Some(PI / 4.0))),
-    };
+    let fuzzy15_1 = re_types::components::AffixFuzzer15(None);
+    let fuzzy15_2 = re_types::components::AffixFuzzer15(Some(
+        re_types::datatypes::AffixFuzzer3::Radians(Some(PI / 4.0)),
+    ));
 
-    let fuzzy16_1 = re_types::components::AffixFuzzer16 {
-        many_required_unions: vec![
+    let fuzzy16_1 = re_types::components::AffixFuzzer16(vec![
+        re_types::datatypes::AffixFuzzer3::Radians(None), //
+        re_types::datatypes::AffixFuzzer3::Degrees(45.0), //
+        re_types::datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
+    ]);
+    let fuzzy16_2 = re_types::components::AffixFuzzer16(vec![
+        re_types::datatypes::AffixFuzzer3::Degrees(20.0), //
+        re_types::datatypes::AffixFuzzer3::Degrees(30.0), //
+        re_types::datatypes::AffixFuzzer3::Radians(Some(0.424242)), //
+    ]);
+
+    let fuzzy17_1 = re_types::components::AffixFuzzer17(None);
+    let fuzzy17_2 = re_types::components::AffixFuzzer17(Some(vec![
+        re_types::datatypes::AffixFuzzer3::Degrees(20.0), //
+        re_types::datatypes::AffixFuzzer3::Degrees(30.0), //
+        re_types::datatypes::AffixFuzzer3::Radians(None), //
+    ]));
+
+    let fuzzy18_1 = re_types::components::AffixFuzzer18(None);
+    let fuzzy18_2 = re_types::components::AffixFuzzer18(Some(vec![
+        re_types::datatypes::AffixFuzzer4::SingleRequired(
+            re_types::datatypes::AffixFuzzer3::Craziness(vec![re_types::datatypes::AffixFuzzer1 {
+                single_float_optional: None,
+                single_string_required: "d".into(),
+                single_string_optional: None,
+                many_floats_optional: Some(vec![4.0, 40.0, 400.0]),
+                many_strings_required: vec!["7".into(), "8".into()],
+                many_strings_optional: None,
+                flattened_scalar: 46.0,
+                almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 46.0 },
+                from_parent: Some(true),
+            }]),
+        ), //
+        re_types::datatypes::AffixFuzzer4::SingleRequired(
+            re_types::datatypes::AffixFuzzer3::Degrees(30.0),
+        ), //
+        re_types::datatypes::AffixFuzzer4::SingleRequired(
+            re_types::datatypes::AffixFuzzer3::Radians(None),
+        ), //
+    ]));
+    let fuzzy18_3 = re_types::components::AffixFuzzer18(Some(vec![
+        re_types::datatypes::AffixFuzzer4::ManyRequired(vec![
             re_types::datatypes::AffixFuzzer3::Radians(None), //
             re_types::datatypes::AffixFuzzer3::Degrees(45.0), //
             re_types::datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
-        ],
-    };
-    let fuzzy16_2 = re_types::components::AffixFuzzer16 {
-        many_required_unions: vec![
-            re_types::datatypes::AffixFuzzer3::Degrees(20.0), //
-            re_types::datatypes::AffixFuzzer3::Degrees(30.0), //
-            re_types::datatypes::AffixFuzzer3::Radians(Some(0.424242)), //
-        ],
-    };
+            re_types::datatypes::AffixFuzzer3::Craziness(vec![re_types::datatypes::AffixFuzzer1 {
+                single_float_optional: Some(3.0),
+                single_string_required: "c".into(),
+                single_string_optional: Some("c".into()),
+                many_floats_optional: Some(vec![3.0, 30.0, 300.0]),
+                many_strings_required: vec!["5".into(), "6".into()],
+                many_strings_optional: Some(vec!["50".into(), "60".into()]),
+                flattened_scalar: 44.0,
+                almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 44.0 },
+                from_parent: None,
+            }]),
+        ]), //
+        re_types::datatypes::AffixFuzzer4::ManyOptional(Some(vec![
+            re_types::datatypes::AffixFuzzer3::Radians(None),
+        ])), //
+        re_types::datatypes::AffixFuzzer4::ManyOptional(None), //
+    ]));
 
-    let fuzzy17_1 = re_types::components::AffixFuzzer17 {
-        many_optional_unions: None,
-    };
-    let fuzzy17_2 = re_types::components::AffixFuzzer17 {
-        many_optional_unions: Some(vec![
-            re_types::datatypes::AffixFuzzer3::Degrees(20.0), //
-            re_types::datatypes::AffixFuzzer3::Degrees(30.0), //
+    let fuzzy19_1 = re_types::components::AffixFuzzer19(re_types::datatypes::AffixFuzzer5 {
+        single_optional_union: Some(re_types::datatypes::AffixFuzzer4::ManyRequired(vec![
             re_types::datatypes::AffixFuzzer3::Radians(None), //
-        ]),
-    };
-
-    let fuzzy18_1 = re_types::components::AffixFuzzer18 {
-        many_optional_unions: None,
-    };
-    let fuzzy18_2 = re_types::components::AffixFuzzer18 {
-        many_optional_unions: Some(vec![
-            re_types::datatypes::AffixFuzzer4::SingleRequired(
-                re_types::datatypes::AffixFuzzer3::Craziness(vec![
-                    re_types::datatypes::AffixFuzzer1 {
-                        single_float_optional: None,
-                        single_string_required: "d".into(),
-                        single_string_optional: None,
-                        many_floats_optional: Some(vec![4.0, 40.0, 400.0]),
-                        many_strings_required: vec!["7".into(), "8".into()],
-                        many_strings_optional: None,
-                        flattened_scalar: 46.0,
-                        almost_flattened_scalar: re_types::datatypes::FlattenedScalar {
-                            value: 46.0,
-                        },
-                        from_parent: Some(true),
-                    },
-                ]),
-            ), //
-            re_types::datatypes::AffixFuzzer4::SingleRequired(
-                re_types::datatypes::AffixFuzzer3::Degrees(30.0),
-            ), //
-            re_types::datatypes::AffixFuzzer4::SingleRequired(
-                re_types::datatypes::AffixFuzzer3::Radians(None),
-            ), //
-        ]),
-    };
-    let fuzzy18_3 = re_types::components::AffixFuzzer18 {
-        many_optional_unions: Some(vec![
-            re_types::datatypes::AffixFuzzer4::ManyRequired(vec![
-                re_types::datatypes::AffixFuzzer3::Radians(None), //
-                re_types::datatypes::AffixFuzzer3::Degrees(45.0), //
-                re_types::datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
-                re_types::datatypes::AffixFuzzer3::Craziness(vec![
-                    re_types::datatypes::AffixFuzzer1 {
-                        single_float_optional: Some(3.0),
-                        single_string_required: "c".into(),
-                        single_string_optional: Some("c".into()),
-                        many_floats_optional: Some(vec![3.0, 30.0, 300.0]),
-                        many_strings_required: vec!["5".into(), "6".into()],
-                        many_strings_optional: Some(vec!["50".into(), "60".into()]),
-                        flattened_scalar: 44.0,
-                        almost_flattened_scalar: re_types::datatypes::FlattenedScalar {
-                            value: 44.0,
-                        },
-                        from_parent: None,
-                    },
-                ]),
-            ]), //
-            re_types::datatypes::AffixFuzzer4::ManyOptional(Some(vec![
-                re_types::datatypes::AffixFuzzer3::Radians(None),
-            ])), //
-            re_types::datatypes::AffixFuzzer4::ManyOptional(None), //
-        ]),
-    };
-
-    let fuzzy19_1 = re_types::components::AffixFuzzer19 {
-        just_a_table_nothing_shady: re_types::datatypes::AffixFuzzer5 {
-            single_optional_union: Some(re_types::datatypes::AffixFuzzer4::ManyRequired(vec![
-                re_types::datatypes::AffixFuzzer3::Radians(None), //
-                re_types::datatypes::AffixFuzzer3::Degrees(45.0), //
-                re_types::datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
-                re_types::datatypes::AffixFuzzer3::Craziness(vec![
-                    re_types::datatypes::AffixFuzzer1 {
-                        single_float_optional: Some(3.0),
-                        single_string_required: "c".into(),
-                        single_string_optional: Some("c".into()),
-                        many_floats_optional: Some(vec![3.0, 30.0, 300.0]),
-                        many_strings_required: vec!["5".into(), "6".into()],
-                        many_strings_optional: Some(vec!["50".into(), "60".into()]),
-                        flattened_scalar: 44.0,
-                        almost_flattened_scalar: re_types::datatypes::FlattenedScalar {
-                            value: 44.0,
-                        },
-                        from_parent: None,
-                    },
-                ]),
-            ])), //
-        },
-    };
+            re_types::datatypes::AffixFuzzer3::Degrees(45.0), //
+            re_types::datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
+            re_types::datatypes::AffixFuzzer3::Craziness(vec![re_types::datatypes::AffixFuzzer1 {
+                single_float_optional: Some(3.0),
+                single_string_required: "c".into(),
+                single_string_optional: Some("c".into()),
+                many_floats_optional: Some(vec![3.0, 30.0, 300.0]),
+                many_strings_required: vec!["5".into(), "6".into()],
+                many_strings_optional: Some(vec!["50".into(), "60".into()]),
+                flattened_scalar: 44.0,
+                almost_flattened_scalar: re_types::datatypes::FlattenedScalar { value: 44.0 },
+                from_parent: None,
+            }]),
+        ])), //
+    });
 
     let arch = AffixFuzzer1::new(
         fuzzy1.clone(), //

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -2254,8 +2254,8 @@ fn quote_arrow_field_deserializer(
 // --- Helpers ---
 
 fn is_tuple_struct_from_obj(obj: &Object) -> bool {
-    let is_tuple_struct =
-        obj.is_struct() && obj.try_get_attr::<String>(ATTR_RUST_TUPLE_STRUCT).is_some();
+    let is_tuple_struct = obj.kind == ObjectKind::Component
+        || (obj.is_struct() && obj.try_get_attr::<String>(ATTR_RUST_TUPLE_STRUCT).is_some());
 
     assert!(
         !is_tuple_struct || obj.fields.len() == 1,


### PR DESCRIPTION
**Commit by commit!**

What the title says.

Fixes #2675
Fixes #2771 

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2772) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2772)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fnicer_components_rust/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fnicer_components_rust/examples)