### PR TITLE
Add missing feature-dependency from `re_sdk` to `re_components/arrow_datagen`.

### DIFF
--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -50,6 +50,8 @@ thiserror.workspace = true
 
 
 [dev-dependencies]
+re_components = { workspace = true, features = ["arrow_datagen"] }
+
 arrow2_convert.workspace = true
 ndarray.workspace = true
 ndarray-rand = "0.14"


### PR DESCRIPTION
### What

This allows `cargo test -p re_sdk` (e.g. invoked from `rust-analyzer`'s “Run Test” function) to successfully build `re_sdk`. Without this fix, this error occurs:

```
error[E0432]: unresolved import `re_components::datagen`
   --> crates/re_sdk/src/recording_stream.rs:995:24
    |
995 |     use re_components::datagen::data_table_example;
    |                        ^^^^^^^ could not find `datagen` in `re_components`
```

This change is to dev-dependencies only, so it will not increase the dependencies seen by Rerun users.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }})~~ (not applicable, build-only change)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
