### PR TITLE
Recreate the analytics state directory if necessary before creating pipeline

### DIFF
--- a/crates/re_analytics/src/pipeline_native.rs
+++ b/crates/re_analytics/src/pipeline_native.rs
@@ -49,6 +49,8 @@ impl Pipeline {
 
         let data_path = config.data_dir().to_owned();
 
+        std::fs::create_dir_all(data_path.clone())?;
+
         let session_file_path = data_path.join(format!("{}.json", config.session_id));
         let session_file = OpenOptions::new()
             .write(true)


### PR DESCRIPTION
Fixes: https://github.com/rerun-io/rerun/issues/2877

### What
It's possible a user has manually deleted their application state directory for any number of reasons, but we need it to exist or creating the pipeline will fail.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2878) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2878)
- [Docs preview](https://rerun.io/preview/pr%3Ajleibs%2Fanalytics_state/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajleibs%2Fanalytics_state/examples)