### PR TITLE
C++ roundtrip test setup, implement for points3d/arrow3d/disconnected_space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,16 @@ function(set_default_warning_settings target)
     # set_property(TARGET ${target} PROPERTY COMPILE_WARNING_AS_ERROR ON)
 endfunction()
 
+# Use makefils on linux, otherwise it might use Ninja which isn't installed by default.
 if(NOT DEFINED CMAKE_GENERATOR AND UNIX)
     set(CMAKE_GENERATOR "Unix Makefiles")
 endif()
 
+# Arrow requires a C++17 compliant compiler.
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 add_subdirectory(rerun_cpp) # The Rerun C++ SDK library
 add_subdirectory(examples/cpp/minimal)
+add_subdirectory(tests/cpp)

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -9,10 +9,6 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-if(NOT DEFINED CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 add_executable(rerun_example main.cpp)
 
 # TODO(andreas): Fix warnings and enable this.

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -15,10 +15,8 @@ int main(int argc, char** argv) {
 
     rr_stream.log_archetype(
         "3d/points",
-        rr::archetypes::Points3D({
-                                     rr::datatypes::Vec3D{1.0, 2.0, 3.0},
-                                     rr::datatypes::Vec3D{4.0, 5.0, 6.0},
-                                 })
+        rr::archetypes::Points3D({rr::datatypes::Vec3D{1.0, 2.0, 3.0},
+                                  rr::datatypes::Vec3D{4.0, 5.0, 6.0}})
             .with_radii({0.42, 0.43})
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({std::string("hello"), std::string("friend")})
@@ -37,13 +35,11 @@ int main(int argc, char** argv) {
         std::vector{
             rr::components::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
             rr::components::Point2D(rr::datatypes::Vec2D{1.0, 3.0}),
-            rr::components::Point2D(rr::datatypes::Vec2D{5.0, 5.0}),
-        },
+            rr::components::Point2D(rr::datatypes::Vec2D{5.0, 5.0})},
         std::array{
             rr::components::Color(0xFF0000FF),
             rr::components::Color(0x00FF00FF),
-            rr::components::Color(0x0000FFFF),
-        },
+            rr::components::Color(0x0000FFFF)},
         c_style_array
     );
 

--- a/rerun_cpp/tests/CMakeLists.txt
+++ b/rerun_cpp/tests/CMakeLists.txt
@@ -9,11 +9,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
-# Test application:
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-endif()
-
 file(GLOB_RECURSE rerun_sdk_tests_SRC CONFIGURE_DEPENDS
     "*.hpp"
     "*.cpp"

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -21,7 +21,7 @@ from os.path import isfile, join
 ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 
 # TODO(andreas): Remove these
-cpp_opt_out = ["points2d", "disconnected_space", "transform3d"]
+cpp_opt_out = ["points2d", "transform3d"]
 
 
 def main() -> None:

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -21,7 +21,7 @@ from os.path import isfile, join
 ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 
 # TODO(andreas): Remove these
-cpp_opt_out = ["points2d", "disconnected_space", "transform3d", "arrows3d"]
+cpp_opt_out = ["points2d", "disconnected_space", "transform3d"]
 
 
 def main() -> None:

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+
+add_subdirectory(roundtrips)

--- a/tests/cpp/roundtrips/CMakeLists.txt
+++ b/tests/cpp/roundtrips/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+
+file(GLOB sources_list LIST_DIRECTORIES true ${CMAKE_CURRENT_SOURCE_DIR}/*)
+
+foreach(DIR ${sources_list})
+    IF(IS_DIRECTORY ${DIR})
+        get_filename_component(ARCHETYPE ${DIR} NAME)
+
+        if(${ARCHETYPE} STREQUAL "CMakeFiles")
+            CONTINUE()
+        endif()
+
+        set(ROUNDTRIP_TARGET roundtrip_${ARCHETYPE})
+
+        add_executable(${ROUNDTRIP_TARGET} ${DIR}/main.cpp)
+        set_default_warning_settings(${ROUNDTRIP_TARGET})
+        target_link_libraries(${ROUNDTRIP_TARGET} PRIVATE rerun_sdk)
+    ELSE()
+        CONTINUE()
+    ENDIF()
+endforeach()

--- a/tests/cpp/roundtrips/arrows3d/main.cpp
+++ b/tests/cpp/roundtrips/arrows3d/main.cpp
@@ -1,0 +1,21 @@
+#include <archetypes/arrows3d.hpp> // TODO(andreas): Should be rerun/ prefixed.
+#include <recording_stream.hpp>
+
+int main(int argc, char** argv) {
+    auto rec_stream = rr::RecordingStream("c-example-app");
+    rec_stream.save(argv[1]);
+
+    rec_stream.log_archetype(
+        "arrows3d",
+        rr::archetypes::Arrows3D({rr::datatypes::Vec3D{4.0f, 5.0f, 6.0f},
+                                  rr::datatypes::Vec3D{40.0f, 50.0f, 60.0f}})
+            .with_origins(
+                {rr::datatypes::Vec3D{1.0f, 2.0f, 3.0f}, rr::datatypes::Vec3D{10.0f, 20.0f, 30.0f}}
+            )
+            .with_radii({0.1f, 1.0f})
+            .with_colors({0xAA0000CC, 0x00BB00DD})
+            .with_labels({std::string("hello"), std::string("friend")})
+            .with_class_ids({126, 127})
+            .with_instance_keys({66, 666})
+    );
+}

--- a/tests/cpp/roundtrips/disconnected_space/main.cpp
+++ b/tests/cpp/roundtrips/disconnected_space/main.cpp
@@ -1,0 +1,9 @@
+#include <archetypes/disconnected_space.hpp> // TODO(andreas): Should be rerun/ prefixed.
+#include <recording_stream.hpp>
+
+int main(int argc, char** argv) {
+    auto rec_stream = rr::RecordingStream("c-example-app");
+    rec_stream.save(argv[1]);
+
+    rec_stream.log_archetype("disconnected_space", rr::archetypes::DisconnectedSpace(true));
+}

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -7,10 +7,8 @@ int main(int argc, char** argv) {
 
     rec_stream.log_archetype(
         "points3d",
-        rr::archetypes::Points3D({
-                                     rr::datatypes::Vec3D{1.0, 2.0, 3.0},
-                                     rr::datatypes::Vec3D{4.0, 5.0, 6.0},
-                                 })
+        rr::archetypes::Points3D({rr::datatypes::Vec3D{1.0, 2.0, 3.0},
+                                  rr::datatypes::Vec3D{4.0, 5.0, 6.0}})
             .with_radii({0.42f, 0.43f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({std::string("hello"), std::string("friend")})

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -1,0 +1,21 @@
+#include <archetypes/points3d.hpp> // TODO(andreas): Should be rerun/ prefixed.
+#include <recording_stream.hpp>
+
+int main(int argc, char** argv) {
+    auto rec_stream = rr::RecordingStream("c-example-app");
+    rec_stream.save(argv[1]);
+
+    rec_stream.log_archetype(
+        "points3d",
+        rr::archetypes::Points3D({
+                                     rr::datatypes::Vec3D{1.0, 2.0, 3.0},
+                                     rr::datatypes::Vec3D{4.0, 5.0, 6.0},
+                                 })
+            .with_radii({0.42f, 0.43f})
+            .with_colors({0xAA0000CC, 0x00BB00DD})
+            .with_labels({std::string("hello"), std::string("friend")})
+            .with_class_ids({126, 127})
+            .with_keypoint_ids({2, 3})
+            .with_instance_keys({66, 666})
+    );
+}


### PR DESCRIPTION
* Fixes #2797 

### What

C++ is starting to catch up! It's now part of the roundtrip tests. A bunch of types are opted-out at this point since the codegen isn't up for it yet (points3d is opted out because it needs an rect archetype which is coming later today or tomorrow)

Does not _yet_ fix the related tickets, for that we still need examples and custom extensions.
(gonna do examples as the next thing)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
