### PR TITLE
Fix outdated links in docs

### DIFF
--- a/docs/content/concepts/annotation-context.md
+++ b/docs/content/concepts/annotation-context.md
@@ -54,7 +54,7 @@ The Annotation Context is defined as a list of Class Descriptions that define ho
 Annotation contexts are logged with:
 
 * Python: [`log_annotation_context`](https://ref.rerun.io/docs/python/latest/common/annotations/#rerun.log_annotation_context)
-* Rust: [`AnnotationContext`](https://docs.rs/rerun/latest/rerun/external/re_log_types/component_types/context/struct.AnnotationContext.html)
+* Rust: [`AnnotationContext`](https://docs.rs/rerun/latest/rerun/components/struct.AnnotationContext.html)
 
 code-example: annotation-context
 
@@ -79,4 +79,5 @@ you can explicitly determine the color of each class.
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/f63cb085ee392f38e6431ab7e8c79aecb1b4e6e1_segmentation_image_768w.png">
   <img src="https://static.rerun.io/716eeff1a99f51a6e77fca85c4e7dccf76b77c69_segmentation_image_full.png" alt="screenshot of a segmentation image">
 </picture>
+
 

--- a/docs/content/concepts/entity-component.md
+++ b/docs/content/concepts/entity-component.md
@@ -42,7 +42,7 @@ aren't relevant to the scene that the space view is drawing are safely ignored. 
 own components.
 
 In Python this is done via [log_extension_components](https://ref.rerun.io/docs/python/latest/common/extension_components/#rerun.log_extension_components)
-, whereas in Rust you implement the [Component](https://docs.rs/rerun/latest/rerun/trait.Component.html) trait.
+, whereas in Rust you implement the [`Component`](https://docs.rs/rerun/latest/rerun/experimental/trait.Component.html) trait.
 
 code-example: extension-components
 

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -181,7 +181,7 @@ MsgSender::new("dna/structure/scaffolding/beads")
     .send(&recording)?;
 ```
 
-Once again, although we are getting fancier and fancier with our iterator mappings, there is nothing new here: it's all about building out vectors of [`Loggable`s](https://docs.rs/re_types/latest/re_types/trait.Loggable.html) and feeding them to the Rerun API.
+Once again, although we are getting fancier and fancier with our iterator mappings, there is nothing new here: it's all about building out vectors of [`Component`s](https://docs.rs/rerun/latest/rerun/experimental/trait.Component.html) and feeding them to the Rerun API.
 
 ![logging data - beads](https://static.rerun.io/60c3c762448f68da3f5fdd7927a6e65e11f5385f_logging_data5_beads.png)
 

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -122,7 +122,7 @@ In particular, when using the Rust SDK, you work directly with [`components`](ht
 By logging multiple components to an Entity, one can build up Primitives that can later be visualized in the viewer.
 For more information on how the rerun data model works, refer to our section on [entities and components](../concepts/entity-component.md).
 
-Logging components is a only a matter of calling [`MsgSender::with_component`](https://docs.rs/rerun/latest/rerun/struct.MsgSender.html#method.with_component) using any type that implements the [`Component` trait](https://docs.rs/rerun/latest/rerun/trait.Component.html). We provide [a few of those](https://docs.rs/rerun/latest/rerun/trait.Component.html#implementors)).
+Logging components is a only a matter of calling [`MsgSender::with_component`](https://docs.rs/rerun/latest/rerun/struct.MsgSender.html#method.with_component) using any type that implements the [`Component` trait](https://docs.rs/rerun/latest/rerun/experimental/trait.Component.html). We provide [a few of those](https://docs.rs/rerun/latest/rerun/experimental/trait.Component.html#implementors)).
 
 #### `Batches`
 
@@ -181,7 +181,7 @@ MsgSender::new("dna/structure/scaffolding/beads")
     .send(&recording)?;
 ```
 
-Once again, although we are getting fancier and fancier with our iterator mappings, there is nothing new here: it's all about building out vectors of [`Component`s](https://docs.rs/rerun/latest/rerun/trait.Component.html) and feeding them to the Rerun API.
+Once again, although we are getting fancier and fancier with our iterator mappings, there is nothing new here: it's all about building out vectors of [`Loggable`s](https://docs.rs/re_types/latest/re_types/trait.Loggable.html) and feeding them to the Rerun API.
 
 ![logging data - beads](https://static.rerun.io/60c3c762448f68da3f5fdd7927a6e65e11f5385f_logging_data5_beads.png)
 
@@ -303,3 +303,4 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
 As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Loggable Data Types](../reference/data_types.md) section for more simple examples of how to use the main data types.
+


### PR DESCRIPTION
Make linkinator happy ASAP.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2854) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2854)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Ffix_links/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Ffix_links/examples)