### PR TITLE
Change the styling of hyperlinks

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -126,11 +126,11 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
 
     egui_style.visuals.widgets.noninteractive.bg_stroke.color = Color32::from_gray(30); // from figma. separator lines, panel lines, etc
 
-    let subudued = get_aliased_color(&json, "{Alias.Color.Text.Subdued.value}");
+    let subdued = get_aliased_color(&json, "{Alias.Color.Text.Subdued.value}");
     let default = get_aliased_color(&json, "{Alias.Color.Text.Default.value}");
     let strong = get_aliased_color(&json, "{Alias.Color.Text.Strong.value}");
 
-    egui_style.visuals.widgets.noninteractive.fg_stroke.color = subudued; // non-interactive text
+    egui_style.visuals.widgets.noninteractive.fg_stroke.color = subdued; // non-interactive text
     egui_style.visuals.widgets.inactive.fg_stroke.color = default; // button text
     egui_style.visuals.widgets.active.fg_stroke.color = strong; // strong text and active button text
 
@@ -166,6 +166,9 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
     egui_style.spacing.scroll_bar_inner_margin = 2.0;
     egui_style.spacing.scroll_bar_width = 6.0;
     egui_style.spacing.scroll_bar_outer_margin = 2.0;
+
+    // don't color hyperlinks #2733
+    egui_style.visuals.hyperlink_color = default;
 
     ctx.set_style(egui_style);
 

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -79,10 +79,17 @@ impl App {
             });
 
             ui.add_space(spacing);
-            ui.hyperlink_to(
-                "Help",
-                "https://www.rerun.io/docs/getting-started/viewer-walkthrough",
-            );
+
+            // dont use `hyperlink_to` for styling reasons
+            if ui.button("Help").clicked() {
+                ui.ctx().output_mut(|o| {
+                    o.open_url = Some(egui::output::OpenUrl {
+                        url: "https://www.rerun.io/docs/getting-started/viewer-walkthrough"
+                            .to_owned(),
+                        new_tab: true,
+                    });
+                });
+            }
 
             #[cfg(not(target_arch = "wasm32"))]
             {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -135,9 +135,6 @@ impl App {
         LLVM {llvm_version}\n\
         Built {datetime}",
         ));
-
-        ui.add_space(12.0);
-        ui.hyperlink_to("www.rerun.io", "https://www.rerun.io/");
     }
 
     fn recordings_menu(&self, ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>) {

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -171,14 +171,6 @@ fn website_link_ui(ui: &mut egui::Ui, app: &mut App) {
         .on_hover_cursor(egui::CursorIcon::PointingHand);
     let url = "https://rerun.io/";
     if response.clicked() {
-        let modifiers = ui.ctx().input(|i| i.modifiers);
-        ui.ctx().output_mut(|o| {
-            o.open_url = Some(egui::output::OpenUrl {
-                url: url.to_owned(),
-                new_tab: modifiers.any(),
-            });
-        });
-    } else if response.middle_clicked() {
         ui.ctx().output_mut(|o| {
             o.open_url = Some(egui::output::OpenUrl {
                 url: url.to_owned(),


### PR DESCRIPTION
### What

This PR changes the styling and behaviour of hyperlinks, of which there are currently ~~two~~ three:

1) The "Help" item in the menu. I changed it to behave just like a normal menu item does. On click, it'll *always* open a new tab, which is a departure from the current behaviour where opening in a new tab required a modifier (alt, etc.) or a middle-click. I believe this behaviour respects better the "rule of least astonishment" in the case of WASM builds. (For native build, it doesn't change anything.)
2) ~~The link in the "About" panel. For this I just changed the style to use "normal" colour (ie. white), but keep the link behaviour (underline on hover).~~ The link in the about panel is removed entirely as it is redundant with the top-bar gigantilink.
3) The gigantilink, which has its own image-based styling (which will soon be revisited). This PR changes its behaviour to open link in new tab.

>[!WARNING]
>~~The forced "new tab" triggered the popup blocker on my computer, so that maybe a motivation to stick with opening help in the same tab by default. Opinions?~~ Opening in new tab used to—and will continue to—trigger popup blocker. This is due to the browser not being aware that some user interaction occurred within the wasm executable.

Fixes #2733 

Before:

<img width="496" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/4e002345-33a9-48ea-9474-b4404f6cc77f">


After (mouse hovering on link, thus the underline):

<img width="495" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/1ea91a13-5bf3-4d4d-aa76-60aaacf1c22b">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2872) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2872)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fhyperlink-style-2733/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fhyperlink-style-2733/examples)