### PR TITLE
Fix objectron 2D view not being 2D

### DIFF
--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -47,6 +47,11 @@ pub fn auto_spawn_heuristic(
         }
     }
 
+    if view_kind == SpatialSpaceViewKind::TwoD {
+        // Prefer 2D views over 3D views.
+        score += 0.1;
+    }
+
     AutoSpawnHeuristic::SpawnClassWithHighestScoreForRoot(score)
 }
 


### PR DESCRIPTION

<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Added a tie breaker for 2D/3D: Slightly preferring 2D views now. Very arbitrary but fixes our sample which exposes a common case: Objectron 2D space has on startup a camera, a transform (extrinsics) and an image. Image adds 1.0 towards 2D, transform3d adds 1.0 towards 3D and camera doesn't partake (since a camera at origin is to be expected for 2D).


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2819) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2819)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-objectron-2d-view-being-3d/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-objectron-2d-view-being-3d/examples)