### PR TITLE
Derive `app_id` from example name for all rust doc examples

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-0b4dfae1af57be022fc3702211e4599f0d5b831302d4b36d11201019aba2b66e
+b82acf657cdff5aca321d933bc9c10bc430f0224f287cba0e4b0243ad82ca1e3

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -32,7 +32,7 @@
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new("annotation_context_rects").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 ///
 ///    // Log an annotation context to assign a label and color to each class
 ///    let annotation = AnnotationContext::new([

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -28,7 +28,7 @@
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new("arrow").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 ///
 ///    let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)
 ///        .map(|i| {

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -30,7 +30,7 @@
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new("disconnect_space").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 ///
 ///    // These two points can be projected into the same space..
 ///    MsgSender::from_archetype("world/room1/point", &Points3D::new([(0.0, 0.0, 0.0)]))?

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -24,7 +24,7 @@
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 ///
 ///    MsgSender::from_archetype("points", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?
 ///        .send(&rec_stream)?;

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -21,7 +21,7 @@
 /// use rerun::{archetypes::Points3D, MsgSender, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 ///
 ///    MsgSender::from_archetype("points", &Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]))?
 ///        .send(&rec_stream)?;

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -30,7 +30,7 @@
 /// use std::f32::consts::PI;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///    let (rec_stream, storage) = RecordingStreamBuilder::new("transform").memory()?;
+///    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 ///
 ///    let vector = Vector3D::from((0.0, 1.0, 0.0));
 ///

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -1,12 +1,12 @@
 //! Log some very simple points.
-use rerun::archetypes::AnnotationContext;
-use rerun::components::{ClassId, Color, KeypointId, Label, Point3D};
+
+use rerun::archetypes::{AnnotationContext, Points3D};
+use rerun::components::{Color, Label};
 use rerun::datatypes::{AnnotationInfo, ClassDescription, KeypointPair};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) =
-        RecordingStreamBuilder::new("annotation_context_connections").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some
@@ -44,21 +44,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     MsgSender::from_archetype("/", &annotation)?.send(&rec_stream)?;
 
     // Log some points with different keypoint IDs
