### PR TITLE
Apply space view heuristics before showing any ui & improve default arrow length for camera extrinsics

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -50,7 +50,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         re_viewer_context::SpaceViewClassLayoutPriority::High
     }
 
-    fn prepare_ui(
+    fn on_frame_start(
         &self,
         ctx: &mut ViewerContext<'_>,
         state: &Self::State,

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -86,7 +86,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         }
     }
 
-    fn prepare_ui(
+    fn on_frame_start(
         &self,
         ctx: &mut ViewerContext<'_>,
         state: &Self::State,

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -123,6 +123,12 @@ impl AppState {
             command_sender,
         };
 
+        // First update the viewport and thus all active space views.
+        // This may update their heuristics, so that all panels that are shown in this frame,
+        // have the latest information.
+        let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
+        viewport.on_frame_start(&mut ctx, &spaces_info);
+
         time_panel.show_panel(&mut ctx, ui, app_blueprint.time_panel_expanded);
         selection_panel.show_panel(
             &mut ctx,
@@ -140,10 +146,6 @@ impl AppState {
         egui::CentralPanel::default()
             .frame(central_panel_frame)
             .show_inside(ui, |ui| {
-                let spaces_info = SpaceInfoCollection::new(&ctx.store_db.entity_db);
-
-                viewport.on_frame_start(&mut ctx, &spaces_info);
-
                 blueprint_panel_ui(
                     &mut viewport.blueprint,
                     &mut ctx,

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -91,6 +91,19 @@ pub trait DynSpaceViewClass {
         ent_paths: &IntSet<EntityPath>,
     ) -> AutoSpawnHeuristic;
 
+    /// Executed for all active space views on frame start (before any ui is drawn),
+    /// can be use for heuristic & state updates before populating the scene.
+    ///
+    /// Is only allowed to access archetypes defined by [`Self::blueprint_archetype`]
+    /// Passed entity properties are individual properties without propagated values.
+    fn on_frame_start(
+        &self,
+        ctx: &mut ViewerContext<'_>,
+        state: &mut dyn SpaceViewState,
+        ent_paths: &IntSet<EntityPath>,
+        entity_properties: &mut EntityPropertyMap,
+    );
+
     /// Ui shown when the user selects a space view of this class.
     ///
     /// TODO(andreas): Should this be instead implemented via a registered `data_ui` of all blueprint relevant types?
@@ -101,18 +114,6 @@ pub trait DynSpaceViewClass {
         state: &mut dyn SpaceViewState,
         space_origin: &EntityPath,
         space_view_id: SpaceViewId,
-    );
-
-    /// Executed before the ui method is called, can be use for heuristic & state updates before populating the scene.
-    ///
-    /// Is only allowed to access archetypes defined by [`Self::blueprint_archetype`]
-    /// Passed entity properties are individual properties without propagated values.
-    fn prepare_ui(
-        &self,
-        ctx: &mut ViewerContext<'_>,
-        state: &mut dyn SpaceViewState,
-        ent_paths: &IntSet<EntityPath>,
-        entity_properties: &mut EntityPropertyMap,
     );
 
     /// Draws the ui for this space view type and handles ui events.

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -65,6 +65,20 @@ pub trait SpaceViewClass: std::marker::Sized {
         None
     }
 
+    /// Executed for all active space views on frame start (before any ui is drawn),
+    /// can be use for heuristic & state updates before populating the scene.
+    ///
+    /// Is only allowed to access archetypes defined by [`Self::blueprint_archetype`]
+    /// Passed entity properties are individual properties without propagated values.
+    fn on_frame_start(
+        &self,
+        _ctx: &mut ViewerContext<'_>,
+        _state: &Self::State,
+        _ent_paths: &IntSet<EntityPath>,
+        _entity_properties: &mut re_data_store::EntityPropertyMap,
+    ) {
+    }
+
     /// Ui shown when the user selects a space view of this class.
     ///
     /// TODO(andreas): Should this be instead implemented via a registered `data_ui` of all blueprint relevant types?
@@ -76,19 +90,6 @@ pub trait SpaceViewClass: std::marker::Sized {
         space_origin: &EntityPath,
         space_view_id: SpaceViewId,
     );
-
-    /// Executed before the ui method is called, can be use for heuristic & state updates before populating the scene.
-    ///
-    /// Is only allowed to access archetypes defined by [`Self::blueprint_archetype`]
-    /// Passed entity properties are individual properties without propagated values.
-    fn prepare_ui(
-        &self,
-        _ctx: &mut ViewerContext<'_>,
-        _state: &Self::State,
-        _ent_paths: &IntSet<EntityPath>,
-        _entity_properties: &mut re_data_store::EntityPropertyMap,
-    ) {
-    }
 
     /// Draws the ui for this space view class and handles ui events.
     ///
@@ -166,7 +167,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
         self.blueprint_archetype()
     }
 
-    fn prepare_ui(
+    fn on_frame_start(
         &self,
         ctx: &mut ViewerContext<'_>,
         state: &mut dyn SpaceViewState,
@@ -174,7 +175,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
         entity_properties: &mut EntityPropertyMap,
     ) {
         typed_state_wrapper_mut(state, |state| {
-            self.prepare_ui(ctx, state, ent_paths, entity_properties);
+            self.on_frame_start(ctx, state, ent_paths, entity_properties);
         });
     }
 

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -128,16 +128,14 @@ impl SpaceViewBlueprint {
         .is_some()
         {}
 
-        // Do ui preparation as it may affect heuristics.
-        // (we want them up-to-date for everything that happens in this frame!)
-        self.class(ctx.space_view_class_registry).prepare_ui(
+        self.class(ctx.space_view_class_registry).on_frame_start(
             ctx,
             view_state,
             &self.data_blueprint.entity_paths().clone(), // Clone to work around borrow checker.
             self.data_blueprint.data_blueprints_individual(),
         );
 
-        // Propagate any changes that may have been made to blueprints right away.
+        // Propagate any heuristic changes that may have been in `on_frame_start` made to blueprints right away.
         self.data_blueprint.propagate_individual_to_tree();
     }
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -150,7 +150,12 @@ impl<'a, 'b> Viewport<'a, 'b> {
         re_tracing::profile_function!();
 
         for space_view in self.blueprint.space_views.values_mut() {
-            space_view.on_frame_start(ctx, spaces_info);
+            let space_view_state = self.state.space_view_state_mut(
+                ctx.space_view_class_registry,
+                space_view.id,
+                space_view.class_name(),
+            );
+            space_view.on_frame_start(ctx, spaces_info, space_view_state);
         }
 
         if self.blueprint.auto_space_views {

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -141,44 +141,44 @@ def run_2d_layering(experimental_api: bool) -> None:
     )
 
 
-def transform_test(experimental_api: bool) -> None:
-    rr.log_view_coordinates("transform_test", up="+Y")
+def transforms(experimental_api: bool) -> None:
+    rr.log_view_coordinates("transforms", up="+Y")
 
     # Log a disconnected space (this doesn't do anything here, but can be used to force a new space)
-    rr.log_disconnected_space("transform_test/disconnected")
+    rr.log_disconnected_space("transforms/disconnected")
 
     if experimental_api:
         import rerun.experimental as rr2
         from rerun.experimental import dt as rrd
 
         # Log scale along the x axis only.
-        rr2.log("transform_test/x_scaled", rrd.TranslationRotationScale3D(scale=(3, 1, 1)))
+        rr2.log("transforms/x_scaled", rrd.TranslationRotationScale3D(scale=(3, 1, 1)))
 
         # Log a rotation around the z axis.
         rr2.log(
-            "transform_test/z_rotated_object",
+            "transforms/z_rotated_object",
             rrd.TranslationRotationScale3D(rotation=rrd.RotationAxisAngle(axis=(1, 0, 0), angle=rrd.Angle(deg=45))),
         )
 
         # Log a transform from parent to child with a translation and skew along y and x.
         rr2.log(
-            "transform_test/child_from_parent_translation",
+            "transforms/child_from_parent_translation",
             rrd.TranslationRotationScale3D(translation=(-1, 0, 0), from_parent=True),
         )
 
         # Log translation only.
-        rr2.log("transform_test/translation", rrd.TranslationRotationScale3D(translation=(2, 0, 0)))
-        rr2.log("transform_test/translation2", rrd.TranslationAndMat3x3(translation=(3, 0, 0)))
+        rr2.log("transforms/translation", rrd.TranslationRotationScale3D(translation=(2, 0, 0)))
+        rr2.log("transforms/translation2", rrd.TranslationAndMat3x3(translation=(3, 0, 0)))
 
         # Log uniform scale followed by translation along the Y-axis.
         rr2.log(
-            "transform_test/scaled_and_translated_object",
+            "transforms/scaled_and_translated_object",
             rrd.TranslationRotationScale3D(translation=[0, 0, 1], scale=3),
         )
 
         # Log translation + rotation, also called a rigid transform.
         rr2.log(
-            "transform_test/rigid3",
+            "transforms/rigid3",
             rrd.TranslationRotationScale3D(
                 translation=[1, 0, 1], rotation=rrd.RotationAxisAngle(axis=(0, 1, 0), angle=rrd.Angle(rad=1.57))
             ),
@@ -186,7 +186,7 @@ def transform_test(experimental_api: bool) -> None:
 
         # Log translation, rotation & scale all at once.
         rr2.log(
-            "transform_test/transformed",
+            "transforms/transformed",
             rrd.TranslationRotationScale3D(
                 translation=[2, 0, 1],
                 rotation=rrd.RotationAxisAngle(axis=(0, 0, 1), angle=rrd.Angle(deg=20)),
@@ -196,40 +196,36 @@ def transform_test(experimental_api: bool) -> None:
 
         # Log a transform with translation and shear along x.
         rr2.log(
-            "transform_test/shear",
+            "transforms/shear",
             rrd.TranslationAndMat3x3(translation=(3, 0, 1), matrix=np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])),
         )
     else:
         # Log scale along the x axis only.
-        rr.log_transform3d("transform_test/x_scaled", rr.Scale3D((3, 1, 1)))
+        rr.log_transform3d("transforms/x_scaled", rr.Scale3D((3, 1, 1)))
 
         # Log a rotation around the z axis.
-        rr.log_transform3d("transform_test/z_rotated_object", rr.RotationAxisAngle((1, 0, 0), degrees=45))
+        rr.log_transform3d("transforms/z_rotated_object", rr.RotationAxisAngle((1, 0, 0), degrees=45))
 
         # Log a transform from parent to child with a translation and skew along y and x.
         rr.log_transform3d(
-            "transform_test/child_from_parent_translation",
+            "transforms/child_from_parent_translation",
             rr.Translation3D((-1, 0, 0)),
             from_parent=True,
         )
 
         # Log translation only.
-        rr.log_transform3d("transform_test/translation", rr.Translation3D((2, 0, 0)))
-        rr.log_transform3d("transform_test/translation2", rr.TranslationAndMat3((3, 0, 0)))
+        rr.log_transform3d("transforms/translation", rr.Translation3D((2, 0, 0)))
+        rr.log_transform3d("transforms/translation2", rr.TranslationAndMat3((3, 0, 0)))
 
         # Log uniform scale followed by translation along the Y-axis.
-        rr.log_transform3d(
-            "transform_test/scaled_and_translated_object", rr.TranslationRotationScale3D([0, 0, 1], scale=3)
-        )
+        rr.log_transform3d("transforms/scaled_and_translated_object", rr.TranslationRotationScale3D([0, 0, 1], scale=3))
 
         # Log translation + rotation, also called a rigid transform.
-        rr.log_transform3d(
-            "transform_test/rigid3", rr.Rigid3D([1, 0, 1], rr.RotationAxisAngle((0, 1, 0), radians=1.57))
-        )
+        rr.log_transform3d("transforms/rigid3", rr.Rigid3D([1, 0, 1], rr.RotationAxisAngle((0, 1, 0), radians=1.57)))
 
         # Log translation, rotation & scale all at once.
         rr.log_transform3d(
-            "transform_test/transformed",
+            "transforms/transformed",
             rr.TranslationRotationScale3D(
                 translation=[2, 0, 1],
                 rotation=rr.RotationAxisAngle((0, 0, 1), degrees=20),
@@ -239,7 +235,7 @@ def transform_test(experimental_api: bool) -> None:
 
         # Log a transform with translation and shear along x.
         rr.log_transform3d(
-            "transform_test/shear",
+            "transforms/shear",
             rr.TranslationAndMat3((3, 0, 1), np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])),
         )
 
@@ -527,7 +523,7 @@ def main() -> None:
         "segmentation": run_segmentation,
         "small_image": small_image,
         "text": run_text_logs,
-        "transform_test": transform_test,
+        "transforms": transforms,
         "transforms_rigid_3d": transforms_rigid_3d,
     }
 
@@ -566,7 +562,7 @@ def main() -> None:
         threads = []
         for name, test in tests.items():
             # Some tests are just a bit… too much
-            if args.test == "most" and name in ["image_tensors", "transform_test"]:
+            if args.test == "most" and name in ["image_tensors", "transforms"]:
                 continue
 
             if args.split_recordings:


### PR DESCRIPTION
### What

Commit by commit review recommended (ignoring the merge commit).

The central piece is fixing #2841 which was done in pair programming with @jleibs:
Until the first change we reset the blueprint every frame which is *fine* as long as heuristics run before any values from the blueprint are used. However, previously the selection panel runs before which may accidentally apply changes like clamping a value from infinity to some other value. This would then introduce a "user change" meaning the incorrect value got persisted.
We solved this "once and for all" by computing the heuristics before displaying any ui! This is likely to fix less well documented bugs in perceived heuristic behavior.

Additionally:
* rename `SpaceViewClass`'s `prepare_ui` to `on_frame_start` because that's what it is now
* transform arrow length are generally longer but are a quarter of the pinhole camera of which they seem to be extrinsics (if detected as such)
* fix test name

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2847) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2847)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-spaceview-heuristic-order-and-improve-arrow-lenght-heuristics-for-extrinsics/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-spaceview-heuristic-order-and-improve-arrow-lenght-heuristics-for-extrinsics/examples)