### PR TITLE
Extend C++ RecordingStream with global/thread_local/flush/save/connect APIs & introduce C++ SDK tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,13 @@ cmake_minimum_required(VERSION 3.16)
 
 project(rerun_cpp_proj LANGUAGES CXX)
 
+function(set_default_warning_settings target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /WX)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wcast-align -Wcast-qual -Wformat=2 -Wmissing-include-dirs -Wnull-dereference -Woverloaded-virtual -Wpointer-arith -Wshadow -Wswitch-enum -Wvla -Wno-sign-compare -Wconversion -Wunused -Wold-style-cast -Wno-missing-braces)
+    endif()
+endfunction()
+
 add_subdirectory(rerun_cpp) # The Rerun C++ SDK library
 add_subdirectory(examples/cpp/minimal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ function(set_default_warning_settings target)
     else()
         target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wcast-align -Wcast-qual -Wformat=2 -Wmissing-include-dirs -Wnull-dereference -Woverloaded-virtual -Wpointer-arith -Wshadow -Wswitch-enum -Wvla -Wno-sign-compare -Wconversion -Wunused -Wold-style-cast -Wno-missing-braces)
     endif()
+
+    # Enable this to fail on warnings.
+    # set_property(TARGET ${target} PROPERTY COMPILE_WARNING_AS_ERROR ON)
 endfunction()
 
 add_subdirectory(rerun_cpp) # The Rerun C++ SDK library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 project(rerun_cpp_proj LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,9 @@ function(set_default_warning_settings target)
     # set_property(TARGET ${target} PROPERTY COMPILE_WARNING_AS_ERROR ON)
 endfunction()
 
+if(NOT DEFINED CMAKE_GENERATOR AND UNIX)
+    set(CMAKE_GENERATOR "Unix Makefiles")
+endif()
+
 add_subdirectory(rerun_cpp) # The Rerun C++ SDK library
 add_subdirectory(examples/cpp/minimal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ function(set_default_warning_settings target)
         target_compile_options(${target} PRIVATE /W4 /WX)
     else()
         target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wcast-align -Wcast-qual -Wformat=2 -Wmissing-include-dirs -Wnull-dereference -Woverloaded-virtual -Wpointer-arith -Wshadow -Wswitch-enum -Wvla -Wno-sign-compare -Wconversion -Wunused -Wold-style-cast -Wno-missing-braces)
