### PR TITLE
Fix blueprint heuristic updates getting lost unless there were manual changes earlier

### DIFF
--- a/crates/re_space_view/src/data_blueprint.rs
+++ b/crates/re_space_view/src/data_blueprint.rs
@@ -218,7 +218,7 @@ impl DataBlueprintTree {
     /// Should be called on frame start.
     ///
     /// Propagates any data blueprint changes along the tree.
-    pub fn on_frame_start(&mut self) {
+    pub fn propagate_individual_to_tree(&mut self) {
         re_tracing::profile_function!();
 
         // NOTE: We could do this projection only when the entity properties changes

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -109,8 +109,6 @@ impl SpaceViewBlueprint {
         ctx: &mut ViewerContext<'_>,
         spaces_info: &SpaceInfoCollection,
     ) {
-        self.data_blueprint.on_frame_start();
-
         if !self.entities_determined_by_user {
             // Add entities that have been logged since we were created
             let queries_entities =
@@ -195,6 +193,9 @@ impl SpaceViewBlueprint {
             &self.data_blueprint.entity_paths().clone(), // Clone to work around borrow checker.
             self.data_blueprint.data_blueprints_individual(),
         );
+
+        // Propagate any changes that may have been made to blueprints right away.
+        self.data_blueprint.propagate_individual_to_tree();
 
         let query = re_viewer_context::ViewQuery {
             space_view_id: self.id,


### PR DESCRIPTION
### What

The issue was easiest to observe in the transform demo which relies completely on heuristics to display anything (all transform arrows have a configurable size): On startup or after reset nothing is visible until something was selected. This happened because `class.prepare_ui` sets the size (via heuristic) on the blueprint but `class.ui` would see the propagated results only by next frame. At this point we discard the entire blueprint unless there are manual changes. It seems changing the selection in the blueprint alone is enough to trigger such a change.

To fix this I'm now simply applying the heuristic changes in the same frame.

However, there seems to be a deeper underlying issue where until the first selection (or other change) is done we're discarding the blueprint every frame - once something is selected `sync_space_view` will overwrite the previous snapshot and heuristic results will be applied. This might be intended but seems rather odd. Expecation is that a lot of this will go away once we reworked blueprints/properties as planned. cc: @jleibs

part of #2779 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
