### PR TITLE
Handle older numpy versions / py 3.8 in `VecND` extensions

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-f9b62fa42033e50d6c8dabe6e409d00661f630890737d0797530d3ddc20e2750
+6d3e21e632db5eed8731cbba82f129f6ae4e7a3807c7c856f0670e94e13938a4

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/arrow3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/arrow3d.py
@@ -18,11 +18,11 @@ def arrow3d_native_to_pa_array(data: Arrow3DArrayLike, data_type: pa.DataType) -
     # TODO(ab): not quite sure why i must unwrap `xyz` or face a cryptic error otherwise.
 
     if isinstance(data, Arrow3D):
-        origins = rrd.Vec3DArray.from_similar(data.origin.xyz).storage
-        vectors = rrd.Vec3DArray.from_similar(data.vector.xyz).storage
+        origins = rrd.Vec3DArray.from_similar(data.origin).storage
+        vectors = rrd.Vec3DArray.from_similar(data.vector).storage
     else:
-        origins = rrd.Vec3DArray.from_similar([d.origin.xyz for d in data]).storage
-        vectors = rrd.Vec3DArray.from_similar([d.vector.xyz for d in data]).storage
+        origins = rrd.Vec3DArray.from_similar([d.origin for d in data]).storage
+        vectors = rrd.Vec3DArray.from_similar([d.vector for d in data]).storage
 
     return pa.StructArray.from_arrays(
         arrays=[origins, vectors],

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/vecxd.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/vecxd.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 import pyarrow as pa
@@ -9,16 +9,46 @@ if TYPE_CHECKING:
     from .. import Vec2DArrayLike, Vec3DArrayLike, Vec4DArrayLike
 
 
+NUMPY_VERSION = tuple(map(int, np.version.version.split(".")[:2]))
+
+
 def vec2d_native_to_pa_array(data: Vec2DArrayLike, data_type: pa.DataType) -> pa.Array:
+    # TODO(ab): get rid of this once we drop support for Python 3.8. Make sure to pin numpy>=1.25.
+    if NUMPY_VERSION < (1, 25):
+        # Older numpy doesn't seem to support `data` in the form of [Point3D(1, 2), Point3D(3, 4)]
+        # this happens for python 3.8 (1.25 supports 3.9+)
+        from .. import Vec2D
+
+        if isinstance(data, Sequence):
+            data = [np.array(p.xy) if isinstance(p, Vec2D) else p for p in data]  # type: ignore[assignment]
+
     points = np.asarray(data, dtype=np.float32).reshape((-1,))
     return pa.FixedSizeListArray.from_arrays(points, type=data_type)
 
 
 def vec3d_native_to_pa_array(data: Vec3DArrayLike, data_type: pa.DataType) -> pa.Array:
+    # TODO(ab): get rid of this once we drop support for Python 3.8. Make sure to pin numpy>=1.25.
+    if NUMPY_VERSION < (1, 25):
+        # Older numpy doesn't seem to support `data` in the form of [Point3D(1, 2), Point3D(3, 4)]
+        # this happens for python 3.8 (1.25 supports 3.9+)
+        from .. import Vec3D
+
+        if isinstance(data, Sequence):
+            data = [np.array(p.xyz) if isinstance(p, Vec3D) else p for p in data]  # type: ignore[assignment]
+
     points = np.asarray(data, dtype=np.float32).reshape((-1,))
     return pa.FixedSizeListArray.from_arrays(points, type=data_type)
 
 
 def vec4d_native_to_pa_array(data: Vec4DArrayLike, data_type: pa.DataType) -> pa.Array:
+    # TODO(ab): get rid of this once we drop support for Python 3.8. Make sure to pin numpy>=1.25.
+    if NUMPY_VERSION < (1, 25):
+        # Older numpy doesn't seem to support `data` in the form of [Point3D(1, 2), Point3D(3, 4)]
+        # this happens for python 3.8 (1.25 supports 3.9+)
+        from .. import Vec4D
+
+        if isinstance(data, Sequence):
+            data = [np.array(p.xyzw) if isinstance(p, Vec4D) else p for p in data]  # type: ignore[assignment]
+
     points = np.asarray(data, dtype=np.float32).reshape((-1,))
     return pa.FixedSizeListArray.from_arrays(points, type=data_type)


### PR DESCRIPTION
What the title says.

This is what prevented us from doing the logical thing in `Arrow3D` extensions (and became even more of an issue after I made the `PointND` components use `VecND` internally in #2894).

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2896) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2896)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Ffix_vecnd_vs_numpy/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Ffix_vecnd_vs_numpy/examples)