### PR TITLE
Improve error message when failing to load application state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,6 +4666,7 @@ dependencies = [
  "re_viewport",
  "re_ws_comms",
  "rfd",
+ "ron",
  "serde",
  "time",
  "wasm-bindgen-futures",

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -89,6 +89,7 @@ image = { workspace = true, default-features = false, features = ["png"] }
 itertools = { workspace = true }
 poll-promise = "0.2"
 rfd.workspace = true
+ron = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 time = { workspace = true, features = ["formatting"] }
 web-time.workspace = true


### PR DESCRIPTION
### What

Before:
```
[2023-07-27T14:07:06Z WARN  eframe::epi] Failed to decode RON: 1:339: Unexpected missing field `kind` in `StoreId`
```

After:
```
[2023-07-27T14:42:22Z WARN  re_viewer::app] Failed to restore application state. This is expected if you have just upgraded Rerun versions.
```

Future work: https://github.com/rerun-io/rerun/issues/2849

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
