### PR TITLE
Remove expansion effect from the large collapsing headers

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -463,6 +463,10 @@ impl ReUi {
             header_size,
             egui::Layout::left_to_right(egui::Align::Center),
             |ui| {
+                ui.visuals_mut().widgets.hovered.expansion = 0.0;
+                ui.visuals_mut().widgets.active.expansion = 0.0;
+                ui.visuals_mut().widgets.open.expansion = 0.0;
+
                 let background_frame = ui.painter().add(egui::Shape::Noop);
 
                 let space_before_icon = 0.0;


### PR DESCRIPTION
### What

Remove the expansion effect on the large collapsible header's triangle.

Fixes #2726

Before:

<img width="178" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/af52e1b4-91cb-4522-af0a-23fda5664929">

After: 

<img width="193" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/fddb8024-fd4f-45b5-94d5-353cf3c6a723">

(Both are being hovered.)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2864) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2864)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fno-expansion-large-header-2726/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fno-expansion-large-header-2726/examples)