### PR TITLE
Improve space view tab design

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -13,6 +13,7 @@ pub struct DesignTokens {
     pub bottom_bar_stroke: egui::Stroke,
     pub bottom_bar_rounding: egui::Rounding,
     pub shadow_gradient_dark_start: egui::Color32,
+    pub tab_bar_color: egui::Color32,
 }
 
 impl DesignTokens {
@@ -183,6 +184,7 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
             se: 0.0,
         }, // copied from figma, should be top only
         shadow_gradient_dark_start: egui::Color32::from_black_alpha(77),
+        tab_bar_color: get_global_color(&json, "{Global.Color.Grey.175}"),
     }
 }
 

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -115,6 +115,10 @@ impl ReUi {
         egui::Margin::symmetric(8.0, 2.0)
     }
 
+    pub fn text_to_icon_padding() -> f32 {
+        4.0
+    }
+
     /// Height of the top-most bar.
     pub fn top_bar_height() -> f32 {
         44.0 // from figma 2022-02-03
@@ -597,8 +601,7 @@ impl ReUi {
             .into()
             .into_galley(ui, None, wrap_width, egui::TextStyle::Button);
 
-        let text_to_icon_padding = 4.0;
-        let icon_width_plus_padding = Self::small_icon_size().x + text_to_icon_padding;
+        let icon_width_plus_padding = Self::small_icon_size().x + ReUi::text_to_icon_padding();
 
         let mut desired_size = total_extra + text.size() + egui::vec2(icon_width_plus_padding, 0.0);
         desired_size.y = desired_size
@@ -646,7 +649,7 @@ impl ReUi {
 
             // Draw text next to the icon.
             let mut text_rect = rect;
-            text_rect.min.x = image_rect.max.x + text_to_icon_padding;
+            text_rect.min.x = image_rect.max.x + ReUi::text_to_icon_padding();
             let text_pos = ui
                 .layout()
                 .align_size_within_rect(text.size(), text_rect)

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -420,6 +420,19 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
     // Styling:
 
+    fn tab_bar_color(&self, _visuals: &egui::Visuals) -> egui::Color32 {
+        self.ctx.re_ui.design_tokens.tab_bar_color
+    }
+
+    fn tab_bg_color(
+        &self,
+        _visuals: &egui::Visuals,
+        _tile_id: egui_tiles::TileId,
+        _active: bool,
+    ) -> egui::Color32 {
+        egui::Color32::TRANSPARENT
+    }
+
     fn tab_outline_stroke(
         &self,
         _visuals: &egui::Visuals,

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -274,7 +274,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         is_being_dragged: bool,
     ) -> egui::Response {
         // custom tab UI when we have a space view
-        let Some(egui_tiles::Tile::Pane(space_view_id)) = tiles.get(tile_id)else {
+        let Some(egui_tiles::Tile::Pane(space_view_id)) = tiles.get(tile_id) else {
             return egui_tiles::Behavior::<SpaceViewId>::tab_ui(
                 self,
                 tiles,
@@ -320,16 +320,17 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
         // Show a gap when dragged
         if ui.is_rect_visible(rect) && !is_being_dragged {
-            let bg_color = self.tab_bg_color(ui.visuals(), tile_id, active);
-            let stroke = self.tab_outline_stroke(ui.visuals(), tile_id, active);
-            ui.painter().rect(rect.shrink(0.5), 0.0, bg_color, stroke);
+            let selected = self
+                .ctx
+                .selection()
+                .contains(&Item::SpaceView(*space_view_id));
 
-            if active {
-                // Make the tab name area connect with the tab ui area:
-                ui.painter().hline(
-                    rect.x_range(),
-                    rect.bottom(),
-                    egui::Stroke::new(stroke.width + 1.0, bg_color),
+            if selected {
+                ui.painter().rect(
+                    rect,
+                    0.0,
+                    ui.visuals().selection.bg_fill,
+                    egui::Stroke::NONE,
                 );
             }
 


### PR DESCRIPTION
### What

This PR improves the space view tab UI:

- [x] add the space view icon to the tab
- [x] Change the color of the Space View title bar to Global/Color/Grey/175
- [x] Change the tab design so that it looks like the design system version (no distinct active tab background)
- [x] Selected tab's background are now fully blue (as opposed to rounded rect.

The following changes will be subject to a follow-up PR:
1. better look of the "dragged" widget
2. (possibly) reuse of `ReUi::selectable_label_with_icon()` for the implementation (if it makes sense after (1))

Closes #2737

New design:

<img width="731" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/d4a6718d-c25a-41bb-b4e7-8584080dac4b">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2879) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2879)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fbetter-tabs/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fbetter-tabs/examples)