### PR TITLE
Rename log_any to log

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-b1231093ce5784a399aa1c02f0b2ad6563b044d1420b4553cbd85830b8365817
+850c40e226cb550a05285b9b2371890c307e0807ea19ec5ef453f95557e375bd

--- a/docs/code-examples/point2d_random_v2.py
+++ b/docs/code-examples/point2d_random_v2.py
@@ -1,6 +1,6 @@
 """Log some random points with color and radii."""
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 from numpy.random import default_rng
 
 rr.init("points", spawn=True)
@@ -10,7 +10,7 @@ positions = rng.uniform(-3, 3, size=[10, 2])
 colors = rng.uniform(0, 255, size=[10, 4])
 radii = rng.uniform(0, 1, size=[10])
 
-rr_exp.log_any("random", rr_exp.Points2D(positions, colors=colors, radii=radii))
+rr2.log("random", rr2.Points2D(positions, colors=colors, radii=radii))
 
 # Log an extra rect to set the view bounds
 rr.log_rect("bounds", [0, 0, 8, 6], rect_format=rr.RectFormat.XCYCWH)

--- a/docs/code-examples/point2d_simple_v2.py
+++ b/docs/code-examples/point2d_simple_v2.py
@@ -1,10 +1,10 @@
 """Log some very simple points."""
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 
 rr.init("points", spawn=True)
 
-rr_exp.log_any("simple", rr_exp.Points2D([[0, 0], [1, 1]]))
+rr2.log("simple", rr2.Points2D([[0, 0], [1, 1]]))
 
 # Log an extra rect to set the view bounds
 rr.log_rect("bounds", [0, 0, 4, 3], rect_format=rr.RectFormat.XCYCWH)

--- a/docs/code-examples/point3d_random_v2.py
+++ b/docs/code-examples/point3d_random_v2.py
@@ -1,6 +1,6 @@
 """Log some random points with color and radii."""
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 from numpy.random import default_rng
 
 rr.init("points", spawn=True)
@@ -10,4 +10,4 @@ positions = rng.uniform(-5, 5, size=[10, 3])
 colors = rng.uniform(0, 255, size=[10, 3])
 radii = rng.uniform(0, 1, size=[10])
 
-rr_exp.log_any("random", rr_exp.Points3D(positions, colors=colors, radii=radii))
+rr2.log("random", rr2.Points3D(positions, colors=colors, radii=radii))

--- a/docs/code-examples/point3d_simple_v2.py
+++ b/docs/code-examples/point3d_simple_v2.py
@@ -1,7 +1,7 @@
 """Log some very simple points."""
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 
 rr.init("points", spawn=True)
 
-rr_exp.log_any("simple", rr_exp.Points3D([[0, 0, 0], [1, 1, 1]]))
+rr2.log("simple", rr2.Points3D([[0, 0, 0], [1, 1, 1]]))

--- a/docs/code-examples/transform3d_simple_v2.py
+++ b/docs/code-examples/transform3d_simple_v2.py
@@ -10,11 +10,11 @@ base_vector = [0, 1, 0]
 
 rr.log_arrow("base", origin=origin, vector=base_vector)
 
-rr2.log_any("base/translated", rr2.Transform3D(rrd.TranslationRotationScale3D(translation=[1, 0, 0])))
+rr2.log("base/translated", rr2.Transform3D(rrd.TranslationRotationScale3D(translation=[1, 0, 0])))
 
 rr.log_arrow("base/translated", origin=origin, vector=base_vector)
 
