### PR TITLE
Actually use sccache in the reusable_checks job

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -40,6 +40,8 @@ env:
   # See: https://github.com/marketplace/actions/sccache-action
   SCCACHE_GHA_ENABLED: "false"
 
+  RUSTC_WRAPPER: "sccache"
+
 permissions:
   contents: "read"
   id-token: "write"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -40,8 +40,6 @@ env:
   # See: https://github.com/marketplace/actions/sccache-action
   SCCACHE_GHA_ENABLED: "false"
 
-  RUSTC_WRAPPER: "sccache"
-
 permissions:
   contents: "read"
   id-token: "write"
@@ -111,6 +109,8 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.7
+    env:
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
 
@@ -192,6 +192,8 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.7
+    env:
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
 
@@ -223,6 +225,8 @@ jobs:
   toml-lints:
     name: Lint TOML files
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
### What
It does not appear that sccache was running in the reusable_checks job. The [document](https://github.com/rerun-io/sccache-action#rust-code) indicates we should be setting this environment variable.

After setting this we see sccache is being used:
![image](https://github.com/rerun-io/rerun/assets/3312232/eac6c4de-a6e2-4335-8a04-bb510fc9950d)

And get a good speedup:
![image](https://github.com/rerun-io/rerun/assets/3312232/94762254-e252-4fbb-9e02-c74b3bf9eacc)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2834) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2834)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Fuse_sccache/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Fuse_sccache/examples)