### PR TITLE
Migrate to custom checkbox/radio_value UI

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -120,6 +120,8 @@ impl SpatialSpaceViewState {
         space_view_id: SpaceViewId,
         spatial_kind: SpatialSpaceViewKind,
     ) {
+        let re_ui = ctx.re_ui;
+
         let view_coordinates = ctx
             .store_db
             .store()
@@ -177,7 +179,7 @@ impl SpatialSpaceViewState {
                     {
                         self.state_3d.reset_camera(&self.scene_bbox_accum, &view_coordinates);
                     }
-                    ui.checkbox(&mut self.state_3d.spin, "Spin")
+                    re_ui.checkbox(ui, &mut self.state_3d.spin, "Spin")
                         .on_hover_text("Spin camera around the orbit center.");
                 }
             });
@@ -200,9 +202,9 @@ impl SpatialSpaceViewState {
                             ui.label(".");
                         });
                     });
-                    ui.checkbox(&mut self.state_3d.show_axes, "Show origin axes").on_hover_text("Show X-Y-Z axes");
-                    ui.checkbox(&mut self.state_3d.show_bbox, "Show bounding box").on_hover_text("Show the current scene bounding box");
-                    ui.checkbox(&mut self.state_3d.show_accumulated_bbox, "Show accumulated bounding box").on_hover_text("Show bounding box accumulated over all rendered frames");
+                    re_ui.checkbox(ui, &mut self.state_3d.show_axes, "Show origin axes").on_hover_text("Show X-Y-Z axes");
+                    re_ui.checkbox(ui, &mut self.state_3d.show_bbox, "Show bounding box").on_hover_text("Show the current scene bounding box");
+                    re_ui.checkbox(ui, &mut self.state_3d.show_accumulated_bbox, "Show accumulated bounding box").on_hover_text("Show bounding box accumulated over all rendered frames");
                 });
                 ui.end_row();
             }

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -536,7 +536,7 @@ impl TextureSettings {
                     selectable_value(ui, TextureScaling::Fill);
                 });
             if *scaling == TextureScaling::Fill {
-                ui.checkbox(keep_aspect_ratio, "Keep aspect ratio");
+                re_ui.checkbox(ui, keep_aspect_ratio, "Keep aspect ratio");
             }
         });
         ui.end_row();

--- a/crates/re_space_view_text/src/space_view_class.rs
+++ b/crates/re_space_view_text/src/space_view_class.rs
@@ -120,8 +120,10 @@ impl SpaceViewClass for TextSpaceView {
 
             ctx.re_ui.grid_left_hand_label(ui, "Text style");
             ui.vertical(|ui| {
-                ui.radio_value(&mut state.monospace, false, "Proportional");
-                ui.radio_value(&mut state.monospace, true, "Monospace");
+                ctx.re_ui
+                    .radio_value(ui, &mut state.monospace, false, "Proportional");
+                ctx.re_ui
+                    .radio_value(ui, &mut state.monospace, true, "Monospace");
             });
             ui.end_row();
         });

--- a/crates/re_space_view_text/src/space_view_class.rs
+++ b/crates/re_space_view_text/src/space_view_class.rs
@@ -97,21 +97,23 @@ impl SpaceViewClass for TextSpaceView {
             row_log_levels,
         } = &mut state.filters;
 
+        let re_ui = ctx.re_ui;
+
         ctx.re_ui.selection_grid(ui, "log_config").show(ui, |ui| {
             ctx.re_ui.grid_left_hand_label(ui, "Columns");
             ui.vertical(|ui| {
                 for (timeline, visible) in col_timelines {
-                    ui.checkbox(visible, timeline.name().to_string());
+                    re_ui.checkbox(ui, visible, timeline.name().to_string());
                 }
-                ui.checkbox(col_entity_path, "Entity path");
-                ui.checkbox(col_log_level, "Log level");
+                re_ui.checkbox(ui, col_entity_path, "Entity path");
+                re_ui.checkbox(ui, col_log_level, "Log level");
             });
             ui.end_row();
 
             ctx.re_ui.grid_left_hand_label(ui, "Level Filter");
             ui.vertical(|ui| {
                 for (log_level, visible) in row_log_levels {
-                    ui.checkbox(visible, level_to_rich_text(ui, log_level));
+                    re_ui.checkbox(ui, visible, level_to_rich_text(ui, log_level));
                 }
             });
             ui.end_row();

--- a/crates/re_space_view_text_box/src/space_view_class.rs
+++ b/crates/re_space_view_text_box/src/space_view_class.rs
@@ -75,7 +75,7 @@ impl SpaceViewClass for TextBoxSpaceView {
             ui.vertical(|ui| {
                 ui.radio_value(&mut state.monospace, false, "Proportional");
                 ui.radio_value(&mut state.monospace, true, "Monospace");
-                ui.checkbox(&mut state.word_wrap, "Word Wrap");
+                ctx.re_ui.checkbox(ui, &mut state.word_wrap, "Word Wrap");
             });
             ui.end_row();
         });

--- a/crates/re_space_view_text_box/src/space_view_class.rs
+++ b/crates/re_space_view_text_box/src/space_view_class.rs
@@ -73,8 +73,10 @@ impl SpaceViewClass for TextBoxSpaceView {
         ctx.re_ui.selection_grid(ui, "text_config").show(ui, |ui| {
             ctx.re_ui.grid_left_hand_label(ui, "Text style");
             ui.vertical(|ui| {
-                ui.radio_value(&mut state.monospace, false, "Proportional");
-                ui.radio_value(&mut state.monospace, true, "Monospace");
+                ctx.re_ui
+                    .radio_value(ui, &mut state.monospace, false, "Proportional");
+                ctx.re_ui
+                    .radio_value(ui, &mut state.monospace, true, "Monospace");
                 ctx.re_ui.checkbox(ui, &mut state.word_wrap, "Word Wrap");
             });
             ui.end_row();

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -210,6 +210,7 @@ impl eframe::App for ExampleApp {
                                 .large_collapsing_header(ui, "Blueprint", true, |ui| {
                                     ui.style_mut().wrap = Some(false);
                                     ui.label("Some blueprint stuff here, that might be wide.");
+                                    self.re_ui.checkbox(ui, &mut self.dummy_bool, "Checkbox");
                                 });
                         });
                     });

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -384,6 +384,25 @@ impl ReUi {
         .inner
     }
 
+    #[allow(clippy::unused_self)]
+    pub fn radio_value<Value: PartialEq>(
+        &self,
+        ui: &mut egui::Ui,
+        current_value: &mut Value,
+        alternative: Value,
+        text: impl Into<egui::WidgetText>,
+    ) -> egui::Response {
+        ui.scope(|ui| {
+            ui.visuals_mut().widgets.hovered.expansion = 0.0;
+            ui.visuals_mut().widgets.active.expansion = 0.0;
+            ui.visuals_mut().widgets.open.expansion = 0.0;
+
+            // NOLINT
+            ui.radio_value(current_value, alternative, text)
+        })
+        .inner
+    }
+
     pub fn large_button(&self, ui: &mut egui::Ui, icon: &Icon) -> egui::Response {
         self.large_button_impl(ui, icon, None, None)
     }

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -378,8 +378,8 @@ impl ReUi {
             ui.visuals_mut().widgets.active.expansion = 0.0;
             ui.visuals_mut().widgets.open.expansion = 0.0;
 
-            // note: fully qualified syntax to dodge script/lint.py
-            egui::Ui::checkbox(ui, selected, text)
+            // NOLINT
+            ui.checkbox(selected, text)
         })
         .inner
     }

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -366,6 +366,24 @@ impl ReUi {
         response
     }
 
