### PR TITLE
Fix selection highlighting in blueprint tree view

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -116,10 +116,9 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
     }
 
     {
-        // Turn off any expansion in the UI (see https://github.com/rerun-io/rerun/issues/2727)
-        egui_style.visuals.widgets.hovered.expansion = 0.0;
-        egui_style.visuals.widgets.active.expansion = 0.0;
-        egui_style.visuals.widgets.open.expansion = 0.0;
+        egui_style.visuals.widgets.hovered.expansion = 2.0;
+        egui_style.visuals.widgets.active.expansion = 2.0;
+        egui_style.visuals.widgets.open.expansion = 2.0;
     }
 
     egui_style.visuals.selection.bg_fill =

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -417,11 +417,6 @@ fn blueprint_row_with_buttons(
 ) {
     let where_to_add_hover_rect = ui.painter().add(egui::Shape::Noop);
 
-    ui.visuals_mut().widgets.hovered.expansion = 2.0;
-    ui.visuals_mut().widgets.active.expansion = 2.0;
-    ui.visuals_mut().widgets.open.expansion = 2.0;
-    ui.visuals_mut().widgets.inactive.expansion = 2.0;
-
     // Make the main button span the whole width to make it easier to click:
     let main_button_response = ui
         .with_layout(egui::Layout::top_down_justified(egui::Align::LEFT), |ui| {


### PR DESCRIPTION
### What

Before:

<img width="170" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3e2c9525-88d9-450d-8f58-b84f13a3ba4d">

After:

<img width="264" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/93437750-ff7b-42e5-8332-507cb1300e5c">

This PR also reverts #2796 (fixes #2828).


#### Changes
- Blue area is properly drawn
- Size of the hover/selection effect is fixed (after being broken in #2796)

Fixes #2728

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2824) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2824)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fblueprint_tree_selection_2728/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fblueprint_tree_selection_2728/examples)