### PR TITLE
C++ Example setup, examples for point3d/arrow3d/disconnectedspace

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -345,3 +345,7 @@ jobs:
       - name: Build and run rerun_cpp tests
         shell: bash
         run: ./rerun_cpp/build_and_run_tests.sh
+
+      - name: Build code examples
+        shell: bash
+        run: ./tests/cpp/build_all_doc_examples.sh

--- a/crates/re_types/definitions/rerun/archetypes/arrows3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/arrows3d.fbs
@@ -21,6 +21,12 @@ namespace rerun.archetypes;
 /// \rs ```ignore
 /// \rs \include:../../../../../docs/code-examples/arrow3d_simple_v2.rs
 /// \rs ```
+///
+/// \cpp ## Example
+/// \cpp
+/// \cpp ```
+/// \cpp \include:../../../../../docs/code-examples/arrow3d_simple_v2.cpp
+/// \cpp ```
 table Arrows3D (
   "attr.rust.derive": "PartialEq",
   order: 100

--- a/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
@@ -24,6 +24,12 @@ namespace rerun.archetypes;
 /// \rs ```ignore
 /// \rs \include:../../../../../docs/code-examples/disconnected_space_v2.rs
 /// \rs ```
+///
+/// \cpp ## Example
+/// \cpp
+/// \cpp ```
+/// \cpp \include:../../../../../docs/code-examples/disconnected_space_v2.cpp
+/// \cpp ```
 table DisconnectedSpace (
   "attr.rust.derive": "Copy, PartialEq, Eq",
   order: 100

--- a/crates/re_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points3d.fbs
@@ -21,6 +21,12 @@ namespace rerun.archetypes;
 /// \rs ```ignore
 /// \rs \include:../../../../../docs/code-examples/point3d_simple_v2.rs
 /// \rs ```
+///
+/// \cpp ## Example
+/// \cpp
+/// \cpp ```
+/// \cpp \include:../../../../../docs/code-examples/point3d_simple_v2.cpp
+/// \cpp ```
 table Points3D (
   "attr.rust.derive": "PartialEq",
   order: 100

--- a/crates/re_types/definitions/rerun/components/point3d.fbs
+++ b/crates/re_types/definitions/rerun/components/point3d.fbs
@@ -17,5 +17,5 @@ struct Point3D (
   "attr.rust.derive": "Default, Copy, PartialEq, PartialOrd",
   order: 100
 ) {
-  xy: rerun.datatypes.Vec3D (order: 100);
+  xyz: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-2af796dfd1a8ef65a6fba51a5d7d62bf8fc882f839326663393b2c9c815a9319
+aa415f481c69fa5c16cb2fc2e3eafd01bdb367bdc69f43aef957200c519ac9fb

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -218,7 +218,7 @@ impl crate::Loggable for Point3D {
         .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
         .map_err(|err| crate::DeserializationError::Context {
-            location: "rerun.components.Point3D#xy".into(),
+            location: "rerun.components.Point3D#xyz".into(),
             source: Box::new(err),
         })?)
     }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -252,7 +252,7 @@ impl QuotedObject {
             ObjectKind::Datatype | ObjectKind::Component => {
                 if obj.fields.len() == 1 {
                     // Single-field struct - it is a newtype wrapper.
-                    // Create a implicit constructor from its own field-type - do so by copy, and if meaningful by rvalue reference.
+                    // Create a implicit constructor and assignment from its own field-type.
                     let obj_field = &obj.fields[0];
                     if let Type::Array { .. } = &obj_field.typ {
                         // TODO(emilk): implicit constructor for arrays
@@ -270,6 +270,20 @@ impl QuotedObject {
                                 }),
                                 ..Method::default()
                             });
+                        methods.push(Method {
+                            declaration: MethodDeclaration {
+                                is_static: false,
+                                return_type: quote!(#type_ident&),
+                                name_and_parameters: quote! {
+                                    operator=(#parameter_declaration)
+                                },
+                            },
+                            definition_body: quote! {
+                                #field_ident = std::move(#field_ident);
+                                return *this;
+                            },
+                            ..Method::default()
+                        });
                     }
                 };
 

--- a/docs/code-examples/arrow3d_simple_v2.cpp
+++ b/docs/code-examples/arrow3d_simple_v2.cpp
@@ -11,22 +11,19 @@ int main() {
     auto rr_stream = rr::RecordingStream("arrow3d");
     rr_stream.connect("127.0.0.1:9876");
 
-    const int arrow_count = 100;
-    std::vector<rr::components::Vector3D> positions;
-    positions.reserve(arrow_count);
+    std::vector<rr::components::Vector3D> vectors;
     std::vector<rr::components::Color> colors;
-    colors.reserve(arrow_count);
 
-    for (int i = 0; i < arrow_count; ++i) {
+    for (int i = 0; i < 100; ++i) {
         float angle = 2.0 * M_PI * i * 0.01f;
         float length = log2f(i + 1);
-        positions.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length * cosf(angle)});
+        vectors.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length * cosf(angle)});
 
-        // TODO(andreas): provide from_unmultiplied_rgba
+        // TODO(andreas): provide `unmultiplied_rgba`
         uint8_t c = static_cast<uint8_t>((angle / (2.0 * M_PI) * 255.0) + 0.5);
         uint32_t color = ((255 - c) << 24) + (c << 16) + (128 << 8) + (128 << 0);
         colors.push_back(color);
     }
 
-    rr_stream.log("arrows", rr::archetypes::Arrows3D(positions).with_colors(colors));
+    rr_stream.log("arrows", rr::archetypes::Arrows3D(vectors).with_colors(colors));
 }

--- a/docs/code-examples/arrow3d_simple_v2.cpp
+++ b/docs/code-examples/arrow3d_simple_v2.cpp
@@ -1,0 +1,32 @@
+// Log a batch of 3D arrows.
+
+#include <rerun.hpp>
+
+#include <cmath>
+#include <numeric>
+
+namespace rr = rerun;
+
+int main() {
+    auto rr_stream = rr::RecordingStream("arrow3d");
+    rr_stream.connect("127.0.0.1:9876");
+
+    const int arrow_count = 100;
+    std::vector<rr::components::Vector3D> positions;
+    positions.reserve(arrow_count);
+    std::vector<rr::components::Color> colors;
+    colors.reserve(arrow_count);
+
+    for (int i = 0; i < arrow_count; ++i) {
+        float angle = 2.0 * M_PI * i * 0.01f;
+        float length = log2f(i + 1);
+        positions.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length * cosf(angle)});
+
+        // TODO(andreas): provide from_unmultiplied_rgba
+        uint8_t c = static_cast<uint8_t>((angle / (2.0 * M_PI) * 255.0) + 0.5);
+        uint32_t color = ((255 - c) << 24) + (c << 16) + (128 << 8) + (128 << 0);
+        colors.push_back(color);
+    }
+
+    rr_stream.log("arrows", rr::archetypes::Arrows3D(positions).with_colors(colors));
+}

--- a/docs/code-examples/disconnected_space_v2.cpp
+++ b/docs/code-examples/disconnected_space_v2.cpp
@@ -14,14 +14,14 @@ int main() {
         rr::archetypes::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f})
     );
     rr_stream.log(
-        "world/room1/point",
+        "world/room2/point",
         rr::archetypes::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f})
     );
 
     // ..but this one lives in a completely separate space!
-    rr_stream.log("world/room1/point", rr::archetypes::DisconnectedSpace(true));
+    rr_stream.log("world/wormhole", rr::archetypes::DisconnectedSpace(true));
     rr_stream.log(
-        "world/room1/point",
+        "world/wormhole/point",
         rr::archetypes::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f})
     );
 }

--- a/docs/code-examples/disconnected_space_v2.cpp
+++ b/docs/code-examples/disconnected_space_v2.cpp
@@ -1,0 +1,27 @@
+// Disconnect two spaces.
+
+#include <rerun.hpp>
+
+namespace rr = rerun;
+
+int main() {
+    auto rr_stream = rr::RecordingStream("disconnected_space");
+    rr_stream.connect("127.0.0.1:9876");
+
+    // These two points can be projected into the same space..
+    rr_stream.log(
+        "world/room1/point",
+        rr::archetypes::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f})
+    );
+    rr_stream.log(
+        "world/room1/point",
+        rr::archetypes::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f})
+    );
+
+    // ..but this one lives in a completely separate space!
+    rr_stream.log("world/room1/point", rr::archetypes::DisconnectedSpace(true));
+    rr_stream.log(
+        "world/room1/point",
+        rr::archetypes::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f})
+    );
+}

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -2,6 +2,7 @@
 
 #include <rerun.hpp>
 
