### PR TITLE
Temporarily switch points2d back to using the legacy entity interface

### DIFF
--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -100,6 +100,7 @@ where
 ///
 /// The callback passed in gets passed a long an [`SpatialSceneEntityContext`] which contains
 /// various useful information about an entity in the context of the current scene.
+#[allow(dead_code)]
 pub fn process_archetype_views<'a, A, const N: usize, F>(
     ctx: &mut ViewerContext<'_>,
     query: &ViewQuery<'_>,

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -124,6 +124,7 @@ where
 }
 
 /// Process [`Color`] components using annotations and default colors.
+#[allow(dead_code)]
 pub fn process_colors_arch<'a, A: Archetype>(
     arch_view: &'a re_query::ArchetypeView<A>,
     ent_path: &'a EntityPath,
@@ -171,6 +172,7 @@ where
 }
 
 /// Process [`Radius`] components to [`re_renderer::Size`] using auto size where no radius is specified.
+#[allow(dead_code)]
 pub fn process_radii_arch<'a, A: Archetype>(
     arch_view: &'a re_query::ArchetypeView<A>,
     ent_path: &EntityPath,
@@ -247,6 +249,7 @@ where
 }
 
 /// Resolves all annotations and keypoints for the given entity view.
+#[allow(dead_code)]
 fn process_annotations_and_keypoints_arch<Primary, A: Archetype>(
     query: &ViewQuery<'_>,
     arch_view: &re_query::ArchetypeView<A>,

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -1,10 +1,7 @@
+use re_components::{ClassId, ColorRGBA, InstanceKey, KeypointId, Label, Point2D, Radius};
 use re_data_store::{EntityPath, InstancePathHash};
-use re_query::{ArchetypeView, QueryError};
-use re_types::{
-    archetypes::Points2D,
-    components::{Label, Point2D},
-    Archetype,
-};
+use re_query::{EntityView, QueryError};
+use re_types::Loggable;
 use re_viewer_context::{
     ArchetypeDefinition, ResolvedAnnotationInfo, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
@@ -13,9 +10,8 @@ use re_viewer_context::{
 use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     parts::{
-        entity_iterator::process_archetype_views, load_keypoint_connections,
-        process_annotations_and_keypoints_arch, process_colors_arch, process_radii_arch, UiLabel,
-        UiLabelTarget,
+        entity_iterator::process_entity_views, load_keypoint_connections,
+        process_annotations_and_keypoints, process_colors, process_radii, UiLabel, UiLabelTarget,
     },
     view_kind::SpatialSpaceViewKind,
 };
@@ -39,15 +35,15 @@ impl Default for Points2DPart {
 
 impl Points2DPart {
     fn process_labels<'a>(
-        arch_view: &'a ArchetypeView<Points2D>,
+        entity_view: &'a EntityView<Point2D>,
         instance_path_hashes: &'a [InstancePathHash],
         colors: &'a [egui::Color32],
         annotation_infos: &'a [ResolvedAnnotationInfo],
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
             annotation_infos.iter(),
-            arch_view.iter_required_component::<Point2D>()?,
-            arch_view.iter_optional_component::<Label>()?,
+            entity_view.iter_primary()?,
+            entity_view.iter_component::<Label>()?,
             colors,
             instance_path_hashes,
         )
@@ -55,10 +51,10 @@ impl Points2DPart {
             move |(annotation_info, point, label, color, labeled_instance)| {
                 let label = annotation_info.label(label.map(|l| l.0).as_ref());
                 match (point, label) {
-                    (point, Some(label)) => Some(UiLabel {
+                    (Some(point), Some(label)) => Some(UiLabel {
                         text: label,
                         color: *color,
-                        target: UiLabelTarget::Point2D(egui::pos2(point.x(), point.y())),
+                        target: UiLabelTarget::Point2D(egui::pos2(point.x, point.y)),
                         labeled_instance: *labeled_instance,
                     }),
                     _ => None,
@@ -68,38 +64,39 @@ impl Points2DPart {
         Ok(labels)
     }
 
-    fn process_arch_view(
+    fn process_entity_view(
         &mut self,
         query: &ViewQuery<'_>,
-        arch_view: &ArchetypeView<Points2D>,
+        entity_view: &EntityView<Point2D>,
         ent_path: &EntityPath,
         ent_context: &SpatialSceneEntityContext<'_>,
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();
 
-        let (annotation_infos, keypoints) = process_annotations_and_keypoints_arch::<
-            Point2D,
-            Points2D,
-        >(query, arch_view, &ent_context.annotations)?;
+        let (annotation_infos, keypoints) = process_annotations_and_keypoints::<Point2D>(
+            query,
+            entity_view,
+            &ent_context.annotations,
+        )?;
 
-        let colors = process_colors_arch(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii_arch(arch_view, ent_path)?;
+        let colors = process_colors(entity_view, ent_path, &annotation_infos)?;
+        let radii = process_radii(ent_path, entity_view)?;
 
-        if arch_view.num_instances() <= self.max_labels {
+        if entity_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.
             let colors =
-                process_colors_arch(arch_view, ent_path, &annotation_infos)?.collect::<Vec<_>>();
+                process_colors(entity_view, ent_path, &annotation_infos)?.collect::<Vec<_>>();
 
             let instance_path_hashes_for_picking = {
                 re_tracing::profile_scope!("instance_hashes");
-                arch_view
+                entity_view
                     .iter_instance_keys()
                     .map(|instance_key| InstancePathHash::instance(ent_path, instance_key))
                     .collect::<Vec<_>>()
             };
 
             self.data.ui_labels.extend(Self::process_labels(
-                arch_view,
+                entity_view,
                 &instance_path_hashes_for_picking,
                 &colors,
                 &annotation_infos,
@@ -121,17 +118,17 @@ impl Points2DPart {
 
             let point_positions = {
                 re_tracing::profile_scope!("collect_points");
-                arch_view
-                    .iter_required_component::<Point2D>()?
-                    .map(|pt| pt.into())
+                entity_view
+                    .iter_primary()?
+                    .filter_map(|pt| pt.map(glam::Vec2::from))
             };
 
-            let picking_instance_ids = arch_view
+            let picking_instance_ids = entity_view
                 .iter_instance_keys()
                 .map(picking_id_from_instance_key);
 
             let mut point_range_builder = point_batch.add_points_2d(
-                arch_view.num_instances(),
+                entity_view.num_instances(),
                 point_positions,
                 radii,
                 colors,
@@ -143,7 +140,7 @@ impl Points2DPart {
                 re_tracing::profile_scope!("marking additional highlight points");
                 for (highlighted_key, instance_mask_ids) in &ent_context.highlight.instances {
                     // TODO(andreas/jeremy): We can do this much more efficiently
-                    let highlighted_point_index = arch_view
+                    let highlighted_point_index = entity_view
                         .iter_instance_keys()
                         .position(|key| *highlighted_key == key);
                     if let Some(highlighted_point_index) = highlighted_point_index {
@@ -160,9 +157,9 @@ impl Points2DPart {
         load_keypoint_connections(ent_context, ent_path, keypoints);
 
         self.data.extend_bounding_box_with_points(
-            arch_view
-                .iter_required_component::<Point2D>()?
-                .map(|pt| pt.into()),
+            entity_view
+                .iter_primary()?
+                .filter_map(|pt| pt.map(|pt| pt.into())),
             ent_context.world_from_obj,
         );
 
@@ -172,7 +169,15 @@ impl Points2DPart {
 
 impl ViewPartSystem for Points2DPart {
     fn archetype(&self) -> ArchetypeDefinition {
-        Points2D::all_components().try_into().unwrap()
+        vec1::vec1![
+            Point2D::name(),
+            InstanceKey::name(),
+            ColorRGBA::name(),
+            Radius::name(),
+            Label::name(),
+            ClassId::name(),
+            KeypointId::name()
+        ]
     }
 
     fn execute(
@@ -183,13 +188,14 @@ impl ViewPartSystem for Points2DPart {
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         re_tracing::profile_scope!("Points2DPart");
 
-        process_archetype_views::<Points2D, { Points2D::NUM_COMPONENTS }, _>(
+        process_entity_views::<re_components::Point2D, 7, _>(
             ctx,
             query,
             view_ctx,
             view_ctx.get::<EntityDepthOffsets>()?.points,
-            |_ctx, ent_path, arch_view, ent_context| {
-                self.process_arch_view(query, &arch_view, ent_path, ent_context)
+            self.archetype(),
+            |_ctx, ent_path, entity_view, ent_context| {
+                self.process_entity_view(query, &entity_view, ent_path, ent_context)
             },
         )?;
 


### PR DESCRIPTION
### What
Until we fix the iteration performance for archetypes, this change was a performance regression.
In order to cut the 0.8 release we'll temporarily undo this change and re-introduce it after cutting the release.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2811) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2811)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Frevert_points2d_archetype/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Frevert_points2d_archetype/examples)