+
+        # arrow has a bunch of unused parameters in its headers.
+        target_compile_options(${target} PRIVATE -Wno-unused-parameter)
     endif()
 
     # Enable this to fail on warnings.

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -392,6 +392,7 @@ impl RecordingStreamBuilder {
 ///
 /// This means that e.g. flushing the pipeline ([`Self::flush_blocking`]) guarantees that all
 /// previous data sent by the calling thread has been recorded; no more, no less.
+/// (e.g. it does not mean that all file caches are flushed)
 ///
 /// ## Shutdown
 ///

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-022d2aaa9bc72abffb4646e73a113a21e4ec49e2bd68d06b697cb043c5831686
+df162329c66869d7860ca8f1605a3ad36de58247d7eaadc5640a431788735ac8

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -324,13 +324,15 @@ impl QuotedObject {
                 // Builder methods for all optional components.
                 for obj_field in obj.fields.iter().filter(|field| field.is_nullable) {
                     let field_ident = format_ident!("{}", obj_field.name);
+                    // C++ compilers give warnings for re-using the same name as the member variable.
+                    let parameter_ident = format_ident!("_{}", obj_field.name);
                     let method_ident = format_ident!("with_{}", obj_field.name);
                     let non_nullable = ObjectField {
                         is_nullable: false,
                         ..obj_field.clone()
                     };
                     let parameter_declaration =
-                        quote_variable(&mut hpp_includes, &non_nullable, &field_ident);
+                        quote_variable(&mut hpp_includes, &non_nullable, &parameter_ident);
                     methods.push(Method {
                         docs: obj_field.docs.clone().into(),
                         declaration: MethodDeclaration {
@@ -341,7 +343,7 @@ impl QuotedObject {
                             },
                         },
                         definition_body: quote! {
-                            this->#field_ident = std::move(#field_ident);
+                            #field_ident = std::move(#parameter_ident);
                             return *this;
                         },
                         inline: true,

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -41,7 +41,7 @@ impl From<CStoreKind> for StoreKind {
     }
 }
 
-/// Simple C version of [`StoreInfo`]
+/// Simple C version of [`CStoreInfo`]
 #[repr(C)]
 #[derive(Debug)]
 pub struct CStoreInfo {

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -12,11 +12,9 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
 use re_sdk::{
-    external::re_log_types::{self, StoreInfo, StoreSource},
+    external::re_log_types::{self},
     log::{DataCell, DataRow},
-    sink::TcpSink,
-    time::Time,
-    ApplicationId, ComponentName, EntityPath, RecordingStream, StoreId, StoreKind,
+    ComponentName, EntityPath, RecordingStream, RecordingStreamBuilder, StoreKind,
 };
 
 // ----------------------------------------------------------------------------
@@ -24,14 +22,23 @@ use re_sdk::{
 
 type CRecStreamId = u32;
 
-#[repr(u32)]
-#[derive(Debug)]
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CStoreKind {
     /// A recording of user-data.
     Recording = 1,
 
     /// Data associated with the blueprint state.
     Blueprint = 2,
+}
+
+impl From<CStoreKind> for StoreKind {
+    fn from(kind: CStoreKind) -> Self {
+        match kind {
+            CStoreKind::Recording => StoreKind::Recording,
+            CStoreKind::Blueprint => StoreKind::Blueprint,
+        }
+    }
 }
 
 /// Simple C version of [`StoreInfo`]
@@ -41,7 +48,7 @@ pub struct CStoreInfo {
     /// The user-chosen name of the application doing the logging.
     pub application_id: *const c_char,
 
-    pub store_kind: u32, // CStoreKind
+    pub store_kind: CStoreKind,
 }
 
 #[repr(C)]
@@ -66,6 +73,9 @@ pub struct CDataRow {
 // ----------------------------------------------------------------------------
 // Global data:
 
+const RERUN_REC_STREAM_CURRENT_RECORDING: CRecStreamId = 0xFFFFFFFF;
+const RERUN_REC_STREAM_CURRENT_BLUEPRINT: CRecStreamId = 0xFFFFFFFE;
+
 #[derive(Default)]
 pub struct RecStreams {
     next_id: CRecStreamId,
@@ -78,6 +88,21 @@ impl RecStreams {
         self.next_id += 1;
         self.streams.insert(id, stream);
         id
+    }
+
+    fn get(&self, id: CRecStreamId) -> Option<RecordingStream> {
+        match id {
+            RERUN_REC_STREAM_CURRENT_RECORDING => RecordingStream::get(StoreKind::Recording, None),
+            RERUN_REC_STREAM_CURRENT_BLUEPRINT => RecordingStream::get(StoreKind::Blueprint, None),
+            _ => self.streams.get(&id).cloned(),
+        }
+    }
+
+    fn remove(&mut self, id: CRecStreamId) -> Option<RecordingStream> {
+        match id {
+            RERUN_REC_STREAM_CURRENT_BLUEPRINT | RERUN_REC_STREAM_CURRENT_RECORDING => None,
+            _ => self.streams.remove(&id),
+        }
     }
 }
 
@@ -100,10 +125,7 @@ pub extern "C" fn rr_version_string() -> *const c_char {
 
 #[allow(unsafe_code)]
 #[no_mangle]
-pub unsafe extern "C" fn rr_recording_stream_new(
-    cstore_info: *const CStoreInfo,
-    tcp_addr: *const c_char,
-) -> CRecStreamId {
+pub unsafe extern "C" fn rr_recording_stream_new(cstore_info: *const CStoreInfo) -> CRecStreamId {
     initialize_logging();
 
     let cstore_info = unsafe { &*cstore_info };
@@ -114,36 +136,19 @@ pub unsafe extern "C" fn rr_recording_stream_new(
     } = *cstore_info;
     let application_id = unsafe { CStr::from_ptr(application_id) };
 
-    let application_id =
-        ApplicationId::from(application_id.to_str().expect("invalid application_id"));
+    let mut rec_stream_builder =
+        RecordingStreamBuilder::new(application_id.to_str().expect("invalid application_id"))
+            //.is_official_example(is_official_example) // TODO(andreas): Is there a meaningful way to expose this?
+            //.store_id(recording_id.clone()) // TODO(andreas): Expose store id.
+            .store_source(re_log_types::StoreSource::CSdk);
 
-    let store_kind = match store_kind {
-        1 => StoreKind::Recording,
-        2 => StoreKind::Blueprint,
-        _ => panic!("invalid store_kind: expected 1 or 2, got {store_kind}"),
-    };
+    if store_kind == CStoreKind::Blueprint {
+        rec_stream_builder = rec_stream_builder.blueprint();
+    }
 
-    let store_info = StoreInfo {
-        application_id,
-        store_id: StoreId::random(store_kind),
-        is_official_example: false,
-        started: Time::now(),
-        store_source: StoreSource::CSdk,
-        store_kind,
-    };
-
-    let batcher_config = Default::default();
-
-    assert!(!tcp_addr.is_null());
-    let tcp_addr = unsafe { CStr::from_ptr(tcp_addr) };
-    let tcp_addr = tcp_addr
-        .to_str()
-        .expect("invalid tcp_addr string")
-        .parse()
-        .expect("invalid tcp_addr");
-    let sink = Box::new(TcpSink::new(tcp_addr, re_sdk::default_flush_timeout()));
-
-    let rec_stream = RecordingStream::new(store_info, batcher_config, sink).unwrap();
+    let rec_stream = rec_stream_builder
+        .buffered()
+        .expect("Failed to create recording stream");
 
     RECORDING_STREAMS.lock().insert(rec_stream)
 }
@@ -151,17 +156,68 @@ pub unsafe extern "C" fn rr_recording_stream_new(
 #[allow(unsafe_code)]
 #[no_mangle]
 pub extern "C" fn rr_recording_stream_free(id: CRecStreamId) {
-    let mut lock = RECORDING_STREAMS.lock();
-    if let Some(sink) = lock.streams.remove(&id) {
-        sink.disconnect();
+    if let Some(stream) = RECORDING_STREAMS.lock().remove(id) {
+        stream.disconnect();
     }
 }
 
 #[allow(unsafe_code)]
 #[no_mangle]
-pub unsafe extern "C" fn rr_log(stream: CRecStreamId, data_row: *const CDataRow) {
-    let lock = RECORDING_STREAMS.lock();
-    let Some(stream) = lock.streams.get(&stream) else {
+pub extern "C" fn rr_recording_stream_set_global(id: CRecStreamId, store_kind: CStoreKind) {
+    let stream = RECORDING_STREAMS.lock().get(id);
+    RecordingStream::set_global(store_kind.into(), stream);
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub extern "C" fn rr_recording_stream_set_thread_local(id: CRecStreamId, store_kind: CStoreKind) {
+    let stream = RECORDING_STREAMS.lock().get(id);
+    RecordingStream::set_thread_local(store_kind.into(), stream);
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub unsafe extern "C" fn rr_recording_stream_connect(
+    id: CRecStreamId,
+    tcp_addr: *const c_char,
+    flush_timeout_sec: f32,
+) {
+    let Some(stream) = RECORDING_STREAMS.lock().get(id) else {
+        return;
+    };
+
+    let tcp_addr = unsafe { CStr::from_ptr(tcp_addr) };
+    let tcp_addr = tcp_addr.to_str().expect("invalid tcp_addr");
+    let tcp_addr = tcp_addr.parse().expect("failed to parse tcp_addr");
+
+    let flush_timeout = if flush_timeout_sec >= 0.0 {
+        Some(std::time::Duration::from_secs_f32(flush_timeout_sec))
+    } else {
+        None
+    };
+
+    stream.connect(tcp_addr, flush_timeout);
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub unsafe extern "C" fn rr_recording_stream_save(id: CRecStreamId, path: *const c_char) {
+    let Some(stream) = RECORDING_STREAMS.lock().get(id) else {
+        return;
+    };
+
+    let path = unsafe { CStr::from_ptr(path) };
+    let path = path.to_str().expect("invalid path");
+
+    stream
+        .save(path)
+        .expect("Failed to save recording stream to file");
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub unsafe extern "C" fn rr_log(id: CRecStreamId, data_row: *const CDataRow, inject_time: bool) {
+    let Some(stream) = RECORDING_STREAMS.lock().get(id) else {
         return;
     };
 
@@ -211,7 +267,6 @@ pub unsafe extern "C" fn rr_log(stream: CRecStreamId, data_row: *const CDataRow)
         cells: re_log_types::DataCellRow(cells),
     };
 
-    let inject_time = true;
     stream.record_row(data_row, inject_time);
 }
 
@@ -273,5 +328,3 @@ fn parse_arrow_ipc_encapsulated_message(
 
     Ok(arrays.into_iter().next().unwrap())
 }
-
-// ----------------------------------------------------------------------------

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -177,6 +177,14 @@ pub extern "C" fn rr_recording_stream_set_thread_local(id: CRecStreamId, store_k
 
 #[allow(unsafe_code)]
 #[no_mangle]
+pub extern "C" fn rr_recording_stream_flush_blocking(id: CRecStreamId) {
+    if let Some(stream) = RECORDING_STREAMS.lock().remove(id) {
+        stream.flush_blocking();
+    }
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
 pub unsafe extern "C" fn rr_recording_stream_connect(
     id: CRecStreamId,
     tcp_addr: *const c_char,

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // ----------------------------------------------------------------------------
@@ -15,15 +16,19 @@ extern "C" {
 #define RERUN_STORE_KIND_RECORDING 1
 #define RERUN_STORE_KIND_BLUEPRINT 2
 
-/// What is returned by the first call to `rr_recording_stream_new`.
-/// Usually you only have one recording stream, so you can call
-/// `rr_recording_stream_new` once, ignore its return value, and use
-/// `RERUN_REC_STREAM_DEFAULT` everywhere in your code.
-#define RERUN_REC_STREAM_DEFAULT 0
+/// Special value for `rr_recording_stream` methods to indicate the most appropriate
+/// globally available recording stream for recordings.
+/// (i.e. thread-local first, then global scope)
+#define RERUN_REC_STREAM_CURRENT_RECORDING 0xFFFFFFFF
+
+/// Special value for `rr_recording_stream` methods to indicate the most appropriate
+/// globally available recording stream for blueprints.
+/// (i.e. thread-local first, then global scope)
+#define RERUN_REC_STREAM_CURRENT_BLUEPRINT 0xFFFFFFFE
 
 /// A unique handle for a recording stream.
 ///
-/// The default is RERUN_REC_STREAM_DEFAULT
+/// The default is RERUN_REC_STREAM_CURRENT
 typedef int32_t rr_recording_stream;
 
 struct rr_store_info {
@@ -74,26 +79,60 @@ struct rr_data_row {
 /// Returns a human-readable version string of the Rerun C SDK.
 extern const char* rr_version_string(void);
 
-/// Create a new recording stream to log to.
+/// Creates a new recording stream to log to.
 ///
 /// You must call this at least once to enable logging.
 ///
-/// The first call always returns `RERUN_REC_STREAM_DEFAULT`.
 /// Usually you only have one recording stream, so you can call
-/// `rr_recording_stream_new` once, ignore its return value, and use
-/// `RERUN_REC_STREAM_DEFAULT` everywhere in your code.
-extern rr_recording_stream rr_recording_stream_new(
-    const struct rr_store_info* store_info, const char* tcp_addr
-);
+/// `rr_recording_stream_set_global` afterwards once to make it available globally via
+/// `RERUN_REC_STREAM_CURRENT_RECORDING` and `RERUN_REC_STREAM_CURRENT_BLUEPRINT` respectively.
+extern rr_recording_stream rr_recording_stream_new(const struct rr_store_info* store_info);
 
 /// Free the given recording stream. The handle will be invalid after this.
+///
+/// Does nothing for `RERUN_REC_STREAM_CURRENT_RECORDING` and `RERUN_REC_STREAM_CURRENT_BLUEPRINT`.
+///
+/// No-op for destroyed/non-existing streams.
 extern void rr_recording_stream_free(rr_recording_stream stream);
+
+/// Replaces the currently active recording of the specified type in the global scope with
+/// the specified one.
+extern void rr_recording_stream_set_global(rr_recording_stream stream, int32_t store_kind);
+
+/// Replaces the currently active recording of the specified type in the thread-local scope
+/// with the specified one.
+extern void rr_recording_stream_set_thread_local(rr_recording_stream stream, int32_t store_kind);
+
+/// Connect to a remote Rerun Viewer on the given ip:port.
+///
+/// Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.
+///
+/// flush_timeout_sec:
+/// The minimum time the SDK will wait during a flush before potentially
+/// dropping data if progress is not being made. Passing a negative value indicates no timeout,
+/// and can cause a call to `flush` to block indefinitely.
+///
+/// This function returns immediately.
+/// No-op for destroyed/non-existing streams.
+extern void rr_recording_stream_connect(
+    rr_recording_stream stream, const char* tcp_addr, float flush_timeout_sec
+);
+
+/// Stream all log-data to a given file.
+///
+/// This function returns immediately.
+/// No-op for destroyed/non-existing streams.
+extern void rr_recording_stream_save(rr_recording_stream stream, const char* path);
 
 /// Log the given data to the given stream.
 ///
 /// If `inject_time` is set to `true`, the row's timestamp data will be
 /// overridden using the recording streams internal clock.
-extern void rr_log(rr_recording_stream stream, const struct rr_data_row* data_row);
+///
+/// No-op for destroyed/non-existing streams.
+extern void rr_log(
+    rr_recording_stream stream, const struct rr_data_row* data_row, bool inject_time
+);
 
 // ----------------------------------------------------------------------------
 

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -38,6 +38,7 @@ extern "C" {
 ///
 /// This means that e.g. flushing the pipeline (`rr_recording_stream_flush_blocking`) guarantees
 /// that all previous data sent by the calling thread has been recorded; no more, no less.
+/// (e.g. it does not mean that all file caches are flushed)
 ///
 /// ## Shutdown
 ///

--- a/examples/c/minimal/main.c
+++ b/examples/c/minimal/main.c
@@ -8,7 +8,8 @@ int main(void) {
         .application_id = "c-example-app",
         .store_kind = RERUN_STORE_KIND_RECORDING,
     };
-    rr_recording_stream rec_stream = rr_recording_stream_new(&store_info, "127.0.0.1:9876");
+    rr_recording_stream rec_stream = rr_recording_stream_new(&store_info);
+    rr_recording_stream_connect(rec_stream, "127.0.0.1:9876", 2.0);
 
     printf("rec_stream: %d\n", rec_stream);
 

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -15,11 +15,7 @@ endif()
 
 add_executable(rerun_example main.cpp)
 
-if(MSVC)
-  target_compile_options(rerun_example PRIVATE /W4 /WX)
-else()
-  target_compile_options(rerun_example PRIVATE -Wall -Wextra -Wpedantic -Wcast-align -Wcast-qual -Wformat=2 -Wmissing-include-dirs -Wnull-dereference -Woverloaded-virtual -Wpointer-arith -Wshadow -Wswitch-enum -Wvla -Wno-sign-compare -Wconversion -Wunused -Wold-style-cast -Wno-missing-braces)
-endif()
+set_default_warning_settings(rerun_example)
 
 include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/../../../rerun_cpp/src) # For rerun.hpp (Rerun C++ SDK)
 

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -15,6 +15,6 @@ endif()
 
 add_executable(rerun_example main.cpp)
 
-set_default_warning_settings(rerun_example)
-
+# TODO(andreas): Fix warnings and enable this.
+# set_default_warning_settings(rerun_example)
 target_link_libraries(rerun_example PRIVATE loguru::loguru rerun_sdk)

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -17,6 +17,4 @@ add_executable(rerun_example main.cpp)
 
 set_default_warning_settings(rerun_example)
 
-include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/../../../rerun_cpp/src) # For rerun.hpp (Rerun C++ SDK)
-
 target_link_libraries(rerun_example PRIVATE loguru::loguru rerun_sdk)

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 # project(RerunExample)
 

--- a/examples/cpp/minimal/build_and_run.sh
+++ b/examples/cpp/minimal/build_and_run.sh
@@ -9,7 +9,7 @@ num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    cmake  -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
     cmake --build . --config Debug --target rerun_example -j ${num_threads}
 popd
 

--- a/examples/cpp/minimal/build_and_run.sh
+++ b/examples/cpp/minimal/build_and_run.sh
@@ -9,7 +9,7 @@ num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake  -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
     cmake --build . --config Debug --target rerun_example -j ${num_threads}
 popd
 

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -2,7 +2,6 @@
 #include <rerun.hpp>
 
 #include <array>
-#include <components/point2d.hpp>
 
 int main(int argc, char** argv) {
     loguru::g_preamble_uptime = false;

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -11,7 +11,8 @@ int main(int argc, char** argv) {
 
     LOG_F(INFO, "Rerun C++ SDK version: %s", rr::version_string());
 
-    auto rr_stream = rr::RecordingStream{"c-example-app", "127.0.0.1:9876"};
+    auto rr_stream = rr::RecordingStream("c-example-app");
+    rr_stream.connect("127.0.0.1:9876");
 
     rr_stream.log_archetype(
         "3d/points",

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -16,8 +16,8 @@ int main(int argc, char** argv) {
     rr_stream.log_archetype(
         "3d/points",
         rr::archetypes::Points3D({
-                                     rr::datatypes::Point3D{1.0, 2.0, 3.0},
-                                     rr::datatypes::Point3D{4.0, 5.0, 6.0},
+                                     rr::datatypes::Vec3D{1.0, 2.0, 3.0},
+                                     rr::datatypes::Vec3D{4.0, 5.0, 6.0},
                                  })
             .with_radii({0.42, 0.43})
             .with_colors({0xAA0000CC, 0x00BB00DD})
@@ -35,9 +35,9 @@ int main(int argc, char** argv) {
     rr_stream.log_components(
         "2d/points",
         std::vector{
-            rr::components::Point2D(rr::datatypes::Point2D{0.0, 0.0}),
-            rr::components::Point2D(rr::datatypes::Point2D{1.0, 3.0}),
-            rr::components::Point2D(rr::datatypes::Point2D{5.0, 5.0}),
+            rr::components::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
+            rr::components::Point2D(rr::datatypes::Vec2D{1.0, 3.0}),
+            rr::components::Point2D(rr::datatypes::Vec2D{5.0, 5.0}),
         },
         std::array{
             rr::components::Color(0xFF0000FF),

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -5,11 +5,12 @@ cmake_minimum_required(VERSION 3.16)
 # However, that won't work for use since we auto-generate the source tree.
 # See https://cmake.org/cmake/help/latest/command/file.html#glob
 file(GLOB_RECURSE rerun_sdk_SRC CONFIGURE_DEPENDS
-    "*.hpp"
-    "*.cpp"
+    "src/*.hpp"
+    "src/*.cpp"
 )
 
 add_library(rerun_sdk ${rerun_sdk_SRC})
+set_default_warning_settings(rerun_sdk)
 
 # ------------------------------------------------------------------------------
 
@@ -69,3 +70,31 @@ if(ARROW_LINK_SHARED)
 else()
     target_link_libraries(rerun_sdk PRIVATE Arrow::arrow_static)
 endif()
+
+# ------------------------------------------------------------------------------
+# Test application
+
+# Catch2:
+Include(FetchContent)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+# Test application:
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+file(GLOB_RECURSE rerun_sdk_tests_SRC CONFIGURE_DEPENDS
+    "tests/*.hpp"
+    "tests/*.cpp"
+)
+add_executable(rerun_sdk_tests ${rerun_sdk_tests_SRC})
+
+set_default_warning_settings(rerun_sdk_tests)
+include_directories(rerun_sdk_tests SYSTEM "src") # Pretend Rerun sdk is a system library, and not local.
+
+target_link_libraries(rerun_sdk_tests PRIVATE Catch2::Catch2WithMain)

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
+add_subdirectory(tests)
+
 # NOTE: CMake docs strongly discourages using GLOB, and instead suggests
 # manually listing all the files, like it's 1972.
 # However, that won't work for use since we auto-generate the source tree.
@@ -10,7 +12,9 @@ file(GLOB_RECURSE rerun_sdk_SRC CONFIGURE_DEPENDS
 )
 
 add_library(rerun_sdk ${rerun_sdk_SRC})
-set_default_warning_settings(rerun_sdk)
+
+# TODO(andreas): Fix all warnings and enable this.
+# set_default_warning_settings(rerun_sdk)
 
 # ------------------------------------------------------------------------------
 
@@ -19,7 +23,8 @@ include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/../crates/rerun_c/src)
 
 # Make sure the compiler can find include files for rerun
 # when other libraries or executables link to rerun:
-target_include_directories(rerun_sdk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# TODO(andreas): These should be prefixed `rerun/`.
+target_include_directories(rerun_sdk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # ------------------------------------------------------------------------------
 # Loguru logging library (https://github.com/emilk/loguru):
@@ -70,31 +75,3 @@ if(ARROW_LINK_SHARED)
 else()
     target_link_libraries(rerun_sdk PRIVATE Arrow::arrow_static)
 endif()
-
-# ------------------------------------------------------------------------------
-# Test application
-
-# Catch2:
-Include(FetchContent)
-FetchContent_Declare(
-    Catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.4.0
-)
-FetchContent_MakeAvailable(Catch2)
-
-# Test application:
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-endif()
-
-file(GLOB_RECURSE rerun_sdk_tests_SRC CONFIGURE_DEPENDS
-    "tests/*.hpp"
-    "tests/*.cpp"
-)
-add_executable(rerun_sdk_tests ${rerun_sdk_tests_SRC})
-
-set_default_warning_settings(rerun_sdk_tests)
-include_directories(rerun_sdk_tests SYSTEM "src") # Pretend Rerun sdk is a system library, and not local.
-
-target_link_libraries(rerun_sdk_tests PRIVATE Catch2::Catch2WithMain)

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 add_subdirectory(tests)
 
@@ -44,8 +44,8 @@ FetchContent_MakeAvailable(LoguruGitRepo) # defines target 'loguru::loguru'
 target_link_libraries(rerun_sdk PRIVATE loguru::loguru)
 
 # ------------------------------------------------------------------------------
-execute_process(COMMAND cargo build -p re_types) # Generates most of the C++ source files
-execute_process(COMMAND cargo build -p rerun_c) # We link against this, so must be up-to-date
+execute_process(COMMAND cargo build -p re_types COMMAND_ERROR_IS_FATAL ANY) # Generates most of the C++ source files
+execute_process(COMMAND cargo build -p rerun_c COMMAND_ERROR_IS_FATAL ANY) # We link against this, so must be up-to-date
 
 # ------------------------------------------------------------------------------
 if(APPLE)

--- a/rerun_cpp/build_and_run_tests.sh
+++ b/rerun_cpp/build_and_run_tests.sh
@@ -9,7 +9,7 @@ num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
     cmake --build . --config Debug --target rerun_sdk_tests -j ${num_threads}
 popd
 

--- a/rerun_cpp/build_and_run_tests.sh
+++ b/rerun_cpp/build_and_run_tests.sh
@@ -13,4 +13,4 @@ pushd build
     cmake --build . --config Debug --target rerun_sdk_tests -j ${num_threads}
 popd
 
-./build/rerun_cpp/rerun_sdk_tests
+./build/rerun_cpp/tests/rerun_sdk_tests

--- a/rerun_cpp/build_and_run_tests.sh
+++ b/rerun_cpp/build_and_run_tests.sh
@@ -9,7 +9,7 @@ num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
     cmake --build . --config Debug --target rerun_sdk_tests -j ${num_threads}
 popd
 

--- a/rerun_cpp/build_and_run_tests.sh
+++ b/rerun_cpp/build_and_run_tests.sh
@@ -2,7 +2,7 @@
 
 set -eu
 script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd "$script_path/../../.."
+cd "$script_path/.."
 set -x
 
 num_threads=$(getconf _NPROCESSORS_ONLN)
@@ -10,7 +10,7 @@ num_threads=$(getconf _NPROCESSORS_ONLN)
 mkdir -p build
 pushd build
     cmake -DCMAKE_BUILD_TYPE=Debug ..
-    cmake --build . --config Debug --target rerun_example -j ${num_threads}
+    cmake --build . --config Debug --target rerun_sdk_tests -j ${num_threads}
 popd
 
-./build/examples/cpp/minimal/rerun_example
+./build/rerun_cpp/rerun_sdk_tests

--- a/rerun_cpp/src/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/archetypes/affix_fuzzer1.hpp
@@ -252,183 +252,183 @@ namespace rr {
                   fuzz1117(std::move(fuzz1117)),
                   fuzz1118(std::move(fuzz1118)) {}
 
-            AffixFuzzer1& with_fuzz2001(rr::components::AffixFuzzer1 fuzz2001) {
-                this->fuzz2001 = std::move(fuzz2001);
+            AffixFuzzer1& with_fuzz2001(rr::components::AffixFuzzer1 _fuzz2001) {
+                fuzz2001 = std::move(_fuzz2001);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2002(rr::components::AffixFuzzer2 fuzz2002) {
-                this->fuzz2002 = std::move(fuzz2002);
+            AffixFuzzer1& with_fuzz2002(rr::components::AffixFuzzer2 _fuzz2002) {
+                fuzz2002 = std::move(_fuzz2002);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2003(rr::components::AffixFuzzer3 fuzz2003) {
-                this->fuzz2003 = std::move(fuzz2003);
+            AffixFuzzer1& with_fuzz2003(rr::components::AffixFuzzer3 _fuzz2003) {
+                fuzz2003 = std::move(_fuzz2003);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2004(rr::components::AffixFuzzer4 fuzz2004) {
-                this->fuzz2004 = std::move(fuzz2004);
+            AffixFuzzer1& with_fuzz2004(rr::components::AffixFuzzer4 _fuzz2004) {
+                fuzz2004 = std::move(_fuzz2004);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2005(rr::components::AffixFuzzer5 fuzz2005) {
-                this->fuzz2005 = std::move(fuzz2005);
+            AffixFuzzer1& with_fuzz2005(rr::components::AffixFuzzer5 _fuzz2005) {
+                fuzz2005 = std::move(_fuzz2005);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2006(rr::components::AffixFuzzer6 fuzz2006) {
-                this->fuzz2006 = std::move(fuzz2006);
+            AffixFuzzer1& with_fuzz2006(rr::components::AffixFuzzer6 _fuzz2006) {
+                fuzz2006 = std::move(_fuzz2006);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2007(rr::components::AffixFuzzer7 fuzz2007) {
-                this->fuzz2007 = std::move(fuzz2007);
+            AffixFuzzer1& with_fuzz2007(rr::components::AffixFuzzer7 _fuzz2007) {
+                fuzz2007 = std::move(_fuzz2007);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2008(rr::components::AffixFuzzer8 fuzz2008) {
-                this->fuzz2008 = std::move(fuzz2008);
+            AffixFuzzer1& with_fuzz2008(rr::components::AffixFuzzer8 _fuzz2008) {
+                fuzz2008 = std::move(_fuzz2008);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2009(rr::components::AffixFuzzer9 fuzz2009) {
-                this->fuzz2009 = std::move(fuzz2009);
+            AffixFuzzer1& with_fuzz2009(rr::components::AffixFuzzer9 _fuzz2009) {
+                fuzz2009 = std::move(_fuzz2009);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2010(rr::components::AffixFuzzer10 fuzz2010) {
-                this->fuzz2010 = std::move(fuzz2010);
+            AffixFuzzer1& with_fuzz2010(rr::components::AffixFuzzer10 _fuzz2010) {
+                fuzz2010 = std::move(_fuzz2010);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2011(rr::components::AffixFuzzer11 fuzz2011) {
-                this->fuzz2011 = std::move(fuzz2011);
+            AffixFuzzer1& with_fuzz2011(rr::components::AffixFuzzer11 _fuzz2011) {
+                fuzz2011 = std::move(_fuzz2011);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2012(rr::components::AffixFuzzer12 fuzz2012) {
-                this->fuzz2012 = std::move(fuzz2012);
+            AffixFuzzer1& with_fuzz2012(rr::components::AffixFuzzer12 _fuzz2012) {
+                fuzz2012 = std::move(_fuzz2012);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2013(rr::components::AffixFuzzer13 fuzz2013) {
-                this->fuzz2013 = std::move(fuzz2013);
+            AffixFuzzer1& with_fuzz2013(rr::components::AffixFuzzer13 _fuzz2013) {
+                fuzz2013 = std::move(_fuzz2013);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2014(rr::components::AffixFuzzer14 fuzz2014) {
-                this->fuzz2014 = std::move(fuzz2014);
+            AffixFuzzer1& with_fuzz2014(rr::components::AffixFuzzer14 _fuzz2014) {
+                fuzz2014 = std::move(_fuzz2014);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2015(rr::components::AffixFuzzer15 fuzz2015) {
-                this->fuzz2015 = std::move(fuzz2015);
+            AffixFuzzer1& with_fuzz2015(rr::components::AffixFuzzer15 _fuzz2015) {
+                fuzz2015 = std::move(_fuzz2015);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2016(rr::components::AffixFuzzer16 fuzz2016) {
-                this->fuzz2016 = std::move(fuzz2016);
+            AffixFuzzer1& with_fuzz2016(rr::components::AffixFuzzer16 _fuzz2016) {
+                fuzz2016 = std::move(_fuzz2016);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2017(rr::components::AffixFuzzer17 fuzz2017) {
-                this->fuzz2017 = std::move(fuzz2017);
+            AffixFuzzer1& with_fuzz2017(rr::components::AffixFuzzer17 _fuzz2017) {
+                fuzz2017 = std::move(_fuzz2017);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2018(rr::components::AffixFuzzer18 fuzz2018) {
-                this->fuzz2018 = std::move(fuzz2018);
+            AffixFuzzer1& with_fuzz2018(rr::components::AffixFuzzer18 _fuzz2018) {
+                fuzz2018 = std::move(_fuzz2018);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2101(std::vector<rr::components::AffixFuzzer1> fuzz2101) {
-                this->fuzz2101 = std::move(fuzz2101);
+            AffixFuzzer1& with_fuzz2101(std::vector<rr::components::AffixFuzzer1> _fuzz2101) {
+                fuzz2101 = std::move(_fuzz2101);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2102(std::vector<rr::components::AffixFuzzer2> fuzz2102) {
-                this->fuzz2102 = std::move(fuzz2102);
+            AffixFuzzer1& with_fuzz2102(std::vector<rr::components::AffixFuzzer2> _fuzz2102) {
+                fuzz2102 = std::move(_fuzz2102);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2103(std::vector<rr::components::AffixFuzzer3> fuzz2103) {
-                this->fuzz2103 = std::move(fuzz2103);
+            AffixFuzzer1& with_fuzz2103(std::vector<rr::components::AffixFuzzer3> _fuzz2103) {
+                fuzz2103 = std::move(_fuzz2103);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2104(std::vector<rr::components::AffixFuzzer4> fuzz2104) {
-                this->fuzz2104 = std::move(fuzz2104);
+            AffixFuzzer1& with_fuzz2104(std::vector<rr::components::AffixFuzzer4> _fuzz2104) {
+                fuzz2104 = std::move(_fuzz2104);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2105(std::vector<rr::components::AffixFuzzer5> fuzz2105) {
-                this->fuzz2105 = std::move(fuzz2105);
+            AffixFuzzer1& with_fuzz2105(std::vector<rr::components::AffixFuzzer5> _fuzz2105) {
+                fuzz2105 = std::move(_fuzz2105);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2106(std::vector<rr::components::AffixFuzzer6> fuzz2106) {
-                this->fuzz2106 = std::move(fuzz2106);
+            AffixFuzzer1& with_fuzz2106(std::vector<rr::components::AffixFuzzer6> _fuzz2106) {
+                fuzz2106 = std::move(_fuzz2106);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2107(std::vector<rr::components::AffixFuzzer7> fuzz2107) {
-                this->fuzz2107 = std::move(fuzz2107);
+            AffixFuzzer1& with_fuzz2107(std::vector<rr::components::AffixFuzzer7> _fuzz2107) {
+                fuzz2107 = std::move(_fuzz2107);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2108(std::vector<rr::components::AffixFuzzer8> fuzz2108) {
-                this->fuzz2108 = std::move(fuzz2108);
+            AffixFuzzer1& with_fuzz2108(std::vector<rr::components::AffixFuzzer8> _fuzz2108) {
+                fuzz2108 = std::move(_fuzz2108);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2109(std::vector<rr::components::AffixFuzzer9> fuzz2109) {
-                this->fuzz2109 = std::move(fuzz2109);
+            AffixFuzzer1& with_fuzz2109(std::vector<rr::components::AffixFuzzer9> _fuzz2109) {
+                fuzz2109 = std::move(_fuzz2109);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2110(std::vector<rr::components::AffixFuzzer10> fuzz2110) {
-                this->fuzz2110 = std::move(fuzz2110);
+            AffixFuzzer1& with_fuzz2110(std::vector<rr::components::AffixFuzzer10> _fuzz2110) {
+                fuzz2110 = std::move(_fuzz2110);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2111(std::vector<rr::components::AffixFuzzer11> fuzz2111) {
-                this->fuzz2111 = std::move(fuzz2111);
+            AffixFuzzer1& with_fuzz2111(std::vector<rr::components::AffixFuzzer11> _fuzz2111) {
+                fuzz2111 = std::move(_fuzz2111);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2112(std::vector<rr::components::AffixFuzzer12> fuzz2112) {
-                this->fuzz2112 = std::move(fuzz2112);
+            AffixFuzzer1& with_fuzz2112(std::vector<rr::components::AffixFuzzer12> _fuzz2112) {
+                fuzz2112 = std::move(_fuzz2112);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2113(std::vector<rr::components::AffixFuzzer13> fuzz2113) {
-                this->fuzz2113 = std::move(fuzz2113);
+            AffixFuzzer1& with_fuzz2113(std::vector<rr::components::AffixFuzzer13> _fuzz2113) {
+                fuzz2113 = std::move(_fuzz2113);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2114(std::vector<rr::components::AffixFuzzer14> fuzz2114) {
-                this->fuzz2114 = std::move(fuzz2114);
+            AffixFuzzer1& with_fuzz2114(std::vector<rr::components::AffixFuzzer14> _fuzz2114) {
+                fuzz2114 = std::move(_fuzz2114);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2115(std::vector<rr::components::AffixFuzzer15> fuzz2115) {
-                this->fuzz2115 = std::move(fuzz2115);
+            AffixFuzzer1& with_fuzz2115(std::vector<rr::components::AffixFuzzer15> _fuzz2115) {
+                fuzz2115 = std::move(_fuzz2115);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2116(std::vector<rr::components::AffixFuzzer16> fuzz2116) {
-                this->fuzz2116 = std::move(fuzz2116);
+            AffixFuzzer1& with_fuzz2116(std::vector<rr::components::AffixFuzzer16> _fuzz2116) {
+                fuzz2116 = std::move(_fuzz2116);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2117(std::vector<rr::components::AffixFuzzer17> fuzz2117) {
-                this->fuzz2117 = std::move(fuzz2117);
+            AffixFuzzer1& with_fuzz2117(std::vector<rr::components::AffixFuzzer17> _fuzz2117) {
+                fuzz2117 = std::move(_fuzz2117);
                 return *this;
             }
 
-            AffixFuzzer1& with_fuzz2118(std::vector<rr::components::AffixFuzzer18> fuzz2118) {
-                this->fuzz2118 = std::move(fuzz2118);
+            AffixFuzzer1& with_fuzz2118(std::vector<rr::components::AffixFuzzer18> _fuzz2118) {
+                fuzz2118 = std::move(_fuzz2118);
                 return *this;
             }
 

--- a/rerun_cpp/src/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/archetypes/arrows3d.hpp
@@ -51,34 +51,34 @@ namespace rr {
             ///
             /// The shaft is rendered as a line with `radius = 0.5 * radius`.
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
-            Arrows3D& with_radii(std::vector<rr::components::Radius> radii) {
-                this->radii = std::move(radii);
+            Arrows3D& with_radii(std::vector<rr::components::Radius> _radii) {
+                radii = std::move(_radii);
                 return *this;
             }
 
             /// Optional colors for the points.
-            Arrows3D& with_colors(std::vector<rr::components::Color> colors) {
-                this->colors = std::move(colors);
+            Arrows3D& with_colors(std::vector<rr::components::Color> _colors) {
+                colors = std::move(_colors);
                 return *this;
             }
 
             /// Optional text labels for the arrows.
-            Arrows3D& with_labels(std::vector<rr::components::Label> labels) {
-                this->labels = std::move(labels);
+            Arrows3D& with_labels(std::vector<rr::components::Label> _labels) {
+                labels = std::move(_labels);
                 return *this;
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Arrows3D& with_class_ids(std::vector<rr::components::ClassId> class_ids) {
-                this->class_ids = std::move(class_ids);
+            Arrows3D& with_class_ids(std::vector<rr::components::ClassId> _class_ids) {
+                class_ids = std::move(_class_ids);
                 return *this;
             }
 
             /// Unique identifiers for each individual point in the batch.
-            Arrows3D& with_instance_keys(std::vector<rr::components::InstanceKey> instance_keys) {
-                this->instance_keys = std::move(instance_keys);
+            Arrows3D& with_instance_keys(std::vector<rr::components::InstanceKey> _instance_keys) {
+                instance_keys = std::move(_instance_keys);
                 return *this;
             }
 

--- a/rerun_cpp/src/archetypes/points2d.hpp
+++ b/rerun_cpp/src/archetypes/points2d.hpp
@@ -62,20 +62,20 @@ namespace rr {
             Points2D(std::vector<rr::components::Point2D> points) : points(std::move(points)) {}
 
             /// Optional radii for the points, effectively turning them into circles.
-            Points2D& with_radii(std::vector<rr::components::Radius> radii) {
-                this->radii = std::move(radii);
+            Points2D& with_radii(std::vector<rr::components::Radius> _radii) {
+                radii = std::move(_radii);
                 return *this;
             }
 
             /// Optional colors for the points.
-            Points2D& with_colors(std::vector<rr::components::Color> colors) {
-                this->colors = std::move(colors);
+            Points2D& with_colors(std::vector<rr::components::Color> _colors) {
+                colors = std::move(_colors);
                 return *this;
             }
 
             /// Optional text labels for the points.
-            Points2D& with_labels(std::vector<rr::components::Label> labels) {
-                this->labels = std::move(labels);
+            Points2D& with_labels(std::vector<rr::components::Label> _labels) {
+                labels = std::move(_labels);
                 return *this;
             }
 
@@ -83,16 +83,16 @@ namespace rr {
             /// Objects with higher values are drawn on top of those with lower values.
             ///
             /// The default for 2D points is 30.0.
-            Points2D& with_draw_order(rr::components::DrawOrder draw_order) {
-                this->draw_order = std::move(draw_order);
+            Points2D& with_draw_order(rr::components::DrawOrder _draw_order) {
+                draw_order = std::move(_draw_order);
                 return *this;
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Points2D& with_class_ids(std::vector<rr::components::ClassId> class_ids) {
-                this->class_ids = std::move(class_ids);
+            Points2D& with_class_ids(std::vector<rr::components::ClassId> _class_ids) {
+                class_ids = std::move(_class_ids);
                 return *this;
             }
 
@@ -103,14 +103,14 @@ namespace rr {
             /// This is useful to identify points within a single classification (which is
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
-            Points2D& with_keypoint_ids(std::vector<rr::components::KeypointId> keypoint_ids) {
-                this->keypoint_ids = std::move(keypoint_ids);
+            Points2D& with_keypoint_ids(std::vector<rr::components::KeypointId> _keypoint_ids) {
+                keypoint_ids = std::move(_keypoint_ids);
                 return *this;
             }
 
             /// Unique identifiers for each individual point in the batch.
-            Points2D& with_instance_keys(std::vector<rr::components::InstanceKey> instance_keys) {
-                this->instance_keys = std::move(instance_keys);
+            Points2D& with_instance_keys(std::vector<rr::components::InstanceKey> _instance_keys) {
+                instance_keys = std::move(_instance_keys);
                 return *this;
             }
 

--- a/rerun_cpp/src/archetypes/points3d.hpp
+++ b/rerun_cpp/src/archetypes/points3d.hpp
@@ -55,28 +55,28 @@ namespace rr {
             Points3D(std::vector<rr::components::Point3D> points) : points(std::move(points)) {}
 
             /// Optional radii for the points, effectively turning them into circles.
-            Points3D& with_radii(std::vector<rr::components::Radius> radii) {
-                this->radii = std::move(radii);
+            Points3D& with_radii(std::vector<rr::components::Radius> _radii) {
+                radii = std::move(_radii);
                 return *this;
             }
 
             /// Optional colors for the points.
-            Points3D& with_colors(std::vector<rr::components::Color> colors) {
-                this->colors = std::move(colors);
+            Points3D& with_colors(std::vector<rr::components::Color> _colors) {
+                colors = std::move(_colors);
                 return *this;
             }
 
             /// Optional text labels for the points.
-            Points3D& with_labels(std::vector<rr::components::Label> labels) {
-                this->labels = std::move(labels);
+            Points3D& with_labels(std::vector<rr::components::Label> _labels) {
+                labels = std::move(_labels);
                 return *this;
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Points3D& with_class_ids(std::vector<rr::components::ClassId> class_ids) {
-                this->class_ids = std::move(class_ids);
+            Points3D& with_class_ids(std::vector<rr::components::ClassId> _class_ids) {
+                class_ids = std::move(_class_ids);
                 return *this;
             }
 
@@ -87,14 +87,14 @@ namespace rr {
             /// This is useful to identify points within a single classification (which is
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
-            Points3D& with_keypoint_ids(std::vector<rr::components::KeypointId> keypoint_ids) {
-                this->keypoint_ids = std::move(keypoint_ids);
+            Points3D& with_keypoint_ids(std::vector<rr::components::KeypointId> _keypoint_ids) {
+                keypoint_ids = std::move(_keypoint_ids);
                 return *this;
             }
 
             /// Unique identifiers for each individual point in the batch.
-            Points3D& with_instance_keys(std::vector<rr::components::InstanceKey> instance_keys) {
-                this->instance_keys = std::move(instance_keys);
+            Points3D& with_instance_keys(std::vector<rr::components::InstanceKey> _instance_keys) {
+                instance_keys = std::move(_instance_keys);
                 return *this;
             }
 

--- a/rerun_cpp/src/recording_stream.cpp
+++ b/rerun_cpp/src/recording_stream.cpp
@@ -42,14 +42,14 @@ namespace rr {
         switch (store_kind) {
             case StoreKind::Recording: {
                 static RecordingStream current_recording(
-                    RERUN_STORE_KIND_RECORDING,
+                    RERUN_REC_STREAM_CURRENT_RECORDING,
                     StoreKind::Recording
                 );
                 return current_recording;
             }
             case StoreKind::Blueprint: {
                 static RecordingStream current_blueprint(
-                    RERUN_STORE_KIND_BLUEPRINT,
+                    RERUN_REC_STREAM_CURRENT_BLUEPRINT,
                     StoreKind::Blueprint
                 );
                 return current_blueprint;
@@ -63,6 +63,10 @@ namespace rr {
 
     void RecordingStream::save(const char* path) {
         rr_recording_stream_save(_id, path);
+    }
+
+    void RecordingStream::flush_blocking() {
+        rr_recording_stream_flush_blocking(_id);
     }
 
     void RecordingStream::log_data_row(

--- a/rerun_cpp/src/recording_stream.cpp
+++ b/rerun_cpp/src/recording_stream.cpp
@@ -66,7 +66,7 @@ namespace rr {
     }
 
     void RecordingStream::log_data_row(
-        const char* entity_path, uint32_t num_instances, size_t num_data_cells,
+        const char* entity_path, size_t num_instances, size_t num_data_cells,
         const DataCell* data_cells
     ) {
         // Map to C API:
@@ -82,7 +82,7 @@ namespace rr {
 
         const rr_data_row c_data_row = {
             .entity_path = entity_path,
-            .num_instances = num_instances,
+            .num_instances = static_cast<uint32_t>(num_instances),
             .num_data_cells = static_cast<uint32_t>(num_data_cells),
             .data_cells = c_data_cells.data(),
         };

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -26,7 +26,7 @@ namespace rr {
     ///   thread originally sent them in, from its point of view.
     /// - There isn't any well defined global order across multiple threads.
     ///
-    /// This means that e.g. flushing the pipeline (`Self::flush_blocking`) guarantees that all
+    /// This means that e.g. flushing the pipeline (`flush_blocking`) guarantees that all
     /// previous data sent by the calling thread has been recorded; no more, no less.
     ///
     /// ## Shutdown
@@ -99,12 +99,17 @@ namespace rr {
         /// timeout, and can cause a call to `flush` to block indefinitely.
         ///
         /// This function returns immediately.
-        void connect(const char* tcp_addr, float flush_timeout_sec = 2.0);
+        void connect(const char* tcp_addr = "127.0.0.1:9876", float flush_timeout_sec = 2.0);
 
         /// Stream all log-data to a given file.
         ///
         /// This function returns immediately.
         void save(const char* path);
+
+        /// Initiates a flush the batching pipeline and waits for it to propagate.
+        ///
+        /// See `RecordingStream` docs for ordering semantics and multithreading guarantees.
+        void flush_blocking();
 
         // -----------------------------------------------------------------------------------------
         // Methods for logging.

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -6,6 +6,9 @@
 
 #include "data_cell.hpp"
 
+// TODO(#2873): Should avoid leaking arrow headers.
+#include <arrow/result.h>
+
 namespace rr {
     struct DataCell;
 
@@ -147,7 +150,7 @@ namespace rr {
         /// I.e. logs a number of components arrays (each with a same number of instances) to a
         /// single entity path.
         void log_data_row(
-            const char* entity_path, uint32_t num_instances, size_t num_data_cells,
+            const char* entity_path, size_t num_instances, size_t num_data_cells,
             const DataCell* data_cells
         );
 

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -9,24 +9,94 @@
 namespace rr {
     struct DataCell;
 
-    enum StoreKind {
+    enum class StoreKind {
         Recording,
         Blueprint,
     };
 
+    /// A `RecordingStream` handles everything related to logging data into Rerun.
+    ///
+    /// ## Multithreading and ordering
+    ///
+    /// Internally, all operations are linearized into a pipeline:
+    /// - All operations sent by a given thread will take effect in the same exact order as that
+    ///   thread originally sent them in, from its point of view.
+    /// - There isn't any well defined global order across multiple threads.
+    ///
+    /// This means that e.g. flushing the pipeline (`Self::flush_blocking`) guarantees that all
+    /// previous data sent by the calling thread has been recorded; no more, no less.
+    ///
+    /// ## Shutdown
+    ///
+    /// The `RecordingStream` can only be shutdown by dropping all instances of it, at which point
+    /// it will automatically take care of flushing any pending data that might remain in the
+    /// pipeline.
+    ///
+    /// TODO(andreas): The only way of having two instances of a `RecordingStream` is currently to
+    /// set it as a the global.
+    ///
+    /// Shutting down cannot ever block.
     class RecordingStream {
       public:
-        RecordingStream(
-            const char* app_id, const char* addr, StoreKind store_kind = StoreKind::Recording
-        );
+        /// Creates a new recording stream to log to.
+        /// @param app_id The user-chosen name of the application doing the logging.
+        RecordingStream(const char* app_id, StoreKind store_kind = StoreKind::Recording);
         ~RecordingStream();
 
-        /// Must be called first, if at all.
-        static void init_global(const char* app_id, const char* addr);
+        // TODO(andreas): We could easily make the recording stream trivial to copy by bumping Rusts
+        // ref counter by adding a copy of the recording stream to the list of C recording streams.
+        // Doing it this way would likely yield the most consistent behavior when interacting with
+        // global streams (and especially when interacting with different languages in the same
+        // application).
+        RecordingStream(const RecordingStream&) = delete;
+        RecordingStream(RecordingStream&&) = delete;
 
-        /// Access the global recording stream.
-        /// Aborts if `init_global` has not yet been called.
-        static RecordingStream global();
+        // -----------------------------------------------------------------------------------------
+        // Controlling globally available instances of RecordingStream.
+
+        /// Replaces the currently active recording for this stream's store kind in the global scope
+        /// with this one.
+        ///
+        /// Afterwards, destroying this recording stream will *not* change the global recording
+        /// stream, as it increases an internal ref-count.
+        void set_global();
+
+        /// Replaces the currently active recording for this stream's store kind in the thread-local
+        /// scope with this one
+        ///
+        /// Afterwards, destroying this recording stream will *not* change the thread local
+        /// recording stream, as it increases an internal ref-count.
+        void set_thread_local();
+
+        /// Retrieves the most appropriate globally available recording stream for the given kind.
+        ///
+        /// I.e. thread-local first, then global.
+        /// If neither was set, any operations on the returned stream will be no-ops.
+        static RecordingStream& current(StoreKind store_kind = StoreKind::Recording);
+
+        // -----------------------------------------------------------------------------------------
+        // Directing the recording stream. Either of these needs to be called, otherwise the stream
+        // will buffer up indefinitely.
+
+        /// Connect to a remote Rerun Viewer on the given ip:port.
+        ///
+        /// Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.
+        ///
+        /// flush_timeout_sec:
+        /// The minimum time the SDK will wait during a flush before potentially
+        /// dropping data if progress is not being made. Passing a negative value indicates no
+        /// timeout, and can cause a call to `flush` to block indefinitely.
+        ///
+        /// This function returns immediately.
+        void connect(const char* tcp_addr, float flush_timeout_sec = 2.0);
+
+        /// Stream all log-data to a given file.
+        ///
+        /// This function returns immediately.
+        void save(const char* path);
+
+        // -----------------------------------------------------------------------------------------
+        // Methods for logging.
 
         /// Logs an archetype.
         ///
@@ -121,12 +191,9 @@ namespace rr {
 
         static void push_data_cells(std::vector<DataCell>& data_cells) {}
 
-        RecordingStream() : _id{0} {}
-
-        RecordingStream(uint32_t id) : _id{id} {}
+        RecordingStream(uint32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
 
         uint32_t _id;
-
-        static RecordingStream s_global;
+        StoreKind _store_kind;
     };
 } // namespace rr

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -28,6 +28,7 @@ namespace rr {
     ///
     /// This means that e.g. flushing the pipeline (`flush_blocking`) guarantees that all
     /// previous data sent by the calling thread has been recorded; no more, no less.
+    /// (e.g. it does not mean that all file caches are flushed)
     ///
     /// ## Shutdown
     ///

--- a/rerun_cpp/src/recording_stream.hpp
+++ b/rerun_cpp/src/recording_stream.hpp
@@ -50,6 +50,14 @@ namespace rr {
         // application).
         RecordingStream(const RecordingStream&) = delete;
         RecordingStream(RecordingStream&&) = delete;
+        RecordingStream() = delete;
+
+        // -----------------------------------------------------------------------------------------
+        // Properties
+
+        StoreKind kind() const {
+            return _store_kind;
+        }
 
         // -----------------------------------------------------------------------------------------
         // Controlling globally available instances of RecordingStream.
@@ -145,17 +153,17 @@ namespace rr {
 
       private:
         template <typename C, typename... Ts>
-        static size_t size_of_first_collection(const std::vector<C>& first, const Ts&... ts) {
+        static size_t size_of_first_collection(const std::vector<C>& first, const Ts&...) {
             return first.size();
         }
 
         template <size_t N, typename C, typename... Ts>
-        static size_t size_of_first_collection(const std::array<C, N>& first, const Ts&... ts) {
+        static size_t size_of_first_collection(const std::array<C, N>& first, const Ts&...) {
             return first.size();
         }
 
         template <size_t N, typename C, typename... Ts>
-        static size_t size_of_first_collection(const C (&first)[N], const Ts&... ts) {
+        static size_t size_of_first_collection(const C (&)[N], const Ts&...) {
             return N;
         }
 
@@ -189,7 +197,7 @@ namespace rr {
             push_data_cells(data_cells, rest...);
         }
 
-        static void push_data_cells(std::vector<DataCell>& data_cells) {}
+        static void push_data_cells(std::vector<DataCell>&) {}
 
         RecordingStream(uint32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
 

--- a/rerun_cpp/tests/CMakeLists.txt
+++ b/rerun_cpp/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 # Catch2:
 Include(FetchContent)

--- a/rerun_cpp/tests/CMakeLists.txt
+++ b/rerun_cpp/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Catch2:
+Include(FetchContent)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+# Test application:
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+file(GLOB_RECURSE rerun_sdk_tests_SRC CONFIGURE_DEPENDS
+    "*.hpp"
+    "*.cpp"
+)
+add_executable(rerun_sdk_tests ${rerun_sdk_tests_SRC})
+
+set_default_warning_settings(rerun_sdk_tests)
+
+target_link_libraries(rerun_sdk_tests PRIVATE Catch2::Catch2WithMain rerun_sdk)

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -1,0 +1,37 @@
+#include <catch2/catch_test_macros.hpp>
+#include <recording_stream.hpp> // TODO(andreas): These should be namespaced `rerun/recording_stream.hpp`
+
+#include <array>
+
+#define TEST_TAG "[recording_stream]"
+
+namespace rr {
+    std::ostream& operator<<(std::ostream& os, StoreKind kind) {
+        switch (kind) {
+            case rr::StoreKind::Recording:
+                os << "StoreKind::Recording";
+                break;
+            case rr::StoreKind::Blueprint:
+                os << "StoreKind::Blueprint";
+                break;
+            default:
+                FAIL("Unknown StoreKind");
+                break;
+        }
+        return os;
+    }
+} // namespace rr
+
+SCENARIO("RecordingStream can be created, destroyed and lists correct properties", TEST_TAG) {
+    for (auto kind : std::array{rr::StoreKind::Recording, rr::StoreKind::Blueprint}) {
+        GIVEN("a new RecordingStream of kind " << kind) {
+            rr::RecordingStream stream("test", kind);
+
+            THEN("it does not crash on destruction") {}
+
+            THEN("it reports the correct kind") {
+                CHECK(stream.kind() == kind);
+            }
+        }
+    }
+}

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -62,7 +62,7 @@ SCENARIO("RecordingStream can be set as global and thread local", TEST_TAG) {
                 THEN("it can be set as global") {
                     stream.set_global();
                 }
-                // TODO(#TODO:): Setting thread locals causes a crash on shutdown on macOS.
+                // TODO(#2889): Setting thread locals causes a crash on shutdown on macOS.
 #ifndef __APPLE__
                 THEN("it can be set as thread local") {
                     stream.set_thread_local();
@@ -157,6 +157,11 @@ void test_logging_to_file(const char* test_rrd, rr::RecordingStream& stream) {
         }
 
         // The file already has some header from the start.
+        //
+        // ATTENTION:
+        // Particularly on MacOS file size checks like this are often unreliable as they tend to not
+        // read the latest state on the file. I have not observed any failure yet, but if this test
+        // ever gets flaky, this is the first place to look.
         auto file_size_before = fs::file_size(test_rrd);
 
         WHEN("logging a component and then flushing") {

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -1,7 +1,13 @@
 #include <catch2/catch_test_macros.hpp>
-#include <recording_stream.hpp> // TODO(andreas): These should be namespaced `rerun/recording_stream.hpp`
+
+// TODO(andreas): These should be namespaced `rerun/recording_stream.hpp`
+#include <archetypes/points2d.hpp>
+#include <components/point2d.hpp>
+#include <datatypes/point2d.hpp>
+#include <recording_stream.hpp>
 
 #include <array>
+#include <vector>
 
 #define TEST_TAG "[recording_stream]"
 
@@ -24,7 +30,7 @@ namespace rr {
 
 SCENARIO("RecordingStream can be created, destroyed and lists correct properties", TEST_TAG) {
     for (auto kind : std::array{rr::StoreKind::Recording, rr::StoreKind::Blueprint}) {
-        GIVEN("a new RecordingStream of kind " << kind) {
+        GIVEN("a new RecordingStream of kind" << kind) {
             rr::RecordingStream stream("test", kind);
 
             THEN("it does not crash on destruction") {}
@@ -35,3 +41,104 @@ SCENARIO("RecordingStream can be created, destroyed and lists correct properties
         }
     }
 }
+
+SCENARIO("RecordingStream can be set as global and thread local", TEST_TAG) {
+    for (auto kind : std::array{rr::StoreKind::Recording, rr::StoreKind::Blueprint}) {
+        GIVEN("a store kind" << kind) {
+            WHEN("querying the current one") {
+                auto& stream = rr::RecordingStream::current(kind);
+
+                THEN("it reports the correct kind") {
+                    CHECK(stream.kind() == kind);
+                }
+            }
+
+            WHEN("creating a new stream") {
+                rr::RecordingStream stream("test", kind);
+
+                THEN("it can be set as global") {
+                    stream.set_global();
+                }
+                THEN("it can be set as thread local") {
+                    stream.set_thread_local();
+                }
+
+                // TODO(andreas): There's no way of telling right now if the set stream is
+                // functional.
+            }
+        }
+    }
+}
+
+SCENARIO("RecordingStream can be used for logging archetypes and components", TEST_TAG) {
+    for (auto kind : std::array{rr::StoreKind::Recording, rr::StoreKind::Blueprint}) {
+        GIVEN("a store kind" << kind) {
+            WHEN("creating a new stream") {
+                rr::RecordingStream stream("test", kind);
+
+                THEN("components as c-array can be logged") {
+                    rr::components::Point2D c_style_array[2] = {
+                        rr::datatypes::Point2D{1.0, 2.0},
+                        rr::datatypes::Point2D{4.0, 5.0},
+                    };
+
+                    stream.log_components("as-carray", c_style_array);
+                }
+                THEN("components as std::array can be logged") {
+                    stream.log_components(
+                        "as-array",
+                        std::array<rr::components::Point2D, 2>{
+                            rr::datatypes::Point2D{1.0, 2.0},
+                            rr::datatypes::Point2D{4.0, 5.0},
+                        }
+                    );
+                }
+                THEN("components as std::vector can be logged") {
+                    stream.log_components(
+                        "as-vector",
+                        std::vector<rr::components::Point2D>{
+                            rr::datatypes::Point2D{1.0, 2.0},
+                            rr::datatypes::Point2D{4.0, 5.0},
+                        }
+                    );
+                }
+                THEN("several components with a mix of vector, array and c-array can be logged") {
+                    rr::components::Label c_style_array[3] = {
+                        rr::components::Label("hello"),
+                        rr::components::Label("friend"),
+                        rr::components::Label("yo"),
+                    };
+                    stream.log_components(
+                        "as-mix",
+                        std::vector{
+                            rr::components::Point2D(rr::datatypes::Point2D{0.0, 0.0}),
+                            rr::components::Point2D(rr::datatypes::Point2D{1.0, 3.0}),
+                            rr::components::Point2D(rr::datatypes::Point2D{5.0, 5.0}),
+                        },
+                        std::array{
+                            rr::components::Color(0xFF0000FF),
+                            rr::components::Color(0x00FF00FF),
+                            rr::components::Color(0x0000FFFF),
+                        },
+                        c_style_array
+                    );
+                }
+
+                THEN("an archetype can be logged") {
+                    stream.log_archetype(
+                        "3d/points",
+                        rr::archetypes::Points2D({
+                            rr::datatypes::Point2D{1.0, 2.0},
+                            rr::datatypes::Point2D{4.0, 5.0},
+                        })
+                    );
+                }
+
+                // TODO(andreas): There's no way of telling right now if the set stream is
+                // functional and where those messages went.
+            }
+        }
+    }
+}
+
+// TODO: save and connect

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -3,7 +3,7 @@
 // TODO(andreas): These should be namespaced `rerun/recording_stream.hpp`
 #include <archetypes/points2d.hpp>
 #include <components/point2d.hpp>
-#include <datatypes/point2d.hpp>
+#include <datatypes/vec2d.hpp>
 #include <recording_stream.hpp>
 
 #include <array>
@@ -84,8 +84,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
 
                 THEN("components as c-array can be logged") {
                     rr::components::Point2D c_style_array[2] = {
-                        rr::datatypes::Point2D{1.0, 2.0},
-                        rr::datatypes::Point2D{4.0, 5.0},
+                        rr::datatypes::Vec2D{1.0, 2.0},
+                        rr::datatypes::Vec2D{4.0, 5.0},
                     };
 
                     stream.log_components("as-carray", c_style_array);
@@ -94,8 +94,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     stream.log_components(
                         "as-array",
                         std::array<rr::components::Point2D, 2>{
-                            rr::datatypes::Point2D{1.0, 2.0},
-                            rr::datatypes::Point2D{4.0, 5.0},
+                            rr::datatypes::Vec2D{1.0, 2.0},
+                            rr::datatypes::Vec2D{4.0, 5.0},
                         }
                     );
                 }
@@ -103,8 +103,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     stream.log_components(
                         "as-vector",
                         std::vector<rr::components::Point2D>{
-                            rr::datatypes::Point2D{1.0, 2.0},
-                            rr::datatypes::Point2D{4.0, 5.0},
+                            rr::datatypes::Vec2D{1.0, 2.0},
+                            rr::datatypes::Vec2D{4.0, 5.0},
                         }
                     );
                 }
@@ -117,9 +117,9 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     stream.log_components(
                         "as-mix",
                         std::vector{
-                            rr::components::Point2D(rr::datatypes::Point2D{0.0, 0.0}),
-                            rr::components::Point2D(rr::datatypes::Point2D{1.0, 3.0}),
-                            rr::components::Point2D(rr::datatypes::Point2D{5.0, 5.0}),
+                            rr::components::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
+                            rr::components::Point2D(rr::datatypes::Vec2D{1.0, 3.0}),
+                            rr::components::Point2D(rr::datatypes::Vec2D{5.0, 5.0}),
                         },
                         std::array{
                             rr::components::Color(0xFF0000FF),
@@ -134,8 +134,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     stream.log_archetype(
                         "archetype",
                         rr::archetypes::Points2D({
-                            rr::datatypes::Point2D{1.0, 2.0},
-                            rr::datatypes::Point2D{4.0, 5.0},
+                            rr::datatypes::Vec2D{1.0, 2.0},
+                            rr::datatypes::Vec2D{4.0, 5.0},
                         })
                     );
                 }
@@ -176,8 +176,8 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
                         stream1->log_components(
                             "as-array",
                             std::array<rr::components::Point2D, 2>{
-                                rr::datatypes::Point2D{1.0, 2.0},
-                                rr::datatypes::Point2D{4.0, 5.0},
+                                rr::datatypes::Vec2D{1.0, 2.0},
+                                rr::datatypes::Vec2D{4.0, 5.0},
                             }
                         );
 
@@ -191,8 +191,8 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
                         stream1->log_archetype(
                             "archetype",
                             rr::archetypes::Points2D({
-                                rr::datatypes::Point2D{1.0, 2.0},
-                                rr::datatypes::Point2D{4.0, 5.0},
+                                rr::datatypes::Vec2D{1.0, 2.0},
+                                rr::datatypes::Vec2D{4.0, 5.0},
                             })
                         );
 
@@ -217,8 +217,8 @@ void test_logging_to_connection(const char* address, rr::RecordingStream& stream
             stream.log_components(
                 "as-array",
                 std::array<rr::components::Point2D, 2>{
-                    rr::datatypes::Point2D{1.0, 2.0},
-                    rr::datatypes::Point2D{4.0, 5.0},
+                    rr::datatypes::Vec2D{1.0, 2.0},
+                    rr::datatypes::Vec2D{4.0, 5.0},
                 }
             );
             stream.flush_blocking();
@@ -231,8 +231,8 @@ void test_logging_to_connection(const char* address, rr::RecordingStream& stream
             stream.log_archetype(
                 "archetype",
                 rr::archetypes::Points2D({
-                    rr::datatypes::Point2D{1.0, 2.0},
-                    rr::datatypes::Point2D{4.0, 5.0},
+                    rr::datatypes::Vec2D{1.0, 2.0},
+                    rr::datatypes::Vec2D{4.0, 5.0},
                 })
             );
 


### PR DESCRIPTION
* Part of #2516
(SDK! Not codegen! :))
* Next in the cpp series after #2874

### What

Adds a test dependency to the [Catch2](https://github.com/catchorg/Catch2/) testing framework in order to start testing all the new RecordingStream features added here.

C++ tests can be conveniently run via `./rerun_cpp/build_and_run_tests.sh` now!

For quick api overview start with the `rerun.h` and `recording_stream.h` headers.

Fixes a range of compiler warnings as a consequence of improving some of the CMake setup, more to do there!
Adds lots more documentation to RecordingStream as well.


Next steps:
* Add C++ to ci (linting, running this test suite)
* Add roundtrip tests
*  Add codegen custom code injection
    * Improve API usability in varous places, including 
* https://github.com/rerun-io/rerun/issues/2873
* add other tests
* serialize unions
* serialize datatypes nested in unions, structs and lists
* more testing & roundtripping

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2890) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2890)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp-api%2Fbetter-recording-stream/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp-api%2Fbetter-recording-stream/examples)