-rr2.log_any(
+rr2.log(
     "base/rotated_scaled",
     rrd.TranslationRotationScale3D(
         rotation=rrd.RotationAxisAngle(axis=[0, 0, 1], radians=3.14 / 4), scale=rrd.Scale3D(2)

--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -5,7 +5,7 @@ import argparse
 
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 
 
 def main() -> None:
@@ -47,11 +47,11 @@ def main() -> None:
 
     if not args.skip_blueprint:
         if args.auto_space_views:
-            rr_exp.set_auto_space_views(True)
+            rr2.set_auto_space_views(True)
 
-        rr_exp.set_panels(all_expanded=False)
+        rr2.set_panels(all_expanded=False)
 
-        rr_exp.add_space_view(name="overlaid", origin="/", entity_paths=["image", "rect/0", "rect/1"])
+        rr2.add_space_view(name="overlaid", origin="/", entity_paths=["image", "rect/0", "rect/1"])
 
 
 if __name__ == "__main__":

--- a/examples/python/notebook/blueprint.ipynb
+++ b/examples/python/notebook/blueprint.ipynb
@@ -1,128 +1,128 @@
 {
- "cells": [
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Set up environment"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import rerun as rr  # pip install rerun-sdk\n",
-    "import rerun.experimental as rr_exp  # Note: blueprint support is still experimental"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Initialize Rerun"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rr.init(\"Blueprint demo\")\n",
-    "rr.start_web_viewer_server()\n",
-    "\n",
-    "rec = rr.memory_recording()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Log Some Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img = np.zeros([128, 128, 3], dtype=\"uint8\")\n",
-    "for i in range(8):\n",
-    "    img[(i * 16) + 4 : (i * 16) + 12, :] = (0, 0, 200)\n",
-    "    rr.log_image(\"image\", img)\n",
-    "    rr.log_rect(\"rect/0\", [16, 16, 64, 64], label=\"Rect1\", color=(255, 0, 0))\n",
-    "    rr.log_rect(\"rect/1\", [48, 48, 64, 64], label=\"Rect2\", color=(0, 255, 0))\n",
-    "\n",
-    "# Show rec with default blueprint\n",
-    "rec"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Add a space view to the default blueprint"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bp = rr_exp.new_blueprint(\"Blueprint demo\", add_to_app_default_blueprint=True)\n",
-    "rr_exp.add_space_view(name=\"overlaid\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp)\n",
-    "bp.memory_recording().show(rec)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bp = rr_exp.new_blueprint(\"Blueprint demo\")\n",
-    "rr_exp.set_panels(all_expanded=False, blueprint=bp)\n",
-    "\n",
-    "rr_exp.add_space_view(name=\"overlaid\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp)\n",
-    "bp.memory_recording().show(rec)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "cells": [
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Set up environment"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import numpy as np\n",
+                "import rerun as rr  # pip install rerun-sdk\n",
+                "import rerun.experimental as rr2  # Note: blueprint support is still experimental"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Initialize Rerun"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "rr.init(\"Blueprint demo\")\n",
+                "rr.start_web_viewer_server()\n",
+                "\n",
+                "rec = rr.memory_recording()"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Log Some Data"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "img = np.zeros([128, 128, 3], dtype=\"uint8\")\n",
+                "for i in range(8):\n",
+                "    img[(i * 16) + 4 : (i * 16) + 12, :] = (0, 0, 200)\n",
+                "    rr.log_image(\"image\", img)\n",
+                "    rr.log_rect(\"rect/0\", [16, 16, 64, 64], label=\"Rect1\", color=(255, 0, 0))\n",
+                "    rr.log_rect(\"rect/1\", [48, 48, 64, 64], label=\"Rect2\", color=(0, 255, 0))\n",
+                "\n",
+                "# Show rec with default blueprint\n",
+                "rec"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Add a space view to the default blueprint"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "bp = rr2.new_blueprint(\"Blueprint demo\", add_to_app_default_blueprint=True)\n",
+                "rr2.add_space_view(name=\"overlaid\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp)\n",
+                "bp.memory_recording().show(rec)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "bp = rr2.new_blueprint(\"Blueprint demo\")\n",
+                "rr2.set_panels(all_expanded=False, blueprint=bp)\n",
+                "\n",
+                "rr2.add_space_view(name=\"overlaid\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp)\n",
+                "bp.memory_recording().show(rec)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.7"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
 }

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points2d.py
@@ -21,11 +21,11 @@ class Points2D(Archetype):
     -------
     ```python
     import rerun as rr
-    import rerun.experimental as rr_exp
+    import rerun.experimental as rr2
 
     rr.init("points", spawn=True)
 
-    rr_exp.log_any("simple", rr_exp.Points2D([[0, 0], [1, 1]]))
+    rr2.log_any("simple", rr2.Points2D([[0, 0], [1, 1]]))
 
     # Log an extra rect to set the view bounds
     rr.log_rect("bounds", [0, 0, 4, 3], rect_format=rr.RectFormat.XCYCWH)

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points2d.py
@@ -25,7 +25,7 @@ class Points2D(Archetype):
 
     rr.init("points", spawn=True)
 
-    rr2.log_any("simple", rr2.Points2D([[0, 0], [1, 1]]))
+    rr2.log("simple", rr2.Points2D([[0, 0], [1, 1]]))
 
     # Log an extra rect to set the view bounds
     rr.log_rect("bounds", [0, 0, 4, 3], rect_format=rr.RectFormat.XCYCWH)

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points3d.py
@@ -25,7 +25,7 @@ class Points3D(Archetype):
 
     rr.init("points", spawn=True)
 
-    rr2.log_any("simple", rr2.Points3D([[0, 0, 0], [1, 1, 1]]))
+    rr2.log("simple", rr2.Points3D([[0, 0, 0], [1, 1, 1]]))
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/points3d.py
@@ -21,11 +21,11 @@ class Points3D(Archetype):
     -------
     ```python
     import rerun as rr
-    import rerun.experimental as rr_exp
+    import rerun.experimental as rr2
 
     rr.init("points", spawn=True)
 
-    rr_exp.log_any("simple", rr_exp.Points3D([[0, 0, 0], [1, 1, 1]]))
+    rr2.log_any("simple", rr2.Points3D([[0, 0, 0], [1, 1, 1]]))
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/transform3d.py
@@ -31,11 +31,11 @@ class Transform3D(Archetype):
 
     rr.log_arrow("base", origin=origin, vector=base_vector)
 
-    rr2.log_any("base/translated", rr2.Transform3D(rrd.TranslationRotationScale3D(translation=[1, 0, 0])))
+    rr2.log("base/translated", rr2.Transform3D(rrd.TranslationRotationScale3D(translation=[1, 0, 0])))
 
     rr.log_arrow("base/translated", origin=origin, vector=base_vector)
 
-    rr2.log_any(
+    rr2.log(
        "base/rotated_scaled",
        rrd.TranslationRotationScale3D(
            rotation=rrd.RotationAxisAngle(axis=[0, 0, 1], radians=3.14 / 4), scale=rrd.Scale3D(2)

--- a/rerun_py/rerun_sdk/rerun/_rerun2/log_any.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/log_any.py
@@ -14,7 +14,7 @@ from . import components as cmp
 from . import datatypes as dt
 from ._baseclasses import Archetype, NamedExtensionArray
 
-__all__ = ["log_any"]
+__all__ = ["log"]
 
 
 EXT_PREFIX = "ext."
@@ -84,7 +84,7 @@ def _splat() -> cmp.InstanceKeyArray:
 
 
 Loggable = Union[Archetype, dt.Transform3DLike]
-"""All the things that `rr.log_any()` can accept and log."""
+"""All the things that `rr.log()` can accept and log."""
 
 
 _UPCASTING_RULES: dict[type[Loggable], Callable[[Any], Archetype]] = {
@@ -107,7 +107,7 @@ def _upcast_entity(entity: Loggable) -> Archetype:
     return cast(Archetype, entity)
 
 
-def log_any(
+def log(
     entity_path: str,
     entity: Loggable,
     ext: dict[str, Any] | None = None,

--- a/rerun_py/rerun_sdk/rerun/experimental.py
+++ b/rerun_py/rerun_sdk/rerun/experimental.py
@@ -21,7 +21,7 @@ __all__ = [
     "Points2D",
     "Points3D",
     "Transform3D",
-    "log_any",
+    "log",
 ]
 
 # Next-gen API imports
@@ -29,4 +29,4 @@ from ._rerun2 import archetypes as arch
 from ._rerun2 import components as cmp
 from ._rerun2 import datatypes as dt
 from ._rerun2.archetypes import Points2D, Points3D, Transform3D
-from ._rerun2.log_any import log_any
+from ._rerun2.log_any import log

--- a/rerun_py/tests/unit/test_log.py
+++ b/rerun_py/tests/unit/test_log.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 
 
 def test_log_point2d_basic() -> None:
     """Basic test: logging a point shouldn't raise an exception..."""
-    points = rr_exp.Points2D([(0, 0), (2, 2), (2, 2.5), (2.5, 2), (3, 4)], radii=0.5)
+    points = rr2.Points2D([(0, 0), (2, 2), (2, 2.5), (2.5, 2), (3, 4)], radii=0.5)
     rr.init("test_log")
-    rr_exp.log_any("points", points)
+    rr2.log("points", points)

--- a/rerun_py/tests/unit/test_points2d.py
+++ b/rerun_py/tests/unit/test_points2d.py
@@ -5,7 +5,7 @@ from typing import Optional, cast
 
 import numpy as np
 import pytest
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 from rerun.experimental import cmp as rr_cmp
 from rerun.experimental import dt as rr_dt
 
@@ -242,7 +242,7 @@ def test_points2d() -> None:
         instance_keys = cast(Optional[rr_cmp.InstanceKeyArrayLike], instance_keys)
 
         print(
-            f"rr_exp.Points2D(\n"
+            f"rr2.Points2D(\n"
             f"    {points}\n"
             f"    radii={radii}\n"
             f"    colors={colors}\n"
@@ -253,7 +253,7 @@ def test_points2d() -> None:
             f"    instance_keys={instance_keys}\n"
             f")"
         )
-        arch = rr_exp.Points2D(
+        arch = rr2.Points2D(
             points,
             radii=radii,
             colors=colors,
@@ -292,7 +292,7 @@ def non_empty(v: object) -> bool:
     ],
 )
 def test_point2d_single_color(data: rr_cmp.ColorArrayLike) -> None:
-    pts = rr_exp.Points2D(points=np.zeros((5, 2)), colors=data)
+    pts = rr2.Points2D(points=np.zeros((5, 2)), colors=data)
 
     assert pts.colors == rr_cmp.ColorArray.from_similar(rr_cmp.Color([0, 128, 0, 255]))
 
@@ -318,7 +318,7 @@ def test_point2d_single_color(data: rr_cmp.ColorArrayLike) -> None:
     ],
 )
 def test_point2d_multiple_colors(data: rr_cmp.ColorArrayLike) -> None:
-    pts = rr_exp.Points2D(points=np.zeros((5, 2)), colors=data)
+    pts = rr2.Points2D(points=np.zeros((5, 2)), colors=data)
 
     assert pts.colors == rr_cmp.ColorArray.from_similar(
         [

--- a/rerun_py/tests/unit/test_points3d.py
+++ b/rerun_py/tests/unit/test_points3d.py
@@ -5,7 +5,7 @@ from typing import Optional, cast
 
 import numpy as np
 import pytest
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 from rerun.experimental import cmp as rr_cmp
 from rerun.experimental import dt as rr_dt
 
@@ -242,7 +242,7 @@ def test_points3d() -> None:
         instance_keys = cast(Optional[rr_cmp.InstanceKeyArrayLike], instance_keys)
 
         print(
-            f"rr_exp.Points3D(\n"
+            f"rr2.Points3D(\n"
             f"    {points}\n"
             f"    radii={radii}\n"
             f"    colors={colors}\n"
@@ -253,7 +253,7 @@ def test_points3d() -> None:
             f"    instance_keys={instance_keys}\n"
             f")"
         )
-        arch = rr_exp.Points3D(
+        arch = rr2.Points3D(
             points,
             radii=radii,
             colors=colors,
@@ -294,7 +294,7 @@ def non_empty(v: object) -> bool:
     ],
 )
 def test_point3d_single_color(data: rr_cmp.ColorArrayLike) -> None:
-    pts = rr_exp.Points3D(points=np.zeros((5, 3)), colors=data)
+    pts = rr2.Points3D(points=np.zeros((5, 3)), colors=data)
 
     assert pts.colors == rr_cmp.ColorArray.from_similar(rr_cmp.Color([0, 128, 0, 255]))
 
@@ -320,7 +320,7 @@ def test_point3d_single_color(data: rr_cmp.ColorArrayLike) -> None:
     ],
 )
 def test_point3d_multiple_colors(data: rr_cmp.ColorArrayLike) -> None:
-    pts = rr_exp.Points3D(points=np.zeros((5, 3)), colors=data)
+    pts = rr2.Points3D(points=np.zeros((5, 3)), colors=data)
 
     assert pts.colors == rr_cmp.ColorArray.from_similar(
         [

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -8,7 +8,7 @@ import argparse
 
 import numpy as np
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 
 
 def main() -> None:
@@ -27,7 +27,7 @@ def main() -> None:
     keypoint_ids = np.array([2, 3], dtype=np.uint64)
     instance_keys = np.array([66, 666], dtype=np.uint64)
 
-    points2d = rr_exp.Points2D(
+    points2d = rr2.Points2D(
         points,
         radii=radii,
         colors=colors,
@@ -44,7 +44,7 @@ def main() -> None:
 
     rr.script_setup(args, "roundtrip_points2d")
 
-    rr_exp.log_any("points2d", points2d)
+    rr2.log("points2d", points2d)
     # Hack to establish 2d view bounds
     rr.log_rect("rect", [0, 0, 4, 6])
 

--- a/tests/python/roundtrips/points3d/main.py
+++ b/tests/python/roundtrips/points3d/main.py
@@ -8,7 +8,7 @@ import argparse
 
 import numpy as np
 import rerun as rr
-import rerun.experimental as rr_exp
+import rerun.experimental as rr2
 
 
 def main() -> None:
@@ -27,7 +27,7 @@ def main() -> None:
     keypoint_ids = np.array([2, 3], dtype=np.uint64)
     instance_keys = np.array([66, 666], dtype=np.uint64)
 
-    points3d = rr_exp.Points3D(
+    points3d = rr2.Points3D(
         points,
         radii=radii,
         colors=colors,
@@ -44,7 +44,7 @@ def main() -> None:
 
     rr.script_setup(args, "roundtrip_points3d")
 
-    rr_exp.log_any("points3d", points3d)
+    rr2.log("points3d", points3d)
 
     rr.script_teardown(args)
 

--- a/tests/python/roundtrips/transform3d/main.py
+++ b/tests/python/roundtrips/transform3d/main.py
@@ -19,29 +19,29 @@ def main() -> None:
 
     rr.script_setup(args, "roundtrip_transform3d")
 
-    rr2.log_any("translation_and_mat3x3/identity", rr2.Transform3D(rrd.TranslationAndMat3x3()))
+    rr2.log("translation_and_mat3x3/identity", rr2.Transform3D(rrd.TranslationAndMat3x3()))
 
-    rr2.log_any(
+    rr2.log(
         "translation_and_mat3x3/translation",
         rr2.Transform3D(rrd.TranslationAndMat3x3(translation=[1, 2, 3], from_parent=True)),
     )
 
-    rr2.log_any(
+    rr2.log(
         "translation_and_mat3x3/rotation",
         rr2.Transform3D(rrd.TranslationAndMat3x3(matrix=[1, 2, 3, 4, 5, 6, 7, 8, 9])),
     )
 
-    rr2.log_any(
+    rr2.log(
         "translation_rotation_scale/identity",
         rr2.Transform3D(rrd.TranslationRotationScale3D()),
     )
 
-    rr2.log_any(
+    rr2.log(
         "translation_rotation_scale/translation_scale",
         rr2.Transform3D(rrd.TranslationRotationScale3D(translation=[1, 2, 3], scale=42, from_parent=True)),
     )
 
-    rr2.log_any(
+    rr2.log(
         "translation_rotation_scale/rigid",
         rr2.Transform3D(
             rrd.TranslationRotationScale3D(
@@ -51,7 +51,7 @@ def main() -> None:
         ),
     )
 
-    rr2.log_any(
+    rr2.log(
         "translation_rotation_scale/affine",
         rr2.Transform3D(
             rrd.TranslationRotationScale3D(

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -34,19 +34,19 @@ def run_segmentation(experimental_api: bool) -> None:
 
     # Log a bunch of classified 2D points
     if experimental_api:
-        import rerun.experimental as rr_exp
+        import rerun.experimental as rr2
 
         # Note: this uses the new, WIP object-oriented API
-        rr_exp.log_any("seg_test/single_point", rr_exp.Points2D([64, 64], class_ids=13))
-        rr_exp.log_any("seg_test/single_point_labeled", rr_exp.Points2D([90, 50], class_ids=13, labels="labeled point"))
-        rr_exp.log_any("seg_test/several_points0", rr_exp.Points2D([[20, 50], [100, 70], [60, 30]], class_ids=42))
-        rr_exp.log_any(
+        rr2.log("seg_test/single_point", rr2.Points2D([64, 64], class_ids=13))
+        rr2.log("seg_test/single_point_labeled", rr2.Points2D([90, 50], class_ids=13, labels="labeled point"))
+        rr2.log("seg_test/several_points0", rr2.Points2D([[20, 50], [100, 70], [60, 30]], class_ids=42))
+        rr2.log(
             "seg_test/several_points1",
-            rr_exp.Points2D([[40, 50], [120, 70], [80, 30]], class_ids=np.array([13, 42, 99], dtype=np.uint8)),
+            rr2.Points2D([[40, 50], [120, 70], [80, 30]], class_ids=np.array([13, 42, 99], dtype=np.uint8)),
         )
-        rr_exp.log_any(
+        rr2.log(
             "seg_test/many points",
-            rr_exp.Points2D(
+            rr2.Points2D(
                 [[100 + (int(i / 5)) * 2, 100 + (i % 5) * 2] for i in range(25)],
                 class_ids=np.array([42], dtype=np.uint8),
             ),
@@ -148,36 +148,36 @@ def transform_test(experimental_api: bool) -> None:
     rr.log_disconnected_space("transform_test/disconnected")
 
     if experimental_api:
-        import rerun.experimental as rr_exp
+        import rerun.experimental as rr2
         from rerun.experimental import dt as rrd
 
         # Log scale along the x axis only.
-        rr_exp.log_any("transform_test/x_scaled", rrd.TranslationRotationScale3D(scale=(3, 1, 1)))
+        rr2.log("transform_test/x_scaled", rrd.TranslationRotationScale3D(scale=(3, 1, 1)))
 
         # Log a rotation around the z axis.
-        rr_exp.log_any(
+        rr2.log(
             "transform_test/z_rotated_object",
             rrd.TranslationRotationScale3D(rotation=rrd.RotationAxisAngle(axis=(1, 0, 0), angle=rrd.Angle(deg=45))),
         )
 
         # Log a transform from parent to child with a translation and skew along y and x.
-        rr_exp.log_any(
+        rr2.log(
             "transform_test/child_from_parent_translation",
             rrd.TranslationRotationScale3D(translation=(-1, 0, 0), from_parent=True),
         )
 
         # Log translation only.
-        rr_exp.log_any("transform_test/translation", rrd.TranslationRotationScale3D(translation=(2, 0, 0)))
-        rr_exp.log_any("transform_test/translation2", rrd.TranslationAndMat3x3(translation=(3, 0, 0)))
+        rr2.log("transform_test/translation", rrd.TranslationRotationScale3D(translation=(2, 0, 0)))
+        rr2.log("transform_test/translation2", rrd.TranslationAndMat3x3(translation=(3, 0, 0)))
 
         # Log uniform scale followed by translation along the Y-axis.
-        rr_exp.log_any(
+        rr2.log(
             "transform_test/scaled_and_translated_object",
             rrd.TranslationRotationScale3D(translation=[0, 0, 1], scale=3),
         )
 
         # Log translation + rotation, also called a rigid transform.
-        rr_exp.log_any(
+        rr2.log(
             "transform_test/rigid3",
             rrd.TranslationRotationScale3D(
                 translation=[1, 0, 1], rotation=rrd.RotationAxisAngle(axis=(0, 1, 0), angle=rrd.Angle(rad=1.57))
@@ -185,7 +185,7 @@ def transform_test(experimental_api: bool) -> None:
         )
 
         # Log translation, rotation & scale all at once.
-        rr_exp.log_any(
+        rr2.log(
             "transform_test/transformed",
             rrd.TranslationRotationScale3D(
                 translation=[2, 0, 1],
@@ -195,7 +195,7 @@ def transform_test(experimental_api: bool) -> None:
         )
 
         # Log a transform with translation and shear along x.
-        rr_exp.log_any(
+        rr2.log(
             "transform_test/shear",
             rrd.TranslationAndMat3x3(translation=(3, 0, 1), matrix=np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])),
         )
@@ -380,10 +380,10 @@ def transforms_rigid_3d(experimental_api: bool) -> None:
         rr.set_time_seconds("sim_time", time)
 
         if experimental_api:
-            import rerun.experimental as rr_exp
+            import rerun.experimental as rr2
             from rerun.experimental import dt as rrd
 
-            rr_exp.log_any(
+            rr2.log(
                 "transforms3d/sun/planet",
                 rrd.TranslationRotationScale3D(
                     translation=[
@@ -394,7 +394,7 @@ def transforms_rigid_3d(experimental_api: bool) -> None:
                     rotation=rrd.RotationAxisAngle(axis=(1, 0, 0), angle=rrd.Angle(deg=20)),
                 ),
             )
-            rr_exp.log_any(
+            rr2.log(
                 "transforms3d/sun/planet/moon",
                 rrd.TranslationRotationScale3D(
                     translation=[


### PR DESCRIPTION
### What
Rename `log_any` to `log` for the new experimental logging API.

Since this is now sub-moduled into `experimental` there isn't a conflict with the existing log module.

Also rename some `rr_exp` to `rr2`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2837) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2837)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Flog_any/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Flog_any/examples)