### PR TITLE
Improved automatic `From` impl in Rust codegen backend

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-91625ffc9f7dd938c9bdc752b637fd56c7cf5a57de61acf21236c26196713b0d
+9c85d8d5bb14eb2bcd395288b6b8acd35592d318644ccff7b3765010066c2ad7

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -16,9 +16,9 @@
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Point2D(pub crate::datatypes::Point2D);
 
-impl From<crate::datatypes::Point2D> for Point2D {
-    fn from(v: crate::datatypes::Point2D) -> Self {
-        Self(v)
+impl<T: Into<crate::datatypes::Point2D>> From<T> for Point2D {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -16,9 +16,9 @@
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd)]
 pub struct Point3D(pub crate::datatypes::Point3D);
 
-impl From<crate::datatypes::Point3D> for Point3D {
-    fn from(v: crate::datatypes::Point3D) -> Self {
-        Self(v)
+impl<T: Into<crate::datatypes::Point3D>> From<T> for Point3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 

--- a/crates/re_types/src/components/point3d_ext.rs
+++ b/crates/re_types/src/components/point3d_ext.rs
@@ -42,14 +42,6 @@ impl From<[f32; 3]> for Point3D {
 }
 
 #[cfg(feature = "glam")]
-impl From<glam::Vec3> for Point3D {
-    #[inline]
-    fn from(pt: glam::Vec3) -> Self {
-        Self::new(pt.x, pt.y, pt.z)
-    }
-}
-
-#[cfg(feature = "glam")]
 impl From<Point3D> for glam::Vec3 {
     #[inline]
     fn from(pt: Point3D) -> Self {

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -19,9 +19,9 @@ pub struct Transform3D(
     pub crate::datatypes::Transform3D,
 );
 
-impl From<crate::datatypes::Transform3D> for Transform3D {
-    fn from(v: crate::datatypes::Transform3D) -> Self {
-        Self(v)
+impl<T: Into<crate::datatypes::Transform3D>> From<T> for Transform3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 

--- a/crates/re_types/src/components/transform3d_ext.rs
+++ b/crates/re_types/src/components/transform3d_ext.rs
@@ -1,9 +1,6 @@
 use super::Transform3D;
 
-use crate::datatypes::{
-    RotationAxisAngle, Transform3D as Transform3DRepr, TranslationAndMat3x3,
-    TranslationRotationScale3D,
-};
+use crate::datatypes::Transform3D as Transform3DRepr;
 
 impl Transform3D {
     /// Identity transform, i.e. parent & child are in the same space.
@@ -35,23 +32,5 @@ impl Transform3D {
         } else {
             transform.inverse()
         }
-    }
-}
-
-impl From<RotationAxisAngle> for Transform3D {
-    fn from(value: RotationAxisAngle) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<TranslationRotationScale3D> for Transform3D {
-    fn from(value: TranslationRotationScale3D) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<TranslationAndMat3x3> for Transform3D {
-    fn from(value: TranslationAndMat3x3) -> Self {
-        Self(value.into())
     }
 }

--- a/crates/re_types/src/datatypes/point2d_ext.rs
+++ b/crates/re_types/src/datatypes/point2d_ext.rs
@@ -12,28 +12,6 @@ impl Point2D {
     }
 }
 
-impl From<(f32, f32)> for Point2D {
-    #[inline]
-    fn from((x, y): (f32, f32)) -> Self {
-        Self { x, y }
-    }
-}
-
-impl From<[f32; 2]> for Point2D {
-    #[inline]
-    fn from([x, y]: [f32; 2]) -> Self {
-        Self { x, y }
-    }
-}
-
-#[cfg(feature = "glam")]
-impl From<glam::Vec2> for Point2D {
-    #[inline]
-    fn from(pt: glam::Vec2) -> Self {
-        Self::new(pt.x, pt.y)
-    }
-}
-
 #[cfg(feature = "glam")]
 impl From<Point2D> for glam::Vec2 {
     #[inline]

--- a/crates/re_types/src/datatypes/point3d_ext.rs
+++ b/crates/re_types/src/datatypes/point3d_ext.rs
@@ -12,20 +12,6 @@ impl Point3D {
     }
 }
 
-impl From<(f32, f32, f32)> for Point3D {
-    #[inline]
-    fn from((x, y, z): (f32, f32, f32)) -> Self {
-        Self { x, y, z }
-    }
-}
-
-impl From<[f32; 3]> for Point3D {
-    #[inline]
-    fn from([x, y, z]: [f32; 3]) -> Self {
-        Self { x, y, z }
-    }
-}
-
 #[cfg(feature = "glam")]
 impl From<glam::Vec3> for Point3D {
     #[inline]

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -15,9 +15,9 @@
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer1(pub crate::testing::datatypes::AffixFuzzer1);
 
-impl From<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer1 {
-    fn from(v: crate::testing::datatypes::AffixFuzzer1) -> Self {
-        Self(v)
+impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer1 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -209,9 +209,9 @@ impl crate::Component for AffixFuzzer1 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer2(pub crate::testing::datatypes::AffixFuzzer1);
 
-impl From<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer2 {
-    fn from(v: crate::testing::datatypes::AffixFuzzer1) -> Self {
-        Self(v)
+impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer2 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -403,9 +403,9 @@ impl crate::Component for AffixFuzzer2 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer3(pub crate::testing::datatypes::AffixFuzzer1);
 
-impl From<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer3 {
-    fn from(v: crate::testing::datatypes::AffixFuzzer1) -> Self {
-        Self(v)
+impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer3 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -597,9 +597,9 @@ impl crate::Component for AffixFuzzer3 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer4(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
-impl From<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer4 {
-    fn from(v: Option<crate::testing::datatypes::AffixFuzzer1>) -> Self {
-        Self(v)
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer4 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -789,9 +789,9 @@ impl crate::Component for AffixFuzzer4 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer5(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
-impl From<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer5 {
-    fn from(v: Option<crate::testing::datatypes::AffixFuzzer1>) -> Self {
-        Self(v)
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer5 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -981,9 +981,9 @@ impl crate::Component for AffixFuzzer5 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer6(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
-impl From<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer6 {
-    fn from(v: Option<crate::testing::datatypes::AffixFuzzer1>) -> Self {
-        Self(v)
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer6 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -1173,9 +1173,9 @@ impl crate::Component for AffixFuzzer6 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer7(pub Option<Vec<crate::testing::datatypes::AffixFuzzer1>>);
 
-impl From<Option<Vec<crate::testing::datatypes::AffixFuzzer1>>> for AffixFuzzer7 {
-    fn from(v: Option<Vec<crate::testing::datatypes::AffixFuzzer1>>) -> Self {
-        Self(v)
+impl<T: Into<Option<Vec<crate::testing::datatypes::AffixFuzzer1>>>> From<T> for AffixFuzzer7 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -2433,9 +2433,9 @@ impl crate::Component for AffixFuzzer13 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer14(pub crate::testing::datatypes::AffixFuzzer3);
 
-impl From<crate::testing::datatypes::AffixFuzzer3> for AffixFuzzer14 {
-    fn from(v: crate::testing::datatypes::AffixFuzzer3) -> Self {
-        Self(v)
+impl<T: Into<crate::testing::datatypes::AffixFuzzer3>> From<T> for AffixFuzzer14 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -2605,9 +2605,9 @@ impl crate::Component for AffixFuzzer14 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer15(pub Option<crate::testing::datatypes::AffixFuzzer3>);
 
-impl From<Option<crate::testing::datatypes::AffixFuzzer3>> for AffixFuzzer15 {
-    fn from(v: Option<crate::testing::datatypes::AffixFuzzer3>) -> Self {
-        Self(v)
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer3>>> From<T> for AffixFuzzer15 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -2775,9 +2775,9 @@ impl crate::Component for AffixFuzzer15 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer16(pub Vec<crate::testing::datatypes::AffixFuzzer3>);
 
-impl From<Vec<crate::testing::datatypes::AffixFuzzer3>> for AffixFuzzer16 {
-    fn from(v: Vec<crate::testing::datatypes::AffixFuzzer3>) -> Self {
-        Self(v)
+impl<T: Into<Vec<crate::testing::datatypes::AffixFuzzer3>>> From<T> for AffixFuzzer16 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -2984,9 +2984,9 @@ impl crate::Component for AffixFuzzer16 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer17(pub Option<Vec<crate::testing::datatypes::AffixFuzzer3>>);
 
-impl From<Option<Vec<crate::testing::datatypes::AffixFuzzer3>>> for AffixFuzzer17 {
-    fn from(v: Option<Vec<crate::testing::datatypes::AffixFuzzer3>>) -> Self {
-        Self(v)
+impl<T: Into<Option<Vec<crate::testing::datatypes::AffixFuzzer3>>>> From<T> for AffixFuzzer17 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -3191,9 +3191,9 @@ impl crate::Component for AffixFuzzer17 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer18(pub Option<Vec<crate::testing::datatypes::AffixFuzzer4>>);
 
-impl From<Option<Vec<crate::testing::datatypes::AffixFuzzer4>>> for AffixFuzzer18 {
-    fn from(v: Option<Vec<crate::testing::datatypes::AffixFuzzer4>>) -> Self {
-        Self(v)
+impl<T: Into<Option<Vec<crate::testing::datatypes::AffixFuzzer4>>>> From<T> for AffixFuzzer18 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 
@@ -3398,9 +3398,9 @@ impl crate::Component for AffixFuzzer18 {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct AffixFuzzer19(pub crate::testing::datatypes::AffixFuzzer5);
 
-impl From<crate::testing::datatypes::AffixFuzzer5> for AffixFuzzer19 {
-    fn from(v: crate::testing::datatypes::AffixFuzzer5) -> Self {
-        Self(v)
+impl<T: Into<crate::testing::datatypes::AffixFuzzer5>> From<T> for AffixFuzzer19 {
+    fn from(v: T) -> Self {
+        Self(v.into())
     }
 }
 

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -1761,10 +1761,10 @@ pub struct AffixFuzzer5 {
     pub single_optional_union: Option<crate::testing::datatypes::AffixFuzzer4>,
 }
 
-impl From<Option<crate::testing::datatypes::AffixFuzzer4>> for AffixFuzzer5 {
-    fn from(v: Option<crate::testing::datatypes::AffixFuzzer4>) -> Self {
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer4>>> From<T> for AffixFuzzer5 {
+    fn from(v: T) -> Self {
         Self {
-            single_optional_union: v,
+            single_optional_union: v.into(),
         }
     }
 }

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -1091,15 +1091,15 @@ fn quote_from_impl_from_obj(obj: &Object) -> TokenStream {
 
         let obj_is_tuple_struct = is_tuple_struct_from_obj(obj);
         let quoted_binding = if obj_is_tuple_struct {
-            quote!(Self(v))
+            quote!(Self(v.into()))
         } else {
             let quoted_obj_field_name = format_ident!("{}", obj_field.name);
-            quote!(Self { #quoted_obj_field_name: v })
+            quote!(Self { #quoted_obj_field_name: v.into() })
         };
 
         quote! {
-            impl From<#quoted_type> for #quoted_obj_name {
-                fn from(v: #quoted_type) -> Self {
+            impl<T: Into<#quoted_type>> From<T> for #quoted_obj_name {
+                fn from(v: T) -> Self {
                     #quoted_binding
                 }
             }


### PR DESCRIPTION
That diff says it all:
```diff
@@ -1091,15 +1091,15 @@ fn quote_from_impl_from_obj(obj: &Object) -> TokenStream {
 
         let obj_is_tuple_struct = is_tuple_struct_from_obj(obj);
         let quoted_binding = if obj_is_tuple_struct {
-            quote!(Self(v))
+            quote!(Self(v.into()))
         } else {
             let quoted_obj_field_name = format_ident!("{}", obj_field.name);
-            quote!(Self { #quoted_obj_field_name: v })
+            quote!(Self { #quoted_obj_field_name: v.into() })
         };
 
         quote! {
-            impl From<#quoted_type> for #quoted_obj_name {
-                fn from(v: #quoted_type) -> Self {
+            impl<T: Into<#quoted_type>> From<T> for #quoted_obj_name {
+                fn from(v: T) -> Self {
                     #quoted_binding
                 }
             }
```

This makes our lives way easier for the upcoming #2884-related work.

Pre-requisite for #2884

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2891) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2891)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fbetter_auto_from/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fbetter_auto_from/examples)