### PR TITLE
Fix shutdown race-condition by introducing a flush_timeout before dropping data

### DIFF
--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -20,7 +20,7 @@ mod recording_stream;
 pub use self::msg_sender::{MsgSender, MsgSenderError};
 pub use self::recording_stream::{RecordingStream, RecordingStreamBuilder};
 
-pub use re_sdk_comms::default_server_addr;
+pub use re_sdk_comms::{default_flush_timeout, default_server_addr};
 
 pub use re_log_types::{ApplicationId, EntityPath, LegacyComponent, StoreId, StoreKind};
 pub use re_types::ComponentName;

--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -190,23 +190,16 @@ pub struct TcpSink {
 }
 
 impl TcpSink {
-    /// Default timeout to use for the `disconnected_timeout` of [`TcpSink::new`]
-    pub const DEFAULT_TIMEOUT: Option<std::time::Duration> =
-        Some(std::time::Duration::from_secs(2));
-
     /// Connect to the given address in a background thread.
     /// Retries until successful.
     ///
-    /// `disconnected_timeout` is the minimum time the [`TcpSink`] will wait during a flush
+    /// `flush_timeout` is the minimum time the [`TcpSink`] will wait during a flush
     /// before potentially dropping data.  Note: Passing `None` here can cause a
     /// call to `flush` to block indefinitely if a connection cannot be established.
     #[inline]
-    pub fn new(
-        addr: std::net::SocketAddr,
-        disconnected_timeout: Option<std::time::Duration>,
-    ) -> Self {
+    pub fn new(addr: std::net::SocketAddr, flush_timeout: Option<std::time::Duration>) -> Self {
         Self {
-            client: re_sdk_comms::Client::new(addr, disconnected_timeout),
+            client: re_sdk_comms::Client::new(addr, flush_timeout),
         }
     }
 }

--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -190,12 +190,23 @@ pub struct TcpSink {
 }
 
 impl TcpSink {
+    /// Default timeout to use for the `disconnected_timeout` of [`TcpSink::new`]
+    pub const DEFAULT_TIMEOUT: Option<std::time::Duration> =
+        Some(std::time::Duration::from_secs(2));
+
     /// Connect to the given address in a background thread.
     /// Retries until successful.
+    ///
+    /// `disconnected_timeout` is the minimum time the [`TcpSink`] will wait during a flush
+    /// before potentially dropping data.  Note: Passing `None` here can cause a
+    /// call to `flush` to block indefinitely if a connection cannot be established.
     #[inline]
-    pub fn new(addr: std::net::SocketAddr) -> Self {
+    pub fn new(
+        addr: std::net::SocketAddr,
+        disconnected_timeout: Option<std::time::Duration>,
+    ) -> Self {
         Self {
-            client: re_sdk_comms::Client::new(addr),
+            client: re_sdk_comms::Client::new(addr, disconnected_timeout),
         }
     }
 }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -218,7 +218,7 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec_stream = re_sdk::RecordingStreamBuilder::new("my_app")
-    ///     .connect(re_sdk::default_server_addr())?;
+    ///     .connect(re_sdk::default_server_addr(), re_sdk::sink::TcpSink::DEFAULT_TIMEOUT)?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn connect(

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -210,6 +210,10 @@ impl RecordingStreamBuilder {
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
     /// remote Rerun instance.
     ///
+    /// `disconnected_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
+    /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
+    /// call to `flush` to block indefinitely if a connection cannot be established.
+    ///
     /// ## Example
     ///
     /// ```no_run
@@ -217,13 +221,17 @@ impl RecordingStreamBuilder {
     ///     .connect(re_sdk::default_server_addr())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn connect(self, addr: std::net::SocketAddr) -> RecordingStreamResult<RecordingStream> {
+    pub fn connect(
+        self,
+        addr: std::net::SocketAddr,
+        disconnected_timeout: Option<std::time::Duration>,
+    ) -> RecordingStreamResult<RecordingStream> {
         let (enabled, store_info, batcher_config) = self.into_args();
         if enabled {
             RecordingStream::new(
                 store_info,
                 batcher_config,
-                Box::new(crate::log_sink::TcpSink::new(addr)),
+                Box::new(crate::log_sink::TcpSink::new(addr, disconnected_timeout)),
             )
         } else {
             re_log::debug!("Rerun disabled - call to connect() ignored");
@@ -794,11 +802,22 @@ impl RecordingStream {
     /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use
     /// the specified address.
     ///
+    /// `disconnected_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
+    /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
+    /// call to `flush` to block indefinitely if a connection cannot be established.
+    ///
     /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
-    pub fn connect(&self, addr: std::net::SocketAddr) {
-        self.set_sink(Box::new(crate::log_sink::TcpSink::new(addr)));
+    pub fn connect(
+        &self,
+        addr: std::net::SocketAddr,
+        disconnected_timeout: Option<std::time::Duration>,
+    ) {
+        self.set_sink(Box::new(crate::log_sink::TcpSink::new(
+            addr,
+            disconnected_timeout,
+        )));
     }
 
     /// Swaps the underlying sink for a [`crate::sink::MemorySink`] sink and returns the associated

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -210,7 +210,7 @@ impl RecordingStreamBuilder {
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
     /// remote Rerun instance.
     ///
-    /// `disconnected_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
+    /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
     /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
     /// call to `flush` to block indefinitely if a connection cannot be established.
     ///
@@ -218,20 +218,20 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec_stream = re_sdk::RecordingStreamBuilder::new("my_app")
-    ///     .connect(re_sdk::default_server_addr(), re_sdk::sink::TcpSink::DEFAULT_TIMEOUT)?;
+    ///     .connect(re_sdk::default_server_addr(), re_sdk::default_flush_timeout())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn connect(
         self,
         addr: std::net::SocketAddr,
-        disconnected_timeout: Option<std::time::Duration>,
+        flush_timeout: Option<std::time::Duration>,
     ) -> RecordingStreamResult<RecordingStream> {
         let (enabled, store_info, batcher_config) = self.into_args();
         if enabled {
             RecordingStream::new(
                 store_info,
                 batcher_config,
-                Box::new(crate::log_sink::TcpSink::new(addr, disconnected_timeout)),
+                Box::new(crate::log_sink::TcpSink::new(addr, flush_timeout)),
             )
         } else {
             re_log::debug!("Rerun disabled - call to connect() ignored");
@@ -802,22 +802,15 @@ impl RecordingStream {
     /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use
     /// the specified address.
     ///
-    /// `disconnected_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
+    /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
     /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
     /// call to `flush` to block indefinitely if a connection cannot be established.
     ///
     /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
-    pub fn connect(
-        &self,
-        addr: std::net::SocketAddr,
-        disconnected_timeout: Option<std::time::Duration>,
-    ) {
-        self.set_sink(Box::new(crate::log_sink::TcpSink::new(
-            addr,
-            disconnected_timeout,
-        )));
+    pub fn connect(&self, addr: std::net::SocketAddr, flush_timeout: Option<std::time::Duration>) {
+        self.set_sink(Box::new(crate::log_sink::TcpSink::new(addr, flush_timeout)));
     }
 
     /// Swaps the underlying sink for a [`crate::sink::MemorySink`] sink and returns the associated

--- a/crates/re_sdk_comms/src/buffered_client.rs
+++ b/crates/re_sdk_comms/src/buffered_client.rs
@@ -55,9 +55,10 @@ pub struct Client {
 impl Client {
     /// Connect via TCP to this log server.
     ///
-    /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
-    /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
-    /// call to `flush` to block indefinitely if a connection cannot be established.
+    /// `flush_timeout` is the minimum time the `TcpClient` will wait during a
+    /// flush before potentially dropping data.  Note: Passing `None` here can
+    /// cause a call to `flush` to block indefinitely if a connection cannot be
+    /// established.
     pub fn new(addr: SocketAddr, flush_timeout: Option<std::time::Duration>) -> Self {
         re_log::debug!("Connecting to remote {addr}…");
 

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -27,3 +27,9 @@ pub const DEFAULT_SERVER_PORT: u16 = 9876;
 pub fn default_server_addr() -> std::net::SocketAddr {
     std::net::SocketAddr::from(([127, 0, 0, 1], DEFAULT_SERVER_PORT))
 }
+
+/// The default amount of time to wait for the TCP connection to resume during a flush
+#[allow(clippy::unnecessary_wraps)]
+pub fn default_flush_timeout() -> Option<std::time::Duration> {
+    Some(std::time::Duration::from_secs(2))
+}

--- a/crates/re_sdk_comms/src/tcp_client.rs
+++ b/crates/re_sdk_comms/src/tcp_client.rs
@@ -65,15 +65,15 @@ impl TcpStreamState {
 pub struct TcpClient {
     addr: SocketAddr,
     stream_state: TcpStreamState,
-    disconnected_timeout: Option<Duration>,
+    flush_timeout: Option<Duration>,
 }
 
 impl TcpClient {
-    pub fn new(addr: SocketAddr, disconnected_timeout: Option<Duration>) -> Self {
+    pub fn new(addr: SocketAddr, flush_timeout: Option<Duration>) -> Self {
         Self {
             addr,
             stream_state: TcpStreamState::reset(),
-            disconnected_timeout,
+            flush_timeout,
         }
     }
 
@@ -172,17 +172,17 @@ impl TcpClient {
     }
 
     /// Check if the underlying [`TcpStream`] is in the [`TcpStreamState::Pending`] state
-    /// and has reached the timeout threshold.
+    /// and has reached the flush timeout threshold.
     ///
     /// Note that this only occurs after a failure to connect or a failure to send.
-    pub fn has_timed_out(&self) -> bool {
+    pub fn has_timed_out_for_flush(&self) -> bool {
         match self.stream_state {
             TcpStreamState::Pending {
                 start_time,
                 num_attempts,
             } => {
                 // If a timeout wasn't provided, never timeout
-                self.disconnected_timeout.map_or(false, |timeout| {
+                self.flush_timeout.map_or(false, |timeout| {
                     Instant::now().duration_since(start_time) > timeout && num_attempts > 0
                 })
             }

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -106,7 +106,10 @@ impl RerunArgs {
         }
 
         let sink: Box<dyn re_sdk::sink::LogSink> = match self.to_behavior()? {
-            RerunBehavior::Connect(addr) => Box::new(crate::sink::TcpSink::new(addr)),
+            RerunBehavior::Connect(addr) => Box::new(crate::sink::TcpSink::new(
+                addr,
+                crate::sink::TcpSink::DEFAULT_TIMEOUT,
+            )),
 
             RerunBehavior::Save(path) => Box::new(crate::sink::FileSink::new(path)?),
 

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -108,7 +108,7 @@ impl RerunArgs {
         let sink: Box<dyn re_sdk::sink::LogSink> = match self.to_behavior()? {
             RerunBehavior::Connect(addr) => Box::new(crate::sink::TcpSink::new(
                 addr,
-                crate::sink::TcpSink::DEFAULT_TIMEOUT,
+                crate::default_flush_timeout(),
             )),
 
             RerunBehavior::Save(path) => Box::new(crate::sink::FileSink::new(path)?),

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -61,7 +61,8 @@
 //! Then do this:
 //!
 //! ```no_run
-//! let rec_stream = rerun::RecordingStreamBuilder::new("my_app").connect(rerun::default_server_addr());
+//! let rec_stream = rerun::RecordingStreamBuilder::new("my_app")
+//!     .connect(rerun::default_server_addr(), rerun::default_flush_timeout());
 //! ```
 //!
 //! #### Buffering

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn rr_recording_stream_new(
         .expect("invalid tcp_addr string")
         .parse()
         .expect("invalid tcp_addr");
-    let sink = Box::new(TcpSink::new(tcp_addr, rerun_sdk::default_flush_timeout()));
+    let sink = Box::new(TcpSink::new(tcp_addr, re_sdk::default_flush_timeout()));
 
     let rec_stream = RecordingStream::new(store_info, batcher_config, sink).unwrap();
 

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn rr_recording_stream_new(
         .expect("invalid tcp_addr string")
         .parse()
         .expect("invalid tcp_addr");
-    let sink = Box::new(TcpSink::new(tcp_addr, TcpSink::DEFAULT_TIMEOUT));
+    let sink = Box::new(TcpSink::new(tcp_addr, rerun_sdk::default_flush_timeout()));
 
     let rec_stream = RecordingStream::new(store_info, batcher_config, sink).unwrap();
 

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn rr_recording_stream_new(
         .expect("invalid tcp_addr string")
         .parse()
         .expect("invalid tcp_addr");
-    let sink = Box::new(TcpSink::new(tcp_addr));
+    let sink = Box::new(TcpSink::new(tcp_addr, TcpSink::DEFAULT_TIMEOUT));
 
     let rec_stream = RecordingStream::new(store_info, batcher_config, sink).unwrap();
 

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -10,7 +10,9 @@ from rerun.recording_stream import RecordingStream
 # --- Sinks ---
 
 
-def connect(addr: str | None = None, recording: RecordingStream | None = None) -> None:
+def connect(
+    addr: str | None = None, disconnected_timeout_sec: float | None = 2.0, recording: RecordingStream | None = None
+) -> None:
     """
     Connect to a remote Rerun Viewer on the given ip:port.
 
@@ -22,6 +24,10 @@ def connect(addr: str | None = None, recording: RecordingStream | None = None) -
     ----------
     addr
         The ip:port to connect to
+    disconnected_timeout_sec: float
+        The minimum time the `TcpSink` will wait during a flush before potentially
+        dropping data. Passing `None` indicates no timeout, and can cause a call to
+        `flush` to block indefinitely.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -29,7 +35,7 @@ def connect(addr: str | None = None, recording: RecordingStream | None = None) -
 
     """
     recording = RecordingStream.to_native(recording)
-    bindings.connect(addr=addr, recording=recording)
+    bindings.connect(addr=addr, disconnected_timeout_sec=disconnected_timeout_sec, recording=recording)
 
 
 _connect = connect  # we need this because Python scoping is horrible

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -11,7 +11,7 @@ from rerun.recording_stream import RecordingStream
 
 
 def connect(
-    addr: str | None = None, disconnected_timeout_sec: float | None = 2.0, recording: RecordingStream | None = None
+    addr: str | None = None, flush_timeout_sec: float | None = 2.0, recording: RecordingStream | None = None
 ) -> None:
     """
     Connect to a remote Rerun Viewer on the given ip:port.
@@ -24,10 +24,10 @@ def connect(
     ----------
     addr
         The ip:port to connect to
-    disconnected_timeout_sec: float
+    flush_timeout_sec: float
         The minimum time the SDK will wait during a flush before potentially
-        dropping data. Passing `None` indicates no timeout, and can cause a call to
-        `flush` to block indefinitely.
+        dropping data if progress is not being made. Passing `None` indicates no timeout,
+        and can cause a call to `flush` to block indefinitely.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -35,7 +35,7 @@ def connect(
 
     """
     recording = RecordingStream.to_native(recording)
-    bindings.connect(addr=addr, disconnected_timeout_sec=disconnected_timeout_sec, recording=recording)
+    bindings.connect(addr=addr, flush_timeout_sec=flush_timeout_sec, recording=recording)
 
 
 _connect = connect  # we need this because Python scoping is horrible

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -25,7 +25,7 @@ def connect(
     addr
         The ip:port to connect to
     disconnected_timeout_sec: float
-        The minimum time the `TcpSink` will wait during a flush before potentially
+        The minimum time the SDK will wait during a flush before potentially
         dropping data. Passing `None` indicates no timeout, and can cause a call to
         `flush` to block indefinitely.
     recording:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -489,10 +489,10 @@ fn is_enabled(recording: Option<&PyRecordingStream>) -> bool {
 }
 
 #[pyfunction]
-#[pyo3(signature = (addr = None, disconnected_timeout_sec=rerun::sink::TcpSink::DEFAULT_TIMEOUT.unwrap().as_secs_f32(), recording = None))]
+#[pyo3(signature = (addr = None, flush_timeout_sec=rerun::default_flush_timeout().unwrap().as_secs_f32(), recording = None))]
 fn connect(
     addr: Option<String>,
-    disconnected_timeout_sec: Option<f32>,
+    flush_timeout_sec: Option<f32>,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     let addr = if let Some(addr) = addr {
@@ -501,18 +501,18 @@ fn connect(
         rerun::default_server_addr()
     };
 
-    let disconnected_timeout = disconnected_timeout_sec.map(std::time::Duration::from_secs_f32);
+    let flush_timeout = flush_timeout_sec.map(std::time::Duration::from_secs_f32);
 
     if let Some(recording) = recording {
         // If the user passed in a recording, use it
-        recording.connect(addr, disconnected_timeout);
+        recording.connect(addr, flush_timeout);
     } else {
         // Otherwise, connect both global defaults
         if let Some(recording) = get_data_recording(None) {
-            recording.connect(addr, disconnected_timeout);
+            recording.connect(addr, flush_timeout);
         };
         if let Some(blueprint) = get_blueprint_recording(None) {
-            blueprint.connect(addr, disconnected_timeout);
+            blueprint.connect(addr, flush_timeout);
         };
     }
 


### PR DESCRIPTION
Resolves: https://github.com/rerun-io/rerun/issues/2556

### What
We've always had a race condition during startup where a viewer might not exist despite a client trying to connect to it.

For users of spawn we could have added a bandaid here by probably increasing this sleep:
https://github.com/rerun-io/rerun/blob/main/rerun_py/rerun_sdk/rerun/sinks.py#L180

This wouldn't resolve issues for other use-cases of manually launching a viewer and client without tight orchestration.

Instead, we introduce a timeout (which can optionally be set to None), to use during the disconnected checks when we are flushing.  This gives power-users the option to specify None and reduce risk of losing data (at an increased risk of blocking during flush when things go wrong).

This PR also bumps a couple of debug logs up to warnings to make it more clear when data is being dropped.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2821) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2821)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Ftimeout_disconnects/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Ftimeout_disconnects/examples)