### PR TITLE
Implement the unit-tests for archetype-based queries and range-queries and fix range-query bug

### DIFF
--- a/crates/re_query/src/range.rs
+++ b/crates/re_query/src/range.rs
@@ -173,7 +173,7 @@ pub fn range_archetype<'a, A: Archetype + 'a, const N: usize>(
     // TODO(jleibs) this shim is super gross
     let components: [ComponentName; N] = A::all_components().try_into().unwrap();
 
-    let primary: ComponentName = A::recommended_components()[0];
+    let primary: ComponentName = A::required_components()[0];
     let cluster_key = store.cluster_key();
 
     // TODO(cmc): Ideally, we'd want to simply add the cluster and primary key to the `components`

--- a/crates/re_query/tests/archetype_query_tests.rs
+++ b/crates/re_query/tests/archetype_query_tests.rs
@@ -68,7 +68,7 @@ fn simple_query() {
     #[cfg(not(feature = "polars"))]
     {
         //TODO(jleibs): non-polars test validation
-        let _used = entity_view;
+        let _used = arch_view;
     }
 }
 
@@ -125,7 +125,7 @@ fn timeless_query() {
     #[cfg(not(feature = "polars"))]
     {
         //TODO(jleibs): non-polars test validation
-        let _used = entity_view;
+        let _used = arch_view;
     }
 }
 
@@ -183,7 +183,7 @@ fn no_instance_join_query() {
     #[cfg(not(feature = "polars"))]
     {
         //TODO(jleibs): non-polars test validation
-        let _used = entity_view;
+        let _used = arch_view;
     }
 }
 
@@ -232,7 +232,7 @@ fn missing_column_join_query() {
     #[cfg(not(feature = "polars"))]
     {
         //TODO(jleibs): non-polars test validation
-        let _used = entity_view;
+        let _used = arch_view;
     }
 }
 
@@ -297,6 +297,6 @@ fn splatted_query() {
     #[cfg(not(feature = "polars"))]
     {
         //TODO(jleibs): non-polars test validation
-        let _used = entity_view;
+        let _used = arch_view;
     }
 }

--- a/crates/re_query/tests/archetype_query_tests.rs
+++ b/crates/re_query/tests/archetype_query_tests.rs
@@ -1,0 +1,302 @@
+mod common;
+
+use re_arrow_store::DataStore;
+use re_components::datagen::build_frame_nr;
+use re_log_types::{DataRow, RowId};
+use re_query::query_archetype;
+use re_types::{
+    archetypes::Points2D,
+    components::{Color, InstanceKey, Point2D},
+    Loggable,
+};
+
+#[test]
+fn simple_query() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some points with implicit instances
+    let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::random(), ent_path, timepoint, 2, points);
+    store.insert_row(&row).unwrap();
+
+    // Assign one of them a color with an explicit instance
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::random(),
+        ent_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    );
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let timeline_query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+
+    let arch_view = query_archetype::<Points2D>(&store, &timeline_query, &ent_path.into()).unwrap();
+
+    // We expect this to generate the following `DataFrame`
+    // ┌──────────┬───────────┬────────────┐
+    // │ instance ┆ point2d   ┆ colorrgba  │
+    // │ ---      ┆ ---       ┆ ---        │
+    // │ u64      ┆ struct[2] ┆ u32        │
+    // ╞══════════╪═══════════╪════════════╡
+    // │ 0        ┆ {1.0,2.0} ┆ null       │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1        ┆ {3.0,4.0} ┆ 4278190080 │
+    // └──────────┴───────────┴────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        common::compare_df(&expected, &arch_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        let _used = entity_view;
+    }
+}
+
+#[test]
+fn timeless_query() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some points with implicit instances
+    let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::random(), ent_path, timepoint, 2, points);
+    store.insert_row(&row).unwrap();
+
+    // Assign one of them a color with an explicit instance.. timelessly!
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row =
+        DataRow::from_cells2_sized(RowId::random(), ent_path, [], 1, (color_instances, colors));
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let timeline_query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+
+    let arch_view = query_archetype::<Points2D>(&store, &timeline_query, &ent_path.into()).unwrap();
+
+    // We expect this to generate the following `DataFrame`
+    // ┌──────────┬───────────┬────────────┐
+    // │ instance ┆ point2d   ┆ colorrgba  │
+    // │ ---      ┆ ---       ┆ ---        │
+    // │ u64      ┆ struct[2] ┆ u32        │
+    // ╞══════════╪═══════════╪════════════╡
+    // │ 0        ┆ {1.0,2.0} ┆ null       │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1        ┆ {3.0,4.0} ┆ 4278190080 │
+    // └──────────┴───────────┴────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        common::compare_df(&expected, &arch_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        let _used = entity_view;
+    }
+}
+
+#[test]
+fn no_instance_join_query() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some points with an implicit instance
+    let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::random(), ent_path, timepoint, 2, points);
+    store.insert_row(&row).unwrap();
+
+    // Assign them colors with explicit instances
+    let colors = vec![Color::from_rgb(255, 0, 0), Color::from_rgb(0, 255, 0)];
+    let row = DataRow::from_cells1_sized(RowId::random(), ent_path, timepoint, 2, colors);
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let timeline_query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+
+    let arch_view = query_archetype::<Points2D>(&store, &timeline_query, &ent_path.into()).unwrap();
+
+    // We expect this to generate the following `DataFrame`
+    // ┌──────────┬───────────┬────────────┐
+    // │ instance ┆ point2d   ┆ colorrgba  │
+    // │ ---      ┆ ---       ┆ ---        │
+    // │ u64      ┆ struct[2] ┆ u32        │
+    // ╞══════════╪═══════════╪════════════╡
+    // │ 0        ┆ {1.0,2.0} ┆ 4278190080 │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1        ┆ {3.0,4.0} ┆ 16711680   │
+    // └──────────┴───────────┴────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![
+            Some(Color::from_rgb(255, 0, 0)),
+            Some(Color::from_rgb(0, 255, 0)),
+        ];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        common::compare_df(&expected, &arch_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        let _used = entity_view;
+    }
+}
+
+#[test]
+fn missing_column_join_query() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some points with an implicit instance
+    let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::random(), ent_path, timepoint, 2, points);
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let timeline_query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+
+    let arch_view = query_archetype::<Points2D>(&store, &timeline_query, &ent_path.into()).unwrap();
+
+    // We expect this to generate the following `DataFrame`
+    //
+    // ┌──────────┬───────────┐
+    // │ instance ┆ point2d   │
+    // │ ---      ┆ ---       │
+    // │ u64      ┆ struct[2] │
+    // ╞══════════╪═══════════╡
+    // │ 0        ┆ {1.0,2.0} │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1        ┆ {3.0,4.0} │
+    // └──────────┴───────────┘
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder2;
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let expected = df_builder2(&instances, &points).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        common::compare_df(&expected, &arch_view.as_df1::<Point2D>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        let _used = entity_view;
+    }
+}
+
+#[test]
+fn splatted_query() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some points with implicit instances
+    let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::random(), ent_path, timepoint, 2, points);
+    store.insert_row(&row).unwrap();
+
+    // Assign all of them a color via splat
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::random(),
+        ent_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    );
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let timeline_query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+
+    let arch_view = query_archetype::<Points2D>(&store, &timeline_query, &ent_path.into()).unwrap();
+
+    // We expect this to generate the following `DataFrame`
+    // ┌──────────┬───────────┬────────────┐
+    // │ instance ┆ point2d   ┆ colorrgba  │
+    // │ ---      ┆ ---       ┆ ---        │
+    // │ u64      ┆ struct[2] ┆ u32        │
+    // ╞══════════╪═══════════╪════════════╡
+    // │ 0        ┆ {1.0,2.0} ┆ 4278190080 │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1        ┆ {3.0,4.0} ┆ 4278190080 │
+    // └──────────┴───────────┴────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![
+            Some(Color::from_rgb(255, 0, 0)),
+            Some(Color::from_rgb(255, 0, 0)),
+        ];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        common::compare_df(&expected, &arch_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        let _used = entity_view;
+    }
+}

