### PR TITLE
C++ basic Archetype & Component logging

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-ac71492cc464a386afe53f104604b3e1656668b6f40cff5a323f5c2966f89085
+a204e509503e42d9fc1512db4eeb8c2588cefe74c0b3ca1bfb873957e390e8b0

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-d824555b3e123065a3064a4f01e963f74f0f5d62a3dd96dfdffaa57c8033ca08
+ac71492cc464a386afe53f104604b3e1656668b6f40cff5a323f5c2966f89085

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-a204e509503e42d9fc1512db4eeb8c2588cefe74c0b3ca1bfb873957e390e8b0
+193f517cba0adad129dff54dc9a19e0c6519c9c852cac586b7634447831e4819

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -648,10 +648,13 @@ fn arrow_data_type_method(datatype: &DataType, cpp_includes: &mut Includes) -> M
         docs: "Returns the arrow data type this type corresponds to.".into(),
         declaration: MethodDeclaration {
             is_static: true,
-            return_type: quote! { std::shared_ptr<arrow::DataType> },
+            return_type: quote! { const std::shared_ptr<arrow::DataType>& },
             name_and_parameters: quote! { to_arrow_datatype() },
         },
-        definition_body: quote! { return #quoted_datatype; },
+        definition_body: quote! {
+            static const auto datatype = #quoted_datatype;
+            return datatype;
+        },
         inline: false,
     }
 }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -866,7 +866,7 @@ fn component_to_data_cell_method(
             is_static: true,
             return_type: quote! { arrow::Result<rr::DataCell> },
             name_and_parameters: quote! {
-                to_data_cell(const #type_ident* components, size_t num_components)
+                to_data_cell(const #type_ident* instances, size_t num_instances)
             },
         },
         definition_body: quote! {
@@ -876,11 +876,11 @@ fn component_to_data_cell_method(
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             ARROW_ASSIGN_OR_RAISE(auto builder, #type_ident::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(#type_ident::fill_arrow_array_builder(
                     builder.get(),
-                    components,
-                    num_components
+                    instances,
+                    num_instances
                 ));
             }
             std::shared_ptr<arrow::Array> array;

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -1,6 +1,8 @@
 #include <loguru.hpp>
 #include <rerun.hpp>
 
+#include <array>
+
 #include <components/point2d.hpp>
 
 int main(int argc, char** argv) {
@@ -12,27 +14,27 @@ int main(int argc, char** argv) {
 
     auto rr_stream = rr::RecordingStream{"c-example-app", "127.0.0.1:9876"};
 
-    // Points3D.
-    {
-        float xyz[9] = {0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 5.0, 5.0, 5.0};
-        const rr::DataCell data_cells[1] = {
-            rr::components::Point3D::to_data_cell((const rr::components::Point3D*)xyz, 3)
-                .ValueOrDie()};
-
-        uint32_t num_instances = 3;
-        rr_stream.log_data_row("3d/points", num_instances, 1, data_cells);
-    }
-
-    // Points2D.
-    {
-        float xy[6] = {0.0, 0.0, 1.0, 3.0, 5.0, 5.0};
-        uint32_t num_instances = 3;
-        const rr::DataCell data_cells[1] = {
-            rr::components::Point2D::to_data_cell((const rr::components::Point2D*)xy, num_instances)
-                .ValueOrDie()};
-
-        rr_stream.log_data_row("2d/points", num_instances, 1, data_cells);
-    }
+    rr_stream.log_components(
+        "3d/points",
+        std::vector{
+            rr::components::Point3D(rr::datatypes::Point3D{0.0, 0.0, 0.0}),
+            rr::components::Point3D(rr::datatypes::Point3D{1.0, 3.0, 3.0}),
+            rr::components::Point3D(rr::datatypes::Point3D{5.0, 5.0, 5.0}),
+        }
+    );
+    rr_stream.log_components(
+        "2d/points",
+        std::vector{
+            rr::components::Point2D(rr::datatypes::Point2D{0.0, 0.0}),
+            rr::components::Point2D(rr::datatypes::Point2D{1.0, 3.0}),
+            rr::components::Point2D(rr::datatypes::Point2D{5.0, 5.0}),
+        },
+        std::array{
+            rr::components::Color(0xFF0000FF),
+            rr::components::Color(0x00FF00FF),
+            rr::components::Color(0x0000FFFF),
+        }
+    );
 
     // Test some type instantiation
     auto tls = rr::datatypes::TranslationRotationScale3D{};

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -3,27 +3,6 @@
 
 #include <components/point2d.hpp>
 
-arrow::Result<std::shared_ptr<arrow::Table>> points2(size_t num_points, const float* xy) {
-    arrow::MemoryPool* pool = arrow::default_memory_pool();
-
-    ARROW_ASSIGN_OR_RAISE(auto builder, rr::components::Point2D::new_arrow_array_builder(pool));
-    ARROW_RETURN_NOT_OK(rr::components::Point2D::fill_arrow_array_builder(
-        builder.get(),
-        (const rr::components::Point2D*)
-            xy, // TODO(andreas): Hack to get Points2D C-style array in an easy fashion
-        num_points
-    ));
-
-    std::shared_ptr<arrow::Array> array;
-    ARROW_RETURN_NOT_OK(builder->Finish(&array));
-
-    auto name = "points"; // Unused, but should be the name of the field in the archetype
-    auto schema =
-        arrow::schema({arrow::field(name, rr::components::Point2D::to_arrow_datatype(), false)});
-
-    return arrow::Table::Make(schema, {array});
-}
-
 int main(int argc, char** argv) {
     loguru::g_preamble_uptime = false;
     loguru::g_preamble_thread = false;
@@ -36,14 +15,9 @@ int main(int argc, char** argv) {
     // Points3D.
     {
         float xyz[9] = {0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 5.0, 5.0, 5.0};
-        auto points = rr::points3(3, xyz).ValueOrDie(); // TODO(andreas): phase this out.
-        auto buffer = rr::ipc_from_table(*points).ValueOrDie();
-
-        const rr::DataCell data_cells[1] = {rr::DataCell{
-            .component_name = "rerun.point3d",
-            .num_bytes = static_cast<size_t>(buffer->size()),
-            .bytes = buffer->data(),
-        }};
+        const rr::DataCell data_cells[1] = {
+            rr::components::Point3D::to_data_cell((const rr::components::Point3D*)xyz, 3)
+                .ValueOrDie()};
 
         uint32_t num_instances = 3;
         rr_stream.log_data_row("3d/points", num_instances, 1, data_cells);
@@ -52,16 +26,11 @@ int main(int argc, char** argv) {
     // Points2D.
     {
         float xy[6] = {0.0, 0.0, 1.0, 3.0, 5.0, 5.0};
-        auto points = points2(3, xy).ValueOrDie();
-        auto buffer = rr::ipc_from_table(*points).ValueOrDie();
-
-        const rr::DataCell data_cells[1] = {rr::DataCell{
-            .component_name = "rerun.point2d",
-            .num_bytes = static_cast<size_t>(buffer->size()),
-            .bytes = buffer->data(),
-        }};
-
         uint32_t num_instances = 3;
+        const rr::DataCell data_cells[1] = {
+            rr::components::Point2D::to_data_cell((const rr::components::Point2D*)xy, num_instances)
+                .ValueOrDie()};
+
         rr_stream.log_data_row("2d/points", num_instances, 1, data_cells);
     }
 

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -27,6 +27,11 @@ int main(int argc, char** argv) {
             .with_instance_keys({66, 666})
     );
 
+    rr::components::Label c_style_array[3] = {
+        rr::components::Label("hello"),
+        rr::components::Label("friend"),
+        rr::components::Label("yo"),
+    };
     rr_stream.log_components(
         "2d/points",
         std::vector{
@@ -38,7 +43,8 @@ int main(int argc, char** argv) {
             rr::components::Color(0xFF0000FF),
             rr::components::Color(0x00FF00FF),
             rr::components::Color(0x0000FFFF),
-        }
+        },
+        c_style_array
     );
 
     // Test some type instantiation

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -2,7 +2,6 @@
 #include <rerun.hpp>
 
 #include <array>
-
 #include <components/point2d.hpp>
 
 int main(int argc, char** argv) {
@@ -14,14 +13,20 @@ int main(int argc, char** argv) {
 
     auto rr_stream = rr::RecordingStream{"c-example-app", "127.0.0.1:9876"};
 
-    rr_stream.log_components(
+    rr_stream.log_archetype(
         "3d/points",
-        std::vector{
-            rr::components::Point3D(rr::datatypes::Point3D{0.0, 0.0, 0.0}),
-            rr::components::Point3D(rr::datatypes::Point3D{1.0, 3.0, 3.0}),
-            rr::components::Point3D(rr::datatypes::Point3D{5.0, 5.0, 5.0}),
-        }
+        rr::archetypes::Points3D({
+                                     rr::datatypes::Point3D{1.0, 2.0, 3.0},
+                                     rr::datatypes::Point3D{4.0, 5.0, 6.0},
+                                 })
+            .with_radii({0.42, 0.43})
+            .with_colors({0xAA0000CC, 0x00BB00DD})
+            .with_labels({std::string("hello"), std::string("friend")})
+            .with_class_ids({126, 127})
+            .with_keypoint_ids({2, 3})
+            .with_instance_keys({66, 666})
     );
+
     rr_stream.log_components(
         "2d/points",
         std::vector{

--- a/rerun_cpp/src/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/archetypes/affix_fuzzer1.cpp
@@ -3,6 +3,583 @@
 
 #include "affix_fuzzer1.hpp"
 
+#include "../components/affix_fuzzer1.hpp"
+#include "../components/affix_fuzzer10.hpp"
+#include "../components/affix_fuzzer11.hpp"
+#include "../components/affix_fuzzer12.hpp"
+#include "../components/affix_fuzzer13.hpp"
+#include "../components/affix_fuzzer14.hpp"
+#include "../components/affix_fuzzer15.hpp"
+#include "../components/affix_fuzzer16.hpp"
+#include "../components/affix_fuzzer17.hpp"
+#include "../components/affix_fuzzer18.hpp"
+#include "../components/affix_fuzzer19.hpp"
+#include "../components/affix_fuzzer2.hpp"
+#include "../components/affix_fuzzer3.hpp"
+#include "../components/affix_fuzzer4.hpp"
+#include "../components/affix_fuzzer5.hpp"
+#include "../components/affix_fuzzer6.hpp"
+#include "../components/affix_fuzzer7.hpp"
+#include "../components/affix_fuzzer8.hpp"
+#include "../components/affix_fuzzer9.hpp"
+
+#include <arrow/api.h>
+
 namespace rr {
-    namespace archetypes {}
+    namespace archetypes {
+        arrow::Result<std::vector<rr::DataCell>> AffixFuzzer1::to_data_cells() const {
+            std::vector<rr::DataCell> cells;
+            cells.reserve(73);
+
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer1::to_data_cell(&fuzz1001, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer2::to_data_cell(&fuzz1002, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer3::to_data_cell(&fuzz1003, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer4::to_data_cell(&fuzz1004, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer5::to_data_cell(&fuzz1005, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer6::to_data_cell(&fuzz1006, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer7::to_data_cell(&fuzz1007, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer8::to_data_cell(&fuzz1008, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer9::to_data_cell(&fuzz1009, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer10::to_data_cell(&fuzz1010, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer11::to_data_cell(&fuzz1011, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer12::to_data_cell(&fuzz1012, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer13::to_data_cell(&fuzz1013, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer14::to_data_cell(&fuzz1014, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer15::to_data_cell(&fuzz1015, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer16::to_data_cell(&fuzz1016, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer17::to_data_cell(&fuzz1017, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer18::to_data_cell(&fuzz1018, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer19::to_data_cell(&fuzz1019, 1)
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer1::to_data_cell(fuzz1101.data(), fuzz1101.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer2::to_data_cell(fuzz1102.data(), fuzz1102.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer3::to_data_cell(fuzz1103.data(), fuzz1103.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer4::to_data_cell(fuzz1104.data(), fuzz1104.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer5::to_data_cell(fuzz1105.data(), fuzz1105.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer6::to_data_cell(fuzz1106.data(), fuzz1106.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer7::to_data_cell(fuzz1107.data(), fuzz1107.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer8::to_data_cell(fuzz1108.data(), fuzz1108.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer9::to_data_cell(fuzz1109.data(), fuzz1109.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer10::to_data_cell(fuzz1110.data(), fuzz1110.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer11::to_data_cell(fuzz1111.data(), fuzz1111.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer12::to_data_cell(fuzz1112.data(), fuzz1112.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer13::to_data_cell(fuzz1113.data(), fuzz1113.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer14::to_data_cell(fuzz1114.data(), fuzz1114.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer15::to_data_cell(fuzz1115.data(), fuzz1115.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer16::to_data_cell(fuzz1116.data(), fuzz1116.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer17::to_data_cell(fuzz1117.data(), fuzz1117.size())
+                );
+                cells.push_back(cell);
+            }
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer18::to_data_cell(fuzz1118.data(), fuzz1118.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2001.has_value()) {
+                const auto& value = fuzz2001.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer1::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2002.has_value()) {
+                const auto& value = fuzz2002.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer2::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2003.has_value()) {
+                const auto& value = fuzz2003.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer3::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2004.has_value()) {
+                const auto& value = fuzz2004.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer4::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2005.has_value()) {
+                const auto& value = fuzz2005.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer5::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2006.has_value()) {
+                const auto& value = fuzz2006.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer6::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2007.has_value()) {
+                const auto& value = fuzz2007.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer7::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2008.has_value()) {
+                const auto& value = fuzz2008.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer8::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2009.has_value()) {
+                const auto& value = fuzz2009.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer9::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2010.has_value()) {
+                const auto& value = fuzz2010.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer10::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2011.has_value()) {
+                const auto& value = fuzz2011.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer11::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2012.has_value()) {
+                const auto& value = fuzz2012.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer12::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2013.has_value()) {
+                const auto& value = fuzz2013.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer13::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2014.has_value()) {
+                const auto& value = fuzz2014.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer14::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2015.has_value()) {
+                const auto& value = fuzz2015.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer15::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2016.has_value()) {
+                const auto& value = fuzz2016.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer16::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2017.has_value()) {
+                const auto& value = fuzz2017.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer17::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2018.has_value()) {
+                const auto& value = fuzz2018.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer18::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2101.has_value()) {
+                const auto& value = fuzz2101.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer1::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2102.has_value()) {
+                const auto& value = fuzz2102.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer2::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2103.has_value()) {
+                const auto& value = fuzz2103.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer3::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2104.has_value()) {
+                const auto& value = fuzz2104.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer4::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2105.has_value()) {
+                const auto& value = fuzz2105.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer5::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2106.has_value()) {
+                const auto& value = fuzz2106.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer6::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2107.has_value()) {
+                const auto& value = fuzz2107.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer7::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2108.has_value()) {
+                const auto& value = fuzz2108.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer8::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2109.has_value()) {
+                const auto& value = fuzz2109.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer9::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2110.has_value()) {
+                const auto& value = fuzz2110.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer10::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2111.has_value()) {
+                const auto& value = fuzz2111.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer11::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2112.has_value()) {
+                const auto& value = fuzz2112.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer12::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2113.has_value()) {
+                const auto& value = fuzz2113.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer13::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2114.has_value()) {
+                const auto& value = fuzz2114.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer14::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2115.has_value()) {
+                const auto& value = fuzz2115.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer15::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2116.has_value()) {
+                const auto& value = fuzz2116.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer16::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2117.has_value()) {
+                const auto& value = fuzz2117.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer17::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (fuzz2118.has_value()) {
+                const auto& value = fuzz2118.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::AffixFuzzer18::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+
+            return cells;
+        }
+    } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/archetypes/affix_fuzzer1.hpp
@@ -22,10 +22,12 @@
 #include "../components/affix_fuzzer7.hpp"
 #include "../components/affix_fuzzer8.hpp"
 #include "../components/affix_fuzzer9.hpp"
+#include "../data_cell.hpp"
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace rr {
@@ -176,6 +178,263 @@ namespace rr {
             std::optional<std::vector<rr::components::AffixFuzzer17>> fuzz2117;
 
             std::optional<std::vector<rr::components::AffixFuzzer18>> fuzz2118;
+
+          public:
+            AffixFuzzer1(
+                rr::components::AffixFuzzer1 fuzz1001, rr::components::AffixFuzzer2 fuzz1002,
+                rr::components::AffixFuzzer3 fuzz1003, rr::components::AffixFuzzer4 fuzz1004,
+                rr::components::AffixFuzzer5 fuzz1005, rr::components::AffixFuzzer6 fuzz1006,
+                rr::components::AffixFuzzer7 fuzz1007, rr::components::AffixFuzzer8 fuzz1008,
+                rr::components::AffixFuzzer9 fuzz1009, rr::components::AffixFuzzer10 fuzz1010,
+                rr::components::AffixFuzzer11 fuzz1011, rr::components::AffixFuzzer12 fuzz1012,
+                rr::components::AffixFuzzer13 fuzz1013, rr::components::AffixFuzzer14 fuzz1014,
+                rr::components::AffixFuzzer15 fuzz1015, rr::components::AffixFuzzer16 fuzz1016,
+                rr::components::AffixFuzzer17 fuzz1017, rr::components::AffixFuzzer18 fuzz1018,
+                rr::components::AffixFuzzer19 fuzz1019,
+                std::vector<rr::components::AffixFuzzer1> fuzz1101,
+                std::vector<rr::components::AffixFuzzer2> fuzz1102,
+                std::vector<rr::components::AffixFuzzer3> fuzz1103,
+                std::vector<rr::components::AffixFuzzer4> fuzz1104,
+                std::vector<rr::components::AffixFuzzer5> fuzz1105,
+                std::vector<rr::components::AffixFuzzer6> fuzz1106,
+                std::vector<rr::components::AffixFuzzer7> fuzz1107,
+                std::vector<rr::components::AffixFuzzer8> fuzz1108,
+                std::vector<rr::components::AffixFuzzer9> fuzz1109,
+                std::vector<rr::components::AffixFuzzer10> fuzz1110,
+                std::vector<rr::components::AffixFuzzer11> fuzz1111,
+                std::vector<rr::components::AffixFuzzer12> fuzz1112,
+                std::vector<rr::components::AffixFuzzer13> fuzz1113,
+                std::vector<rr::components::AffixFuzzer14> fuzz1114,
+                std::vector<rr::components::AffixFuzzer15> fuzz1115,
+                std::vector<rr::components::AffixFuzzer16> fuzz1116,
+                std::vector<rr::components::AffixFuzzer17> fuzz1117,
+                std::vector<rr::components::AffixFuzzer18> fuzz1118
+            )
+                : fuzz1001(std::move(fuzz1001)),
+                  fuzz1002(std::move(fuzz1002)),
+                  fuzz1003(std::move(fuzz1003)),
+                  fuzz1004(std::move(fuzz1004)),
+                  fuzz1005(std::move(fuzz1005)),
+                  fuzz1006(std::move(fuzz1006)),
+                  fuzz1007(std::move(fuzz1007)),
+                  fuzz1008(std::move(fuzz1008)),
+                  fuzz1009(std::move(fuzz1009)),
+                  fuzz1010(std::move(fuzz1010)),
+                  fuzz1011(std::move(fuzz1011)),
+                  fuzz1012(std::move(fuzz1012)),
+                  fuzz1013(std::move(fuzz1013)),
+                  fuzz1014(std::move(fuzz1014)),
+                  fuzz1015(std::move(fuzz1015)),
+                  fuzz1016(std::move(fuzz1016)),
+                  fuzz1017(std::move(fuzz1017)),
+                  fuzz1018(std::move(fuzz1018)),
+                  fuzz1019(std::move(fuzz1019)),
+                  fuzz1101(std::move(fuzz1101)),
+                  fuzz1102(std::move(fuzz1102)),
+                  fuzz1103(std::move(fuzz1103)),
+                  fuzz1104(std::move(fuzz1104)),
+                  fuzz1105(std::move(fuzz1105)),
+                  fuzz1106(std::move(fuzz1106)),
+                  fuzz1107(std::move(fuzz1107)),
+                  fuzz1108(std::move(fuzz1108)),
+                  fuzz1109(std::move(fuzz1109)),
+                  fuzz1110(std::move(fuzz1110)),
+                  fuzz1111(std::move(fuzz1111)),
+                  fuzz1112(std::move(fuzz1112)),
+                  fuzz1113(std::move(fuzz1113)),
+                  fuzz1114(std::move(fuzz1114)),
+                  fuzz1115(std::move(fuzz1115)),
+                  fuzz1116(std::move(fuzz1116)),
+                  fuzz1117(std::move(fuzz1117)),
+                  fuzz1118(std::move(fuzz1118)) {}
+
+            AffixFuzzer1& with_fuzz2001(rr::components::AffixFuzzer1 fuzz2001) {
+                this->fuzz2001 = std::move(fuzz2001);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2002(rr::components::AffixFuzzer2 fuzz2002) {
+                this->fuzz2002 = std::move(fuzz2002);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2003(rr::components::AffixFuzzer3 fuzz2003) {
+                this->fuzz2003 = std::move(fuzz2003);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2004(rr::components::AffixFuzzer4 fuzz2004) {
+                this->fuzz2004 = std::move(fuzz2004);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2005(rr::components::AffixFuzzer5 fuzz2005) {
+                this->fuzz2005 = std::move(fuzz2005);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2006(rr::components::AffixFuzzer6 fuzz2006) {
+                this->fuzz2006 = std::move(fuzz2006);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2007(rr::components::AffixFuzzer7 fuzz2007) {
+                this->fuzz2007 = std::move(fuzz2007);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2008(rr::components::AffixFuzzer8 fuzz2008) {
+                this->fuzz2008 = std::move(fuzz2008);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2009(rr::components::AffixFuzzer9 fuzz2009) {
+                this->fuzz2009 = std::move(fuzz2009);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2010(rr::components::AffixFuzzer10 fuzz2010) {
+                this->fuzz2010 = std::move(fuzz2010);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2011(rr::components::AffixFuzzer11 fuzz2011) {
+                this->fuzz2011 = std::move(fuzz2011);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2012(rr::components::AffixFuzzer12 fuzz2012) {
+                this->fuzz2012 = std::move(fuzz2012);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2013(rr::components::AffixFuzzer13 fuzz2013) {
+                this->fuzz2013 = std::move(fuzz2013);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2014(rr::components::AffixFuzzer14 fuzz2014) {
+                this->fuzz2014 = std::move(fuzz2014);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2015(rr::components::AffixFuzzer15 fuzz2015) {
+                this->fuzz2015 = std::move(fuzz2015);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2016(rr::components::AffixFuzzer16 fuzz2016) {
+                this->fuzz2016 = std::move(fuzz2016);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2017(rr::components::AffixFuzzer17 fuzz2017) {
+                this->fuzz2017 = std::move(fuzz2017);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2018(rr::components::AffixFuzzer18 fuzz2018) {
+                this->fuzz2018 = std::move(fuzz2018);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2101(std::vector<rr::components::AffixFuzzer1> fuzz2101) {
+                this->fuzz2101 = std::move(fuzz2101);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2102(std::vector<rr::components::AffixFuzzer2> fuzz2102) {
+                this->fuzz2102 = std::move(fuzz2102);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2103(std::vector<rr::components::AffixFuzzer3> fuzz2103) {
+                this->fuzz2103 = std::move(fuzz2103);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2104(std::vector<rr::components::AffixFuzzer4> fuzz2104) {
+                this->fuzz2104 = std::move(fuzz2104);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2105(std::vector<rr::components::AffixFuzzer5> fuzz2105) {
+                this->fuzz2105 = std::move(fuzz2105);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2106(std::vector<rr::components::AffixFuzzer6> fuzz2106) {
+                this->fuzz2106 = std::move(fuzz2106);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2107(std::vector<rr::components::AffixFuzzer7> fuzz2107) {
+                this->fuzz2107 = std::move(fuzz2107);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2108(std::vector<rr::components::AffixFuzzer8> fuzz2108) {
+                this->fuzz2108 = std::move(fuzz2108);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2109(std::vector<rr::components::AffixFuzzer9> fuzz2109) {
+                this->fuzz2109 = std::move(fuzz2109);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2110(std::vector<rr::components::AffixFuzzer10> fuzz2110) {
+                this->fuzz2110 = std::move(fuzz2110);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2111(std::vector<rr::components::AffixFuzzer11> fuzz2111) {
+                this->fuzz2111 = std::move(fuzz2111);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2112(std::vector<rr::components::AffixFuzzer12> fuzz2112) {
+                this->fuzz2112 = std::move(fuzz2112);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2113(std::vector<rr::components::AffixFuzzer13> fuzz2113) {
+                this->fuzz2113 = std::move(fuzz2113);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2114(std::vector<rr::components::AffixFuzzer14> fuzz2114) {
+                this->fuzz2114 = std::move(fuzz2114);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2115(std::vector<rr::components::AffixFuzzer15> fuzz2115) {
+                this->fuzz2115 = std::move(fuzz2115);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2116(std::vector<rr::components::AffixFuzzer16> fuzz2116) {
+                this->fuzz2116 = std::move(fuzz2116);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2117(std::vector<rr::components::AffixFuzzer17> fuzz2117) {
+                this->fuzz2117 = std::move(fuzz2117);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2118(std::vector<rr::components::AffixFuzzer18> fuzz2118) {
+                this->fuzz2118 = std::move(fuzz2118);
+                return *this;
+            }
+
+            /// Returns the number of primary instances of this archetype.
+            size_t num_instances() const {
+                return 1;
+            }
+
+            /// Creates a list of Rerun DataCell from this archetype.
+            arrow::Result<std::vector<rr::DataCell>> to_data_cells() const;
         };
     } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/archetypes/disconnected_space.cpp
@@ -3,6 +3,25 @@
 
 #include "disconnected_space.hpp"
 
+#include "../components/disconnected_space.hpp"
+
+#include <arrow/api.h>
+
 namespace rr {
-    namespace archetypes {}
+    namespace archetypes {
+        arrow::Result<std::vector<rr::DataCell>> DisconnectedSpace::to_data_cells() const {
+            std::vector<rr::DataCell> cells;
+            cells.reserve(1);
+
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::DisconnectedSpace::to_data_cell(&disconnected_space, 1)
+                );
+                cells.push_back(cell);
+            }
+
+            return cells;
+        }
+    } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/archetypes/disconnected_space.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../components/disconnected_space.hpp"
+#include "../data_cell.hpp"
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
@@ -23,6 +24,14 @@ namespace rr {
           public:
             DisconnectedSpace(rr::components::DisconnectedSpace disconnected_space)
                 : disconnected_space(std::move(disconnected_space)) {}
+
+            /// Returns the number of primary instances of this archetype.
+            size_t num_instances() const {
+                return 1;
+            }
+
+            /// Creates a list of Rerun DataCell from this archetype.
+            arrow::Result<std::vector<rr::DataCell>> to_data_cells() const;
         };
     } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/points2d.cpp
+++ b/rerun_cpp/src/archetypes/points2d.cpp
@@ -3,6 +3,88 @@
 
 #include "points2d.hpp"
 
+#include "../components/class_id.hpp"
+#include "../components/color.hpp"
+#include "../components/draw_order.hpp"
+#include "../components/instance_key.hpp"
+#include "../components/keypoint_id.hpp"
+#include "../components/label.hpp"
+#include "../components/point2d.hpp"
+#include "../components/radius.hpp"
+
+#include <arrow/api.h>
+
 namespace rr {
-    namespace archetypes {}
+    namespace archetypes {
+        arrow::Result<std::vector<rr::DataCell>> Points2D::to_data_cells() const {
+            std::vector<rr::DataCell> cells;
+            cells.reserve(8);
+
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Point2D::to_data_cell(points.data(), points.size())
+                );
+                cells.push_back(cell);
+            }
+            if (radii.has_value()) {
+                const auto& value = radii.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Radius::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (colors.has_value()) {
+                const auto& value = colors.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Color::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (labels.has_value()) {
+                const auto& value = labels.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Label::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (draw_order.has_value()) {
+                const auto& value = draw_order.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::DrawOrder::to_data_cell(&value, 1)
+                );
+                cells.push_back(cell);
+            }
+            if (class_ids.has_value()) {
+                const auto& value = class_ids.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::ClassId::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (keypoint_ids.has_value()) {
+                const auto& value = keypoint_ids.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::KeypointId::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (instance_keys.has_value()) {
+                const auto& value = instance_keys.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::InstanceKey::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+
+            return cells;
+        }
+    } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/points2d.hpp
+++ b/rerun_cpp/src/archetypes/points2d.hpp
@@ -11,10 +11,12 @@
 #include "../components/label.hpp"
 #include "../components/point2d.hpp"
 #include "../components/radius.hpp"
+#include "../data_cell.hpp"
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace rr {
@@ -55,6 +57,70 @@ namespace rr {
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<std::vector<rr::components::InstanceKey>> instance_keys;
+
+          public:
+            Points2D(std::vector<rr::components::Point2D> points) : points(std::move(points)) {}
+
+            /// Optional radii for the points, effectively turning them into circles.
+            Points2D& with_radii(std::vector<rr::components::Radius> radii) {
+                this->radii = std::move(radii);
+                return *this;
+            }
+
+            /// Optional colors for the points.
+            Points2D& with_colors(std::vector<rr::components::Color> colors) {
+                this->colors = std::move(colors);
+                return *this;
+            }
+
+            /// Optional text labels for the points.
+            Points2D& with_labels(std::vector<rr::components::Label> labels) {
+                this->labels = std::move(labels);
+                return *this;
+            }
+
+            /// An optional floating point value that specifies the 2D drawing order.
+            /// Objects with higher values are drawn on top of those with lower values.
+            ///
+            /// The default for 2D points is 30.0.
+            Points2D& with_draw_order(rr::components::DrawOrder draw_order) {
+                this->draw_order = std::move(draw_order);
+                return *this;
+            }
+
+            /// Optional class Ids for the points.
+            ///
+            /// The class ID provides colors and labels if not specified explicitly.
+            Points2D& with_class_ids(std::vector<rr::components::ClassId> class_ids) {
+                this->class_ids = std::move(class_ids);
+                return *this;
+            }
+
+            /// Optional keypoint IDs for the points, identifying them within a class.
+            ///
+            /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
+            /// default to 0.
+            /// This is useful to identify points within a single classification (which is
+            /// identified with `class_id`). E.g. the classification might be 'Person' and the
+            /// keypoints refer to joints on a detected skeleton.
+            Points2D& with_keypoint_ids(std::vector<rr::components::KeypointId> keypoint_ids) {
+                this->keypoint_ids = std::move(keypoint_ids);
+                return *this;
+            }
+
+            /// Unique identifiers for each individual point in the batch.
+            Points2D& with_instance_keys(std::vector<rr::components::InstanceKey> instance_keys) {
+                this->instance_keys = std::move(instance_keys);
+                return *this;
+            }
+
+            /// Returns the number of primary instances of this archetype.
+            size_t num_instances() const {
+                return points.size();
+            }
+
+            /// Creates a list of Rerun DataCell from this archetype.
+            arrow::Result<std::vector<rr::DataCell>> to_data_cells() const;
         };
     } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/points3d.cpp
+++ b/rerun_cpp/src/archetypes/points3d.cpp
@@ -3,6 +3,79 @@
 
 #include "points3d.hpp"
 
+#include "../components/class_id.hpp"
+#include "../components/color.hpp"
+#include "../components/instance_key.hpp"
+#include "../components/keypoint_id.hpp"
+#include "../components/label.hpp"
+#include "../components/point3d.hpp"
+#include "../components/radius.hpp"
+
+#include <arrow/api.h>
+
 namespace rr {
-    namespace archetypes {}
+    namespace archetypes {
+        arrow::Result<std::vector<rr::DataCell>> Points3D::to_data_cells() const {
+            std::vector<rr::DataCell> cells;
+            cells.reserve(7);
+
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Point3D::to_data_cell(points.data(), points.size())
+                );
+                cells.push_back(cell);
+            }
+            if (radii.has_value()) {
+                const auto& value = radii.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Radius::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (colors.has_value()) {
+                const auto& value = colors.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Color::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (labels.has_value()) {
+                const auto& value = labels.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Label::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (class_ids.has_value()) {
+                const auto& value = class_ids.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::ClassId::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (keypoint_ids.has_value()) {
+                const auto& value = keypoint_ids.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::KeypointId::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+            if (instance_keys.has_value()) {
+                const auto& value = instance_keys.value();
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::InstanceKey::to_data_cell(value.data(), value.size())
+                );
+                cells.push_back(cell);
+            }
+
+            return cells;
+        }
+    } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/points3d.hpp
+++ b/rerun_cpp/src/archetypes/points3d.hpp
@@ -10,10 +10,12 @@
 #include "../components/label.hpp"
 #include "../components/point3d.hpp"
 #include "../components/radius.hpp"
+#include "../data_cell.hpp"
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace rr {
@@ -48,6 +50,61 @@ namespace rr {
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<std::vector<rr::components::InstanceKey>> instance_keys;
+
+          public:
+            Points3D(std::vector<rr::components::Point3D> points) : points(std::move(points)) {}
+
+            /// Optional radii for the points, effectively turning them into circles.
+            Points3D& with_radii(std::vector<rr::components::Radius> radii) {
+                this->radii = std::move(radii);
+                return *this;
+            }
+
+            /// Optional colors for the points.
+            Points3D& with_colors(std::vector<rr::components::Color> colors) {
+                this->colors = std::move(colors);
+                return *this;
+            }
+
+            /// Optional text labels for the points.
+            Points3D& with_labels(std::vector<rr::components::Label> labels) {
+                this->labels = std::move(labels);
+                return *this;
+            }
+
+            /// Optional class Ids for the points.
+            ///
+            /// The class ID provides colors and labels if not specified explicitly.
+            Points3D& with_class_ids(std::vector<rr::components::ClassId> class_ids) {
+                this->class_ids = std::move(class_ids);
+                return *this;
+            }
+
+            /// Optional keypoint IDs for the points, identifying them within a class.
+            ///
+            /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
+            /// default to 0.
+            /// This is useful to identify points within a single classification (which is
+            /// identified with `class_id`). E.g. the classification might be 'Person' and the
+            /// keypoints refer to joints on a detected skeleton.
+            Points3D& with_keypoint_ids(std::vector<rr::components::KeypointId> keypoint_ids) {
+                this->keypoint_ids = std::move(keypoint_ids);
+                return *this;
+            }
+
+            /// Unique identifiers for each individual point in the batch.
+            Points3D& with_instance_keys(std::vector<rr::components::InstanceKey> instance_keys) {
+                this->instance_keys = std::move(instance_keys);
+                return *this;
+            }
+
+            /// Returns the number of primary instances of this archetype.
+            size_t num_instances() const {
+                return points.size();
+            }
+
+            /// Creates a list of Rerun DataCell from this archetype.
+            arrow::Result<std::vector<rr::DataCell>> to_data_cells() const;
         };
     } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/archetypes/transform3d.cpp
@@ -3,6 +3,25 @@
 
 #include "transform3d.hpp"
 
+#include "../components/transform3d.hpp"
+
+#include <arrow/api.h>
+
 namespace rr {
-    namespace archetypes {}
+    namespace archetypes {
+        arrow::Result<std::vector<rr::DataCell>> Transform3D::to_data_cells() const {
+            std::vector<rr::DataCell> cells;
+            cells.reserve(1);
+
+            {
+                ARROW_ASSIGN_OR_RAISE(
+                    const auto cell,
+                    rr::components::Transform3D::to_data_cell(&transform, 1)
+                );
+                cells.push_back(cell);
+            }
+
+            return cells;
+        }
+    } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/archetypes/transform3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../components/transform3d.hpp"
+#include "../data_cell.hpp"
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
@@ -18,6 +19,14 @@ namespace rr {
 
           public:
             Transform3D(rr::components::Transform3D transform) : transform(std::move(transform)) {}
+
+            /// Returns the number of primary instances of this archetype.
+            size_t num_instances() const {
+                return 1;
+            }
+
+            /// Creates a list of Rerun DataCell from this archetype.
+            arrow::Result<std::vector<rr::DataCell>> to_data_cells() const;
         };
     } // namespace archetypes
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer1.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer1.hpp"
 
 #include "../datatypes/affix_fuzzer1.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer1::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+        const char *AffixFuzzer1::NAME = "rerun.testing.components.AffixFuzzer1";
+
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer1::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer1::new_arrow_array_builder(
@@ -43,6 +47,37 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer1::to_data_cell(
+            const AffixFuzzer1 *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer1::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer1::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer1::NAME, AffixFuzzer1::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer1::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer1.cpp
@@ -50,18 +50,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer1::to_data_cell(
-            const AffixFuzzer1 *components, size_t num_components
+            const AffixFuzzer1 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer1::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer1::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer1::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer1.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer1 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer1* components, size_t num_components
+                const AffixFuzzer1* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer1.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -14,12 +15,15 @@ namespace rr {
         struct AffixFuzzer1 {
             rr::datatypes::AffixFuzzer1 single_required;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer1(rr::datatypes::AffixFuzzer1 single_required)
                 : single_required(std::move(single_required)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -29,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer1 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer1* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer10.cpp
@@ -50,18 +50,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer10::to_data_cell(
-            const AffixFuzzer10* components, size_t num_components
+            const AffixFuzzer10* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer10::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer10::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer10::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer10.cpp
@@ -3,12 +3,17 @@
 
 #include "affix_fuzzer10.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer10::to_arrow_datatype() {
-            return arrow::utf8();
+        const char* AffixFuzzer10::NAME = "rerun.testing.components.AffixFuzzer10";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer10::to_arrow_datatype() {
+            static const auto datatype = arrow::utf8();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StringBuilder>> AffixFuzzer10::new_arrow_array_builder(
@@ -42,6 +47,37 @@ namespace rr {
             }
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer10::to_data_cell(
+            const AffixFuzzer10* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer10::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer10::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer10::NAME, AffixFuzzer10::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer10::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer10.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
@@ -14,12 +16,15 @@ namespace rr {
         struct AffixFuzzer10 {
             std::optional<std::string> single_string_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer10(std::optional<std::string> single_string_optional)
                 : single_string_optional(std::move(single_string_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
@@ -29,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer10 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer10* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer10.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer10 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer10* components, size_t num_components
+                const AffixFuzzer10* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer11.cpp
@@ -62,18 +62,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer11::to_data_cell(
-            const AffixFuzzer11 *components, size_t num_components
+            const AffixFuzzer11 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer11::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer11::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer11::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer11.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer11 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer11* components, size_t num_components
+                const AffixFuzzer11* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer11.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
@@ -14,12 +16,15 @@ namespace rr {
         struct AffixFuzzer11 {
             std::optional<std::vector<float>> many_floats_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer11(std::optional<std::vector<float>> many_floats_optional)
                 : many_floats_optional(std::move(many_floats_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -29,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer11* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer11 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer11* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer12.cpp
@@ -59,18 +59,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer12::to_data_cell(
-            const AffixFuzzer12 *components, size_t num_components
+            const AffixFuzzer12 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer12::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer12::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer12::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer12.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <string>
@@ -14,12 +16,15 @@ namespace rr {
         struct AffixFuzzer12 {
             std::vector<std::string> many_strings_required;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer12(std::vector<std::string> many_strings_required)
                 : many_strings_required(std::move(many_strings_required)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -29,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer12* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer12 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer12* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer12.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer12 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer12* components, size_t num_components
+                const AffixFuzzer12* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer13.cpp
@@ -3,12 +3,18 @@
 
 #include "affix_fuzzer13.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer13::to_arrow_datatype() {
-            return arrow::list(arrow::field("item", arrow::utf8(), true, nullptr));
+        const char *AffixFuzzer13::NAME = "rerun.testing.components.AffixFuzzer13";
+
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer13::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::list(arrow::field("item", arrow::utf8(), true, nullptr));
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer13::new_arrow_array_builder(
@@ -43,7 +49,9 @@ namespace rr {
                 if (element.many_strings_optional.has_value()) {
                     for (auto item_idx = 0; item_idx < element.many_strings_optional.value().size();
                          item_idx += 1) {
-                        value_builder->Append(element.many_strings_optional.value()[item_idx]);
+                        ARROW_RETURN_NOT_OK(
+                            value_builder->Append(element.many_strings_optional.value()[item_idx])
+                        );
                     }
                     ARROW_RETURN_NOT_OK(builder->Append());
                 } else {
@@ -52,6 +60,37 @@ namespace rr {
             }
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer13::to_data_cell(
+            const AffixFuzzer13 *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer13::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer13::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer13::NAME, AffixFuzzer13::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer13::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer13.cpp
@@ -63,18 +63,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer13::to_data_cell(
-            const AffixFuzzer13 *components, size_t num_components
+            const AffixFuzzer13 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer13::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer13::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer13::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer13.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
@@ -15,12 +17,15 @@ namespace rr {
         struct AffixFuzzer13 {
             std::optional<std::vector<std::string>> many_strings_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer13(std::optional<std::vector<std::string>> many_strings_optional)
                 : many_strings_optional(std::move(many_strings_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -30,6 +35,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer13* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer13 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer13* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer13.hpp
@@ -39,7 +39,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer13 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer13* components, size_t num_components
+                const AffixFuzzer13* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer14.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer14.hpp"
 
 #include "../datatypes/affix_fuzzer3.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer14::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer3::to_arrow_datatype();
+        const char *AffixFuzzer14::NAME = "rerun.testing.components.AffixFuzzer14";
+
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer14::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer3::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
@@ -42,6 +46,37 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer14::to_data_cell(
+            const AffixFuzzer14 *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer14::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer14::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer14::NAME, AffixFuzzer14::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer14::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer14.cpp
@@ -49,18 +49,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer14::to_data_cell(
-            const AffixFuzzer14 *components, size_t num_components
+            const AffixFuzzer14 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer14::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer14::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer14::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer14.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer14 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer14* components, size_t num_components
+                const AffixFuzzer14* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer14.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/type_fwd.h>
@@ -14,12 +15,15 @@ namespace rr {
         struct AffixFuzzer14 {
             rr::datatypes::AffixFuzzer3 single_required_union;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer14(rr::datatypes::AffixFuzzer3 single_required_union)
                 : single_required_union(std::move(single_required_union)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -30,6 +34,11 @@ namespace rr {
             static arrow::Status fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer14* elements,
                 size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer14 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer14* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer15.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer15.hpp"
 
 #include "../datatypes/affix_fuzzer3.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer15::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer3::to_arrow_datatype();
+        const char* AffixFuzzer15::NAME = "rerun.testing.components.AffixFuzzer15";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer15::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer3::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
@@ -37,6 +41,37 @@ namespace rr {
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer15::to_data_cell(
+            const AffixFuzzer15* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer15::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer15::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer15::NAME, AffixFuzzer15::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer15::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer15.cpp
@@ -44,18 +44,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer15::to_data_cell(
-            const AffixFuzzer15* components, size_t num_components
+            const AffixFuzzer15* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer15::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer15::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer15::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer15.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,12 +16,15 @@ namespace rr {
         struct AffixFuzzer15 {
             std::optional<rr::datatypes::AffixFuzzer3> single_optional_union;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer15(std::optional<rr::datatypes::AffixFuzzer3> single_optional_union)
                 : single_optional_union(std::move(single_optional_union)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -31,6 +35,11 @@ namespace rr {
             static arrow::Status fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements,
                 size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer15 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer15* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer15.hpp
@@ -39,7 +39,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer15 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer15* components, size_t num_components
+                const AffixFuzzer15* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer16.cpp
@@ -53,18 +53,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer16::to_data_cell(
-            const AffixFuzzer16* components, size_t num_components
+            const AffixFuzzer16* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer16::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer16::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer16::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer16.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer16 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer16* components, size_t num_components
+                const AffixFuzzer16* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer16.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,12 +16,15 @@ namespace rr {
         struct AffixFuzzer16 {
             std::vector<rr::datatypes::AffixFuzzer3> many_required_unions;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer16(std::vector<rr::datatypes::AffixFuzzer3> many_required_unions)
                 : many_required_unions(std::move(many_required_unions)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -30,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer16 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer16* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer17.cpp
@@ -4,18 +4,22 @@
 #include "affix_fuzzer17.hpp"
 
 #include "../datatypes/affix_fuzzer3.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer17::to_arrow_datatype() {
-            return arrow::list(arrow::field(
+        const char* AffixFuzzer17::NAME = "rerun.testing.components.AffixFuzzer17";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer17::to_arrow_datatype() {
+            static const auto datatype = arrow::list(arrow::field(
                 "item",
                 rr::datatypes::AffixFuzzer3::to_arrow_datatype(),
                 true,
                 nullptr
             ));
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer17::new_arrow_array_builder(
@@ -46,6 +50,37 @@ namespace rr {
             );
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer17::to_data_cell(
+            const AffixFuzzer17* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer17::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer17::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer17::NAME, AffixFuzzer17::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer17::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer17.cpp
@@ -53,18 +53,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer17::to_data_cell(
-            const AffixFuzzer17* components, size_t num_components
+            const AffixFuzzer17* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer17::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer17::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer17::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer17.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/type_fwd.h>
@@ -16,6 +17,9 @@ namespace rr {
         struct AffixFuzzer17 {
             std::optional<std::vector<rr::datatypes::AffixFuzzer3>> many_optional_unions;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer17(
                 std::optional<std::vector<rr::datatypes::AffixFuzzer3>> many_optional_unions
@@ -23,7 +27,7 @@ namespace rr {
                 : many_optional_unions(std::move(many_optional_unions)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -33,6 +37,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer17 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer17* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer17.hpp
@@ -41,7 +41,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer17 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer17* components, size_t num_components
+                const AffixFuzzer17* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer18.cpp
@@ -53,18 +53,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer18::to_data_cell(
-            const AffixFuzzer18* components, size_t num_components
+            const AffixFuzzer18* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer18::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer18::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer18::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer18.hpp
@@ -41,7 +41,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer18 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer18* components, size_t num_components
+                const AffixFuzzer18* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer18.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer4.hpp"
 
 #include <arrow/type_fwd.h>
@@ -16,6 +17,9 @@ namespace rr {
         struct AffixFuzzer18 {
             std::optional<std::vector<rr::datatypes::AffixFuzzer4>> many_optional_unions;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer18(
                 std::optional<std::vector<rr::datatypes::AffixFuzzer4>> many_optional_unions
@@ -23,7 +27,7 @@ namespace rr {
                 : many_optional_unions(std::move(many_optional_unions)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -33,6 +37,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer18 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer18* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer19.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer19.hpp"
 
 #include "../datatypes/affix_fuzzer5.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer19::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer5::to_arrow_datatype();
+        const char *AffixFuzzer19::NAME = "rerun.testing.components.AffixFuzzer19";
+
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer19::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer5::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer19::new_arrow_array_builder(
@@ -43,6 +47,37 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer19::to_data_cell(
+            const AffixFuzzer19 *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer19::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer19::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer19::NAME, AffixFuzzer19::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer19::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer19.cpp
@@ -50,18 +50,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer19::to_data_cell(
-            const AffixFuzzer19 *components, size_t num_components
+            const AffixFuzzer19 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer19::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer19::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer19::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer19.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer5.hpp"
 
 #include <arrow/type_fwd.h>
@@ -14,12 +15,15 @@ namespace rr {
         struct AffixFuzzer19 {
             rr::datatypes::AffixFuzzer5 just_a_table_nothing_shady;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer19(rr::datatypes::AffixFuzzer5 just_a_table_nothing_shady)
                 : just_a_table_nothing_shady(std::move(just_a_table_nothing_shady)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -29,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer19* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer19 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer19* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer19.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer19 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer19* components, size_t num_components
+                const AffixFuzzer19* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer2.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer2.hpp"
 
 #include "../datatypes/affix_fuzzer1.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer2::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+        const char *AffixFuzzer2::NAME = "rerun.testing.components.AffixFuzzer2";
+
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer2::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer2::new_arrow_array_builder(
@@ -43,6 +47,37 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer2::to_data_cell(
+            const AffixFuzzer2 *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer2::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer2::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer2::NAME, AffixFuzzer2::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer2::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer2.cpp
@@ -50,18 +50,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer2::to_data_cell(
-            const AffixFuzzer2 *components, size_t num_components
+            const AffixFuzzer2 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer2::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer2::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer2::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer2.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -14,12 +15,15 @@ namespace rr {
         struct AffixFuzzer2 {
             rr::datatypes::AffixFuzzer1 single_required;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer2(rr::datatypes::AffixFuzzer1 single_required)
                 : single_required(std::move(single_required)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -29,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer2 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer2* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer2.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer2 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer2* components, size_t num_components
+                const AffixFuzzer2* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer3.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer3.cpp
@@ -50,18 +50,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer3::to_data_cell(
-            const AffixFuzzer3 *components, size_t num_components
+            const AffixFuzzer3 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer3::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer3::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer3::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer3.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -14,12 +15,15 @@ namespace rr {
         struct AffixFuzzer3 {
             rr::datatypes::AffixFuzzer1 single_required;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer3(rr::datatypes::AffixFuzzer1 single_required)
                 : single_required(std::move(single_required)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -29,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer3 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer3* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer3.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer3 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer3* components, size_t num_components
+                const AffixFuzzer3* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer4.cpp
@@ -45,18 +45,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer4::to_data_cell(
-            const AffixFuzzer4* components, size_t num_components
+            const AffixFuzzer4* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer4::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer4::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer4::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer4.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer4.hpp"
 
 #include "../datatypes/affix_fuzzer1.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer4::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+        const char* AffixFuzzer4::NAME = "rerun.testing.components.AffixFuzzer4";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer4::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer4::new_arrow_array_builder(
@@ -38,6 +42,37 @@ namespace rr {
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer4::to_data_cell(
+            const AffixFuzzer4* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer4::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer4::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer4::NAME, AffixFuzzer4::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer4::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer4.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,12 +16,15 @@ namespace rr {
         struct AffixFuzzer4 {
             std::optional<rr::datatypes::AffixFuzzer1> single_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer4(std::optional<rr::datatypes::AffixFuzzer1> single_optional)
                 : single_optional(std::move(single_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -30,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer4 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer4* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer4.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer4 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer4* components, size_t num_components
+                const AffixFuzzer4* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer5.cpp
@@ -45,18 +45,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer5::to_data_cell(
-            const AffixFuzzer5* components, size_t num_components
+            const AffixFuzzer5* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer5::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer5::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer5::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer5.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer5.hpp"
 
 #include "../datatypes/affix_fuzzer1.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer5::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+        const char* AffixFuzzer5::NAME = "rerun.testing.components.AffixFuzzer5";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer5::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(
@@ -38,6 +42,37 @@ namespace rr {
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer5::to_data_cell(
+            const AffixFuzzer5* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer5::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer5::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer5::NAME, AffixFuzzer5::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer5::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer5.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,12 +16,15 @@ namespace rr {
         struct AffixFuzzer5 {
             std::optional<rr::datatypes::AffixFuzzer1> single_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer5(std::optional<rr::datatypes::AffixFuzzer1> single_optional)
                 : single_optional(std::move(single_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -30,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer5 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer5* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer5.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer5 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer5* components, size_t num_components
+                const AffixFuzzer5* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer6.cpp
@@ -45,18 +45,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer6::to_data_cell(
-            const AffixFuzzer6* components, size_t num_components
+            const AffixFuzzer6* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer6::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer6::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer6::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer6.cpp
@@ -4,13 +4,17 @@
 #include "affix_fuzzer6.hpp"
 
 #include "../datatypes/affix_fuzzer1.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer6::to_arrow_datatype() {
-            return rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+        const char* AffixFuzzer6::NAME = "rerun.testing.components.AffixFuzzer6";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer6::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::AffixFuzzer1::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer6::new_arrow_array_builder(
@@ -38,6 +42,37 @@ namespace rr {
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer6::to_data_cell(
+            const AffixFuzzer6* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer6::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer6::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer6::NAME, AffixFuzzer6::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer6::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer6.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer6 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer6* components, size_t num_components
+                const AffixFuzzer6* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer6.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,12 +16,15 @@ namespace rr {
         struct AffixFuzzer6 {
             std::optional<rr::datatypes::AffixFuzzer1> single_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer6(std::optional<rr::datatypes::AffixFuzzer1> single_optional)
                 : single_optional(std::move(single_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -30,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer6 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer6* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer7.cpp
@@ -53,18 +53,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer7::to_data_cell(
-            const AffixFuzzer7* components, size_t num_components
+            const AffixFuzzer7* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer7::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer7::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer7::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer7.cpp
@@ -4,18 +4,22 @@
 #include "affix_fuzzer7.hpp"
 
 #include "../datatypes/affix_fuzzer1.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer7::to_arrow_datatype() {
-            return arrow::list(arrow::field(
+        const char* AffixFuzzer7::NAME = "rerun.testing.components.AffixFuzzer7";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer7::to_arrow_datatype() {
+            static const auto datatype = arrow::list(arrow::field(
                 "item",
                 rr::datatypes::AffixFuzzer1::to_arrow_datatype(),
                 true,
                 nullptr
             ));
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer7::new_arrow_array_builder(
@@ -46,6 +50,37 @@ namespace rr {
             );
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer7::to_data_cell(
+            const AffixFuzzer7* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer7::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer7::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer7::NAME, AffixFuzzer7::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer7::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer7.hpp
@@ -39,7 +39,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer7 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer7* components, size_t num_components
+                const AffixFuzzer7* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer7.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/type_fwd.h>
@@ -16,12 +17,15 @@ namespace rr {
         struct AffixFuzzer7 {
             std::optional<std::vector<rr::datatypes::AffixFuzzer1>> many_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer7(std::optional<std::vector<rr::datatypes::AffixFuzzer1>> many_optional)
                 : many_optional(std::move(many_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
@@ -31,6 +35,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer7 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer7* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer8.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer8.cpp
@@ -50,18 +50,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer8::to_data_cell(
-            const AffixFuzzer8* components, size_t num_components
+            const AffixFuzzer8* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer8::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer8::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer8::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer8.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer8 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer8* components, size_t num_components
+                const AffixFuzzer8* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer8.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
@@ -13,12 +15,15 @@ namespace rr {
         struct AffixFuzzer8 {
             std::optional<float> single_float_optional;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer8(std::optional<float> single_float_optional)
                 : single_float_optional(std::move(single_float_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
@@ -28,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const AffixFuzzer8* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer8 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer8* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer9.cpp
@@ -45,18 +45,16 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> AffixFuzzer9::to_data_cell(
-            const AffixFuzzer9* components, size_t num_components
+            const AffixFuzzer9* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer9::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
-                ARROW_RETURN_NOT_OK(AffixFuzzer9::fill_arrow_array_builder(
-                    builder.get(),
-                    components,
-                    num_components
-                ));
+            if (instances && num_instances > 0) {
+                ARROW_RETURN_NOT_OK(
+                    AffixFuzzer9::fill_arrow_array_builder(builder.get(), instances, num_instances)
+                );
             }
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));

--- a/rerun_cpp/src/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/src/components/affix_fuzzer9.cpp
@@ -3,12 +3,17 @@
 
 #include "affix_fuzzer9.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> AffixFuzzer9::to_arrow_datatype() {
-            return arrow::utf8();
+        const char* AffixFuzzer9::NAME = "rerun.testing.components.AffixFuzzer9";
+
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer9::to_arrow_datatype() {
+            static const auto datatype = arrow::utf8();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StringBuilder>> AffixFuzzer9::new_arrow_array_builder(
@@ -37,6 +42,37 @@ namespace rr {
             }
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> AffixFuzzer9::to_data_cell(
+            const AffixFuzzer9* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer9::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(AffixFuzzer9::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(AffixFuzzer9::NAME, AffixFuzzer9::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = AffixFuzzer9::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer9.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <string>
@@ -13,12 +15,15 @@ namespace rr {
         struct AffixFuzzer9 {
             std::string single_string_required;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             AffixFuzzer9(std::string single_string_required)
                 : single_string_required(std::move(single_string_required)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
@@ -28,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of AffixFuzzer9 components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const AffixFuzzer9* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/src/components/affix_fuzzer9.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of AffixFuzzer9 components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const AffixFuzzer9* components, size_t num_components
+                const AffixFuzzer9* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/class_id.cpp
+++ b/rerun_cpp/src/components/class_id.cpp
@@ -3,12 +3,17 @@
 
 #include "class_id.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> ClassId::to_arrow_datatype() {
-            return arrow::uint16();
+        const char* ClassId::NAME = "rerun.class_id";
+
+        const std::shared_ptr<arrow::DataType>& ClassId::to_arrow_datatype() {
+            static const auto datatype = arrow::uint16();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::UInt16Builder>> ClassId::new_arrow_array_builder(
@@ -35,6 +40,34 @@ namespace rr {
             ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->id, num_elements));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> ClassId::to_data_cell(
+            const ClassId* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, ClassId::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    ClassId::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(ClassId::NAME, ClassId::to_arrow_datatype(), false)});
+
+            rr::DataCell cell;
+            cell.component_name = ClassId::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/class_id.cpp
+++ b/rerun_cpp/src/components/class_id.cpp
@@ -43,15 +43,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> ClassId::to_data_cell(
-            const ClassId* components, size_t num_components
+            const ClassId* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, ClassId::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    ClassId::fill_arrow_array_builder(builder.get(), components, num_components)
+                    ClassId::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/class_id.hpp
+++ b/rerun_cpp/src/components/class_id.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -13,11 +15,14 @@ namespace rr {
         struct ClassId {
             uint16_t id;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             ClassId(uint16_t id) : id(std::move(id)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
@@ -27,6 +32,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of ClassId components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const ClassId* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/class_id.hpp
+++ b/rerun_cpp/src/components/class_id.hpp
@@ -36,7 +36,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of ClassId components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const ClassId* components, size_t num_components
+                const ClassId* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/color.cpp
+++ b/rerun_cpp/src/components/color.cpp
@@ -43,15 +43,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> Color::to_data_cell(
-            const Color* components, size_t num_components
+            const Color* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, Color::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    Color::fill_arrow_array_builder(builder.get(), components, num_components)
+                    Color::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/color.cpp
+++ b/rerun_cpp/src/components/color.cpp
@@ -3,12 +3,17 @@
 
 #include "color.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> Color::to_arrow_datatype() {
-            return arrow::uint32();
+        const char* Color::NAME = "rerun.colorrgba";
+
+        const std::shared_ptr<arrow::DataType>& Color::to_arrow_datatype() {
+            static const auto datatype = arrow::uint32();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::UInt32Builder>> Color::new_arrow_array_builder(
@@ -35,6 +40,34 @@ namespace rr {
             ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->rgba, num_elements));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> Color::to_data_cell(
+            const Color* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, Color::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    Color::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(Color::NAME, Color::to_arrow_datatype(), false)});
+
+            rr::DataCell cell;
+            cell.component_name = Color::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/color.hpp
+++ b/rerun_cpp/src/components/color.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -14,11 +16,14 @@ namespace rr {
         struct Color {
             uint32_t rgba;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             Color(uint32_t rgba) : rgba(std::move(rgba)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
@@ -28,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of Color components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const Color* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/color.hpp
+++ b/rerun_cpp/src/components/color.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of Color components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const Color* components, size_t num_components
+                const Color* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/disconnected_space.cpp
+++ b/rerun_cpp/src/components/disconnected_space.cpp
@@ -3,16 +3,21 @@
 
 #include "disconnected_space.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> DisconnectedSpace::to_arrow_datatype() {
-            return arrow::boolean();
+        const char *DisconnectedSpace::NAME = "rerun.disconnected_space";
+
+        const std::shared_ptr<arrow::DataType> &DisconnectedSpace::to_arrow_datatype() {
+            static const auto datatype = arrow::boolean();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::BooleanBuilder>>
-            DisconnectedSpace::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            DisconnectedSpace::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -21,7 +26,7 @@ namespace rr {
         }
 
         arrow::Status DisconnectedSpace::fill_arrow_array_builder(
-            arrow::BooleanBuilder* builder, const DisconnectedSpace* elements, size_t num_elements
+            arrow::BooleanBuilder *builder, const DisconnectedSpace *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -31,9 +36,45 @@ namespace rr {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->is_disconnected));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->is_disconnected, num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(
+                reinterpret_cast<const uint8_t *>(&elements->is_disconnected),
+                num_elements
+            ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> DisconnectedSpace::to_data_cell(
+            const DisconnectedSpace *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, DisconnectedSpace::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(DisconnectedSpace::fill_arrow_array_builder(
+                    builder.get(),
+                    components,
+                    num_components
+                ));
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema({arrow::field(
+                DisconnectedSpace::NAME,
+                DisconnectedSpace::to_arrow_datatype(),
+                false
+            )});
+
+            rr::DataCell cell;
+            cell.component_name = DisconnectedSpace::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/disconnected_space.cpp
+++ b/rerun_cpp/src/components/disconnected_space.cpp
@@ -45,17 +45,17 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> DisconnectedSpace::to_data_cell(
-            const DisconnectedSpace *components, size_t num_components
+            const DisconnectedSpace *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, DisconnectedSpace::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(DisconnectedSpace::fill_arrow_array_builder(
                     builder.get(),
-                    components,
-                    num_components
+                    instances,
+                    num_instances
                 ));
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/disconnected_space.hpp
+++ b/rerun_cpp/src/components/disconnected_space.hpp
@@ -41,7 +41,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of DisconnectedSpace components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const DisconnectedSpace* components, size_t num_components
+                const DisconnectedSpace* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/disconnected_space.hpp
+++ b/rerun_cpp/src/components/disconnected_space.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -17,11 +19,14 @@ namespace rr {
         struct DisconnectedSpace {
             bool is_disconnected;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             DisconnectedSpace(bool is_disconnected) : is_disconnected(std::move(is_disconnected)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::BooleanBuilder>> new_arrow_array_builder(
@@ -32,6 +37,11 @@ namespace rr {
             static arrow::Status fill_arrow_array_builder(
                 arrow::BooleanBuilder* builder, const DisconnectedSpace* elements,
                 size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of DisconnectedSpace components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const DisconnectedSpace* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/draw_order.cpp
+++ b/rerun_cpp/src/components/draw_order.cpp
@@ -3,12 +3,17 @@
 
 #include "draw_order.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> DrawOrder::to_arrow_datatype() {
-            return arrow::float32();
+        const char* DrawOrder::NAME = "rerun.draw_order";
+
+        const std::shared_ptr<arrow::DataType>& DrawOrder::to_arrow_datatype() {
+            static const auto datatype = arrow::float32();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FloatBuilder>> DrawOrder::new_arrow_array_builder(
@@ -35,6 +40,35 @@ namespace rr {
             ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->value, num_elements));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> DrawOrder::to_data_cell(
+            const DrawOrder* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, DrawOrder::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    DrawOrder::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(DrawOrder::NAME, DrawOrder::to_arrow_datatype(), false)}
+                );
+
+            rr::DataCell cell;
+            cell.component_name = DrawOrder::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/draw_order.cpp
+++ b/rerun_cpp/src/components/draw_order.cpp
@@ -43,15 +43,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> DrawOrder::to_data_cell(
-            const DrawOrder* components, size_t num_components
+            const DrawOrder* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, DrawOrder::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    DrawOrder::fill_arrow_array_builder(builder.get(), components, num_components)
+                    DrawOrder::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/draw_order.hpp
+++ b/rerun_cpp/src/components/draw_order.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -19,11 +21,14 @@ namespace rr {
         struct DrawOrder {
             float value;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             DrawOrder(float value) : value(std::move(value)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
@@ -33,6 +38,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of DrawOrder components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const DrawOrder* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/draw_order.hpp
+++ b/rerun_cpp/src/components/draw_order.hpp
@@ -42,7 +42,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of DrawOrder components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const DrawOrder* components, size_t num_components
+                const DrawOrder* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/instance_key.cpp
+++ b/rerun_cpp/src/components/instance_key.cpp
@@ -43,15 +43,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> InstanceKey::to_data_cell(
-            const InstanceKey* components, size_t num_components
+            const InstanceKey* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, InstanceKey::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    InstanceKey::fill_arrow_array_builder(builder.get(), components, num_components)
+                    InstanceKey::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/instance_key.hpp
+++ b/rerun_cpp/src/components/instance_key.hpp
@@ -36,7 +36,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of InstanceKey components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const InstanceKey* components, size_t num_components
+                const InstanceKey* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/instance_key.hpp
+++ b/rerun_cpp/src/components/instance_key.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -13,11 +15,14 @@ namespace rr {
         struct InstanceKey {
             uint64_t value;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             InstanceKey(uint64_t value) : value(std::move(value)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::UInt64Builder>> new_arrow_array_builder(
@@ -27,6 +32,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of InstanceKey components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const InstanceKey* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/keypoint_id.cpp
+++ b/rerun_cpp/src/components/keypoint_id.cpp
@@ -3,12 +3,17 @@
 
 #include "keypoint_id.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> KeypointId::to_arrow_datatype() {
-            return arrow::uint16();
+        const char* KeypointId::NAME = "rerun.keypoint_id";
+
+        const std::shared_ptr<arrow::DataType>& KeypointId::to_arrow_datatype() {
+            static const auto datatype = arrow::uint16();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::UInt16Builder>> KeypointId::new_arrow_array_builder(
@@ -35,6 +40,35 @@ namespace rr {
             ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->id, num_elements));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> KeypointId::to_data_cell(
+            const KeypointId* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, KeypointId::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    KeypointId::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(KeypointId::NAME, KeypointId::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = KeypointId::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/keypoint_id.cpp
+++ b/rerun_cpp/src/components/keypoint_id.cpp
@@ -43,15 +43,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> KeypointId::to_data_cell(
-            const KeypointId* components, size_t num_components
+            const KeypointId* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, KeypointId::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    KeypointId::fill_arrow_array_builder(builder.get(), components, num_components)
+                    KeypointId::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/keypoint_id.hpp
+++ b/rerun_cpp/src/components/keypoint_id.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -13,11 +15,14 @@ namespace rr {
         struct KeypointId {
             uint16_t id;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             KeypointId(uint16_t id) : id(std::move(id)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
@@ -27,6 +32,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of KeypointId components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const KeypointId* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/keypoint_id.hpp
+++ b/rerun_cpp/src/components/keypoint_id.hpp
@@ -36,7 +36,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of KeypointId components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const KeypointId* components, size_t num_components
+                const KeypointId* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/label.cpp
+++ b/rerun_cpp/src/components/label.cpp
@@ -3,12 +3,17 @@
 
 #include "label.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> Label::to_arrow_datatype() {
-            return arrow::utf8();
+        const char* Label::NAME = "rerun.label";
+
+        const std::shared_ptr<arrow::DataType>& Label::to_arrow_datatype() {
+            static const auto datatype = arrow::utf8();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StringBuilder>> Label::new_arrow_array_builder(
@@ -37,6 +42,34 @@ namespace rr {
             }
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> Label::to_data_cell(
+            const Label* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, Label::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    Label::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(Label::NAME, Label::to_arrow_datatype(), false)});
+
+            rr::DataCell cell;
+            cell.component_name = Label::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/label.cpp
+++ b/rerun_cpp/src/components/label.cpp
@@ -45,15 +45,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> Label::to_data_cell(
-            const Label* components, size_t num_components
+            const Label* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, Label::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    Label::fill_arrow_array_builder(builder.get(), components, num_components)
+                    Label::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/label.hpp
+++ b/rerun_cpp/src/components/label.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <string>
@@ -14,11 +16,14 @@ namespace rr {
         struct Label {
             std::string value;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             Label(std::string value) : value(std::move(value)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
@@ -28,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const Label* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of Label components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const Label* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/label.hpp
+++ b/rerun_cpp/src/components/label.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of Label components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const Label* components, size_t num_components
+                const Label* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/point2d.cpp
+++ b/rerun_cpp/src/components/point2d.cpp
@@ -4,13 +4,17 @@
 #include "point2d.hpp"
 
 #include "../datatypes/point2d.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> Point2D::to_arrow_datatype() {
-            return rr::datatypes::Point2D::to_arrow_datatype();
+        const char *Point2D::NAME = "rerun.point2d";
+
+        const std::shared_ptr<arrow::DataType> &Point2D::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::Point2D::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> Point2D::new_arrow_array_builder(
@@ -43,6 +47,34 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> Point2D::to_data_cell(
+            const Point2D *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, Point2D::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    Point2D::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(Point2D::NAME, Point2D::to_arrow_datatype(), false)});
+
+            rr::DataCell cell;
+            cell.component_name = Point2D::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/point2d.cpp
+++ b/rerun_cpp/src/components/point2d.cpp
@@ -50,15 +50,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> Point2D::to_data_cell(
-            const Point2D *components, size_t num_components
+            const Point2D *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, Point2D::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    Point2D::fill_arrow_array_builder(builder.get(), components, num_components)
+                    Point2D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/point2d.hpp
+++ b/rerun_cpp/src/components/point2d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/point2d.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,11 +16,14 @@ namespace rr {
         struct Point2D {
             rr::datatypes::Point2D xy;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             Point2D(rr::datatypes::Point2D xy) : xy(std::move(xy)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -29,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const Point2D* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of Point2D components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const Point2D* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/point2d.hpp
+++ b/rerun_cpp/src/components/point2d.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of Point2D components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const Point2D* components, size_t num_components
+                const Point2D* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/point3d.cpp
+++ b/rerun_cpp/src/components/point3d.cpp
@@ -50,15 +50,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> Point3D::to_data_cell(
-            const Point3D *components, size_t num_components
+            const Point3D *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, Point3D::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    Point3D::fill_arrow_array_builder(builder.get(), components, num_components)
+                    Point3D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/point3d.cpp
+++ b/rerun_cpp/src/components/point3d.cpp
@@ -4,13 +4,17 @@
 #include "point3d.hpp"
 
 #include "../datatypes/point3d.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> Point3D::to_arrow_datatype() {
-            return rr::datatypes::Point3D::to_arrow_datatype();
+        const char *Point3D::NAME = "rerun.point3d";
+
+        const std::shared_ptr<arrow::DataType> &Point3D::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::Point3D::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> Point3D::new_arrow_array_builder(
@@ -43,6 +47,34 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> Point3D::to_data_cell(
+            const Point3D *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, Point3D::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    Point3D::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(Point3D::NAME, Point3D::to_arrow_datatype(), false)});
+
+            rr::DataCell cell;
+            cell.component_name = Point3D::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/point3d.hpp
+++ b/rerun_cpp/src/components/point3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/point3d.hpp"
 
 #include <arrow/type_fwd.h>
@@ -15,11 +16,14 @@ namespace rr {
         struct Point3D {
             rr::datatypes::Point3D xy;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             Point3D(rr::datatypes::Point3D xy) : xy(std::move(xy)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
@@ -29,6 +33,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const Point3D* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of Point3D components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const Point3D* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/point3d.hpp
+++ b/rerun_cpp/src/components/point3d.hpp
@@ -37,7 +37,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of Point3D components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const Point3D* components, size_t num_components
+                const Point3D* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/radius.cpp
+++ b/rerun_cpp/src/components/radius.cpp
@@ -43,15 +43,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> Radius::to_data_cell(
-            const Radius* components, size_t num_components
+            const Radius* instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, Radius::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    Radius::fill_arrow_array_builder(builder.get(), components, num_components)
+                    Radius::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/radius.cpp
+++ b/rerun_cpp/src/components/radius.cpp
@@ -3,12 +3,17 @@
 
 #include "radius.hpp"
 
+#include "../rerun.hpp"
+
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> Radius::to_arrow_datatype() {
-            return arrow::float32();
+        const char* Radius::NAME = "rerun.radius";
+
+        const std::shared_ptr<arrow::DataType>& Radius::to_arrow_datatype() {
+            static const auto datatype = arrow::float32();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FloatBuilder>> Radius::new_arrow_array_builder(
@@ -35,6 +40,34 @@ namespace rr {
             ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->value, num_elements));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> Radius::to_data_cell(
+            const Radius* components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, Radius::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    Radius::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema =
+                arrow::schema({arrow::field(Radius::NAME, Radius::to_arrow_datatype(), false)});
+
+            rr::DataCell cell;
+            cell.component_name = Radius::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/radius.hpp
+++ b/rerun_cpp/src/components/radius.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
+
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
@@ -13,11 +15,14 @@ namespace rr {
         struct Radius {
             float value;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             Radius(float value) : value(std::move(value)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
@@ -27,6 +32,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of Radius components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const Radius* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/radius.hpp
+++ b/rerun_cpp/src/components/radius.hpp
@@ -36,7 +36,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of Radius components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const Radius* components, size_t num_components
+                const Radius* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/transform3d.cpp
+++ b/rerun_cpp/src/components/transform3d.cpp
@@ -4,13 +4,17 @@
 #include "transform3d.hpp"
 
 #include "../datatypes/transform3d.hpp"
+#include "../rerun.hpp"
 
 #include <arrow/api.h>
 
 namespace rr {
     namespace components {
-        std::shared_ptr<arrow::DataType> Transform3D::to_arrow_datatype() {
-            return rr::datatypes::Transform3D::to_arrow_datatype();
+        const char *Transform3D::NAME = "rerun.components.Transform3D";
+
+        const std::shared_ptr<arrow::DataType> &Transform3D::to_arrow_datatype() {
+            static const auto datatype = rr::datatypes::Transform3D::to_arrow_datatype();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
@@ -42,6 +46,35 @@ namespace rr {
             ));
 
             return arrow::Status::OK();
+        }
+
+        arrow::Result<rr::DataCell> Transform3D::to_data_cell(
+            const Transform3D *components, size_t num_components
+        ) {
+            // TODO(andreas): Allow configuring the memory pool.
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
+
+            ARROW_ASSIGN_OR_RAISE(auto builder, Transform3D::new_arrow_array_builder(pool));
+            if (components && num_components > 0) {
+                ARROW_RETURN_NOT_OK(
+                    Transform3D::fill_arrow_array_builder(builder.get(), components, num_components)
+                );
+            }
+            std::shared_ptr<arrow::Array> array;
+            ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+            auto schema = arrow::schema(
+                {arrow::field(Transform3D::NAME, Transform3D::to_arrow_datatype(), false)}
+            );
+
+            rr::DataCell cell;
+            cell.component_name = Transform3D::NAME;
+            ARROW_ASSIGN_OR_RAISE(
+                cell.buffer,
+                rr::ipc_from_table(*arrow::Table::Make(schema, {array}))
+            );
+
+            return cell;
         }
     } // namespace components
 } // namespace rr

--- a/rerun_cpp/src/components/transform3d.cpp
+++ b/rerun_cpp/src/components/transform3d.cpp
@@ -49,15 +49,15 @@ namespace rr {
         }
 
         arrow::Result<rr::DataCell> Transform3D::to_data_cell(
-            const Transform3D *components, size_t num_components
+            const Transform3D *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, Transform3D::new_arrow_array_builder(pool));
-            if (components && num_components > 0) {
+            if (instances && num_instances > 0) {
                 ARROW_RETURN_NOT_OK(
-                    Transform3D::fill_arrow_array_builder(builder.get(), components, num_components)
+                    Transform3D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
             std::shared_ptr<arrow::Array> array;

--- a/rerun_cpp/src/components/transform3d.hpp
+++ b/rerun_cpp/src/components/transform3d.hpp
@@ -38,7 +38,7 @@ namespace rr {
 
             /// Creates a Rerun DataCell from an array of Transform3D components.
             static arrow::Result<rr::DataCell> to_data_cell(
-                const Transform3D* components, size_t num_components
+                const Transform3D* instances, size_t num_instances
             );
         };
     } // namespace components

--- a/rerun_cpp/src/components/transform3d.hpp
+++ b/rerun_cpp/src/components/transform3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../datatypes/transform3d.hpp"
 
 #include <arrow/type_fwd.h>
@@ -16,11 +17,14 @@ namespace rr {
             /// Representation of the transform.
             rr::datatypes::Transform3D repr;
 
+            /// Name of the component, used for serialization.
+            static const char* NAME;
+
           public:
             Transform3D(rr::datatypes::Transform3D repr) : repr(std::move(repr)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -30,6 +34,11 @@ namespace rr {
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
+            );
+
+            /// Creates a Rerun DataCell from an array of Transform3D components.
+            static arrow::Result<rr::DataCell> to_data_cell(
+                const Transform3D* components, size_t num_components
             );
         };
     } // namespace components

--- a/rerun_cpp/src/data_cell.hpp
+++ b/rerun_cpp/src/data_cell.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory> // shared_ptr
+
+namespace arrow {
+    class Buffer;
+}
+
+namespace rr {
+    struct DataCell {
+        /// Name of the logged component.
+        const char* component_name;
+
+        /// Data in the Arrow IPC encapsulated message format.
+        ///
+        /// There must be exactly one chunk of data.
+        ///
+        /// * <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>
+        /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
+        std::shared_ptr<arrow::Buffer> buffer;
+    };
+} // namespace rr

--- a/rerun_cpp/src/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer1.cpp
@@ -9,8 +9,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> AffixFuzzer1::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer1::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field("single_float_optional", arrow::float32(), true, nullptr),
                 arrow::field("single_string_required", arrow::utf8(), false, nullptr),
                 arrow::field("single_string_optional", arrow::utf8(), true, nullptr),
@@ -41,6 +41,7 @@ namespace rr {
                 ),
                 arrow::field("from_parent", arrow::boolean(), true, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer1::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer1.hpp
@@ -34,7 +34,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer2.cpp
@@ -7,8 +7,9 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> AffixFuzzer2::to_arrow_datatype() {
-            return arrow::float32();
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer2::to_arrow_datatype() {
+            static const auto datatype = arrow::float32();
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FloatBuilder>> AffixFuzzer2::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer2.hpp
@@ -18,7 +18,7 @@ namespace rr {
                 : single_float_optional(std::move(single_float_optional)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer3.cpp
@@ -9,8 +9,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> AffixFuzzer3::to_arrow_datatype() {
-            return arrow::dense_union({
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer3::to_arrow_datatype() {
+            static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field("degrees", arrow::float32(), false, nullptr),
                 arrow::field("radians", arrow::float32(), false, nullptr),
@@ -35,6 +35,7 @@ namespace rr {
                     nullptr
                 ),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>

--- a/rerun_cpp/src/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer3.hpp
@@ -52,13 +52,24 @@ namespace rr {
         } // namespace detail
 
         struct AffixFuzzer3 {
-          private:
-            detail::AffixFuzzer3Tag _tag;
-            detail::AffixFuzzer3Data _data;
+            AffixFuzzer3(const AffixFuzzer3& other) : _tag(other._tag) {
+                switch (other._tag) {
+                    case detail::AffixFuzzer3Tag::craziness: {
+                        _data.craziness = other._data.craziness;
+                        break;
+                    }
+                    default:
+                        memcpy(&this->_data, &other._data, sizeof(detail::AffixFuzzer3Data));
+                        break;
+                }
+            }
 
-            AffixFuzzer3() : _tag(detail::AffixFuzzer3Tag::NONE) {}
+            AffixFuzzer3& operator=(const AffixFuzzer3& other) noexcept {
+                AffixFuzzer3 tmp(other);
+                this->swap(tmp);
+                return *this;
+            }
 
-          public:
             AffixFuzzer3(AffixFuzzer3&& other) noexcept : _tag(detail::AffixFuzzer3Tag::NONE) {
                 this->swap(other);
             }
@@ -88,6 +99,13 @@ namespace rr {
                         break; // has a trivial destructor
                     }
                 }
+            }
+
+            void swap(AffixFuzzer3& other) noexcept {
+                auto tag_temp = this->_tag;
+                this->_tag = other._tag;
+                other._tag = tag_temp;
+                this->_data.swap(other._data);
             }
 
             static AffixFuzzer3 degrees(float degrees) {
@@ -123,7 +141,7 @@ namespace rr {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -135,12 +153,13 @@ namespace rr {
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
             );
 
-            void swap(AffixFuzzer3& other) noexcept {
-                auto tag_temp = this->_tag;
-                this->_tag = other._tag;
-                other._tag = tag_temp;
-                this->_data.swap(other._data);
-            }
+          private:
+            detail::AffixFuzzer3Tag _tag;
+            detail::AffixFuzzer3Data _data;
+
+            AffixFuzzer3() : _tag(detail::AffixFuzzer3Tag::NONE) {}
+
+          public:
         };
     } // namespace datatypes
 } // namespace rr

--- a/rerun_cpp/src/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer4.cpp
@@ -9,8 +9,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> AffixFuzzer4::to_arrow_datatype() {
-            return arrow::dense_union({
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer4::to_arrow_datatype() {
+            static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field(
                     "single_required",
@@ -41,6 +41,7 @@ namespace rr {
                     nullptr
                 ),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>

--- a/rerun_cpp/src/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer4.hpp
@@ -49,13 +49,32 @@ namespace rr {
         } // namespace detail
 
         struct AffixFuzzer4 {
-          private:
-            detail::AffixFuzzer4Tag _tag;
-            detail::AffixFuzzer4Data _data;
+            AffixFuzzer4(const AffixFuzzer4& other) : _tag(other._tag) {
+                switch (other._tag) {
+                    case detail::AffixFuzzer4Tag::single_required: {
+                        _data.single_required = other._data.single_required;
+                        break;
+                    }
+                    case detail::AffixFuzzer4Tag::many_required: {
+                        _data.many_required = other._data.many_required;
+                        break;
+                    }
+                    case detail::AffixFuzzer4Tag::many_optional: {
+                        _data.many_optional = other._data.many_optional;
+                        break;
+                    }
+                    default:
+                        memcpy(&this->_data, &other._data, sizeof(detail::AffixFuzzer4Data));
+                        break;
+                }
+            }
 
-            AffixFuzzer4() : _tag(detail::AffixFuzzer4Tag::NONE) {}
+            AffixFuzzer4& operator=(const AffixFuzzer4& other) noexcept {
+                AffixFuzzer4 tmp(other);
+                this->swap(tmp);
+                return *this;
+            }
 
-          public:
             AffixFuzzer4(AffixFuzzer4&& other) noexcept : _tag(detail::AffixFuzzer4Tag::NONE) {
                 this->swap(other);
             }
@@ -88,6 +107,13 @@ namespace rr {
                 }
             }
 
+            void swap(AffixFuzzer4& other) noexcept {
+                auto tag_temp = this->_tag;
+                this->_tag = other._tag;
+                other._tag = tag_temp;
+                this->_data.swap(other._data);
+            }
+
             static AffixFuzzer4 single_required(rr::datatypes::AffixFuzzer3 single_required) {
                 typedef rr::datatypes::AffixFuzzer3 TypeAlias;
                 AffixFuzzer4 self;
@@ -116,7 +142,7 @@ namespace rr {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -128,12 +154,13 @@ namespace rr {
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
             );
 
-            void swap(AffixFuzzer4& other) noexcept {
-                auto tag_temp = this->_tag;
-                this->_tag = other._tag;
-                other._tag = tag_temp;
-                this->_data.swap(other._data);
-            }
+          private:
+            detail::AffixFuzzer4Tag _tag;
+            detail::AffixFuzzer4Data _data;
+
+            AffixFuzzer4() : _tag(detail::AffixFuzzer4Tag::NONE) {}
+
+          public:
         };
     } // namespace datatypes
 } // namespace rr

--- a/rerun_cpp/src/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer5.cpp
@@ -9,8 +9,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> AffixFuzzer5::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType>& AffixFuzzer5::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field(
                     "single_optional_union",
                     rr::datatypes::AffixFuzzer4::to_arrow_datatype(),
@@ -18,6 +18,7 @@ namespace rr {
                     nullptr
                 ),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/src/datatypes/affix_fuzzer5.hpp
@@ -20,7 +20,7 @@ namespace rr {
                 : single_optional_union(std::move(single_optional_union)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/angle.cpp
+++ b/rerun_cpp/src/datatypes/angle.cpp
@@ -7,12 +7,13 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Angle::to_arrow_datatype() {
-            return arrow::dense_union({
+        const std::shared_ptr<arrow::DataType>& Angle::to_arrow_datatype() {
+            static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field("Radians", arrow::float32(), false, nullptr),
                 arrow::field("Degrees", arrow::float32(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> Angle::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/angle.hpp
+++ b/rerun_cpp/src/datatypes/angle.hpp
@@ -42,13 +42,16 @@ namespace rr {
 
         /// Angle in either radians or degrees.
         struct Angle {
-          private:
-            detail::AngleTag _tag;
-            detail::AngleData _data;
+            Angle(const Angle& other) : _tag(other._tag) {
+                memcpy(&this->_data, &other._data, sizeof(detail::AngleData));
+            }
 
-            Angle() : _tag(detail::AngleTag::NONE) {}
+            Angle& operator=(const Angle& other) noexcept {
+                Angle tmp(other);
+                this->swap(tmp);
+                return *this;
+            }
 
-          public:
             Angle(Angle&& other) noexcept : _tag(detail::AngleTag::NONE) {
                 this->swap(other);
             }
@@ -56,6 +59,13 @@ namespace rr {
             Angle& operator=(Angle&& other) noexcept {
                 this->swap(other);
                 return *this;
+            }
+
+            void swap(Angle& other) noexcept {
+                auto tag_temp = this->_tag;
+                this->_tag = other._tag;
+                other._tag = tag_temp;
+                this->_data.swap(other._data);
             }
 
             static Angle radians(float radians) {
@@ -73,7 +83,7 @@ namespace rr {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -85,12 +95,13 @@ namespace rr {
                 arrow::DenseUnionBuilder* builder, const Angle* elements, size_t num_elements
             );
 
-            void swap(Angle& other) noexcept {
-                auto tag_temp = this->_tag;
-                this->_tag = other._tag;
-                other._tag = tag_temp;
-                this->_data.swap(other._data);
-            }
+          private:
+            detail::AngleTag _tag;
+            detail::AngleData _data;
+
+            Angle() : _tag(detail::AngleTag::NONE) {}
+
+          public:
         };
     } // namespace datatypes
 } // namespace rr

--- a/rerun_cpp/src/datatypes/flattened_scalar.cpp
+++ b/rerun_cpp/src/datatypes/flattened_scalar.cpp
@@ -7,10 +7,11 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> FlattenedScalar::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType> &FlattenedScalar::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field("value", arrow::float32(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>

--- a/rerun_cpp/src/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/src/datatypes/flattened_scalar.hpp
@@ -16,7 +16,7 @@ namespace rr {
             FlattenedScalar(float value) : value(std::move(value)) {}
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/datatypes/mat3x3.cpp
@@ -7,11 +7,10 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Mat3x3::to_arrow_datatype() {
-            return arrow::fixed_size_list(
-                arrow::field("item", arrow::float32(), false, nullptr),
-                9
-            );
+        const std::shared_ptr<arrow::DataType> &Mat3x3::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 9);
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Mat3x3::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/datatypes/mat3x3.hpp
@@ -14,7 +14,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/datatypes/mat4x4.cpp
@@ -7,11 +7,10 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Mat4x4::to_arrow_datatype() {
-            return arrow::fixed_size_list(
-                arrow::field("item", arrow::float32(), false, nullptr),
-                16
-            );
+        const std::shared_ptr<arrow::DataType> &Mat4x4::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 16);
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Mat4x4::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/datatypes/mat4x4.hpp
@@ -14,7 +14,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/datatypes/point2d.cpp
+++ b/rerun_cpp/src/datatypes/point2d.cpp
@@ -7,11 +7,12 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Point2D::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType> &Point2D::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field("x", arrow::float32(), false, nullptr),
                 arrow::field("y", arrow::float32(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> Point2D::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/point2d.hpp
+++ b/rerun_cpp/src/datatypes/point2d.hpp
@@ -16,7 +16,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/point3d.cpp
+++ b/rerun_cpp/src/datatypes/point3d.cpp
@@ -7,12 +7,13 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Point3D::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType> &Point3D::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field("x", arrow::float32(), false, nullptr),
                 arrow::field("y", arrow::float32(), false, nullptr),
                 arrow::field("z", arrow::float32(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> Point3D::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/point3d.hpp
+++ b/rerun_cpp/src/datatypes/point3d.hpp
@@ -18,7 +18,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/datatypes/quaternion.cpp
@@ -7,11 +7,10 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Quaternion::to_arrow_datatype() {
-            return arrow::fixed_size_list(
-                arrow::field("item", arrow::float32(), false, nullptr),
-                4
-            );
+        const std::shared_ptr<arrow::DataType> &Quaternion::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 4);
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/datatypes/quaternion.hpp
@@ -14,7 +14,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/datatypes/rotation3d.cpp
@@ -10,8 +10,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Rotation3D::to_arrow_datatype() {
-            return arrow::dense_union({
+        const std::shared_ptr<arrow::DataType>& Rotation3D::to_arrow_datatype() {
+            static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field(
                     "Quaternion",
@@ -26,6 +26,7 @@ namespace rr {
                     nullptr
                 ),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>

--- a/rerun_cpp/src/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/datatypes/rotation3d.hpp
@@ -47,13 +47,16 @@ namespace rr {
 
         /// A 3D rotation.
         struct Rotation3D {
-          private:
-            detail::Rotation3DTag _tag;
-            detail::Rotation3DData _data;
+            Rotation3D(const Rotation3D& other) : _tag(other._tag) {
+                memcpy(&this->_data, &other._data, sizeof(detail::Rotation3DData));
+            }
 
-            Rotation3D() : _tag(detail::Rotation3DTag::NONE) {}
+            Rotation3D& operator=(const Rotation3D& other) noexcept {
+                Rotation3D tmp(other);
+                this->swap(tmp);
+                return *this;
+            }
 
-          public:
             Rotation3D(Rotation3D&& other) noexcept : _tag(detail::Rotation3DTag::NONE) {
                 this->swap(other);
             }
@@ -61,6 +64,13 @@ namespace rr {
             Rotation3D& operator=(Rotation3D&& other) noexcept {
                 this->swap(other);
                 return *this;
+            }
+
+            void swap(Rotation3D& other) noexcept {
+                auto tag_temp = this->_tag;
+                this->_tag = other._tag;
+                other._tag = tag_temp;
+                this->_data.swap(other._data);
             }
 
             /// Rotation defined by a quaternion.
@@ -90,7 +100,7 @@ namespace rr {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -102,12 +112,13 @@ namespace rr {
                 arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
             );
 
-            void swap(Rotation3D& other) noexcept {
-                auto tag_temp = this->_tag;
-                this->_tag = other._tag;
-                other._tag = tag_temp;
-                this->_data.swap(other._data);
-            }
+          private:
+            detail::Rotation3DTag _tag;
+            detail::Rotation3DData _data;
+
+            Rotation3D() : _tag(detail::Rotation3DTag::NONE) {}
+
+          public:
         };
     } // namespace datatypes
 } // namespace rr

--- a/rerun_cpp/src/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/datatypes/rotation_axis_angle.cpp
@@ -10,11 +10,12 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> RotationAxisAngle::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType>& RotationAxisAngle::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field("axis", rr::datatypes::Vec3D::to_arrow_datatype(), false, nullptr),
                 arrow::field("angle", rr::datatypes::Angle::to_arrow_datatype(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>

--- a/rerun_cpp/src/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/datatypes/rotation_axis_angle.hpp
@@ -25,7 +25,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/datatypes/scale3d.cpp
@@ -9,12 +9,13 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Scale3D::to_arrow_datatype() {
-            return arrow::dense_union({
+        const std::shared_ptr<arrow::DataType>& Scale3D::to_arrow_datatype() {
+            static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field("ThreeD", rr::datatypes::Vec3D::to_arrow_datatype(), false, nullptr),
                 arrow::field("Uniform", arrow::float32(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> Scale3D::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/datatypes/scale3d.hpp
@@ -46,13 +46,16 @@ namespace rr {
 
         /// 3D scaling factor, part of a transform representation.
         struct Scale3D {
-          private:
-            detail::Scale3DTag _tag;
-            detail::Scale3DData _data;
+            Scale3D(const Scale3D& other) : _tag(other._tag) {
+                memcpy(&this->_data, &other._data, sizeof(detail::Scale3DData));
+            }
 
-            Scale3D() : _tag(detail::Scale3DTag::NONE) {}
+            Scale3D& operator=(const Scale3D& other) noexcept {
+                Scale3D tmp(other);
+                this->swap(tmp);
+                return *this;
+            }
 
-          public:
             Scale3D(Scale3D&& other) noexcept : _tag(detail::Scale3DTag::NONE) {
                 this->swap(other);
             }
@@ -60,6 +63,13 @@ namespace rr {
             Scale3D& operator=(Scale3D&& other) noexcept {
                 this->swap(other);
                 return *this;
+            }
+
+            void swap(Scale3D& other) noexcept {
+                auto tag_temp = this->_tag;
+                this->_tag = other._tag;
+                other._tag = tag_temp;
+                this->_data.swap(other._data);
             }
 
             /// Individual scaling factors for each axis, distorting the original object.
@@ -89,7 +99,7 @@ namespace rr {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -101,12 +111,13 @@ namespace rr {
                 arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
             );
 
-            void swap(Scale3D& other) noexcept {
-                auto tag_temp = this->_tag;
-                this->_tag = other._tag;
-                other._tag = tag_temp;
-                this->_data.swap(other._data);
-            }
+          private:
+            detail::Scale3DTag _tag;
+            detail::Scale3DData _data;
+
+            Scale3D() : _tag(detail::Scale3DTag::NONE) {}
+
+          public:
         };
     } // namespace datatypes
 } // namespace rr

--- a/rerun_cpp/src/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/datatypes/transform3d.cpp
@@ -10,8 +10,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Transform3D::to_arrow_datatype() {
-            return arrow::dense_union({
+        const std::shared_ptr<arrow::DataType>& Transform3D::to_arrow_datatype() {
+            static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field(
                     "TranslationAndMat3x3",
@@ -26,6 +26,7 @@ namespace rr {
                     nullptr
                 ),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>

--- a/rerun_cpp/src/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/datatypes/transform3d.hpp
@@ -45,13 +45,16 @@ namespace rr {
 
         /// Representation of a 3D affine transform.
         struct Transform3D {
-          private:
-            detail::Transform3DTag _tag;
-            detail::Transform3DData _data;
+            Transform3D(const Transform3D& other) : _tag(other._tag) {
+                memcpy(&this->_data, &other._data, sizeof(detail::Transform3DData));
+            }
 
-            Transform3D() : _tag(detail::Transform3DTag::NONE) {}
+            Transform3D& operator=(const Transform3D& other) noexcept {
+                Transform3D tmp(other);
+                this->swap(tmp);
+                return *this;
+            }
 
-          public:
             Transform3D(Transform3D&& other) noexcept : _tag(detail::Transform3DTag::NONE) {
                 this->swap(other);
             }
@@ -59,6 +62,13 @@ namespace rr {
             Transform3D& operator=(Transform3D&& other) noexcept {
                 this->swap(other);
                 return *this;
+            }
+
+            void swap(Transform3D& other) noexcept {
+                auto tag_temp = this->_tag;
+                this->_tag = other._tag;
+                other._tag = tag_temp;
+                this->_data.swap(other._data);
             }
 
             static Transform3D translation_and_mat3x3(
@@ -89,7 +99,7 @@ namespace rr {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
@@ -101,12 +111,13 @@ namespace rr {
                 arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
             );
 
-            void swap(Transform3D& other) noexcept {
-                auto tag_temp = this->_tag;
-                this->_tag = other._tag;
-                other._tag = tag_temp;
-                this->_data.swap(other._data);
-            }
+          private:
+            detail::Transform3DTag _tag;
+            detail::Transform3DData _data;
+
+            Transform3D() : _tag(detail::Transform3DTag::NONE) {}
+
+          public:
         };
     } // namespace datatypes
 } // namespace rr

--- a/rerun_cpp/src/datatypes/translation_and_mat3x3.cpp
+++ b/rerun_cpp/src/datatypes/translation_and_mat3x3.cpp
@@ -10,8 +10,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> TranslationAndMat3x3::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType> &TranslationAndMat3x3::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field(
                     "translation",
                     rr::datatypes::Vec3D::to_arrow_datatype(),
@@ -21,6 +21,7 @@ namespace rr {
                 arrow::field("matrix", rr::datatypes::Mat3x3::to_arrow_datatype(), true, nullptr),
                 arrow::field("from_parent", arrow::boolean(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>

--- a/rerun_cpp/src/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/datatypes/translation_and_mat3x3.hpp
@@ -28,7 +28,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/translation_rotation_scale3d.cpp
+++ b/rerun_cpp/src/datatypes/translation_rotation_scale3d.cpp
@@ -11,8 +11,8 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> TranslationRotationScale3D::to_arrow_datatype() {
-            return arrow::struct_({
+        const std::shared_ptr<arrow::DataType> &TranslationRotationScale3D::to_arrow_datatype() {
+            static const auto datatype = arrow::struct_({
                 arrow::field(
                     "translation",
                     rr::datatypes::Vec3D::to_arrow_datatype(),
@@ -28,6 +28,7 @@ namespace rr {
                 arrow::field("scale", rr::datatypes::Scale3D::to_arrow_datatype(), true, nullptr),
                 arrow::field("from_parent", arrow::boolean(), false, nullptr),
             });
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>

--- a/rerun_cpp/src/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/datatypes/translation_rotation_scale3d.hpp
@@ -30,7 +30,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/datatypes/vec2d.cpp
@@ -7,11 +7,10 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Vec2D::to_arrow_datatype() {
-            return arrow::fixed_size_list(
-                arrow::field("item", arrow::float32(), false, nullptr),
-                2
-            );
+        const std::shared_ptr<arrow::DataType> &Vec2D::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 2);
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec2D::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/datatypes/vec2d.hpp
@@ -14,7 +14,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/datatypes/vec3d.cpp
@@ -7,11 +7,10 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Vec3D::to_arrow_datatype() {
-            return arrow::fixed_size_list(
-                arrow::field("item", arrow::float32(), false, nullptr),
-                3
-            );
+        const std::shared_ptr<arrow::DataType> &Vec3D::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 3);
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec3D::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/datatypes/vec3d.hpp
@@ -14,7 +14,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/datatypes/vec4d.cpp
@@ -7,11 +7,10 @@
 
 namespace rr {
     namespace datatypes {
-        std::shared_ptr<arrow::DataType> Vec4D::to_arrow_datatype() {
-            return arrow::fixed_size_list(
-                arrow::field("item", arrow::float32(), false, nullptr),
-                4
-            );
+        const std::shared_ptr<arrow::DataType> &Vec4D::to_arrow_datatype() {
+            static const auto datatype =
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 4);
+            return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec4D::new_arrow_array_builder(

--- a/rerun_cpp/src/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/datatypes/vec4d.hpp
@@ -14,7 +14,7 @@ namespace rr {
 
           public:
             /// Returns the arrow data type this type corresponds to.
-            static std::shared_ptr<arrow::DataType> to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>

--- a/rerun_cpp/src/recording_stream.cpp
+++ b/rerun_cpp/src/recording_stream.cpp
@@ -1,7 +1,9 @@
 #include "recording_stream.hpp"
 
-#include <rerun.h>
+#include "data_cell.hpp"
+#include "rerun.h"
 
+#include <arrow/buffer.h>
 #include <loguru.hpp>
 #include <vector>
 
@@ -50,8 +52,8 @@ namespace rr {
         for (size_t i = 0; i < num_data_cells; ++i) {
             c_data_cells.push_back({
                 .component_name = data_cells[i].component_name,
-                .num_bytes = data_cells[i].num_bytes,
-                .bytes = data_cells[i].bytes,
+                .num_bytes = static_cast<uint64_t>(data_cells[i].buffer->size()),
+                .bytes = data_cells[i].buffer->data(),
             });
         }
 

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -28,17 +28,21 @@ namespace rr {
         /// Aborts if `init_global` has not yet been called.
         static RecordingStream global();
 
-        // TODO: docs
-
-        // template <typename T>
-        // void log(const char* entity_path, const T& archetype) {
-        //     log_archetype(entity_path, archetype);
-        // }
-
-        // template <typename T>
-        // void log_archetype(const char* entity_path, const T& archetype) {
-        //     // TODO:
-        // }
+        /// Logs an archetype.
+        ///
+        /// Prefer this interface for ease of use over the more general `log_components` interface.
+        template <typename T>
+        void log_archetype(const char* entity_path, const T& archetype) {
+            // TODO(andreas): Handle splats.
+            // TODO(andreas): Error handling.
+            const auto data_cells = archetype.to_data_cells().ValueOrDie();
+            log_data_row(
+                entity_path,
+                archetype.num_instances(),
+                data_cells.size(),
+                data_cells.data()
+            );
+        }
 
         /// Logs a list of component arrays.
         ///
@@ -51,7 +55,6 @@ namespace rr {
         /// TODO(andreas): More documentation, examples etc.
         /// TODO(andreas): Test with different array types - vector/array seem to work but we should
         /// also support C arrays.
-        /// TODO(andreas): Error handling.
         template <typename... Ts>
         void log_components(const char* entity_path, const Ts&... component_array) {
             // TODO(andreas): Handle splats.
@@ -64,7 +67,7 @@ namespace rr {
                     using ComponentType = std::remove_pointer_t<decltype(component_array.data())>;
                     const auto cell =
                         ComponentType::to_data_cell(component_array.data(), component_array.size())
-                            .ValueOrDie();
+                            .ValueOrDie(); // TODO(andreas): Error handling.
                     data_cells.push_back(cell);
                 }(),
                 ...

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -4,15 +4,11 @@
 #include <cstdint> // uint32_t etc
 
 namespace rr {
+    struct DataCell;
+
     enum StoreKind {
         Recording,
         Blueprint,
-    };
-
-    struct DataCell {
-        const char* component_name;
-        size_t num_bytes;
-        const uint8_t* bytes;
     };
 
     class RecordingStream {
@@ -29,7 +25,27 @@ namespace rr {
         /// Aborts if `init_global` has not yet been called.
         static RecordingStream global();
 
-        /// Logs raw data row to the recording stream.
+        // TODO: docs
+
+        // template <typename T>
+        // void log(const char* entity_path, const T& archetype) {
+        //     log_archetype(entity_path, archetype);
+        // }
+
+        // template <typename T>
+        // void log_archetype(const char* entity_path, const T& archetype) {
+        //     // TODO:
+        // }
+
+        // template <typename T>
+        // void log_components(
+        //     const char* entity_path, const std::vector<T>* component_arrays, size_t
+        //     num_components
+        // ) {
+        //     // TODO:
+        // }
+
+        /// Low level API that logs raw data cells to the recording stream.
         ///
         /// I.e. logs a number of components arrays (each with a same number of instances) to a
         /// single entity path.

--- a/rerun_cpp/src/rerun.cpp
+++ b/rerun_cpp/src/rerun.cpp
@@ -14,29 +14,6 @@ namespace rr {
 
     // ------------------------------------------------------------------------
 
-    arrow::Result<std::shared_ptr<arrow::Table>> points3(size_t num_points, const float* xyz) {
-        arrow::MemoryPool* pool = arrow::default_memory_pool();
-
-        auto nullable = false;
-
-        ARROW_ASSIGN_OR_RAISE(auto builder, rr::components::Point3D::new_arrow_array_builder(pool));
-        ARROW_RETURN_NOT_OK(rr::components::Point3D::fill_arrow_array_builder(
-            builder.get(),
-            (rr::components::Point3D*)xyz,
-            num_points
-        ));
-
-        std::shared_ptr<arrow::Array> array;
-        ARROW_RETURN_NOT_OK(builder->Finish(&array));
-
-        auto name = "points"; // Unused, but should be the name of the field in the archetype
-        auto schema = arrow::schema(
-            {arrow::field(name, rr::components::Point3D::to_arrow_datatype(), nullable)}
-        );
-
-        return arrow::Table::Make(schema, {array});
-    }
-
     arrow::Result<std::shared_ptr<arrow::Buffer>> ipc_from_table(const arrow::Table& table) {
         ERROR_CONTEXT("ipc_from_table", "");
         ARROW_ASSIGN_OR_RAISE(auto output, arrow::io::BufferOutputStream::Create());

--- a/rerun_cpp/src/rerun.hpp
+++ b/rerun_cpp/src/rerun.hpp
@@ -20,8 +20,6 @@ namespace rr {
 #include <arrow/api.h>
 
 namespace rr {
-    arrow::Result<std::shared_ptr<arrow::Table>> points3(size_t num_points, const float* xyz);
-
     /// Encode the given arrow table in the Arrow IPC encapsulated message format.
     ///
     /// * <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/2647
* Next step after https://github.com/rerun-io/rerun/pull/2820

### What

Introduces APIs for component and archetype logging as well as the necessary methods in codegen to do so. A very basic example is included in `main.cpp`.
Largely unrelated to the rest:
* Makes C++ tagged union types copy-able
* `to_arrow_datatype` constructs/allocates the datatype lazily exactly once (using C++'s crazy local `static` variable guarantees)

Commit by commit review possible.

![image](https://github.com/rerun-io/rerun/assets/1220815/8e7fdf3a-4fe7-45b1-a835-463b13fc34d8)

Next steps:
* Add roundtrip tests
* Add C++ to ci (roundtrip, linting, etc.)
* Add codegen custom code injection
* Improve API usability in varous places, including #2873 
* add other tests
* serialize unions
* serialize datatypes nested in unions, structs and lists
* more testing & roundtripping

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2874) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2874)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp-codegen%2Farchetype-builder-and-logging/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp-codegen%2Farchetype-builder-and-logging/examples)