### PR TITLE
Add (debug-only) style panel

### DIFF
--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -32,6 +32,9 @@ pub enum UICommand {
     ToggleSelectionPanel,
     ToggleTimePanel,
 
+    #[cfg(debug_assertions)]
+    ToggleStylePanel,
+
     #[cfg(not(target_arch = "wasm32"))]
     ToggleFullscreen,
     #[cfg(not(target_arch = "wasm32"))]
@@ -104,6 +107,12 @@ impl UICommand {
             UICommand::ToggleBlueprintPanel => ("Toggle Blueprint Panel", "Toggle the left panel"),
             UICommand::ToggleSelectionPanel => ("Toggle Selection Panel", "Toggle the right panel"),
             UICommand::ToggleTimePanel => ("Toggle Time Panel", "Toggle the bottom panel"),
+
+            #[cfg(debug_assertions)]
+            UICommand::ToggleStylePanel => (
+                "Toggle Style Panel",
+                "View and change global egui style settings",
+            ),
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ToggleFullscreen => (
@@ -191,6 +200,9 @@ impl UICommand {
             UICommand::ToggleBlueprintPanel => Some(ctrl_shift(Key::B)),
             UICommand::ToggleSelectionPanel => Some(ctrl_shift(Key::S)),
             UICommand::ToggleTimePanel => Some(ctrl_shift(Key::T)),
+
+            #[cfg(debug_assertions)]
+            UICommand::ToggleStylePanel => Some(ctrl_shift(Key::U)),
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ToggleFullscreen => Some(key(Key::F11)),

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -502,7 +502,11 @@ impl App {
             .default_width(300.0)
             .resizable(true)
             .frame(self.re_ui.top_panel_frame())
-            .show_animated_inside(ui, self.style_panel_open, |ui| ctx.settings_ui(ui));
+            .show_animated_inside(ui, self.style_panel_open, |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    ctx.settings_ui(ui);
+                });
+            });
     }
 
     /// Top-level ui function.

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -104,6 +104,8 @@ pub struct App {
     memory_panel: crate::memory_panel::MemoryPanel,
     memory_panel_open: bool,
 
+    style_panel_open: bool,
+
     pub(crate) latest_queue_interest: web_time::Instant,
 
     /// Measures how long a frame takes to paint
@@ -201,6 +203,8 @@ impl App {
             toasts: toasts::Toasts::new(),
             memory_panel: Default::default(),
             memory_panel_open: false,
+
+            style_panel_open: false,
 
             latest_queue_interest: web_time::Instant::now(), // TODO(emilk): `Instant::MIN` when we have our own `Instant` that supports it.
 
@@ -358,6 +362,11 @@ impl App {
             }
             UICommand::ToggleTimePanel => app_blueprint.toggle_time_panel(&self.command_sender),
 
+            #[cfg(debug_assertions)]
+            UICommand::ToggleStylePanel => {
+                self.style_panel_open ^= true;
+            }
+
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ToggleFullscreen => {
                 _frame.set_fullscreen(!_frame.info().window_info.fullscreen);
@@ -488,6 +497,14 @@ impl App {
             });
     }
 
+    fn style_panel_ui(&mut self, ctx: &egui::Context, ui: &mut egui::Ui) {
+        egui::SidePanel::left("style_panel")
+            .default_width(300.0)
+            .resizable(true)
+            .frame(self.re_ui.top_panel_frame())
+            .show_animated_inside(ui, self.style_panel_open, |ui| ctx.settings_ui(ui));
+    }
+
     /// Top-level ui function.
     ///
     /// Shows the viewer ui.
@@ -523,6 +540,8 @@ impl App {
                 );
 
                 self.memory_panel_ui(ui, gpu_resource_stats, store_stats);
+
+                self.style_panel_ui(egui_ctx, ui);
 
                 if let Some(store_view) = store_context {
                     // TODO(jleibs): We don't necessarily want to show the wait

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -66,6 +66,9 @@ impl App {
                 UICommand::OpenProfiler.menu_button_ui(ui, &self.command_sender);
 
                 UICommand::ToggleMemoryPanel.menu_button_ui(ui, &self.command_sender);
+
+                #[cfg(debug_assertions)]
+                UICommand::ToggleStylePanel.menu_button_ui(ui, &self.command_sender);
             }
 
             ui.add_space(spacing);


### PR DESCRIPTION
### What

This PR adds the egui style editor in a "left-left-panel". That's a debug-only feature, as the behaviour is often unexpected due to how often we bypass egui-native styling hooks.

>[!NOTE]
>Cannot be tested with demo site as this is debug-only.

<img width="1728" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/1d3c9368-d617-4855-b08a-1a078fd2bf55">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/2914) (if applicable)~~

- [PR Build Summary](https://build.rerun.io/pr/2914)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fstyle-panel/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fstyle-panel/examples)