-    let points = [
-        [0., 0., 0.],
-        [50., 0., 20.],
-        [100., 100., 30.],
-        [0., 50., 40.],
-    ]
-    .into_iter()
-    .map(Point3D::from)
-    .collect::<Vec<_>>();
-
-    MsgSender::new("points")
-        .with_component(&points)?
-        .with_component(&[KeypointId(0), KeypointId(1), KeypointId(2), KeypointId(3)])?
-        .with_splat(ClassId(0))?
-        .send(&rec_stream)?;
+    MsgSender::from_archetype(
+        "points",
+        &Points3D::new([
+            [0., 0., 0.],
+            [50., 0., 20.],
+            [100., 100., 30.],
+            [0., 50., 40.],
+        ])
+        .with_keypoint_ids([0, 1, 2, 3])
+        .with_class_ids([0]),
+    )?
+    .send(&rec_stream)?;
 
     rerun::native_viewer::show(storage.take())?;
 

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -7,7 +7,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("annotation_context_rects").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     // Log an annotation context to assign a label and color to each class
     let annotation = AnnotationContext::new([

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -5,8 +5,7 @@ use rerun::datatypes::{AnnotationInfo, ClassDescription};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) =
-        RecordingStreamBuilder::new("annotation_context_segmentation").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     // create a segmentation image
     let mut data = Array::<u8, _>::zeros((200, 300).f());

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -6,7 +6,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("arrow").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let arrow = Vector3D::from((0.0, 1.0, 0.0));
 

--- a/docs/code-examples/arrow3d_simple_v2.rs
+++ b/docs/code-examples/arrow3d_simple_v2.rs
@@ -9,7 +9,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("arrow").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)
         .map(|i| {

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -3,7 +3,7 @@ use rerun::components::Box3D;
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("box3d").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     MsgSender::new("simple")
         .with_component(&[Box3D::new(2.0, 2.0, 1.0)])?

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -7,7 +7,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("depth_image").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     // Create a dummy depth image
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -4,7 +4,7 @@ use rerun::components::{Tensor, TensorDataMeaning};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("depth_image").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/disconnected_space_v2.rs
+++ b/docs/code-examples/disconnected_space_v2.rs
@@ -6,7 +6,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("disconnect_space").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     // These two points can be projected into the same space..
     MsgSender::from_archetype("world/room1/point", &Points3D::new([(0.0, 0.0, 0.0)]))?

--- a/docs/code-examples/extension-components/example.rs
+++ b/docs/code-examples/extension-components/example.rs
@@ -17,4 +17,3 @@ fn log_custom(session: &mut Session) -> Result<(), rerun::MsgSenderError> {
         .with_splat(MyComponent(0.9))?
         .send(session)
 }
-c

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -4,7 +4,7 @@ use rerun::components::Tensor;
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("pinhole").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -6,7 +6,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("linestrip2d").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let points = vec![[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -2,7 +2,7 @@
 use rerun::{components::LineStrip3D, MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("linestrip2d").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let points = vec![
         [0., 0., 0.],

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -6,7 +6,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("linestrip2d").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let points = vec![[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -3,7 +3,7 @@ use rerun::components::LineStrip3D;
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("linestrip2d").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let points = vec![
         [0., 0., 0.],

--- a/docs/code-examples/mesh_simple.rs
+++ b/docs/code-examples/mesh_simple.rs
@@ -3,7 +3,7 @@ use rerun::components::{Mesh3D, MeshId, RawMesh3D};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("mesh").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mesh = RawMesh3D {
         mesh_id: MeshId::random(),

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -7,7 +7,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("pinhole").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -8,7 +8,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut rng = rand::thread_rng();
     let position_distribs = Uniform::new(-3., 3.);

--- a/docs/code-examples/point2d_random_v2.rs
+++ b/docs/code-examples/point2d_random_v2.rs
@@ -10,7 +10,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -6,7 +6,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let points = [[0.0, 0.0], [1.0, 1.0]]
         .into_iter()

--- a/docs/code-examples/point2d_simple_v2.rs
+++ b/docs/code-examples/point2d_simple_v2.rs
@@ -5,7 +5,7 @@ use rerun::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     MsgSender::from_archetype("points", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?
         .send(&rec_stream)?;

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -5,7 +5,7 @@ use rerun::components::{Color, Point3D, Radius};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut rng = rand::thread_rng();
     let position_distribs = Uniform::new(-5., 5.);

--- a/docs/code-examples/point3d_random_v2.rs
+++ b/docs/code-examples/point3d_random_v2.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use rerun::{archetypes::Points3D, components::Color, MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -3,7 +3,7 @@
 use rerun::{components::Point3D, MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let points = [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
         .into_iter()

--- a/docs/code-examples/point3d_simple_v2.rs
+++ b/docs/code-examples/point3d_simple_v2.rs
@@ -2,7 +2,7 @@
 use rerun::{archetypes::Points3D, MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("points").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     MsgSender::from_archetype("points", &Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]))?
         .send(&rec_stream)?;

--- a/docs/code-examples/rect2d_simple.rs
+++ b/docs/code-examples/rect2d_simple.rs
@@ -2,7 +2,7 @@
 use rerun::{components::Rect2D, datatypes::Vec4D, MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("rect2d").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     MsgSender::new("simple")
         .with_component(&[Rect2D::XYWH(Vec4D([-1., -1., 2., 2.]).into())])?

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -6,7 +6,7 @@ use rerun::time::{TimeType, Timeline};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("scalar").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let step_timeline = Timeline::new("step", TimeType::Sequence);
 

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -6,7 +6,7 @@ use rerun::datatypes::{AnnotationInfo, ClassDescription};
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("segmentation_image").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((200, 300).f());

--- a/docs/code-examples/tensor_one_dim.rs
+++ b/docs/code-examples/tensor_one_dim.rs
@@ -6,7 +6,7 @@ use rerun::components::Tensor;
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("tensors").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut data = Array::<f64, _>::default((100).f());
     data.map_inplace(|x| *x = thread_rng().sample(StandardNormal));

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -4,7 +4,7 @@ use rerun::components::Tensor;
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("tensors").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/text_entry_simple.rs
+++ b/docs/code-examples/text_entry_simple.rs
@@ -3,7 +3,7 @@ use rerun::components::TextEntry;
 use rerun::{MsgSender, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("text_entry").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     MsgSender::new("logs")
         .with_component(&[TextEntry::new(

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -11,7 +11,7 @@ use rerun::{
 use std::f32::consts::PI;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("transform").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let vector = Vector3D::from((0.0, 1.0, 0.0));
 

--- a/docs/code-examples/transform3d_simple_v2.rs
+++ b/docs/code-examples/transform3d_simple_v2.rs
@@ -11,7 +11,7 @@ use rerun::{
 use std::f32::consts::PI;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec_stream, storage) = RecordingStreamBuilder::new("transform").memory()?;
+    let (rec_stream, storage) = RecordingStreamBuilder::new(env!("CARGO_BIN_NAME")).memory()?;
 
     let vector = Vector3D::from((0.0, 1.0, 0.0));
 


### PR DESCRIPTION
What the title says (tired of correcting typos :upside_down_face:)

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2912) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2912)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fappid_from_bin/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fappid_from_bin/examples)