### PR TITLE
Make `cargo codegen` work irrelevant of CWD

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-ac9463a359809ef6d9007263e6dc079e346bfc4052892e67c0ef628049f2dfba
+0b4dfae1af57be022fc3702211e4599f0d5b831302d4b36d11201019aba2b66e


### PR DESCRIPTION
What the title says.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2913) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2913)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fcargo_codegen_anywhere/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fcargo_codegen_anywhere/examples)