--- a/crates/re_query/tests/archetype_range_tests.rs
+++ b/crates/re_query/tests/archetype_range_tests.rs
@@ -1,0 +1,873 @@
+mod common;
+
+use re_arrow_store::{DataStore, TimeInt, TimeRange};
+use re_components::datagen::build_frame_nr;
+use re_log_types::{DataRow, EntityPath, RowId};
+use re_query::range_archetype;
+use re_types::{
+    archetypes::Points2D,
+    components::{Color, InstanceKey, Point2D},
+    Loggable as _,
+};
+
+#[test]
+fn simple_range() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path: EntityPath = "point".into();
+
+    let timepoint1 = [build_frame_nr(123.into())];
+    {
+        // Create some points with implicit instances
+        let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), timepoint1, 2, points);
+        store.insert_row(&row).unwrap();
+
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(1)];
+        let colors = vec![Color::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint1,
+            1,
+            (color_instances, colors),
+        );
+        store.insert_row(&row).unwrap();
+    }
+
+    let timepoint2 = [build_frame_nr(223.into())];
+    {
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(0)];
+        let colors = vec![Color::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint2,
+            1,
+            (color_instances, colors),
+        );
+        store.insert_row(&row).unwrap();
+    }
+
+    let timepoint3 = [build_frame_nr(323.into())];
+    {
+        // Create some points with implicit instances
+        let points = vec![Point2D::new(10.0, 20.0), Point2D::new(30.0, 40.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), timepoint3, 2, points);
+        store.insert_row(&row).unwrap();
+    }
+
+    // --- First test: `(timepoint1, timepoint3]` ---
+
+    // The exclusion of `timepoint1` means latest-at semantics will kick in!
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ 4278190080      │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Frame #123
+
+        let (time, ent_view) = &results[0];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[1];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![Some(Color::from_rgb(255, 0, 0)), None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+
+    // --- Second test: `[timepoint1, timepoint3]` ---
+
+    // The inclusion of `timepoint1` means latest-at semantics will _not_ kick in!
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1, timepoint3[0].1),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Frame #123
+
+        let (time, ent_view) = &results[0];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors: Vec<Option<Color>> = vec![None, None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[1];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![Some(Color::from_rgb(255, 0, 0)), None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+}
+
+#[test]
+fn timeless_range() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path: EntityPath = "point".into();
+
+    let timepoint1 = [build_frame_nr(123.into())];
+    {
+        // Create some points with implicit instances
+        let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+        let mut row =
+            DataRow::from_cells1(RowId::random(), ent_path.clone(), timepoint1, 2, &points);
+        row.compute_all_size_bytes();
+        store.insert_row(&row).unwrap();
+
+        // Insert timelessly too!
+        let row = DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), [], 2, &points);
+        store.insert_row(&row).unwrap();
+
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(1)];
+        let colors = vec![Color::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint1,
+            1,
+            (color_instances.clone(), colors.clone()),
+        );
+        store.insert_row(&row).unwrap();
+
+        // Insert timelessly too!
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            [],
+            1,
+            (color_instances, colors),
+        );
+        store.insert_row(&row).unwrap();
+    }
+
+    let timepoint2 = [build_frame_nr(223.into())];
+    {
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(0)];
+        let colors = vec![Color::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint2,
+            1,
+            (color_instances.clone(), colors.clone()),
+        );
+        store.insert_row(&row).unwrap();
+
+        // Insert timelessly too!
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint2,
+            1,
+            (color_instances, colors),
+        );
+        store.insert_row(&row).unwrap();
+    }
+
+    let timepoint3 = [build_frame_nr(323.into())];
+    {
+        // Create some points with implicit instances
+        let points = vec![Point2D::new(10.0, 20.0), Point2D::new(30.0, 40.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), timepoint3, 2, &points);
+        store.insert_row(&row).unwrap();
+
+        // Insert timelessly too!
+        let row = DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), [], 2, &points);
+        store.insert_row(&row).unwrap();
+    }
+
+    // ┌───────────┬──────────┬────────┬─────────────────┬────────────────────┬──────────────────────┬────────────────────────────┐
+    // │ insert_id ┆ frame_nr ┆ entity ┆ rerun.colorrgba ┆ rerun.instance_key ┆ rerun.row_id         ┆ rerun.point2d              │
+    // ╞═══════════╪══════════╪════════╪═════════════════╪════════════════════╪══════════════════════╪════════════════════════════╡
+    // │ 2         ┆ null     ┆ point  ┆ null            ┆ [0, 1]             ┆ [{167328063302243... ┆ [{1.0,2.0}, {3.0,4.0}]     │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 4         ┆ null     ┆ point  ┆ [4278190080]    ┆ [1]                ┆ [{167328063302246... ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 8         ┆ null     ┆ point  ┆ null            ┆ [0, 1]             ┆ [{167328063302249... ┆ [{10.0,20.0}, {30.0,40.0}] │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1         ┆ 123      ┆ point  ┆ null            ┆ [0, 1]             ┆ [{167328063302236... ┆ [{1.0,2.0}, {3.0,4.0}]     │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 3         ┆ 123      ┆ point  ┆ [4278190080]    ┆ [1]                ┆ [{167328063302245... ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 5         ┆ 223      ┆ point  ┆ [4278190080]    ┆ [0]                ┆ [{167328063302247... ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 6         ┆ 223      ┆ point  ┆ [4278190080]    ┆ [0]                ┆ [{167328063302248... ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 7         ┆ 323      ┆ point  ┆ null            ┆ [0, 1]             ┆ [{167328063302248... ┆ [{10.0,20.0}, {30.0,40.0}] │
+    // └───────────┴──────────┴────────┴─────────────────┴────────────────────┴──────────────────────┴────────────────────────────┘
+
+    // --- First test: `(timepoint1, timepoint3]` ---
+
+    // The exclusion of `timepoint1` means latest-at semantics will kick in!
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ 4278190080      │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Frame #123
+
+        let (time, ent_view) = &results[0];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[1];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![Some(Color::from_rgb(255, 0, 0)), None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+
+    // --- Second test: `[timepoint1, timepoint3]` ---
+
+    // The inclusion of `timepoint1` means latest-at semantics will fall back to timeless data!
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1, timepoint3[0].1),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #122:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ 4278190080      │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Frame #122 (all timeless)
+
+        let (time, ent_view) = &results[0];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(122), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #123 (partially timeless)
+
+        let (time, ent_view) = &results[1];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[2];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![Some(Color::from_rgb(255, 0, 0)), None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+
+    // --- Third test: `[-inf, +inf]` ---
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(TimeInt::MIN, TimeInt::MAX),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Timeless #1:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Timeless #2:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ 4278190080      │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ 4278190080      │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Timeless #1
+
+        let (time, ent_view) = &results[0];
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors: Vec<Option<Color>> = vec![None, None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(&None, time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Timeless #2
+
+        let (time, ent_view) = &results[1];
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(&None, time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #123 (partially timeless)
+
+        let (time, ent_view) = &results[2];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[3];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![Some(Color::from_rgb(255, 0, 0)), None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+}
+
+#[test]
+fn simple_splatted_range() {
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let ent_path: EntityPath = "point".into();
+
+    let timepoint1 = [build_frame_nr(123.into())];
+    {
+        // Create some points with implicit instances
+        let points = vec![Point2D::new(1.0, 2.0), Point2D::new(3.0, 4.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), timepoint1, 2, points);
+        store.insert_row(&row).unwrap();
+
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(1)];
+        let colors = vec![Color::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint1,
+            1,
+            (color_instances, colors),
+        );
+        store.insert_row(&row).unwrap();
+    }
+
+    let timepoint2 = [build_frame_nr(223.into())];
+    {
+        // Assign one of them a color with a splatted instance
+        let color_instances = vec![InstanceKey::SPLAT];
+        let colors = vec![Color::from_rgb(0, 255, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::random(),
+            ent_path.clone(),
+            timepoint2,
+            1,
+            (color_instances, colors),
+        );
+        store.insert_row(&row).unwrap();
+    }
+
+    let timepoint3 = [build_frame_nr(323.into())];
+    {
+        // Create some points with implicit instances
+        let points = vec![Point2D::new(10.0, 20.0), Point2D::new(30.0, 40.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::random(), ent_path.clone(), timepoint3, 2, points);
+        store.insert_row(&row).unwrap();
+    }
+
+    // --- First test: `(timepoint1, timepoint3]` ---
+
+    // The exclusion of `timepoint1` means latest-at semantics will kick in!
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ 4278190080      │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 16711680        │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ 16711680        │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    assert_eq!(results.len(), 2);
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Frame #123
+
+        let (time, ent_view) = &results[0];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[1];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![
+            Some(Color::from_rgb(0, 255, 0)),
+            Some(Color::from_rgb(0, 255, 0)),
+        ];
+
+        let df = ent_view.as_df2::<Point2D, Color>().unwrap();
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &df);
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+
+    // --- Second test: `[timepoint1, timepoint3]` ---
+
+    // The inclusion of `timepoint1` means latest-at semantics will _not_ kick in!
+
+    let query = re_arrow_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1, timepoint3[0].1),
+    );
+
+    let arch_views =
+        range_archetype::<Points2D, { Points2D::NUM_COMPONENTS }>(&store, &query, &ent_path);
+
+    let results = arch_views.collect::<Vec<_>>();
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #123:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {3.0,4.0}     ┆ null            │
+    // └────────────────────┴───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌────────────────────┬───────────────┬─────────────────┐
+    // │ rerun.instance_key ┆ rerun.point2d ┆ rerun.colorrgba │
+    // ╞════════════════════╪═══════════════╪═════════════════╡
+    // │ 0                  ┆ {10.0,20.0}   ┆ 16711680        │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 1                  ┆ {30.0,40.0}   ┆ 16711680        │
+    // └────────────────────┴───────────────┴─────────────────┘
+
+    #[cfg(feature = "polars")]
+    {
+        use re_query::dataframe_util::df_builder3;
+
+        // Frame #123
+
+        let (time, ent_view) = &results[0];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![Some(Point2D::new(1.0, 2.0)), Some(Point2D::new(3.0, 4.0))];
+        let colors: Vec<Option<Color>> = vec![None, None];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(123), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+
+        // Frame #323
+
+        let (time, ent_view) = &results[1];
+        let time = time.unwrap();
+
+        // Build expected df manually
+        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
+        let points = vec![
+            Some(Point2D::new(10.0, 20.0)),
+            Some(Point2D::new(30.0, 40.0)),
+        ];
+        let colors = vec![
+            Some(Color::from_rgb(0, 255, 0)),
+            Some(Color::from_rgb(0, 255, 0)),
+        ];
+        let expected = df_builder3(&instances, &points, &colors).unwrap();
+
+        //eprintln!("{df:?}");
+        //eprintln!("{expected:?}");
+
+        assert_eq!(TimeInt::from(323), time);
+        common::compare_df(&expected, &ent_view.as_df2::<Point2D, Color>().unwrap());
+    }
+    #[cfg(not(feature = "polars"))]
+    {
+        //TODO(jleibs): non-polars test validation
+        _ = results;
+    }
+}

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-8a61bc4eacb4fa00dbe356fb31d7cb5fb6bf2ece3fd8c5096cc4714339ed67bb
+a6155422d0c30e81606db3b51a3a162891a79c47dde29d8e4451e1c4fee24293

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-a6155422d0c30e81606db3b51a3a162891a79c47dde29d8e4451e1c4fee24293
+8a61bc4eacb4fa00dbe356fb31d7cb5fb6bf2ece3fd8c5096cc4714339ed67bb


### PR DESCRIPTION
Fixes: https://github.com/rerun-io/rerun/issues/2802

### What
Straight-forward translation from the entity-view versions of these tests. Literally all regex search-replace for constructions and function invocations.

Bug was straight-forward to identify once the tests were in place.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2803) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2803)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Farchetype_tests/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Farchetype_tests/examples)