### PR TITLE
Remove expansion effect from time panel toolbar

### DIFF
--- a/crates/re_time_panel/src/time_control_ui.rs
+++ b/crates/re_time_panel/src/time_control_ui.rs
@@ -18,37 +18,48 @@ impl TimeControlUi {
     ) {
         time_control.select_a_valid_timeline(times_per_timeline);
 
-        egui::ComboBox::from_id_source("timeline")
-            .selected_text(time_control.timeline().name().as_str())
-            .show_ui(ui, |ui| {
-                ui.style_mut().wrap = Some(false);
-                ui.set_min_width(64.0);
+        ui.scope(|ui| {
+            ui.spacing_mut().button_padding += egui::Vec2::new(2.0, 0.0);
+            ui.visuals_mut().widgets.active.expansion = 0.0;
+            ui.visuals_mut().widgets.hovered.expansion = 0.0;
+            ui.visuals_mut().widgets.open.expansion = 0.0;
 
-                for timeline in times_per_timeline.timelines() {
-                    if ui
-                        .selectable_label(
-                            timeline == time_control.timeline(),
-                            timeline.name().as_str(),
-                        )
-                        .clicked()
-                    {
-                        time_control.set_timeline(*timeline);
+            egui::ComboBox::from_id_source("timeline")
+                .selected_text(time_control.timeline().name().as_str())
+                .show_ui(ui, |ui| {
+                    ui.style_mut().wrap = Some(false);
+                    ui.set_min_width(64.0);
+
+                    for timeline in times_per_timeline.timelines() {
+                        if ui
+                            .selectable_label(
+                                timeline == time_control.timeline(),
+                                timeline.name().as_str(),
+                            )
+                            .clicked()
+                        {
+                            time_control.set_timeline(*timeline);
+                        }
                     }
-                }
-            });
+                });
+        });
     }
 
     #[allow(clippy::unused_self)]
     pub fn fps_ui(&mut self, time_control: &mut TimeControl, ui: &mut egui::Ui) {
         if time_control.time_type() == TimeType::Sequence {
             if let Some(mut fps) = time_control.fps() {
-                ui.add(
-                    egui::DragValue::new(&mut fps)
-                        .suffix(" FPS")
-                        .speed(1)
-                        .clamp_range(0.0..=f32::INFINITY),
-                )
-                .on_hover_text("Frames Per Second");
+                ui.scope(|ui| {
+                    ui.spacing_mut().interact_size -= egui::Vec2::new(0., 4.);
+
+                    ui.add(
+                        egui::DragValue::new(&mut fps)
+                            .suffix(" FPS")
+                            .speed(1)
+                            .clamp_range(0.0..=f32::INFINITY),
+                    )
+                    .on_hover_text("Frames Per Second");
+                });
                 time_control.set_fps(fps);
             }
         }
@@ -202,12 +213,16 @@ impl TimeControlUi {
     pub fn playback_speed_ui(&mut self, time_control: &mut TimeControl, ui: &mut egui::Ui) {
         let mut speed = time_control.speed();
         let drag_speed = (speed * 0.02).at_least(0.01);
-        ui.add(
-            egui::DragValue::new(&mut speed)
-                .speed(drag_speed)
-                .suffix("x"),
-        )
-        .on_hover_text("Playback speed.");
+        ui.scope(|ui| {
+            ui.spacing_mut().interact_size -= egui::Vec2::new(0., 4.);
+            ui.add(
+                egui::DragValue::new(&mut speed)
+                    .speed(drag_speed)
+                    .suffix("x"),
+            )
+            .on_hover_text("Playback speed.");
+        });
+
         time_control.set_speed(speed);
     }
 }

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -332,6 +332,11 @@ impl ReUi {
             // For big buttons we have a background color even when inactive:
             let visuals = ui.visuals_mut();
             visuals.widgets.inactive.weak_bg_fill = visuals.widgets.inactive.bg_fill;
+
+            // no expansion effect
+            visuals.widgets.hovered.expansion = 0.0;
+            visuals.widgets.active.expansion = 0.0;
+            visuals.widgets.open.expansion = 0.0;
         }
 
         let image = self.icon_image(icon);


### PR DESCRIPTION
### What

Remove expansion effect from the time panel buttons and adjust hover area of nearby controls to keep everything aligned.

Fixes #2730

Before:

<img width="466" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/c45cff2c-161b-4645-9ec2-e366725dd30c">
<img width="457" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/ae91c8c7-101d-49f3-81d9-e626b179c87b">

After:

<img width="484" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/20113a18-2071-4910-bb05-94aaeafce2c6">
<img width="459" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/4d8c8937-6097-4b63-800b-ca5281368ba1">






### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2863) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2863)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fno-expansion-time-panel/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fno-expansion-time-panel/examples)