### PR TITLE
Fix ui-scale based point/line sizes incorrectly scaled when zooming based on horizontal dimension

### DIFF
--- a/crates/re_renderer/src/transform.rs
+++ b/crates/re_renderer/src/transform.rs
@@ -80,7 +80,7 @@ impl RectTransform {
     }
 
     pub fn scale(&self) -> glam::Vec2 {
-        self.region.extent / self.region_of_interest.extent
+        self.region_of_interest.extent / self.region.extent
     }
 }
 
@@ -122,6 +122,7 @@ mod tests {
                 scale,
                 glam::Mat4::from_scale(1.0 / scale_factor.extend(1.0))
             );
+            assert_eq!(rect_transform.scale(), scale_factor);
         }
 
         // Translation
@@ -142,6 +143,7 @@ mod tests {
                     glam::vec3(-translation_vec.x, translation_vec.y, 0.0) * 2.0
                 )
             );
+            assert_eq!(rect_transform.scale(), glam::Vec2::ONE);
         }
 
         // Scale + translation
@@ -166,6 +168,7 @@ mod tests {
                         glam::vec3(-translation_vec.x, translation_vec.y, 0.0) * 2.0
                     )
             );
+            assert_eq!(rect_transform.scale(), scale_factor);
         }
     }
 }

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -403,10 +403,7 @@ impl ViewBuilder {
         let projection_from_view = ndc_scale_and_translation * projection_from_view;
         // Need to take into account that a smaller portion of the world scale is visible now.
         let pixel_world_size_from_camera_distance = pixel_world_size_from_camera_distance
-            / ndc_scale_and_translation
-                .col(0)
-                .x
-                .max(ndc_scale_and_translation.col(1).y);
+            * config.viewport_transformation.scale().max_element();
 
         let mut view_from_world = config.view_from_world.to_mat4();
         // For OrthographicCameraMode::TopLeftCorner, we want Z facing forward.


### PR DESCRIPTION
### What

Fixes #2758 
* #2758

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
