### PR TITLE
"Show bounding box" now shows correct bounding box, added "Show accumulated bounding box" for previous behavior

### DIFF
--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -299,11 +299,13 @@ impl framework::Example for RenderDepthClouds {
             let mut builder = LineStripSeriesBuilder::new(re_ctx);
             {
                 let mut line_batch = builder.batch("frame").world_from_obj(world_from_model);
-                line_batch.add_box_outline(glam::Affine3A::from_scale_rotation_translation(
-                    glam::Vec3::new(1.0, 1.0, 0.0),
-                    Default::default(),
-                    glam::Vec3::ONE * 0.5,
-                ));
+                line_batch.add_box_outline_from_transform(
+                    glam::Affine3A::from_scale_rotation_translation(
+                        glam::Vec3::new(1.0, 1.0, 0.0),
+                        Default::default(),
+                        glam::Vec3::ONE * 0.5,
+                    ),
+                );
             }
             builder.into_draw_data(re_ctx).unwrap()
         };

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -256,7 +256,10 @@ impl<'a> LineBatchBuilder<'a> {
     /// Internally adds 12 line segments with rounded line heads.
     /// Disables color gradient since we don't support gradients in this setup yet (i.e. enabling them does not look good)
     #[inline]
-    pub fn add_box_outline(&mut self, transform: glam::Affine3A) -> LineStripBuilder<'_> {
+    pub fn add_box_outline_from_transform(
+        &mut self,
+        transform: glam::Affine3A,
+    ) -> LineStripBuilder<'_> {
         let corners = [
             transform.transform_point3(glam::vec3(-0.5, -0.5, -0.5)),
             transform.transform_point3(glam::vec3(-0.5, -0.5, 0.5)),
@@ -288,6 +291,44 @@ impl<'a> LineBatchBuilder<'a> {
             .into_iter(),
         )
         .flags(LineStripSeriesBuilder::default_box_flags())
+    }
+
+    /// Add box outlines.
+    ///
+    /// Internally adds 12 line segments with rounded line heads.
+    /// Disables color gradient since we don't support gradients in this setup yet (i.e. enabling them does not look good)
+    ///
+    /// Returns None for empty and non-finite boxes.
+    #[inline]
+    pub fn add_box_outline(&mut self, bbox: &macaw::BoundingBox) -> Option<LineStripBuilder<'_>> {
+        if !bbox.is_something() || !bbox.is_finite() {
+            return None;
+        }
+
+        let corners = bbox.corners();
+        Some(
+            self.add_segments(
+                [
+                    // bottom:
+                    (corners[0b000], corners[0b001]),
+                    (corners[0b000], corners[0b010]),
+                    (corners[0b011], corners[0b001]),
+                    (corners[0b011], corners[0b010]),
+                    // top:
+                    (corners[0b100], corners[0b101]),
+                    (corners[0b100], corners[0b110]),
+                    (corners[0b111], corners[0b101]),
+                    (corners[0b111], corners[0b110]),
+                    // sides:
+                    (corners[0b000], corners[0b100]),
+                    (corners[0b001], corners[0b101]),
+                    (corners[0b010], corners[0b110]),
+                    (corners[0b011], corners[0b111]),
+                ]
+                .into_iter(),
+            )
+            .flags(LineStripSeriesBuilder::default_box_flags()),
+        )
     }
 
     /// Add rectangle outlines.

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -63,7 +63,7 @@ impl Boxes3DPart {
                 glam::Affine3A::from_scale_rotation_translation(half_size * 2.0, rot, tran);
 
             let box_lines = line_batch
-                .add_box_outline(transform)
+                .add_box_outline_from_transform(transform)
                 .radius(radius)
                 .color(color)
                 .picking_instance_id(picking_id_from_instance_key(instance_key));

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -202,6 +202,7 @@ impl SpatialSpaceViewState {
                     });
                     ui.checkbox(&mut self.state_3d.show_axes, "Show origin axes").on_hover_text("Show X-Y-Z axes");
                     ui.checkbox(&mut self.state_3d.show_bbox, "Show bounding box").on_hover_text("Show the current scene bounding box");
+                    ui.checkbox(&mut self.state_3d.show_accumulated_bbox, "Show accumulated bounding box").on_hover_text("Show bounding box accumulated over all rendered frames");
                 });
                 ui.end_row();
             }


### PR DESCRIPTION
### What

https://github.com/rerun-io/rerun/assets/1220815/4b835b83-b379-4806-90c7-0e5a08dcb735

.. mostly because it's very useful for debugging to see the accumualted bbox. Noticed then that the existing option showed the wrong thing.
 Considered only exposing it in debug builds, but we might run into a situation where we want to debug a user's installation and need it.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2844) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2844)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fshow-both-real-and-accumulated-bounding-box/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fshow-both-real-and-accumulated-bounding-box/examples)