+#include <algorithm>
 #include <random>
 
 namespace rr = rerun;

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -1,0 +1,33 @@
+// Log some random points with color and radii.
+
+#include <rerun.hpp>
+
+#include <random>
+
+namespace rr = rerun;
+
+int main() {
+    auto rr_stream = rr::RecordingStream("points3d_random");
+    rr_stream.connect("127.0.0.1:9876");
+
+    std::default_random_engine gen;
+    std::uniform_real_distribution<float> dist(-5.0, 5.0);
+    std::uniform_int_distribution<uint8_t> dist_byte(0, 255);
+
+    std::vector<rr::components::Point3D> points3d(10);
+    std::generate(points3d.begin(), points3d.end(), [&] {
+        return rr::datatypes::Vec3D{dist(gen), dist(gen), dist(gen)};
+    });
+    std::vector<rr::components::Color> colors(10);
+    std::generate(colors.begin(), colors.end(), [&] {
+        // TODO(andreas): provide a `rgb` factory method.
+        return (dist_byte(gen) << 24) + (dist_byte(gen) << 16) + (dist_byte(gen) << 8);
+    });
+    std::vector<rr::components::Radius> radii(10);
+    std::generate(radii.begin(), radii.end(), [&] { return dist(gen); });
+
+    rr_stream.log(
+        "random",
+        rr::archetypes::Points3D(points3d).with_colors(colors).with_radii(radii)
+    );
+}

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -23,7 +23,7 @@ int main() {
     std::vector<rr::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
         // TODO(andreas): provide a `rgb` factory method.
-        return (dist_color(gen) << 24) + (dist_color(gen) << 16) + (dist_color(gen) << 8);
+        return (dist_color(gen) << 24) + (dist_color(gen) << 16) + (dist_color(gen) << 8) + 255;
     });
     std::vector<rr::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -11,20 +11,21 @@ int main() {
     rr_stream.connect("127.0.0.1:9876");
 
     std::default_random_engine gen;
-    std::uniform_real_distribution<float> dist(-5.0, 5.0);
-    std::uniform_int_distribution<uint8_t> dist_byte(0, 255);
+    std::uniform_real_distribution<float> dist_pos(-5.0, 5.0);
+    std::uniform_real_distribution<float> dist_radius(0.1, 1.0);
+    std::uniform_int_distribution<uint8_t> dist_color(0, 255);
 
     std::vector<rr::components::Point3D> points3d(10);
     std::generate(points3d.begin(), points3d.end(), [&] {
-        return rr::datatypes::Vec3D{dist(gen), dist(gen), dist(gen)};
+        return rr::datatypes::Vec3D{dist_pos(gen), dist_pos(gen), dist_pos(gen)};
     });
     std::vector<rr::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
         // TODO(andreas): provide a `rgb` factory method.
-        return (dist_byte(gen) << 24) + (dist_byte(gen) << 16) + (dist_byte(gen) << 8);
+        return (dist_color(gen) << 24) + (dist_color(gen) << 16) + (dist_color(gen) << 8);
     });
     std::vector<rr::components::Radius> radii(10);
-    std::generate(radii.begin(), radii.end(), [&] { return dist(gen); });
+    std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
 
     rr_stream.log(
         "random",

--- a/docs/code-examples/point3d_random_v2.rs
+++ b/docs/code-examples/point3d_random_v2.rs
@@ -1,4 +1,5 @@
-//! Log some random points with color and radii."""
+//! Log some random points with color and radii.
+
 use rand::distributions::Uniform;
 use rand::Rng;
 use rerun::{archetypes::Points3D, components::Color, MsgSender, RecordingStreamBuilder};

--- a/docs/code-examples/point3d_simple_v2.cpp
+++ b/docs/code-examples/point3d_simple_v2.cpp
@@ -1,0 +1,17 @@
+// Log some very simple points.
+
+#include <rerun.hpp>
+
+namespace rr = rerun;
+
+int main() {
+    auto rr_stream = rr::RecordingStream("points3d_simple");
+    rr_stream.connect("127.0.0.1:9876");
+
+    rr_stream.log(
+        "points",
+        rr::archetypes::Points3D(
+            {rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f}, rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}}
+        )
+    );
+}