+    #[allow(clippy::unused_self)]
+    pub fn checkbox(
+        &self,
+        ui: &mut egui::Ui,
+        selected: &mut bool,
+        text: impl Into<egui::WidgetText>,
+    ) -> egui::Response {
+        ui.scope(|ui| {
+            ui.visuals_mut().widgets.hovered.expansion = 0.0;
+            ui.visuals_mut().widgets.active.expansion = 0.0;
+            ui.visuals_mut().widgets.open.expansion = 0.0;
+
+            // note: fully qualified syntax to dodge script/lint.py
+            egui::Ui::checkbox(ui, selected, text)
+        })
+        .inner
+    }
+
     pub fn large_button(&self, ui: &mut egui::Ui, icon: &Icon) -> egui::Response {
         self.large_button_impl(ui, icon, None, None)
     }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -76,7 +76,7 @@ pub struct App {
     build_info: re_build_info::BuildInfo,
     startup_options: StartupOptions,
     ram_limit_warner: re_memory::RamLimitWarner,
-    re_ui: re_ui::ReUi,
+    pub(crate) re_ui: re_ui::ReUi,
     screenshotter: crate::screenshotter::Screenshotter,
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -480,6 +480,7 @@ impl App {
             .show_animated_inside(ui, self.memory_panel_open, |ui| {
                 self.memory_panel.ui(
                     ui,
+                    self.re_ui(),
                     &self.startup_options.memory_limit,
                     gpu_resource_stats,
                     store_stats,

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -17,7 +17,7 @@ const WATERMARK: bool = false; // Nice for recording media material
 #[serde(default)]
 pub struct AppState {
     /// Global options for the whole viewer.
-    app_options: AppOptions,
+    pub(crate) app_options: AppOptions,
 
     /// Things that need caching.
     #[serde(skip)]

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -40,6 +40,7 @@ impl MemoryPanel {
     pub fn ui(
         &self,
         ui: &mut egui::Ui,
+        re_ui: &re_ui::ReUi,
         limit: &MemoryLimit,
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_stats: &StoreHubStats,
@@ -54,7 +55,7 @@ impl MemoryPanel {
             .min_width(250.0)
             .default_width(300.0)
             .show_inside(ui, |ui| {
-                Self::left_side(ui, limit, gpu_resource_stats, store_stats);
+                Self::left_side(ui, re_ui, limit, gpu_resource_stats, store_stats);
             });
 
         egui::CentralPanel::default().show_inside(ui, |ui| {
@@ -65,6 +66,7 @@ impl MemoryPanel {
 
     fn left_side(
         ui: &mut egui::Ui,
+        re_ui: &re_ui::ReUi,
         limit: &MemoryLimit,
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_stats: &StoreHubStats,
@@ -73,7 +75,7 @@ impl MemoryPanel {
 
         ui.separator();
         ui.collapsing("CPU Resources", |ui| {
-            Self::cpu_stats(ui, limit);
+            Self::cpu_stats(ui, re_ui, limit);
         });
 
         ui.separator();
@@ -100,7 +102,7 @@ impl MemoryPanel {
         });
     }
 
-    fn cpu_stats(ui: &mut egui::Ui, limit: &MemoryLimit) {
+    fn cpu_stats(ui: &mut egui::Ui, re_ui: &re_ui::ReUi, limit: &MemoryLimit) {
         if let Some(limit) = limit.limit {
             ui.label(format!("Memory limit: {}", format_bytes(limit as _)));
         } else {
@@ -129,7 +131,12 @@ impl MemoryPanel {
         }
 
         let mut is_tracking_callstacks = re_memory::accounting_allocator::is_tracking_callstacks();
-        ui.checkbox(&mut is_tracking_callstacks, "Detailed allocation tracking")
+        re_ui
+            .checkbox(
+                ui,
+                &mut is_tracking_callstacks,
+                "Detailed allocation tracking",
+            )
             .on_hover_text("This will slow down the program.");
         re_memory::accounting_allocator::set_tracking_callstacks(is_tracking_callstacks);
 

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -12,6 +12,6 @@ pub use blueprint_panel::blueprint_panel_ui;
 // ----
 
 pub(crate) use {
-    self::mobile_warning_ui::mobile_warning_ui, self::rerun_menu::rerun_menu_button_ui,
-    self::top_panel::top_panel, self::wait_screen_ui::wait_screen_ui,
+    self::mobile_warning_ui::mobile_warning_ui, self::top_panel::top_panel,
+    self::wait_screen_ui::wait_screen_ui,
 };

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -3,375 +3,385 @@
 use egui::NumExt as _;
 
 use re_ui::UICommand;
-use re_viewer_context::{AppOptions, StoreContext, SystemCommand, SystemCommandSender};
+use re_viewer_context::{StoreContext, SystemCommand, SystemCommandSender};
 
 use crate::App;
 
-pub fn rerun_menu_button_ui(
-    store_context: Option<&StoreContext<'_>>,
-    ui: &mut egui::Ui,
-    frame: &mut eframe::Frame,
-    app: &mut App,
-) {
-    // let desired_icon_height = ui.max_rect().height() - 2.0 * ui.spacing_mut().button_padding.y;
-    let desired_icon_height = ui.max_rect().height() - 4.0; // TODO(emilk): figure out this fudge
-    let desired_icon_height = desired_icon_height.at_most(28.0); // figma size 2023-02-03
+impl App {
+    pub fn rerun_menu_button_ui(
+        &mut self,
+        store_context: Option<&StoreContext<'_>>,
+        ui: &mut egui::Ui,
+        frame: &mut eframe::Frame,
+    ) {
+        // let desired_icon_height = ui.max_rect().height() - 2.0 * ui.spacing_mut().button_padding.y;
+        let desired_icon_height = ui.max_rect().height() - 4.0; // TODO(emilk): figure out this fudge
+        let desired_icon_height = desired_icon_height.at_most(28.0); // figma size 2023-02-03
 
-    let icon_image = app.re_ui().icon_image(&re_ui::icons::RERUN_MENU);
-    let image_size = icon_image.size_vec2() * (desired_icon_height / icon_image.size_vec2().y);
-    let texture_id = icon_image.texture_id(ui.ctx());
+        let icon_image = self.re_ui().icon_image(&re_ui::icons::RERUN_MENU);
+        let image_size = icon_image.size_vec2() * (desired_icon_height / icon_image.size_vec2().y);
+        let texture_id = icon_image.texture_id(ui.ctx());
 
-    ui.menu_image_button(texture_id, image_size, |ui| {
-        ui.set_min_width(220.0);
-        let spacing = 12.0;
+        ui.menu_image_button(texture_id, image_size, |ui| {
+            ui.set_min_width(220.0);
+            let spacing = 12.0;
 
-        ui.menu_button("About", |ui| about_rerun_ui(ui, app.build_info()));
-
-        ui.add_space(spacing);
-
-        UICommand::ToggleCommandPalette.menu_button_ui(ui, &app.command_sender);
-
-        ui.add_space(spacing);
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            UICommand::Open.menu_button_ui(ui, &app.command_sender);
-
-            save_buttons_ui(ui, store_context, app);
+            ui.menu_button("About", |ui| self.about_rerun_ui(ui));
 
             ui.add_space(spacing);
 
-            // On the web the browser controls the zoom
-            let zoom_factor = app.app_options().zoom_factor;
-            ui.weak(format!("Zoom {:.0}%", zoom_factor * 100.0))
-                .on_hover_text("The zoom factor applied on top of the OS scaling factor.");
-            UICommand::ZoomIn.menu_button_ui(ui, &app.command_sender);
-            UICommand::ZoomOut.menu_button_ui(ui, &app.command_sender);
-            ui.add_enabled_ui(zoom_factor != 1.0, |ui| {
-                UICommand::ZoomReset.menu_button_ui(ui, &app.command_sender)
-            });
-
-            UICommand::ToggleFullscreen.menu_button_ui(ui, &app.command_sender);
+            UICommand::ToggleCommandPalette.menu_button_ui(ui, &self.command_sender);
 
             ui.add_space(spacing);
-        }
-
-        {
-            UICommand::ResetViewer.menu_button_ui(ui, &app.command_sender);
 
             #[cfg(not(target_arch = "wasm32"))]
-            UICommand::OpenProfiler.menu_button_ui(ui, &app.command_sender);
+            {
+                UICommand::Open.menu_button_ui(ui, &self.command_sender);
 
-            UICommand::ToggleMemoryPanel.menu_button_ui(ui, &app.command_sender);
-        }
+                self.save_buttons_ui(ui, store_context);
 
-        ui.add_space(spacing);
+                ui.add_space(spacing);
 
-        {
-            ui.menu_button("Recordings", |ui| {
-                recordings_menu(ui, store_context, app);
-            });
-        }
+                // On the web the browser controls the zoom
+                let zoom_factor = self.app_options().zoom_factor;
+                ui.weak(format!("Zoom {:.0}%", zoom_factor * 100.0))
+                    .on_hover_text("The zoom factor applied on top of the OS scaling factor.");
+                UICommand::ZoomIn.menu_button_ui(ui, &self.command_sender);
+                UICommand::ZoomOut.menu_button_ui(ui, &self.command_sender);
+                ui.add_enabled_ui(zoom_factor != 1.0, |ui| {
+                    UICommand::ZoomReset.menu_button_ui(ui, &self.command_sender)
+                });
 
-        ui.menu_button("Options", |ui| {
-            options_menu_ui(ui, frame, app.app_options_mut());
-        });
+                UICommand::ToggleFullscreen.menu_button_ui(ui, &self.command_sender);
 
-        ui.add_space(spacing);
-        ui.hyperlink_to(
-            "Help",
-            "https://www.rerun.io/docs/getting-started/viewer-walkthrough",
-        );
+                ui.add_space(spacing);
+            }
 
-        #[cfg(not(target_arch = "wasm32"))]
-        {
+            {
+                UICommand::ResetViewer.menu_button_ui(ui, &self.command_sender);
+
+                #[cfg(not(target_arch = "wasm32"))]
+                UICommand::OpenProfiler.menu_button_ui(ui, &self.command_sender);
+
+                UICommand::ToggleMemoryPanel.menu_button_ui(ui, &self.command_sender);
+            }
+
             ui.add_space(spacing);
-            UICommand::Quit.menu_button_ui(ui, &app.command_sender);
-        }
-    });
-}
 
-fn about_rerun_ui(ui: &mut egui::Ui, build_info: &re_build_info::BuildInfo) {
-    let re_build_info::BuildInfo {
-        crate_name,
-        version,
-        rustc_version,
-        llvm_version,
-        git_hash,
-        git_branch: _,
-        is_in_rerun_workspace: _,
-        target_triple,
-        datetime,
-    } = *build_info;
+            {
+                ui.menu_button("Recordings", |ui| {
+                    self.recordings_menu(ui, store_context);
+                });
+            }
 
-    ui.style_mut().wrap = Some(false);
+            ui.menu_button("Options", |ui| {
+                self.options_menu_ui(ui, frame);
+            });
 
-    let rustc_version = if rustc_version.is_empty() {
-        "unknown"
-    } else {
-        rustc_version
-    };
+            ui.add_space(spacing);
+            ui.hyperlink_to(
+                "Help",
+                "https://www.rerun.io/docs/getting-started/viewer-walkthrough",
+            );
 
-    let llvm_version = if llvm_version.is_empty() {
-        "unknown"
-    } else {
-        llvm_version
-    };
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                ui.add_space(spacing);
+                UICommand::Quit.menu_button_ui(ui, &self.command_sender);
+            }
+        });
+    }
 
-    let short_git_hash = &git_hash[..std::cmp::min(git_hash.len(), 7)];
+    fn about_rerun_ui(&self, ui: &mut egui::Ui) {
+        let re_build_info::BuildInfo {
+            crate_name,
+            version,
+            rustc_version,
+            llvm_version,
+            git_hash,
+            git_branch: _,
+            is_in_rerun_workspace: _,
+            target_triple,
+            datetime,
+        } = *self.build_info();
 
-    ui.label(format!(
-        "{crate_name} {version} ({short_git_hash})\n\
+        ui.style_mut().wrap = Some(false);
+
+        let rustc_version = if rustc_version.is_empty() {
+            "unknown"
+        } else {
+            rustc_version
+        };
+
+        let llvm_version = if llvm_version.is_empty() {
+            "unknown"
+        } else {
+            llvm_version
+        };
+
+        let short_git_hash = &git_hash[..std::cmp::min(git_hash.len(), 7)];
+
+        ui.label(format!(
+            "{crate_name} {version} ({short_git_hash})\n\
         {target_triple}\n\
         rustc {rustc_version}\n\
         LLVM {llvm_version}\n\
         Built {datetime}",
-    ));
+        ));
 
-    ui.add_space(12.0);
-    ui.hyperlink_to("www.rerun.io", "https://www.rerun.io/");
-}
-
-fn recordings_menu(ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>, app: &App) {
-    let store_dbs = store_context.map_or(vec![], |ctx| ctx.alternate_recordings.clone());
-
-    if store_dbs.is_empty() {
-        ui.weak("(empty)");
-        return;
+        ui.add_space(12.0);
+        ui.hyperlink_to("www.rerun.io", "https://www.rerun.io/");
     }
 
-    let active_recording = store_context
-        .and_then(|ctx| ctx.recording)
-        .map(|rec| rec.store_id());
+    fn recordings_menu(&self, ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>) {
+        let store_dbs = store_context.map_or(vec![], |ctx| ctx.alternate_recordings.clone());
 
-    ui.style_mut().wrap = Some(false);
-    for store_db in &store_dbs {
-        let info = if let Some(store_info) = store_db.store_info() {
-            format!(
-                "{} - {}",
-                store_info.application_id,
-                store_info.started.format()
-            )
-        } else {
-            "<UNKNOWN>".to_owned()
-        };
-        if ui
-            .radio(active_recording == Some(store_db.store_id()), info)
-            .clicked()
-        {
-            app.command_sender
-                .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
+        if store_dbs.is_empty() {
+            ui.weak("(empty)");
+            return;
+        }
+
+        let active_recording = store_context
+            .and_then(|ctx| ctx.recording)
+            .map(|rec| rec.store_id());
+
+        ui.style_mut().wrap = Some(false);
+        for store_db in &store_dbs {
+            let info = if let Some(store_info) = store_db.store_info() {
+                format!(
+                    "{} - {}",
+                    store_info.application_id,
+                    store_info.started.format()
+                )
+            } else {
+                "<UNKNOWN>".to_owned()
+            };
+            if ui
+                .radio(active_recording == Some(store_db.store_id()), info)
+                .clicked()
+            {
+                self.command_sender
+                    .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
+            }
         }
     }
-}
 
-fn options_menu_ui(ui: &mut egui::Ui, _frame: &mut eframe::Frame, options: &mut AppOptions) {
-    ui.style_mut().wrap = Some(false);
+    fn options_menu_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        ui.style_mut().wrap = Some(false);
 
-    if ui
-        .checkbox(&mut options.show_metrics, "Show performance metrics")
-        .on_hover_text("Show metrics for milliseconds/frame and RAM usage in the top bar.")
-        .clicked()
-    {
-        ui.close_menu();
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        if ui
-            .checkbox(&mut options.experimental_space_view_screenshots, "(experimental) Space View screenshots")
-            .on_hover_text("Allow taking screenshots of 2D & 3D space views via their context menu. Does not contain labels.")
+        if self
+            .re_ui
+            .checkbox(
+                ui,
+                &mut self.state.app_options.show_metrics,
+                "Show performance metrics",
+            )
+            .on_hover_text("Show metrics for milliseconds/frame and RAM usage in the top bar.")
             .clicked()
         {
             ui.close_menu();
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if self.re_ui
+                .checkbox(ui, &mut self.state.app_options.experimental_space_view_screenshots, "(experimental) Space View screenshots")
+                .on_hover_text("Allow taking screenshots of 2D & 3D space views via their context menu. Does not contain labels.")
+                .clicked()
+            {
+                ui.close_menu();
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            ui.separator();
+            ui.label("Debug:");
+
+            self.egui_debug_options_ui(ui);
+            ui.separator();
+            self.debug_menu_options_ui(ui, _frame);
+        }
+    }
+
+    // TODO(emilk): support saving data on web
+    #[cfg(not(target_arch = "wasm32"))]
+    fn save_buttons_ui(&mut self, ui: &mut egui::Ui, store_view: Option<&StoreContext<'_>>) {
+        use re_ui::UICommandSender;
+
+        let file_save_in_progress = self.background_tasks.is_file_save_in_progress();
+
+        let save_button = UICommand::Save.menu_button(ui.ctx());
+        let save_selection_button = UICommand::SaveSelection.menu_button(ui.ctx());
+
+        if file_save_in_progress {
+            ui.add_enabled_ui(false, |ui| {
+                ui.horizontal(|ui| {
+                    ui.add(save_button);
+                    ui.spinner();
+                });
+                ui.horizontal(|ui| {
+                    ui.add(save_selection_button);
+                    ui.spinner();
+                });
+            });
+        } else {
+            let store_db_is_nonempty = store_view
+                .and_then(|view| view.recording)
+                .map_or(false, |recording| !recording.is_empty());
+            ui.add_enabled_ui(store_db_is_nonempty, |ui| {
+                if ui
+                    .add(save_button)
+                    .on_hover_text("Save all data to a Rerun data file (.rrd)")
+                    .clicked()
+                {
+                    ui.close_menu();
+                    self.command_sender.send_ui(UICommand::Save);
+                }
+
+                // We need to know the loop selection _before_ we can even display the
+                // button, as this will determine whether its grayed out or not!
+                // TODO(cmc): In practice the loop (green) selection is always there
+                // at the moment so...
+                let loop_selection = self.state.loop_selection(store_view);
+
+                if ui
+                    .add_enabled(loop_selection.is_some(), save_selection_button)
+                    .on_hover_text(
+                        "Save data for the current loop selection to a Rerun data file (.rrd)",
+                    )
+                    .clicked()
+                {
+                    ui.close_menu();
+                    self.command_sender.send_ui(UICommand::SaveSelection);
+                }
+            });
         }
     }
 
     #[cfg(debug_assertions)]
-    {
-        ui.separator();
-        ui.label("Debug:");
+    fn egui_debug_options_ui(&self, ui: &mut egui::Ui) {
+        let mut debug = ui.style().debug;
+        let mut any_clicked = false;
 
-        egui_debug_options_ui(ui);
-        ui.separator();
-        debug_menu_options_ui(ui, options, _frame);
+        let re_ui = self.re_ui();
+        any_clicked |= re_ui
+            .checkbox(ui, &mut debug.debug_on_hover, "Ui debug on hover")
+            .on_hover_text("However over widgets to see their rectangles")
+            .changed();
+        any_clicked |= re_ui
+            .checkbox(ui, &mut debug.show_expand_width, "Show expand width")
+            .on_hover_text("Show which widgets make their parent wider")
+            .changed();
+        any_clicked |= re_ui
+            .checkbox(ui, &mut debug.show_expand_height, "Show expand height")
+            .on_hover_text("Show which widgets make their parent higher")
+            .changed();
+        any_clicked |= re_ui
+            .checkbox(ui, &mut debug.show_resize, "Show resize")
+            .changed();
+        any_clicked |= re_ui
+            .checkbox(
+                ui,
+                &mut debug.show_interactive_widgets,
+                "Show interactive widgets",
+            )
+            .on_hover_text("Show an overlay on all interactive widgets.")
+            .changed();
+        any_clicked |= re_ui
+            .checkbox(ui, &mut debug.show_blocking_widget, "Show blocking widgets")
+            .on_hover_text("Show what widget blocks the interaction of another widget.")
+            .changed();
+
+        if any_clicked {
+            let mut style = (*ui.ctx().style()).clone();
+            style.debug = debug;
+            ui.ctx().set_style(style);
+        }
     }
-}
 
-// TODO(emilk): support saving data on web
-#[cfg(not(target_arch = "wasm32"))]
-fn save_buttons_ui(ui: &mut egui::Ui, store_view: Option<&StoreContext<'_>>, app: &mut App) {
-    use re_ui::UICommandSender;
-
-    let file_save_in_progress = app.background_tasks.is_file_save_in_progress();
-
-    let save_button = UICommand::Save.menu_button(ui.ctx());
-    let save_selection_button = UICommand::SaveSelection.menu_button(ui.ctx());
-
-    if file_save_in_progress {
-        ui.add_enabled_ui(false, |ui| {
-            ui.horizontal(|ui| {
-                ui.add(save_button);
-                ui.spinner();
-            });
-            ui.horizontal(|ui| {
-                ui.add(save_selection_button);
-                ui.spinner();
-            });
-        });
-    } else {
-        let store_db_is_nonempty = store_view
-            .and_then(|view| view.recording)
-            .map_or(false, |recording| !recording.is_empty());
-        ui.add_enabled_ui(store_db_is_nonempty, |ui| {
-            if ui
-                .add(save_button)
-                .on_hover_text("Save all data to a Rerun data file (.rrd)")
-                .clicked()
-            {
+    #[cfg(debug_assertions)]
+    fn debug_menu_options_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if ui.button("Mobile size").clicked() {
+                // frame.set_window_size(egui::vec2(375.0, 812.0)); // iPhone 12 mini
+                _frame.set_window_size(egui::vec2(375.0, 667.0)); //  iPhone SE 2nd gen
+                _frame.set_fullscreen(false);
                 ui.close_menu();
-                app.command_sender.send_ui(UICommand::Save);
             }
+            ui.separator();
+        }
 
-            // We need to know the loop selection _before_ we can even display the
-            // button, as this will determine whether its grayed out or not!
-            // TODO(cmc): In practice the loop (green) selection is always there
-            // at the moment so...
-            let loop_selection = app.state.loop_selection(store_view);
+        if ui.button("Log info").clicked() {
+            re_log::info!("Logging some info");
+        }
 
-            if ui
-                .add_enabled(loop_selection.is_some(), save_selection_button)
-                .on_hover_text(
-                    "Save data for the current loop selection to a Rerun data file (.rrd)",
-                )
-                .clicked()
-            {
-                ui.close_menu();
-                app.command_sender.send_ui(UICommand::SaveSelection);
-            }
-        });
-    }
-}
-
-#[cfg(debug_assertions)]
-fn egui_debug_options_ui(ui: &mut egui::Ui) {
-    let mut debug = ui.style().debug;
-    let mut any_clicked = false;
-
-    any_clicked |= ui
-        .checkbox(&mut debug.debug_on_hover, "Ui debug on hover")
-        .on_hover_text("However over widgets to see their rectangles")
-        .changed();
-    any_clicked |= ui
-        .checkbox(&mut debug.show_expand_width, "Show expand width")
-        .on_hover_text("Show which widgets make their parent wider")
-        .changed();
-    any_clicked |= ui
-        .checkbox(&mut debug.show_expand_height, "Show expand height")
-        .on_hover_text("Show which widgets make their parent higher")
-        .changed();
-    any_clicked |= ui.checkbox(&mut debug.show_resize, "Show resize").changed();
-    any_clicked |= ui
-        .checkbox(
-            &mut debug.show_interactive_widgets,
-            "Show interactive widgets",
+        self.re_ui.checkbox(ui,
+                       &mut self.state.app_options.show_picking_debug_overlay,
+                       "Picking Debug Overlay",
         )
-        .on_hover_text("Show an overlay on all interactive widgets.")
-        .changed();
-    any_clicked |= ui
-        .checkbox(&mut debug.show_blocking_widget, "Show blocking widgets")
-        .on_hover_text("Show what widget blocks the interaction of another widget.")
-        .changed();
+            .on_hover_text("Show a debug overlay that renders the picking layer information using the `debug_overlay.wgsl` shader.");
 
-    if any_clicked {
-        let mut style = (*ui.ctx().style()).clone();
-        style.debug = debug;
-        ui.ctx().set_style(style);
+        ui.menu_button("Crash", |ui| {
+            #[allow(clippy::manual_assert)]
+            if ui.button("panic!").clicked() {
+                panic!("Intentional panic");
+            }
+
+            if ui.button("panic! during unwind").clicked() {
+                struct PanicOnDrop {}
+
+                impl Drop for PanicOnDrop {
+                    fn drop(&mut self) {
+                        panic!("Second intentional panic in Drop::drop");
+                    }
+                }
+
+                let _this_will_panic_when_dropped = PanicOnDrop {};
+                panic!("First intentional panic");
+            }
+
+            if ui.button("SEGFAULT").clicked() {
+                // Taken from https://github.com/EmbarkStudios/crash-handling/blob/main/sadness-generator/src/lib.rs
+
+                /// This is the fixed address used to generate a segfault. It's possible that
+                /// this address can be mapped and writable by the your process in which case a
+                /// crash may not occur
+                #[cfg(target_pointer_width = "64")]
+                pub const SEGFAULT_ADDRESS: u64 = u32::MAX as u64 + 0x42;
+                #[cfg(target_pointer_width = "32")]
+                pub const SEGFAULT_ADDRESS: u32 = 0x42;
+
+                let bad_ptr: *mut u8 = SEGFAULT_ADDRESS as _;
+                #[allow(unsafe_code)]
+                // SAFETY: this is not safe. We are _trying_ to crash.
+                unsafe {
+                    std::ptr::write_volatile(bad_ptr, 1);
+                }
+            }
+
+            if ui.button("Stack overflow").clicked() {
+                // Taken from https://github.com/EmbarkStudios/crash-handling/blob/main/sadness-generator/src/lib.rs
+                fn recurse(data: u64) -> u64 {
+                    let mut buff = [0u8; 256];
+                    buff[..9].copy_from_slice(b"junk data");
+
+                    let mut result = data;
+                    for c in buff {
+                        result += c as u64;
+                    }
+
+                    if result == 0 {
+                        result
+                    } else {
+                        recurse(result) + 1
+                    }
+                }
+
+                recurse(42);
+            }
+        });
     }
 }
-
-#[cfg(debug_assertions)]
-fn debug_menu_options_ui(ui: &mut egui::Ui, options: &mut AppOptions, _frame: &mut eframe::Frame) {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        if ui.button("Mobile size").clicked() {
-            // frame.set_window_size(egui::vec2(375.0, 812.0)); // iPhone 12 mini
-            _frame.set_window_size(egui::vec2(375.0, 667.0)); //  iPhone SE 2nd gen
-            _frame.set_fullscreen(false);
-            ui.close_menu();
-        }
-        ui.separator();
-    }
-
-    if ui.button("Log info").clicked() {
-        re_log::info!("Logging some info");
-    }
-
-    ui.checkbox(
-        &mut options.show_picking_debug_overlay,
-        "Picking Debug Overlay",
-    )
-    .on_hover_text("Show a debug overlay that renders the picking layer information using the `debug_overlay.wgsl` shader.");
-
-    ui.menu_button("Crash", |ui| {
-        #[allow(clippy::manual_assert)]
-        if ui.button("panic!").clicked() {
-            panic!("Intentional panic");
-        }
-
-        if ui.button("panic! during unwind").clicked() {
-            struct PanicOnDrop {}
-
-            impl Drop for PanicOnDrop {
-                fn drop(&mut self) {
-                    panic!("Second intentional panic in Drop::drop");
-                }
-            }
-
-            let _this_will_panic_when_dropped = PanicOnDrop {};
-            panic!("First intentional panic");
-        }
-
-        if ui.button("SEGFAULT").clicked() {
-            // Taken from https://github.com/EmbarkStudios/crash-handling/blob/main/sadness-generator/src/lib.rs
-
-            /// This is the fixed address used to generate a segfault. It's possible that
-            /// this address can be mapped and writable by the your process in which case a
-            /// crash may not occur
-            #[cfg(target_pointer_width = "64")]
-            pub const SEGFAULT_ADDRESS: u64 = u32::MAX as u64 + 0x42;
-            #[cfg(target_pointer_width = "32")]
-            pub const SEGFAULT_ADDRESS: u32 = 0x42;
-
-            let bad_ptr: *mut u8 = SEGFAULT_ADDRESS as _;
-            #[allow(unsafe_code)]
-            // SAFETY: this is not safe. We are _trying_ to crash.
-            unsafe {
-                std::ptr::write_volatile(bad_ptr, 1);
-            }
-        }
-
-        if ui.button("Stack overflow").clicked() {
-            // Taken from https://github.com/EmbarkStudios/crash-handling/blob/main/sadness-generator/src/lib.rs
-            fn recurse(data: u64) -> u64 {
-                let mut buff = [0u8; 256];
-                buff[..9].copy_from_slice(b"junk data");
-
-                let mut result = data;
-                for c in buff {
-                    result += c as u64;
-                }
-
-                if result == 0 {
-                    result
-                } else {
-                    recurse(result) + 1
-                }
-            }
-
-            recurse(42);
-        }
-    });
-}
-
 // ---

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -347,8 +347,10 @@ fn entity_props_ui(
     entity_path: Option<&EntityPath>,
     entity_props: &mut EntityProperties,
 ) {
-    ui.checkbox(&mut entity_props.visible, "Visible");
-    ui.checkbox(&mut entity_props.interactive, "Interactive")
+    let re_ui = ctx.re_ui;
+    re_ui.checkbox(ui, &mut entity_props.visible, "Visible");
+    re_ui
+        .checkbox(ui, &mut entity_props.interactive, "Interactive")
         .on_hover_text("If disabled, the entity will not react to any mouse interaction");
 
     egui::Grid::new("entity_properties")
@@ -475,8 +477,9 @@ fn depth_props_ui(
 
     let mut backproject_depth = *entity_props.backproject_depth.get();
 
-    if ui
-        .checkbox(&mut backproject_depth, "Backproject Depth")
+    if ctx
+        .re_ui
+        .checkbox(ui, &mut backproject_depth, "Backproject Depth")
         .on_hover_text(
             "If enabled, the depth texture will be backprojected into a point cloud rather \
                 than simply displayed as an image.",
@@ -576,7 +579,7 @@ fn transform3d_visualization_ui(
 
     {
         let mut checked = *show_arrows.get();
-        let response = ui.checkbox(&mut checked, "Show transform").on_hover_text(
+        let response = ctx.re_ui.checkbox(ui, &mut checked, "Show transform").on_hover_text(
             "Enables/disables the display of three arrows to visualize the (accumulated) transform at this entity. Red/green/blue show the x/y/z axis respectively.");
         if response.changed() {
             *show_arrows = EditableAutoValue::UserEdited(checked);

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -71,7 +71,7 @@ fn top_bar_ui(
     app: &mut App,
     gpu_resource_stats: &WgpuResourcePoolStatistics,
 ) {
-    crate::ui::rerun_menu_button_ui(store_context, ui, frame, app);
+    app.rerun_menu_button_ui(store_context, ui, frame);
 
     ui.add_space(12.0);
     website_link_ui(ui, app);

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -11,7 +11,7 @@ import argparse
 import os
 import re
 import sys
-from typing import Any
+from typing import Any, Iterator
 
 from gitignore_parser import parse_gitignore
 
@@ -374,51 +374,115 @@ def test_lint_workspace_deps() -> None:
 
 
 # -----------------------------------------------------------------------------
+# We may not use egui's widgets for which we have a custom version in re_ui.
+#
+# Note: this lint may be bypassed by using the fully qualified name, e.g. `egui::Ui::checkbox(ui, ...)`.
+
+re_checkbox = re.compile(r"(?<!\w)ui\s*.\s*checkbox(?!\w)", re.MULTILINE)
+
+
+def lint_forbidden_widgets(content: str) -> Iterator[tuple[str, int]]:
+    for match in re_checkbox.finditer(content):
+        yield "ui.checkbox is forbidden", match.start(0)
+
+
+def test_lint_forbidden_widgets() -> None:
+    assert re_checkbox.search("ui.checkbox")
+    assert re_checkbox.search("  ui.\n\t\t   checkbox  ")
+    assert re_checkbox.search("  ui.\n\t\t   checkbox()")
+    assert re_checkbox.search("  ui\n\t\t   .checkbox()")
+    assert not re_checkbox.search("re_ui.checkbox")
+    assert not re_checkbox.search("ui.checkbox_re")
+
+    should_fail_two_times = """
+        ui.checkbox()
+        re_ui.checkbox()
+        ui.checkbox_re()
+        
+        ui
+            .checkbox()
+            .bla()    
+    """
+
+    res = list(lint_forbidden_widgets(should_fail_two_times))
+    assert len(res) == 2
+    assert _index_to_line_nr(should_fail_two_times, res[0][1]) == 1
+    assert _index_to_line_nr(should_fail_two_times, res[1][1]) == 5
+
+
+# -----------------------------------------------------------------------------
+
+
+def _index_to_line_nr(content: str, index: int) -> int:
+    """Converts a 0-based index into a 0-based line number."""
+    return content[:index].count("\n")
+
+
+class SourceFile:
+    """Wrapper over a source file with some utility functions."""
+
+    def __init__(self, path: str):
+        self.path = os.path.abspath(path)
+        self.ext = path.split(".")[-1]
+        with open(path, "r") as f:
+            self.lines = f.readlines()
+        self.content = "".join(self.lines)
+
+    def rewrite(self, new_lines: list[str]) -> None:
+        """Rewrite the contents of the file."""
+        if new_lines != self.lines:
+            self.lines = new_lines
+            self.content = "".join(new_lines)
+            with open(self.path, "w") as f:
+                f.writelines(new_lines)
+            print(f"{self.path} fixed.")
+
+    def error(self, message: str, *, line_nr: int | None = None, index: int | None = None) -> str:
+        """Construct an error message. If either `line_nr` or `index` is passed, it's used to indicate a line number."""
+        if line_nr is None and index is not None:
+            line_nr = _index_to_line_nr(self.content, index)
+        if line_nr is None:
+            return f"{self.path}: {message}"
+        else:
+            return f"{self.path}:{line_nr+1}: {message}"
 
 
 def lint_file(filepath: str, args: Any) -> int:
-    file_extension = filepath.split(".")[-1]
-
-    with open(filepath) as f:
-        lines_in = f.readlines()
-
+    source = SourceFile(filepath)
     num_errors = 0
 
-    for line_nr, line in enumerate(lines_in):
+    for line_nr, line in enumerate(source.lines):
         if line == "" or line[-1] != "\n":
             error = "Missing newline at end of file"
         else:
             line = line[:-1]
-            error = lint_line(line, file_extension)
+            error = lint_line(line, source.ext)
         if error is not None:
             num_errors += 1
-            print(f"{filepath}:{line_nr+1}: {error}")
+            print(source.error(error, line_nr=line_nr))
 
     if filepath.endswith(".rs"):
-        errors, lines_out = lint_vertical_spacing(lines_in)
+        for error, index in lint_forbidden_widgets(source.content):
+            print(source.error(error, index=index))
+            num_errors += 1
 
+        errors, lines_out = lint_vertical_spacing(source.lines)
         for error in errors:
-            print(f"{filepath}:{error}")
-
-        if args.fix and lines_in != lines_out:
-            with open(filepath, "w") as f:
-                f.writelines(lines_out)
-            print(f"{filepath} fixed.")
-
+            print(source.error(error))
         num_errors += len(errors)
+
+        if args.fix:
+            source.rewrite(lines_out)
 
     if filepath.startswith("./examples/rust") and filepath.endswith("Cargo.toml"):
-        errors, lines_out = lint_workspace_deps(lines_in)
+        errors, lines_out = lint_workspace_deps(source.lines)
 
         for error in errors:
-            print(f"{filepath}:{error}")
-
-        if args.fix and lines_in != lines_out:
-            with open(filepath, "w") as f:
-                f.writelines(lines_out)
-            print(f"{filepath} fixed.")
-
+            print(source.error(error))
         num_errors += len(errors)
+
+        if args.fix:
+            source.rewrite(lines_out)
 
     return num_errors
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -400,10 +400,10 @@ def test_lint_forbidden_widgets() -> None:
         ui.checkbox()
         re_ui.checkbox()
         ui.checkbox_re()
-        
+
         ui  // hello!
             .checkbox()
-            .bla()    
+            .bla()
     """
 
     res = list(lint_forbidden_widgets(should_fail_two_times))
@@ -426,12 +426,12 @@ class SourceFile:
     def __init__(self, path: str):
         self.path = os.path.abspath(path)
         self.ext = path.split(".")[-1]
-        with open(path, "r") as f:
+        with open(path) as f:
             self.lines = f.readlines()
         self._update_content()
 
     def _update_content(self) -> None:
-        """Sync everything with `self.lines`"""
+        """Sync everything with `self.lines`."""
         self.content = "".join(self.lines)
 
         # gather lines with a `NOLINT` marker
@@ -447,13 +447,10 @@ class SourceFile:
             print(f"{self.path} fixed.")
 
     def should_ignore(self, from_line: int, to_line: int | None = None) -> bool:
-        """Should we ignore a violation?
+        """
+        Determines if we should ignore a violation.
 
         NOLINT might be on the same line(s) as the violation or the previous line.
-
-        Args:
-            from_line: 0-based line number of the violation
-            to_line: if the violation spans multiple lines, the last line of the violation (inclusive)
         """
 
         if to_line is None:


### PR DESCRIPTION
### What

This PR migrates our checkboxes and radio_values to a custom implementation in `re_ui`. Currently, the only change is the removal of the extension effect. In the future, the customisation might go deeper (e.g. custom tick mark, a variant for popup menu, etc.), possibly all the way to copy/pasting and rewriting the entire checkbox code.

This PR also introduces a lint to forbid the use of `ui.checkbox()`/`ui.radio_value()`.

Fixes #2727

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2851) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2851)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fui-custom-checkbox/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fui-custom-checkbox/examples)