### PR TITLE
Disable expansion effects in the UI

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -116,10 +116,10 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
     }
 
     {
-        // Expand hovered and active button frames:
-        egui_style.visuals.widgets.hovered.expansion = 2.0;
-        egui_style.visuals.widgets.active.expansion = 2.0;
-        egui_style.visuals.widgets.open.expansion = 2.0;
+        // Turn off any expansion in the UI (see https://github.com/rerun-io/rerun/issues/2727)
+        egui_style.visuals.widgets.hovered.expansion = 0.0;
+        egui_style.visuals.widgets.active.expansion = 0.0;
+        egui_style.visuals.widgets.open.expansion = 0.0;
     }
 
     egui_style.visuals.selection.bg_fill =


### PR DESCRIPTION
### What

Fixes #2727
Fixes #2726
Fixes #2730

Questions for the reviewers:
- This affects the popup menu controls. Due to their styling the expansion effect was invisible, but resulted in the greyed hover area to be larger by 2px all around. The difference is visible in the videos below. Is that OK? @martenbjork 
- This PR removes the expansion effect from the blueprint tree's triangles, and the play/pause/etc. buttons (desired, not shown in the videos below). Did I miss some other, undesirable side-effect elsewhere?

Before:

https://github.com/rerun-io/rerun/assets/49431240/9990dc45-0294-4e04-9331-94eccba4a1d7

After:

https://github.com/rerun-io/rerun/assets/49431240/4fa29bf8-e9cf-4224-8c23-3427474576cc

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2796) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2796)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fno-expansion-2727/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fno-expansion-2727/examples)