--- a/rerun_cpp/src/rerun/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/rerun/archetypes/affix_fuzzer1.hpp
@@ -183,79 +183,165 @@ namespace rerun {
             std::optional<std::vector<rerun::components::AffixFuzzer18>> fuzz2118;
 
           public:
+            AffixFuzzer1() = default;
+
             AffixFuzzer1(
-                rerun::components::AffixFuzzer1 fuzz1001, rerun::components::AffixFuzzer2 fuzz1002,
-                rerun::components::AffixFuzzer3 fuzz1003, rerun::components::AffixFuzzer4 fuzz1004,
-                rerun::components::AffixFuzzer5 fuzz1005, rerun::components::AffixFuzzer6 fuzz1006,
-                rerun::components::AffixFuzzer7 fuzz1007, rerun::components::AffixFuzzer8 fuzz1008,
-                rerun::components::AffixFuzzer9 fuzz1009, rerun::components::AffixFuzzer10 fuzz1010,
-                rerun::components::AffixFuzzer11 fuzz1011,
-                rerun::components::AffixFuzzer12 fuzz1012,
-                rerun::components::AffixFuzzer13 fuzz1013,
-                rerun::components::AffixFuzzer14 fuzz1014,
-                rerun::components::AffixFuzzer15 fuzz1015,
-                rerun::components::AffixFuzzer16 fuzz1016,
-                rerun::components::AffixFuzzer17 fuzz1017,
-                rerun::components::AffixFuzzer18 fuzz1018,
-                rerun::components::AffixFuzzer19 fuzz1019,
-                rerun::components::AffixFuzzer20 fuzz1020,
-                std::vector<rerun::components::AffixFuzzer1> fuzz1101,
-                std::vector<rerun::components::AffixFuzzer2> fuzz1102,
-                std::vector<rerun::components::AffixFuzzer3> fuzz1103,
-                std::vector<rerun::components::AffixFuzzer4> fuzz1104,
-                std::vector<rerun::components::AffixFuzzer5> fuzz1105,
-                std::vector<rerun::components::AffixFuzzer6> fuzz1106,
-                std::vector<rerun::components::AffixFuzzer7> fuzz1107,
-                std::vector<rerun::components::AffixFuzzer8> fuzz1108,
-                std::vector<rerun::components::AffixFuzzer9> fuzz1109,
-                std::vector<rerun::components::AffixFuzzer10> fuzz1110,
-                std::vector<rerun::components::AffixFuzzer11> fuzz1111,
-                std::vector<rerun::components::AffixFuzzer12> fuzz1112,
-                std::vector<rerun::components::AffixFuzzer13> fuzz1113,
-                std::vector<rerun::components::AffixFuzzer14> fuzz1114,
-                std::vector<rerun::components::AffixFuzzer15> fuzz1115,
-                std::vector<rerun::components::AffixFuzzer16> fuzz1116,
-                std::vector<rerun::components::AffixFuzzer17> fuzz1117,
-                std::vector<rerun::components::AffixFuzzer18> fuzz1118
+                rerun::components::AffixFuzzer1 _fuzz1001,
+                rerun::components::AffixFuzzer2 _fuzz1002,
+                rerun::components::AffixFuzzer3 _fuzz1003,
+                rerun::components::AffixFuzzer4 _fuzz1004,
+                rerun::components::AffixFuzzer5 _fuzz1005,
+                rerun::components::AffixFuzzer6 _fuzz1006,
+                rerun::components::AffixFuzzer7 _fuzz1007,
+                rerun::components::AffixFuzzer8 _fuzz1008,
+                rerun::components::AffixFuzzer9 _fuzz1009,
+                rerun::components::AffixFuzzer10 _fuzz1010,
+                rerun::components::AffixFuzzer11 _fuzz1011,
+                rerun::components::AffixFuzzer12 _fuzz1012,
+                rerun::components::AffixFuzzer13 _fuzz1013,
+                rerun::components::AffixFuzzer14 _fuzz1014,
+                rerun::components::AffixFuzzer15 _fuzz1015,
+                rerun::components::AffixFuzzer16 _fuzz1016,
+                rerun::components::AffixFuzzer17 _fuzz1017,
+                rerun::components::AffixFuzzer18 _fuzz1018,
+                rerun::components::AffixFuzzer19 _fuzz1019,
+                rerun::components::AffixFuzzer20 _fuzz1020,
+                std::vector<rerun::components::AffixFuzzer1> _fuzz1101,
+                std::vector<rerun::components::AffixFuzzer2> _fuzz1102,
+                std::vector<rerun::components::AffixFuzzer3> _fuzz1103,
+                std::vector<rerun::components::AffixFuzzer4> _fuzz1104,
+                std::vector<rerun::components::AffixFuzzer5> _fuzz1105,
+                std::vector<rerun::components::AffixFuzzer6> _fuzz1106,
+                std::vector<rerun::components::AffixFuzzer7> _fuzz1107,
+                std::vector<rerun::components::AffixFuzzer8> _fuzz1108,
+                std::vector<rerun::components::AffixFuzzer9> _fuzz1109,
+                std::vector<rerun::components::AffixFuzzer10> _fuzz1110,
+                std::vector<rerun::components::AffixFuzzer11> _fuzz1111,
+                std::vector<rerun::components::AffixFuzzer12> _fuzz1112,
+                std::vector<rerun::components::AffixFuzzer13> _fuzz1113,
+                std::vector<rerun::components::AffixFuzzer14> _fuzz1114,
+                std::vector<rerun::components::AffixFuzzer15> _fuzz1115,
+                std::vector<rerun::components::AffixFuzzer16> _fuzz1116,
+                std::vector<rerun::components::AffixFuzzer17> _fuzz1117,
+                std::vector<rerun::components::AffixFuzzer18> _fuzz1118
             )
-                : fuzz1001(std::move(fuzz1001)),
-                  fuzz1002(std::move(fuzz1002)),
-                  fuzz1003(std::move(fuzz1003)),
-                  fuzz1004(std::move(fuzz1004)),
-                  fuzz1005(std::move(fuzz1005)),
-                  fuzz1006(std::move(fuzz1006)),
-                  fuzz1007(std::move(fuzz1007)),
-                  fuzz1008(std::move(fuzz1008)),
-                  fuzz1009(std::move(fuzz1009)),
-                  fuzz1010(std::move(fuzz1010)),
-                  fuzz1011(std::move(fuzz1011)),
-                  fuzz1012(std::move(fuzz1012)),
-                  fuzz1013(std::move(fuzz1013)),
-                  fuzz1014(std::move(fuzz1014)),
-                  fuzz1015(std::move(fuzz1015)),
-                  fuzz1016(std::move(fuzz1016)),
-                  fuzz1017(std::move(fuzz1017)),
-                  fuzz1018(std::move(fuzz1018)),
-                  fuzz1019(std::move(fuzz1019)),
-                  fuzz1020(std::move(fuzz1020)),
-                  fuzz1101(std::move(fuzz1101)),
-                  fuzz1102(std::move(fuzz1102)),
-                  fuzz1103(std::move(fuzz1103)),
-                  fuzz1104(std::move(fuzz1104)),
-                  fuzz1105(std::move(fuzz1105)),
-                  fuzz1106(std::move(fuzz1106)),
-                  fuzz1107(std::move(fuzz1107)),
-                  fuzz1108(std::move(fuzz1108)),
-                  fuzz1109(std::move(fuzz1109)),
-                  fuzz1110(std::move(fuzz1110)),
-                  fuzz1111(std::move(fuzz1111)),
-                  fuzz1112(std::move(fuzz1112)),
-                  fuzz1113(std::move(fuzz1113)),
-                  fuzz1114(std::move(fuzz1114)),
-                  fuzz1115(std::move(fuzz1115)),
-                  fuzz1116(std::move(fuzz1116)),
-                  fuzz1117(std::move(fuzz1117)),
-                  fuzz1118(std::move(fuzz1118)) {}
+                : fuzz1001(std::move(_fuzz1001)),
+                  fuzz1002(std::move(_fuzz1002)),
+                  fuzz1003(std::move(_fuzz1003)),
+                  fuzz1004(std::move(_fuzz1004)),
+                  fuzz1005(std::move(_fuzz1005)),
+                  fuzz1006(std::move(_fuzz1006)),
+                  fuzz1007(std::move(_fuzz1007)),
+                  fuzz1008(std::move(_fuzz1008)),
+                  fuzz1009(std::move(_fuzz1009)),
+                  fuzz1010(std::move(_fuzz1010)),
+                  fuzz1011(std::move(_fuzz1011)),
+                  fuzz1012(std::move(_fuzz1012)),
+                  fuzz1013(std::move(_fuzz1013)),
+                  fuzz1014(std::move(_fuzz1014)),
+                  fuzz1015(std::move(_fuzz1015)),
+                  fuzz1016(std::move(_fuzz1016)),
+                  fuzz1017(std::move(_fuzz1017)),
+                  fuzz1018(std::move(_fuzz1018)),
+                  fuzz1019(std::move(_fuzz1019)),
+                  fuzz1020(std::move(_fuzz1020)),
+                  fuzz1101(std::move(_fuzz1101)),
+                  fuzz1102(std::move(_fuzz1102)),
+                  fuzz1103(std::move(_fuzz1103)),
+                  fuzz1104(std::move(_fuzz1104)),
+                  fuzz1105(std::move(_fuzz1105)),
+                  fuzz1106(std::move(_fuzz1106)),
+                  fuzz1107(std::move(_fuzz1107)),
+                  fuzz1108(std::move(_fuzz1108)),
+                  fuzz1109(std::move(_fuzz1109)),
+                  fuzz1110(std::move(_fuzz1110)),
+                  fuzz1111(std::move(_fuzz1111)),
+                  fuzz1112(std::move(_fuzz1112)),
+                  fuzz1113(std::move(_fuzz1113)),
+                  fuzz1114(std::move(_fuzz1114)),
+                  fuzz1115(std::move(_fuzz1115)),
+                  fuzz1116(std::move(_fuzz1116)),
+                  fuzz1117(std::move(_fuzz1117)),
+                  fuzz1118(std::move(_fuzz1118)) {}
+
+            AffixFuzzer1(
+                rerun::components::AffixFuzzer1 _fuzz1001,
+                rerun::components::AffixFuzzer2 _fuzz1002,
+                rerun::components::AffixFuzzer3 _fuzz1003,
+                rerun::components::AffixFuzzer4 _fuzz1004,
+                rerun::components::AffixFuzzer5 _fuzz1005,
+                rerun::components::AffixFuzzer6 _fuzz1006,
+                rerun::components::AffixFuzzer7 _fuzz1007,
+                rerun::components::AffixFuzzer8 _fuzz1008,
+                rerun::components::AffixFuzzer9 _fuzz1009,
+                rerun::components::AffixFuzzer10 _fuzz1010,
+                rerun::components::AffixFuzzer11 _fuzz1011,
+                rerun::components::AffixFuzzer12 _fuzz1012,
+                rerun::components::AffixFuzzer13 _fuzz1013,
+                rerun::components::AffixFuzzer14 _fuzz1014,
+                rerun::components::AffixFuzzer15 _fuzz1015,
+                rerun::components::AffixFuzzer16 _fuzz1016,
+                rerun::components::AffixFuzzer17 _fuzz1017,
+                rerun::components::AffixFuzzer18 _fuzz1018,
+                rerun::components::AffixFuzzer19 _fuzz1019,
+                rerun::components::AffixFuzzer20 _fuzz1020,
+                rerun::components::AffixFuzzer1 _fuzz1101,
+                rerun::components::AffixFuzzer2 _fuzz1102,
+                rerun::components::AffixFuzzer3 _fuzz1103,
+                rerun::components::AffixFuzzer4 _fuzz1104,
+                rerun::components::AffixFuzzer5 _fuzz1105,
+                rerun::components::AffixFuzzer6 _fuzz1106,
+                rerun::components::AffixFuzzer7 _fuzz1107,
+                rerun::components::AffixFuzzer8 _fuzz1108,
+                rerun::components::AffixFuzzer9 _fuzz1109,
+                rerun::components::AffixFuzzer10 _fuzz1110,
+                rerun::components::AffixFuzzer11 _fuzz1111,
+                rerun::components::AffixFuzzer12 _fuzz1112,
+                rerun::components::AffixFuzzer13 _fuzz1113,
+                rerun::components::AffixFuzzer14 _fuzz1114,
+                rerun::components::AffixFuzzer15 _fuzz1115,
+                rerun::components::AffixFuzzer16 _fuzz1116,
+                rerun::components::AffixFuzzer17 _fuzz1117,
+                rerun::components::AffixFuzzer18 _fuzz1118
+            )
+                : fuzz1001(std::move(_fuzz1001)),
+                  fuzz1002(std::move(_fuzz1002)),
+                  fuzz1003(std::move(_fuzz1003)),
+                  fuzz1004(std::move(_fuzz1004)),
+                  fuzz1005(std::move(_fuzz1005)),
+                  fuzz1006(std::move(_fuzz1006)),
+                  fuzz1007(std::move(_fuzz1007)),
+                  fuzz1008(std::move(_fuzz1008)),
+                  fuzz1009(std::move(_fuzz1009)),
+                  fuzz1010(std::move(_fuzz1010)),
+                  fuzz1011(std::move(_fuzz1011)),
+                  fuzz1012(std::move(_fuzz1012)),
+                  fuzz1013(std::move(_fuzz1013)),
+                  fuzz1014(std::move(_fuzz1014)),
+                  fuzz1015(std::move(_fuzz1015)),
+                  fuzz1016(std::move(_fuzz1016)),
+                  fuzz1017(std::move(_fuzz1017)),
+                  fuzz1018(std::move(_fuzz1018)),
+                  fuzz1019(std::move(_fuzz1019)),
+                  fuzz1020(std::move(_fuzz1020)),
+                  fuzz1101(1, std::move(_fuzz1101)),
+                  fuzz1102(1, std::move(_fuzz1102)),
+                  fuzz1103(1, std::move(_fuzz1103)),
+                  fuzz1104(1, std::move(_fuzz1104)),
+                  fuzz1105(1, std::move(_fuzz1105)),
+                  fuzz1106(1, std::move(_fuzz1106)),
+                  fuzz1107(1, std::move(_fuzz1107)),
+                  fuzz1108(1, std::move(_fuzz1108)),
+                  fuzz1109(1, std::move(_fuzz1109)),
+                  fuzz1110(1, std::move(_fuzz1110)),
+                  fuzz1111(1, std::move(_fuzz1111)),
+                  fuzz1112(1, std::move(_fuzz1112)),
+                  fuzz1113(1, std::move(_fuzz1113)),
+                  fuzz1114(1, std::move(_fuzz1114)),
+                  fuzz1115(1, std::move(_fuzz1115)),
+                  fuzz1116(1, std::move(_fuzz1116)),
+                  fuzz1117(1, std::move(_fuzz1117)),
+                  fuzz1118(1, std::move(_fuzz1118)) {}
 
             AffixFuzzer1& with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) {
                 fuzz2001 = std::move(_fuzz2001);
@@ -352,8 +438,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2101(rerun::components::AffixFuzzer1 _fuzz2101) {
+                fuzz2101 = std::move(std::vector(1, std::move(_fuzz2101)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2102(std::vector<rerun::components::AffixFuzzer2> _fuzz2102) {
                 fuzz2102 = std::move(_fuzz2102);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2102(rerun::components::AffixFuzzer2 _fuzz2102) {
+                fuzz2102 = std::move(std::vector(1, std::move(_fuzz2102)));
                 return *this;
             }
 
@@ -362,8 +458,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2103(rerun::components::AffixFuzzer3 _fuzz2103) {
+                fuzz2103 = std::move(std::vector(1, std::move(_fuzz2103)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2104(std::vector<rerun::components::AffixFuzzer4> _fuzz2104) {
                 fuzz2104 = std::move(_fuzz2104);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2104(rerun::components::AffixFuzzer4 _fuzz2104) {
+                fuzz2104 = std::move(std::vector(1, std::move(_fuzz2104)));
                 return *this;
             }
 
@@ -372,8 +478,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2105(rerun::components::AffixFuzzer5 _fuzz2105) {
+                fuzz2105 = std::move(std::vector(1, std::move(_fuzz2105)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2106(std::vector<rerun::components::AffixFuzzer6> _fuzz2106) {
                 fuzz2106 = std::move(_fuzz2106);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2106(rerun::components::AffixFuzzer6 _fuzz2106) {
+                fuzz2106 = std::move(std::vector(1, std::move(_fuzz2106)));
                 return *this;
             }
 
@@ -382,8 +498,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2107(rerun::components::AffixFuzzer7 _fuzz2107) {
+                fuzz2107 = std::move(std::vector(1, std::move(_fuzz2107)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2108(std::vector<rerun::components::AffixFuzzer8> _fuzz2108) {
                 fuzz2108 = std::move(_fuzz2108);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2108(rerun::components::AffixFuzzer8 _fuzz2108) {
+                fuzz2108 = std::move(std::vector(1, std::move(_fuzz2108)));
                 return *this;
             }
 
@@ -392,8 +518,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2109(rerun::components::AffixFuzzer9 _fuzz2109) {
+                fuzz2109 = std::move(std::vector(1, std::move(_fuzz2109)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2110(std::vector<rerun::components::AffixFuzzer10> _fuzz2110) {
                 fuzz2110 = std::move(_fuzz2110);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2110(rerun::components::AffixFuzzer10 _fuzz2110) {
+                fuzz2110 = std::move(std::vector(1, std::move(_fuzz2110)));
                 return *this;
             }
 
@@ -402,8 +538,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2111(rerun::components::AffixFuzzer11 _fuzz2111) {
+                fuzz2111 = std::move(std::vector(1, std::move(_fuzz2111)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2112(std::vector<rerun::components::AffixFuzzer12> _fuzz2112) {
                 fuzz2112 = std::move(_fuzz2112);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2112(rerun::components::AffixFuzzer12 _fuzz2112) {
+                fuzz2112 = std::move(std::vector(1, std::move(_fuzz2112)));
                 return *this;
             }
 
@@ -412,8 +558,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2113(rerun::components::AffixFuzzer13 _fuzz2113) {
+                fuzz2113 = std::move(std::vector(1, std::move(_fuzz2113)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2114(std::vector<rerun::components::AffixFuzzer14> _fuzz2114) {
                 fuzz2114 = std::move(_fuzz2114);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2114(rerun::components::AffixFuzzer14 _fuzz2114) {
+                fuzz2114 = std::move(std::vector(1, std::move(_fuzz2114)));
                 return *this;
             }
 
@@ -422,8 +578,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2115(rerun::components::AffixFuzzer15 _fuzz2115) {
+                fuzz2115 = std::move(std::vector(1, std::move(_fuzz2115)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2116(std::vector<rerun::components::AffixFuzzer16> _fuzz2116) {
                 fuzz2116 = std::move(_fuzz2116);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2116(rerun::components::AffixFuzzer16 _fuzz2116) {
+                fuzz2116 = std::move(std::vector(1, std::move(_fuzz2116)));
                 return *this;
             }
 
@@ -432,8 +598,18 @@ namespace rerun {
                 return *this;
             }
 
+            AffixFuzzer1& with_fuzz2117(rerun::components::AffixFuzzer17 _fuzz2117) {
+                fuzz2117 = std::move(std::vector(1, std::move(_fuzz2117)));
+                return *this;
+            }
+
             AffixFuzzer1& with_fuzz2118(std::vector<rerun::components::AffixFuzzer18> _fuzz2118) {
                 fuzz2118 = std::move(_fuzz2118);
+                return *this;
+            }
+
+            AffixFuzzer1& with_fuzz2118(rerun::components::AffixFuzzer18 _fuzz2118) {
+                fuzz2118 = std::move(std::vector(1, std::move(_fuzz2118)));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -23,8 +23,10 @@ namespace rerun {
             rerun::components::AnnotationContext context;
 
           public:
-            AnnotationContext(rerun::components::AnnotationContext context)
-                : context(std::move(context)) {}
+            AnnotationContext() = default;
+
+            AnnotationContext(rerun::components::AnnotationContext _context)
+                : context(std::move(_context)) {}
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -21,6 +21,41 @@
 namespace rerun {
     namespace archetypes {
         /// A batch of 3D arrows with optional colors, radii, labels, etc.
+        ///
+        /// ## Example
+        ///
+        ///```
+        ///// Log a batch of 3D arrows.
+        ///
+        /// #include <rerun.hpp>
+        ///
+        /// #include <cmath>
+        /// #include <numeric>
+        ///
+        /// namespace rr = rerun;
+        ///
+        /// int main() {
+        ///    auto rr_stream = rr::RecordingStream(\"arrow3d\");
+        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///
+        ///    std::vector<rr::components::Vector3D> vectors;
+        ///    std::vector<rr::components::Color> colors;
+        ///
+        ///    for (int i = 0; i <100; ++i) {
+        ///        float angle = 2.0 * M_PI * i * 0.01f;
+        ///        float length = log2f(i + 1);
+        ///        vectors.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length *
+        ///        cosf(angle)});
+        ///
+        ///        // TODO(andreas): provide `unmultiplied_rgba`
+        ///        uint8_t c = static_cast<uint8_t>((angle / (2.0 * M_PI) * 255.0) + 0.5);
+        ///        uint32_t color = ((255 - c) <<24) + (c <<16) + (128 <<8) + (128 <<0);
+        ///        colors.push_back(color);
+        ///    }
+        ///
+        ///    rr_stream.log(\"arrows\", rr::archetypes::Arrows3D(vectors).with_colors(colors));
+        /// }
+        ///```
         struct Arrows3D {
             /// All the vectors for each arrow in the batch.
             std::vector<rerun::components::Vector3D> vectors;
@@ -49,12 +84,22 @@ namespace rerun {
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
 
           public:
-            Arrows3D(std::vector<rerun::components::Vector3D> vectors)
-                : vectors(std::move(vectors)) {}
+            Arrows3D() = default;
+
+            Arrows3D(std::vector<rerun::components::Vector3D> _vectors)
+                : vectors(std::move(_vectors)) {}
+
+            Arrows3D(rerun::components::Vector3D _vectors) : vectors(1, std::move(_vectors)) {}
 
             /// All the origin points for each arrow in the batch.
             Arrows3D& with_origins(std::vector<rerun::components::Origin3D> _origins) {
                 origins = std::move(_origins);
+                return *this;
+            }
+
+            /// All the origin points for each arrow in the batch.
+            Arrows3D& with_origins(rerun::components::Origin3D _origins) {
+                origins = std::move(std::vector(1, std::move(_origins)));
                 return *this;
             }
 
@@ -67,15 +112,36 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional radii for the arrows.
+            ///
+            /// The shaft is rendered as a line with `radius = 0.5 * radius`.
+            /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
+            Arrows3D& with_radii(rerun::components::Radius _radii) {
+                radii = std::move(std::vector(1, std::move(_radii)));
+                return *this;
+            }
+
             /// Optional colors for the points.
             Arrows3D& with_colors(std::vector<rerun::components::Color> _colors) {
                 colors = std::move(_colors);
                 return *this;
             }
 
+            /// Optional colors for the points.
+            Arrows3D& with_colors(rerun::components::Color _colors) {
+                colors = std::move(std::vector(1, std::move(_colors)));
+                return *this;
+            }
+
             /// Optional text labels for the arrows.
             Arrows3D& with_labels(std::vector<rerun::components::Label> _labels) {
                 labels = std::move(_labels);
+                return *this;
+            }
+
+            /// Optional text labels for the arrows.
+            Arrows3D& with_labels(rerun::components::Label _labels) {
+                labels = std::move(std::vector(1, std::move(_labels)));
                 return *this;
             }
 
@@ -87,10 +153,24 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional class Ids for the points.
+            ///
+            /// The class ID provides colors and labels if not specified explicitly.
+            Arrows3D& with_class_ids(rerun::components::ClassId _class_ids) {
+                class_ids = std::move(std::vector(1, std::move(_class_ids)));
+                return *this;
+            }
+
             /// Unique identifiers for each individual point in the batch.
             Arrows3D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
             ) {
                 instance_keys = std::move(_instance_keys);
+                return *this;
+            }
+
+            /// Unique identifiers for each individual point in the batch.
+            Arrows3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
+                instance_keys = std::move(std::vector(1, std::move(_instance_keys)));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -18,12 +18,46 @@ namespace rerun {
         ///
         /// If a transform or pinhole is logged on the same path, this archetype's components
         /// will be ignored.
+        ///
+        /// ## Example
+        ///
+        ///```
+        ///// Disconnect two spaces.
+        ///
+        /// #include <rerun.hpp>
+        ///
+        /// namespace rr = rerun;
+        ///
+        /// int main() {
+        ///    auto rr_stream = rr::RecordingStream(\"disconnected_space\");
+        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///
+        ///    // These two points can be projected into the same space..
+        ///    rr_stream.log(
+        ///        \"world/room1/point\",
+        ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f})
+        ///    );
+        ///    rr_stream.log(
+        ///        \"world/room2/point\",
+        ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f})
+        ///    );
+        ///
+        ///    // ..but this one lives in a completely separate space!
+        ///    rr_stream.log(\"world/wormhole\", rr::archetypes::DisconnectedSpace(true));
+        ///    rr_stream.log(
+        ///        \"world/wormhole/point\",
+        ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f})
+        ///    );
+        /// }
+        ///```
         struct DisconnectedSpace {
             rerun::components::DisconnectedSpace disconnected_space;
 
           public:
-            DisconnectedSpace(rerun::components::DisconnectedSpace disconnected_space)
-                : disconnected_space(std::move(disconnected_space)) {}
+            DisconnectedSpace() = default;
+
+            DisconnectedSpace(rerun::components::DisconnectedSpace _disconnected_space)
+                : disconnected_space(std::move(_disconnected_space)) {}
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -59,11 +59,22 @@ namespace rerun {
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
 
           public:
-            Points2D(std::vector<rerun::components::Point2D> points) : points(std::move(points)) {}
+            Points2D() = default;
+
+            Points2D(std::vector<rerun::components::Point2D> _points)
+                : points(std::move(_points)) {}
+
+            Points2D(rerun::components::Point2D _points) : points(1, std::move(_points)) {}
 
             /// Optional radii for the points, effectively turning them into circles.
             Points2D& with_radii(std::vector<rerun::components::Radius> _radii) {
                 radii = std::move(_radii);
+                return *this;
+            }
+
+            /// Optional radii for the points, effectively turning them into circles.
+            Points2D& with_radii(rerun::components::Radius _radii) {
+                radii = std::move(std::vector(1, std::move(_radii)));
                 return *this;
             }
 
@@ -73,9 +84,21 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional colors for the points.
+            Points2D& with_colors(rerun::components::Color _colors) {
+                colors = std::move(std::vector(1, std::move(_colors)));
+                return *this;
+            }
+
             /// Optional text labels for the points.
             Points2D& with_labels(std::vector<rerun::components::Label> _labels) {
                 labels = std::move(_labels);
+                return *this;
+            }
+
+            /// Optional text labels for the points.
+            Points2D& with_labels(rerun::components::Label _labels) {
+                labels = std::move(std::vector(1, std::move(_labels)));
                 return *this;
             }
 
@@ -96,6 +119,14 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional class Ids for the points.
+            ///
+            /// The class ID provides colors and labels if not specified explicitly.
+            Points2D& with_class_ids(rerun::components::ClassId _class_ids) {
+                class_ids = std::move(std::vector(1, std::move(_class_ids)));
+                return *this;
+            }
+
             /// Optional keypoint IDs for the points, identifying them within a class.
             ///
             /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
@@ -108,10 +139,28 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional keypoint IDs for the points, identifying them within a class.
+            ///
+            /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
+            /// default to 0.
+            /// This is useful to identify points within a single classification (which is
+            /// identified with `class_id`). E.g. the classification might be 'Person' and the
+            /// keypoints refer to joints on a detected skeleton.
+            Points2D& with_keypoint_ids(rerun::components::KeypointId _keypoint_ids) {
+                keypoint_ids = std::move(std::vector(1, std::move(_keypoint_ids)));
+                return *this;
+            }
+
             /// Unique identifiers for each individual point in the batch.
             Points2D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
             ) {
                 instance_keys = std::move(_instance_keys);
+                return *this;
+            }
+
+            /// Unique identifiers for each individual point in the batch.
+            Points2D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
+                instance_keys = std::move(std::vector(1, std::move(_instance_keys)));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -21,6 +21,29 @@
 namespace rerun {
     namespace archetypes {
         /// A 3D point cloud with positions and optional colors, radii, labels, etc.
+        ///
+        /// ## Example
+        ///
+        ///```
+        ///// Log some very simple points.
+        ///
+        /// #include <rerun.hpp>
+        ///
+        /// namespace rr = rerun;
+        ///
+        /// int main() {
+        ///    auto rr_stream = rr::RecordingStream(\"points3d_simple\");
+        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///
+        ///    rr_stream.log(
+        ///        \"points\",
+        ///        rr::archetypes::Points3D(
+        ///            {rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f},
+        ///            rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}}
+        ///        )
+        ///    );
+        /// }
+        ///```
         struct Points3D {
             /// All the actual 3D points that make up the point cloud.
             std::vector<rerun::components::Point3D> points;
@@ -52,11 +75,22 @@ namespace rerun {
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
 
           public:
-            Points3D(std::vector<rerun::components::Point3D> points) : points(std::move(points)) {}
+            Points3D() = default;
+
+            Points3D(std::vector<rerun::components::Point3D> _points)
+                : points(std::move(_points)) {}
+
+            Points3D(rerun::components::Point3D _points) : points(1, std::move(_points)) {}
 
             /// Optional radii for the points, effectively turning them into circles.
             Points3D& with_radii(std::vector<rerun::components::Radius> _radii) {
                 radii = std::move(_radii);
+                return *this;
+            }
+
+            /// Optional radii for the points, effectively turning them into circles.
+            Points3D& with_radii(rerun::components::Radius _radii) {
+                radii = std::move(std::vector(1, std::move(_radii)));
                 return *this;
             }
 
@@ -66,9 +100,21 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional colors for the points.
+            Points3D& with_colors(rerun::components::Color _colors) {
+                colors = std::move(std::vector(1, std::move(_colors)));
+                return *this;
+            }
+
             /// Optional text labels for the points.
             Points3D& with_labels(std::vector<rerun::components::Label> _labels) {
                 labels = std::move(_labels);
+                return *this;
+            }
+
+            /// Optional text labels for the points.
+            Points3D& with_labels(rerun::components::Label _labels) {
+                labels = std::move(std::vector(1, std::move(_labels)));
                 return *this;
             }
 
@@ -77,6 +123,14 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Points3D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
                 class_ids = std::move(_class_ids);
+                return *this;
+            }
+
+            /// Optional class Ids for the points.
+            ///
+            /// The class ID provides colors and labels if not specified explicitly.
+            Points3D& with_class_ids(rerun::components::ClassId _class_ids) {
+                class_ids = std::move(std::vector(1, std::move(_class_ids)));
                 return *this;
             }
 
@@ -92,10 +146,28 @@ namespace rerun {
                 return *this;
             }
 
+            /// Optional keypoint IDs for the points, identifying them within a class.
+            ///
+            /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
+            /// default to 0.
+            /// This is useful to identify points within a single classification (which is
+            /// identified with `class_id`). E.g. the classification might be 'Person' and the
+            /// keypoints refer to joints on a detected skeleton.
+            Points3D& with_keypoint_ids(rerun::components::KeypointId _keypoint_ids) {
+                keypoint_ids = std::move(std::vector(1, std::move(_keypoint_ids)));
+                return *this;
+            }
+
             /// Unique identifiers for each individual point in the batch.
             Points3D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
             ) {
                 instance_keys = std::move(_instance_keys);
+                return *this;
+            }
+
+            /// Unique identifiers for each individual point in the batch.
+            Points3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
+                instance_keys = std::move(std::vector(1, std::move(_instance_keys)));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -18,8 +18,10 @@ namespace rerun {
             rerun::components::Transform3D transform;
 
           public:
-            Transform3D(rerun::components::Transform3D transform)
-                : transform(std::move(transform)) {}
+            Transform3D() = default;
+
+            Transform3D(rerun::components::Transform3D _transform)
+                : transform(std::move(_transform)) {}
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer1.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer1(rerun::datatypes::AffixFuzzer1 single_required)
-                : single_required(std::move(single_required)) {}
+            AffixFuzzer1() = default;
+
+            AffixFuzzer1(rerun::datatypes::AffixFuzzer1 _single_required)
+                : single_required(std::move(_single_required)) {}
+
+            AffixFuzzer1& operator=(rerun::datatypes::AffixFuzzer1 _single_required) {
+                single_required = std::move(_single_required);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer10.hpp
@@ -20,8 +20,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer10(std::optional<std::string> single_string_optional)
-                : single_string_optional(std::move(single_string_optional)) {}
+            AffixFuzzer10() = default;
+
+            AffixFuzzer10(std::optional<std::string> _single_string_optional)
+                : single_string_optional(std::move(_single_string_optional)) {}
+
+            AffixFuzzer10& operator=(std::optional<std::string> _single_string_optional) {
+                single_string_optional = std::move(_single_string_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer11.hpp
@@ -20,8 +20,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer11(std::optional<std::vector<float>> many_floats_optional)
-                : many_floats_optional(std::move(many_floats_optional)) {}
+            AffixFuzzer11() = default;
+
+            AffixFuzzer11(std::optional<std::vector<float>> _many_floats_optional)
+                : many_floats_optional(std::move(_many_floats_optional)) {}
+
+            AffixFuzzer11& operator=(std::optional<std::vector<float>> _many_floats_optional) {
+                many_floats_optional = std::move(_many_floats_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer12.hpp
@@ -20,8 +20,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer12(std::vector<std::string> many_strings_required)
-                : many_strings_required(std::move(many_strings_required)) {}
+            AffixFuzzer12() = default;
+
+            AffixFuzzer12(std::vector<std::string> _many_strings_required)
+                : many_strings_required(std::move(_many_strings_required)) {}
+
+            AffixFuzzer12& operator=(std::vector<std::string> _many_strings_required) {
+                many_strings_required = std::move(_many_strings_required);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer13.hpp
@@ -21,8 +21,16 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer13(std::optional<std::vector<std::string>> many_strings_optional)
-                : many_strings_optional(std::move(many_strings_optional)) {}
+            AffixFuzzer13() = default;
+
+            AffixFuzzer13(std::optional<std::vector<std::string>> _many_strings_optional)
+                : many_strings_optional(std::move(_many_strings_optional)) {}
+
+            AffixFuzzer13& operator=(std::optional<std::vector<std::string>> _many_strings_optional
+            ) {
+                many_strings_optional = std::move(_many_strings_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer14.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer14(rerun::datatypes::AffixFuzzer3 single_required_union)
-                : single_required_union(std::move(single_required_union)) {}
+            AffixFuzzer14() = default;
+
+            AffixFuzzer14(rerun::datatypes::AffixFuzzer3 _single_required_union)
+                : single_required_union(std::move(_single_required_union)) {}
+
+            AffixFuzzer14& operator=(rerun::datatypes::AffixFuzzer3 _single_required_union) {
+                single_required_union = std::move(_single_required_union);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer15.hpp
@@ -20,8 +20,17 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer15(std::optional<rerun::datatypes::AffixFuzzer3> single_optional_union)
-                : single_optional_union(std::move(single_optional_union)) {}
+            AffixFuzzer15() = default;
+
+            AffixFuzzer15(std::optional<rerun::datatypes::AffixFuzzer3> _single_optional_union)
+                : single_optional_union(std::move(_single_optional_union)) {}
+
+            AffixFuzzer15& operator=(
+                std::optional<rerun::datatypes::AffixFuzzer3> _single_optional_union
+            ) {
+                single_optional_union = std::move(_single_optional_union);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer16.hpp
@@ -20,8 +20,17 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer16(std::vector<rerun::datatypes::AffixFuzzer3> many_required_unions)
-                : many_required_unions(std::move(many_required_unions)) {}
+            AffixFuzzer16() = default;
+
+            AffixFuzzer16(std::vector<rerun::datatypes::AffixFuzzer3> _many_required_unions)
+                : many_required_unions(std::move(_many_required_unions)) {}
+
+            AffixFuzzer16& operator=(
+                std::vector<rerun::datatypes::AffixFuzzer3> _many_required_unions
+            ) {
+                many_required_unions = std::move(_many_required_unions);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer17.hpp
@@ -21,10 +21,19 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            AffixFuzzer17() = default;
+
             AffixFuzzer17(
-                std::optional<std::vector<rerun::datatypes::AffixFuzzer3>> many_optional_unions
+                std::optional<std::vector<rerun::datatypes::AffixFuzzer3>> _many_optional_unions
             )
-                : many_optional_unions(std::move(many_optional_unions)) {}
+                : many_optional_unions(std::move(_many_optional_unions)) {}
+
+            AffixFuzzer17& operator=(
+                std::optional<std::vector<rerun::datatypes::AffixFuzzer3>> _many_optional_unions
+            ) {
+                many_optional_unions = std::move(_many_optional_unions);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer18.hpp
@@ -21,10 +21,19 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            AffixFuzzer18() = default;
+
             AffixFuzzer18(
-                std::optional<std::vector<rerun::datatypes::AffixFuzzer4>> many_optional_unions
+                std::optional<std::vector<rerun::datatypes::AffixFuzzer4>> _many_optional_unions
             )
-                : many_optional_unions(std::move(many_optional_unions)) {}
+                : many_optional_unions(std::move(_many_optional_unions)) {}
+
+            AffixFuzzer18& operator=(
+                std::optional<std::vector<rerun::datatypes::AffixFuzzer4>> _many_optional_unions
+            ) {
+                many_optional_unions = std::move(_many_optional_unions);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer19.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer19(rerun::datatypes::AffixFuzzer5 just_a_table_nothing_shady)
-                : just_a_table_nothing_shady(std::move(just_a_table_nothing_shady)) {}
+            AffixFuzzer19() = default;
+
+            AffixFuzzer19(rerun::datatypes::AffixFuzzer5 _just_a_table_nothing_shady)
+                : just_a_table_nothing_shady(std::move(_just_a_table_nothing_shady)) {}
+
+            AffixFuzzer19& operator=(rerun::datatypes::AffixFuzzer5 _just_a_table_nothing_shady) {
+                just_a_table_nothing_shady = std::move(_just_a_table_nothing_shady);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer2.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer2(rerun::datatypes::AffixFuzzer1 single_required)
-                : single_required(std::move(single_required)) {}
+            AffixFuzzer2() = default;
+
+            AffixFuzzer2(rerun::datatypes::AffixFuzzer1 _single_required)
+                : single_required(std::move(_single_required)) {}
+
+            AffixFuzzer2& operator=(rerun::datatypes::AffixFuzzer1 _single_required) {
+                single_required = std::move(_single_required);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer20.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer20(rerun::datatypes::AffixFuzzer20 nested_transparent)
-                : nested_transparent(std::move(nested_transparent)) {}
+            AffixFuzzer20() = default;
+
+            AffixFuzzer20(rerun::datatypes::AffixFuzzer20 _nested_transparent)
+                : nested_transparent(std::move(_nested_transparent)) {}
+
+            AffixFuzzer20& operator=(rerun::datatypes::AffixFuzzer20 _nested_transparent) {
+                nested_transparent = std::move(_nested_transparent);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer3.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer3(rerun::datatypes::AffixFuzzer1 single_required)
-                : single_required(std::move(single_required)) {}
+            AffixFuzzer3() = default;
+
+            AffixFuzzer3(rerun::datatypes::AffixFuzzer1 _single_required)
+                : single_required(std::move(_single_required)) {}
+
+            AffixFuzzer3& operator=(rerun::datatypes::AffixFuzzer1 _single_required) {
+                single_required = std::move(_single_required);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer4.hpp
@@ -20,8 +20,16 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer4(std::optional<rerun::datatypes::AffixFuzzer1> single_optional)
-                : single_optional(std::move(single_optional)) {}
+            AffixFuzzer4() = default;
+
+            AffixFuzzer4(std::optional<rerun::datatypes::AffixFuzzer1> _single_optional)
+                : single_optional(std::move(_single_optional)) {}
+
+            AffixFuzzer4& operator=(std::optional<rerun::datatypes::AffixFuzzer1> _single_optional
+            ) {
+                single_optional = std::move(_single_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer5.hpp
@@ -20,8 +20,16 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer5(std::optional<rerun::datatypes::AffixFuzzer1> single_optional)
-                : single_optional(std::move(single_optional)) {}
+            AffixFuzzer5() = default;
+
+            AffixFuzzer5(std::optional<rerun::datatypes::AffixFuzzer1> _single_optional)
+                : single_optional(std::move(_single_optional)) {}
+
+            AffixFuzzer5& operator=(std::optional<rerun::datatypes::AffixFuzzer1> _single_optional
+            ) {
+                single_optional = std::move(_single_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer6.hpp
@@ -20,8 +20,16 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer6(std::optional<rerun::datatypes::AffixFuzzer1> single_optional)
-                : single_optional(std::move(single_optional)) {}
+            AffixFuzzer6() = default;
+
+            AffixFuzzer6(std::optional<rerun::datatypes::AffixFuzzer1> _single_optional)
+                : single_optional(std::move(_single_optional)) {}
+
+            AffixFuzzer6& operator=(std::optional<rerun::datatypes::AffixFuzzer1> _single_optional
+            ) {
+                single_optional = std::move(_single_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer7.hpp
@@ -21,8 +21,17 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer7(std::optional<std::vector<rerun::datatypes::AffixFuzzer1>> many_optional)
-                : many_optional(std::move(many_optional)) {}
+            AffixFuzzer7() = default;
+
+            AffixFuzzer7(std::optional<std::vector<rerun::datatypes::AffixFuzzer1>> _many_optional)
+                : many_optional(std::move(_many_optional)) {}
+
+            AffixFuzzer7& operator=(
+                std::optional<std::vector<rerun::datatypes::AffixFuzzer1>> _many_optional
+            ) {
+                many_optional = std::move(_many_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer8.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer8(std::optional<float> single_float_optional)
-                : single_float_optional(std::move(single_float_optional)) {}
+            AffixFuzzer8() = default;
+
+            AffixFuzzer8(std::optional<float> _single_float_optional)
+                : single_float_optional(std::move(_single_float_optional)) {}
+
+            AffixFuzzer8& operator=(std::optional<float> _single_float_optional) {
+                single_float_optional = std::move(_single_float_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer9.hpp
@@ -19,8 +19,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AffixFuzzer9(std::string single_string_required)
-                : single_string_required(std::move(single_string_required)) {}
+            AffixFuzzer9() = default;
+
+            AffixFuzzer9(std::string _single_string_required)
+                : single_string_required(std::move(_single_string_required)) {}
+
+            AffixFuzzer9& operator=(std::string _single_string_required) {
+                single_string_required = std::move(_single_string_required);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -27,8 +27,17 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            AnnotationContext(std::vector<rerun::datatypes::ClassDescriptionMapElem> class_map)
-                : class_map(std::move(class_map)) {}
+            AnnotationContext() = default;
+
+            AnnotationContext(std::vector<rerun::datatypes::ClassDescriptionMapElem> _class_map)
+                : class_map(std::move(_class_map)) {}
+
+            AnnotationContext& operator=(
+                std::vector<rerun::datatypes::ClassDescriptionMapElem> _class_map
+            ) {
+                class_map = std::move(_class_map);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -19,7 +19,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            ClassId(uint16_t id) : id(std::move(id)) {}
+            ClassId() = default;
+
+            ClassId(uint16_t _id) : id(std::move(_id)) {}
+
+            ClassId& operator=(uint16_t _id) {
+                id = std::move(_id);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -20,7 +20,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Color(uint32_t rgba) : rgba(std::move(rgba)) {}
+            Color() = default;
+
+            Color(uint32_t _rgba) : rgba(std::move(_rgba)) {}
+
+            Color& operator=(uint32_t _rgba) {
+                rgba = std::move(_rgba);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -23,7 +23,15 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            DisconnectedSpace(bool is_disconnected) : is_disconnected(std::move(is_disconnected)) {}
+            DisconnectedSpace() = default;
+
+            DisconnectedSpace(bool _is_disconnected)
+                : is_disconnected(std::move(_is_disconnected)) {}
+
+            DisconnectedSpace& operator=(bool _is_disconnected) {
+                is_disconnected = std::move(_is_disconnected);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -25,7 +25,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            DrawOrder(float value) : value(std::move(value)) {}
+            DrawOrder() = default;
+
+            DrawOrder(float _value) : value(std::move(_value)) {}
+
+            DrawOrder& operator=(float _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -19,7 +19,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            InstanceKey(uint64_t value) : value(std::move(value)) {}
+            InstanceKey() = default;
+
+            InstanceKey(uint64_t _value) : value(std::move(_value)) {}
+
+            InstanceKey& operator=(uint64_t _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -19,7 +19,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            KeypointId(uint16_t id) : id(std::move(id)) {}
+            KeypointId() = default;
+
+            KeypointId(uint16_t _id) : id(std::move(_id)) {}
+
+            KeypointId& operator=(uint16_t _id) {
+                id = std::move(_id);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/label.hpp
+++ b/rerun_cpp/src/rerun/components/label.hpp
@@ -20,7 +20,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Label(std::string value) : value(std::move(value)) {}
+            Label() = default;
+
+            Label(std::string _value) : value(std::move(_value)) {}
+
+            Label& operator=(std::string _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/origin3d.hpp
+++ b/rerun_cpp/src/rerun/components/origin3d.hpp
@@ -20,7 +20,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Origin3D(rerun::datatypes::Vec3D origin) : origin(std::move(origin)) {}
+            Origin3D() = default;
+
+            Origin3D(rerun::datatypes::Vec3D _origin) : origin(std::move(_origin)) {}
+
+            Origin3D& operator=(rerun::datatypes::Vec3D _origin) {
+                origin = std::move(_origin);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/point2d.hpp
+++ b/rerun_cpp/src/rerun/components/point2d.hpp
@@ -20,7 +20,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Point2D(rerun::datatypes::Vec2D xy) : xy(std::move(xy)) {}
+            Point2D() = default;
+
+            Point2D(rerun::datatypes::Vec2D _xy) : xy(std::move(_xy)) {}
+
+            Point2D& operator=(rerun::datatypes::Vec2D _xy) {
+                xy = std::move(_xy);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/point3d.hpp
+++ b/rerun_cpp/src/rerun/components/point3d.hpp
@@ -14,13 +14,20 @@ namespace rerun {
     namespace components {
         /// A point in 3D space.
         struct Point3D {
-            rerun::datatypes::Vec3D xy;
+            rerun::datatypes::Vec3D xyz;
 
             /// Name of the component, used for serialization.
             static const char* NAME;
 
           public:
-            Point3D(rerun::datatypes::Vec3D xy) : xy(std::move(xy)) {}
+            Point3D() = default;
+
+            Point3D(rerun::datatypes::Vec3D _xyz) : xyz(std::move(_xyz)) {}
+
+            Point3D& operator=(rerun::datatypes::Vec3D _xyz) {
+                xyz = std::move(_xyz);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/primitive_component.hpp
+++ b/rerun_cpp/src/rerun/components/primitive_component.hpp
@@ -18,7 +18,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            PrimitiveComponent(uint32_t value) : value(std::move(value)) {}
+            PrimitiveComponent() = default;
+
+            PrimitiveComponent(uint32_t _value) : value(std::move(_value)) {}
+
+            PrimitiveComponent& operator=(uint32_t _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -19,7 +19,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Radius(float value) : value(std::move(value)) {}
+            Radius() = default;
+
+            Radius(float _value) : value(std::move(_value)) {}
+
+            Radius& operator=(float _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/string_component.hpp
+++ b/rerun_cpp/src/rerun/components/string_component.hpp
@@ -19,7 +19,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            StringComponent(std::string value) : value(std::move(value)) {}
+            StringComponent() = default;
+
+            StringComponent(std::string _value) : value(std::move(_value)) {}
+
+            StringComponent& operator=(std::string _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -21,7 +21,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Transform3D(rerun::datatypes::Transform3D repr) : repr(std::move(repr)) {}
+            Transform3D() = default;
+
+            Transform3D(rerun::datatypes::Transform3D _repr) : repr(std::move(_repr)) {}
+
+            Transform3D& operator=(rerun::datatypes::Transform3D _repr) {
+                repr = std::move(_repr);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -20,7 +20,14 @@ namespace rerun {
             static const char* NAME;
 
           public:
-            Vector3D(rerun::datatypes::Vec3D vector) : vector(std::move(vector)) {}
+            Vector3D() = default;
+
+            Vector3D(rerun::datatypes::Vec3D _vector) : vector(std::move(_vector)) {}
+
+            Vector3D& operator=(rerun::datatypes::Vec3D _vector) {
+                vector = std::move(_vector);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.hpp
@@ -33,6 +33,8 @@ namespace rerun {
             std::optional<bool> from_parent;
 
           public:
+            AffixFuzzer1() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer2.hpp
@@ -14,8 +14,15 @@ namespace rerun {
             std::optional<float> single_float_optional;
 
           public:
-            AffixFuzzer2(std::optional<float> single_float_optional)
-                : single_float_optional(std::move(single_float_optional)) {}
+            AffixFuzzer2() = default;
+
+            AffixFuzzer2(std::optional<float> _single_float_optional)
+                : single_float_optional(std::move(_single_float_optional)) {}
+
+            AffixFuzzer2& operator=(std::optional<float> _single_float_optional) {
+                single_float_optional = std::move(_single_float_optional);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer20.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer20.hpp
@@ -17,6 +17,8 @@ namespace rerun {
             rerun::components::StringComponent s;
 
           public:
+            AffixFuzzer20() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.hpp
@@ -52,6 +52,8 @@ namespace rerun {
         } // namespace detail
 
         struct AffixFuzzer3 {
+            AffixFuzzer3() : _tag(detail::AffixFuzzer3Tag::NONE) {}
+
             AffixFuzzer3(const AffixFuzzer3& other) : _tag(other._tag) {
                 switch (other._tag) {
                     case detail::AffixFuzzer3Tag::craziness: {
@@ -156,10 +158,6 @@ namespace rerun {
           private:
             detail::AffixFuzzer3Tag _tag;
             detail::AffixFuzzer3Data _data;
-
-            AffixFuzzer3() : _tag(detail::AffixFuzzer3Tag::NONE) {}
-
-          public:
         };
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.hpp
@@ -49,6 +49,8 @@ namespace rerun {
         } // namespace detail
 
         struct AffixFuzzer4 {
+            AffixFuzzer4() : _tag(detail::AffixFuzzer4Tag::NONE) {}
+
             AffixFuzzer4(const AffixFuzzer4& other) : _tag(other._tag) {
                 switch (other._tag) {
                     case detail::AffixFuzzer4Tag::single_required: {
@@ -159,10 +161,6 @@ namespace rerun {
           private:
             detail::AffixFuzzer4Tag _tag;
             detail::AffixFuzzer4Data _data;
-
-            AffixFuzzer4() : _tag(detail::AffixFuzzer4Tag::NONE) {}
-
-          public:
         };
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer5.hpp
@@ -16,8 +16,17 @@ namespace rerun {
             std::optional<rerun::datatypes::AffixFuzzer4> single_optional_union;
 
           public:
-            AffixFuzzer5(std::optional<rerun::datatypes::AffixFuzzer4> single_optional_union)
-                : single_optional_union(std::move(single_optional_union)) {}
+            AffixFuzzer5() = default;
+
+            AffixFuzzer5(std::optional<rerun::datatypes::AffixFuzzer4> _single_optional_union)
+                : single_optional_union(std::move(_single_optional_union)) {}
+
+            AffixFuzzer5& operator=(
+                std::optional<rerun::datatypes::AffixFuzzer4> _single_optional_union
+            ) {
+                single_optional_union = std::move(_single_optional_union);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -42,6 +42,8 @@ namespace rerun {
 
         /// Angle in either radians or degrees.
         struct Angle {
+            Angle() : _tag(detail::AngleTag::NONE) {}
+
             Angle(const Angle& other) : _tag(other._tag) {
                 memcpy(&this->_data, &other._data, sizeof(detail::AngleData));
             }
@@ -98,10 +100,6 @@ namespace rerun {
           private:
             detail::AngleTag _tag;
             detail::AngleData _data;
-
-            Angle() : _tag(detail::AngleTag::NONE) {}
-
-          public:
         };
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -27,6 +27,8 @@ namespace rerun {
             std::optional<rerun::components::Color> color;
 
           public:
+            AnnotationInfo() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -37,6 +37,8 @@ namespace rerun {
             std::vector<rerun::datatypes::KeypointPair> keypoint_connections;
 
           public:
+            ClassDescription() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -20,6 +20,8 @@ namespace rerun {
             rerun::datatypes::ClassDescription class_description;
 
           public:
+            ClassDescriptionMapElem() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/src/rerun/datatypes/flattened_scalar.hpp
@@ -13,7 +13,14 @@ namespace rerun {
             float value;
 
           public:
-            FlattenedScalar(float value) : value(std::move(value)) {}
+            FlattenedScalar() = default;
+
+            FlattenedScalar(float _value) : value(std::move(_value)) {}
+
+            FlattenedScalar& operator=(float _value) {
+                value = std::move(_value);
+                return *this;
+            }
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -17,6 +17,8 @@ namespace rerun {
             rerun::components::KeypointId keypoint1;
 
           public:
+            KeypointPair() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -13,6 +13,8 @@ namespace rerun {
             float coeffs[9];
 
           public:
+            Mat3x3() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -13,6 +13,8 @@ namespace rerun {
             float coeffs[16];
 
           public:
+            Mat4x4() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -13,6 +13,8 @@ namespace rerun {
             float xyzw[4];
 
           public:
+            Quaternion() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -47,6 +47,8 @@ namespace rerun {
 
         /// A 3D rotation.
         struct Rotation3D {
+            Rotation3D() : _tag(detail::Rotation3DTag::NONE) {}
+
             Rotation3D(const Rotation3D& other) : _tag(other._tag) {
                 memcpy(&this->_data, &other._data, sizeof(detail::Rotation3DData));
             }
@@ -115,10 +117,6 @@ namespace rerun {
           private:
             detail::Rotation3DTag _tag;
             detail::Rotation3DData _data;
-
-            Rotation3D() : _tag(detail::Rotation3DTag::NONE) {}
-
-          public:
         };
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -24,6 +24,8 @@ namespace rerun {
             rerun::datatypes::Angle angle;
 
           public:
+            RotationAxisAngle() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -46,6 +46,8 @@ namespace rerun {
 
         /// 3D scaling factor, part of a transform representation.
         struct Scale3D {
+            Scale3D() : _tag(detail::Scale3DTag::NONE) {}
+
             Scale3D(const Scale3D& other) : _tag(other._tag) {
                 memcpy(&this->_data, &other._data, sizeof(detail::Scale3DData));
             }
@@ -114,10 +116,6 @@ namespace rerun {
           private:
             detail::Scale3DTag _tag;
             detail::Scale3DData _data;
-
-            Scale3D() : _tag(detail::Scale3DTag::NONE) {}
-
-          public:
         };
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -45,6 +45,8 @@ namespace rerun {
 
         /// Representation of a 3D affine transform.
         struct Transform3D {
+            Transform3D() : _tag(detail::Transform3DTag::NONE) {}
+
             Transform3D(const Transform3D& other) : _tag(other._tag) {
                 memcpy(&this->_data, &other._data, sizeof(detail::Transform3DData));
             }
@@ -114,10 +116,6 @@ namespace rerun {
           private:
             detail::Transform3DTag _tag;
             detail::Transform3DData _data;
-
-            Transform3D() : _tag(detail::Transform3DTag::NONE) {}
-
-          public:
         };
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -27,6 +27,8 @@ namespace rerun {
             bool from_parent;
 
           public:
+            TranslationAndMat3x3() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -29,6 +29,8 @@ namespace rerun {
             bool from_parent;
 
           public:
+            TranslationRotationScale3D() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -13,6 +13,8 @@ namespace rerun {
             float xy[2];
 
           public:
+            Vec2D() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -13,6 +13,8 @@ namespace rerun {
             float xyz[3];
 
           public:
+            Vec3D() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -13,6 +13,8 @@ namespace rerun {
             float xyzw[4];
 
           public:
+            Vec4D() = default;
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -118,6 +118,18 @@ namespace rerun {
         /// Logs an archetype.
         ///
         /// Prefer this interface for ease of use over the more general `log_components` interface.
+        ///
+        /// Alias for `log_archetype`.
+        /// TODO(andreas): Would be nice if this were able to combine both log_archetype and
+        /// log_components!
+        template <typename T>
+        void log(const char* entity_path, const T& archetype) {
+            log_archetype(entity_path, archetype);
+        }
+
+        /// Logs an archetype.
+        ///
+        /// Prefer this interface for ease of use over the more general `log_components` interface.
         template <typename T>
         void log_archetype(const char* entity_path, const T& archetype) {
             // TODO(andreas): Handle splats.

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,3 +1,26 @@
 cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(roundtrips)
+
+# Setup builds for examples
+file(GLOB sources_list true ${CMAKE_CURRENT_SOURCE_DIR}/../../docs/code-examples/*.cpp)
+
+add_custom_target(doc_examples)
+
+foreach(SOURCE_PATH ${sources_list})
+    get_filename_component(SOURCE_NAME ${SOURCE_PATH} NAME_WLE)
+
+    if(${SOURCE_NAME} STREQUAL "CMakeFiles")
+        CONTINUE()
+    endif()
+
+    set(EXAMPLE_TARGET doc_example_${SOURCE_NAME})
+
+    add_executable(${EXAMPLE_TARGET} ${SOURCE_PATH})
+
+    # TODO(andreas): Fix warnings and enable this.
+    # set_default_warning_settings(rerun_example)
+    target_link_libraries(${EXAMPLE_TARGET} PRIVATE rerun_sdk)
+
+    add_dependencies(doc_examples ${EXAMPLE_TARGET})
+endforeach()

--- a/tests/cpp/build_all_doc_examples.sh
+++ b/tests/cpp/build_all_doc_examples.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$script_path/../.."
+set -x
+
+num_threads=$(getconf _NPROCESSORS_ONLN)
+
+mkdir -p build
+pushd build
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    cmake --build . --config Debug --target doc_examples -j ${num_threads}
+popd


### PR DESCRIPTION
### What

Adds C++ example build setup and examples for:

* Point3D  #2789
* Arrow3D #2785
* DisconnectedSpace #2791

as before Point2D example is blocked on rects for the moment.

Generating a bunch more methods now for better usability. Still lacking user extensions though, in particular Point3D construction is poor right now

Examples can be built in bulk with ` ./tests/cpp/build_all_doc_examples.sh`
Then run with `./build/tests/cpp/doc_example_point3d_EXAMPLE_NAME`
They all connect to localhost on default port for now.


Point3D Simple:
<img width="1336" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/61ca8dba-690f-4bcf-96d2-25cb010881fb">

Point3D Random:
<img width="1341" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/48fa902d-7858-4580-b64b-69815dab47e3">

Arrow3D:
<img width="1360" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/131d0efa-af94-418a-b08f-653c1d9eafb0">

Disconnected Space:
<img width="1339" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/5da1bb64-984a-4ff5-903a-1ea060dd296a">

Dependent on #2906 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2908) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2908)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fexamplesv2/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fexamplesv2/examples)