### PR TITLE
Fix loading file via CLI

### DIFF
--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -327,6 +327,12 @@ pub enum StoreSource {
         llvm_version: String,
     },
 
+    /// Loading a file directly from disk via the CLI.
+    FileFromCLI {
+        rustc_version: String,
+        llvm_version: String,
+    },
+
     /// Perhaps from some manual data ingestion?
     Other(String),
 }
@@ -338,9 +344,13 @@ impl std::fmt::Display for StoreSource {
             Self::CSdk => "C SDK".fmt(f),
             Self::PythonSdk(version) => write!(f, "Python {version} SDK"),
             Self::RustSdk {
-                rustc_version: rust_version,
+                rustc_version,
                 llvm_version: _,
-            } => write!(f, "Rust {rust_version} SDK"),
+            } => write!(f, "Rust {rustc_version} SDK"),
+            Self::FileFromCLI {
+                rustc_version,
+                llvm_version: _,
+            } => write!(f, "File via CLI {rustc_version} "),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes
         }
     }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -328,7 +328,7 @@ pub enum StoreSource {
     },
 
     /// Loading a file directly from disk via the CLI.
-    FileFromCLI {
+    FileFromCli {
         rustc_version: String,
         llvm_version: String,
     },
@@ -347,7 +347,7 @@ impl std::fmt::Display for StoreSource {
                 rustc_version,
                 llvm_version: _,
             } => write!(f, "Rust {rustc_version} SDK"),
-            Self::FileFromCLI {
+            Self::FileFromCli {
                 rustc_version,
                 llvm_version: _,
             } => write!(f, "File via CLI {rustc_version} "),

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -477,7 +477,6 @@ impl App {
     /// Top-level ui function.
     ///
     /// Shows the viewer ui.
-    #[allow(clippy::too_many_arguments)]
     fn ui(
         &mut self,
         egui_ctx: &egui::Context,

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -95,10 +95,17 @@ impl AppEnvironment {
             StoreSource::CSdk => Self::CSdk,
             StoreSource::PythonSdk(python_version) => Self::PythonSdk(python_version.clone()),
             StoreSource::RustSdk {
-                rustc_version: rust_version,
+                rustc_version,
                 llvm_version,
             } => Self::RustSdk {
-                rustc_version: rust_version.clone(),
+                rustc_version: rustc_version.clone(),
+                llvm_version: llvm_version.clone(),
+            },
+            StoreSource::FileFromCLI {
+                rustc_version,
+                llvm_version,
+            } => Self::RerunCli {
+                rustc_version: rustc_version.clone(),
                 llvm_version: llvm_version.clone(),
             },
             StoreSource::Unknown | StoreSource::Other(_) => Self::RustSdk {

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -101,7 +101,7 @@ impl AppEnvironment {
                 rustc_version: rustc_version.clone(),
                 llvm_version: llvm_version.clone(),
             },
-            StoreSource::FileFromCLI {
+            StoreSource::FileFromCli {
                 rustc_version,
                 llvm_version,
             } => Self::RerunCli {

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -160,7 +160,7 @@ impl ViewerAnalytics {
                 StoreSource::CSdk => "c_sdk".to_owned(),
                 StoreSource::PythonSdk(_version) => "python_sdk".to_owned(),
                 StoreSource::RustSdk { .. } => "rust_sdk".to_owned(),
-                StoreSource::FileFromCLI { .. } => "file_cli".to_owned(),
+                StoreSource::FileFromCli { .. } => "file_cli".to_owned(),
                 StoreSource::Other(other) => other.clone(),
             };
 
@@ -171,7 +171,7 @@ impl ViewerAnalytics {
             // environment, _not_ the environment in which the viewer is running!
             #[allow(clippy::match_same_arms)]
             match &store_info.store_source {
-                StoreSource::FileFromCLI {
+                StoreSource::FileFromCli {
                     rustc_version,
                     llvm_version,
                 }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -160,6 +160,7 @@ impl ViewerAnalytics {
                 StoreSource::CSdk => "c_sdk".to_owned(),
                 StoreSource::PythonSdk(_version) => "python_sdk".to_owned(),
                 StoreSource::RustSdk { .. } => "rust_sdk".to_owned(),
+                StoreSource::FileFromCLI { .. } => "file_cli".to_owned(),
                 StoreSource::Other(other) => other.clone(),
             };
 
@@ -168,19 +169,27 @@ impl ViewerAnalytics {
             //
             // The Python/Rust versions appearing in events always apply to the recording
             // environment, _not_ the environment in which the viewer is running!
-            if let StoreSource::RustSdk {
-                rustc_version: rust_version,
-                llvm_version,
-            } = &store_info.store_source
-            {
-                self.register("rust_version", rust_version.to_string());
-                self.register("llvm_version", llvm_version.to_string());
-                self.deregister("python_version"); // can't be both!
-            }
-            if let StoreSource::PythonSdk(version) = &store_info.store_source {
-                self.register("python_version", version.to_string());
-                self.deregister("rust_version"); // can't be both!
-                self.deregister("llvm_version"); // can't be both!
+            #[allow(clippy::match_same_arms)]
+            match &store_info.store_source {
+                StoreSource::FileFromCLI {
+                    rustc_version,
+                    llvm_version,
+                }
+                | StoreSource::RustSdk {
+                    rustc_version,
+                    llvm_version,
+                } => {
+                    self.register("rust_version", rustc_version.to_string());
+                    self.register("llvm_version", llvm_version.to_string());
+                    self.deregister("python_version"); // can't be both!
+                }
+                StoreSource::PythonSdk(version) => {
+                    self.register("python_version", version.to_string());
+                    self.deregister("rust_version"); // can't be both!
+                    self.deregister("llvm_version"); // can't be both!
+                }
+                StoreSource::CSdk => {} // TODO(andreas): Send version and set it.
+                StoreSource::Unknown | StoreSource::Other(_) => {}
             }
 
             self.register("store_source", store_source);

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -882,7 +882,7 @@ fn load_file_to_channel_at(
                     store_id: store_id.clone(),
                     is_official_example: false,
                     started: re_log_types::Time::now(),
-                    store_source: re_log_types::StoreSource::FileFromCLI {
+                    store_source: re_log_types::StoreSource::FileFromCli {
                         rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
                         llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
                     },

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
-use re_log_types::{LogMsg, PythonVersion, SetStoreInfo};
+use re_log_types::{LogMsg, PythonVersion};
 use re_smart_channel::{Receiver, SmartMessagePayload};
 
 use anyhow::Context as _;
@@ -872,6 +872,7 @@ fn load_file_to_channel_at(
     } else {
         #[cfg(feature = "sdk")]
         {
+            use re_log_types::SetStoreInfo;
             // First, set a store info since this is the first thing the application expects.
             tx.send(LogMsg::SetStoreInfo(SetStoreInfo {
                 row_id: re_log_types::RowId::random(),


### PR DESCRIPTION
### What

Setting the `StoreSource` now before sending the file, propagating information about the kind of startup/store.

Fixes #2507
* #2507

<img width="1210" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/d9f15b59-1981-41d8-aaf7-f64f7f552cc5">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2807) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2807)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-cli-file-loading/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-cli-file-loading/examples)