### PR TITLE
Fix disconnected space APIs in Python SDK

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log/transform.py
+++ b/rerun_py/rerun_sdk/rerun/log/transform.py
@@ -161,7 +161,7 @@ def log_unknown_transform(
     recording = RecordingStream.to_native(recording)
 
     instanced: dict[str, Any] = {}
-    instanced["rerun.disconnected_transform"] = DisconnectedSpaceArray.single()
+    instanced["rerun.disconnected_space"] = DisconnectedSpaceArray.single()
     bindings.log_arrow_msg(entity_path, components=instanced, timeless=timeless, recording=recording)
 
 
@@ -193,7 +193,7 @@ def log_disconnected_space(
     recording = RecordingStream.to_native(recording)
 
     instanced: dict[str, Any] = {}
-    instanced["rerun.disconnected_transform"] = DisconnectedSpaceArray.single()
+    instanced["rerun.disconnected_space"] = DisconnectedSpaceArray.single()
     bindings.log_arrow_msg(entity_path, components=instanced, timeless=timeless, recording=recording)
 
 


### PR DESCRIPTION
The component name is `rerun.disconnected_space`, not `rerun.disconnect_transform`.

This will be checked by roundtrip tests in the archetype-based APIs.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2832) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2832)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Ffix_disconnected_space/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Ffix_disconnected_space/examples)