### PR TITLE
C++ codegen extensions, archetype tests, array ctors

### DIFF
--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -14,8 +14,8 @@ mod rebuild_detector;
 pub(crate) use self::rebuild_detector::Packages;
 
 pub use self::hashing::{
-    compute_crate_hash, compute_dir_hash, compute_file_hash, compute_strings_hash, iter_dir,
-    read_versioning_hash, write_versioning_hash,
+    compute_crate_hash, compute_dir_filtered_hash, compute_dir_hash, compute_file_hash,
+    compute_strings_hash, iter_dir, read_versioning_hash, write_versioning_hash,
 };
 pub use self::rebuild_detector::{
     get_and_track_env_var, is_tracked_env_var_set, rebuild_if_crate_changed, rerun_if_changed,

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -3,9 +3,9 @@
 use std::path::PathBuf;
 
 use re_build_tools::{
-    compute_crate_hash, compute_dir_hash, compute_strings_hash, is_tracked_env_var_set, iter_dir,
-    read_versioning_hash, rerun_if_changed, rerun_if_changed_or_doesnt_exist,
-    write_versioning_hash,
+    compute_crate_hash, compute_dir_filtered_hash, compute_dir_hash, compute_strings_hash,
+    is_tracked_env_var_set, iter_dir, read_versioning_hash, rerun_if_changed,
+    rerun_if_changed_or_doesnt_exist, write_versioning_hash,
 };
 
 // ---
@@ -49,36 +49,40 @@ fn main() {
     let cur_hash = read_versioning_hash(SOURCE_HASH_PATH);
     let re_types_builder_hash = compute_crate_hash("re_types_builder");
     let definitions_hash = compute_dir_hash(DEFINITIONS_DIR_PATH, Some(&["fbs"]));
-    let doc_examples_hash = compute_dir_hash(DOC_EXAMPLES_DIR_PATH, Some(&["rs", "py"]));
-    let archetype_overrides_hash = compute_dir_hash(
+    let doc_examples_hash = compute_dir_hash(DOC_EXAMPLES_DIR_PATH, Some(&["rs", "py", "cpp"]));
+    let python_archetype_overrides_hash = compute_dir_hash(
         PathBuf::from(PYTHON_OUTPUT_DIR_PATH).join(ARCHETYPE_OVERRIDES_SUB_DIR_PATH),
         Some(&["py"]),
     );
-    let component_overrides_hash = compute_dir_hash(
+    let python_component_overrides_hash = compute_dir_hash(
         PathBuf::from(PYTHON_OUTPUT_DIR_PATH).join(COMPONENT_OVERRIDES_SUB_DIR_PATH),
         Some(&["py"]),
     );
-    let datatype_overrides_hash = compute_dir_hash(
+    let python_datatype_overrides_hash = compute_dir_hash(
         PathBuf::from(PYTHON_OUTPUT_DIR_PATH).join(DATATYPE_OVERRIDES_SUB_DIR_PATH),
         Some(&["py"]),
     );
+    let cpp_extensions_hash = compute_dir_filtered_hash(CPP_OUTPUT_DIR_PATH, |path| {
+        path.to_str().unwrap().ends_with("_ext.cpp")
+    });
 
     let new_hash = compute_strings_hash(&[
         &re_types_builder_hash,
         &definitions_hash,
         &doc_examples_hash,
-        &archetype_overrides_hash,
-        &component_overrides_hash,
-        &datatype_overrides_hash,
+        &python_archetype_overrides_hash,
+        &python_component_overrides_hash,
+        &python_datatype_overrides_hash,
+        &cpp_extensions_hash,
     ]);
 
     // Leave these be please, very useful when debugging.
     eprintln!("re_types_builder_hash: {re_types_builder_hash:?}");
     eprintln!("definitions_hash: {definitions_hash:?}");
     eprintln!("doc_examples_hash: {doc_examples_hash:?}");
-    eprintln!("archetype_overrides_hash: {archetype_overrides_hash:?}");
-    eprintln!("component_overrides_hash: {component_overrides_hash:?}");
-    eprintln!("datatype_overrides_hash: {datatype_overrides_hash:?}");
+    eprintln!("archetype_overrides_hash: {python_archetype_overrides_hash:?}");
+    eprintln!("component_overrides_hash: {python_component_overrides_hash:?}");
+    eprintln!("datatype_overrides_hash: {python_datatype_overrides_hash:?}");
     eprintln!("new_hash: {new_hash:?}");
     eprintln!("cur_hash: {cur_hash:?}");
 

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -80,9 +80,10 @@ fn main() {
     eprintln!("re_types_builder_hash: {re_types_builder_hash:?}");
     eprintln!("definitions_hash: {definitions_hash:?}");
     eprintln!("doc_examples_hash: {doc_examples_hash:?}");
-    eprintln!("archetype_overrides_hash: {python_archetype_overrides_hash:?}");
-    eprintln!("component_overrides_hash: {python_component_overrides_hash:?}");
-    eprintln!("datatype_overrides_hash: {python_datatype_overrides_hash:?}");
+    eprintln!("python_archetype_overrides_hash: {python_archetype_overrides_hash:?}");
+    eprintln!("python_component_overrides_hash: {python_component_overrides_hash:?}");
+    eprintln!("python_datatype_overrides_hash: {python_datatype_overrides_hash:?}");
+    eprintln!("cpp_extensions_hash: {cpp_extensions_hash:?}");
     eprintln!("new_hash: {new_hash:?}");
     eprintln!("cur_hash: {cur_hash:?}");
 

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-b82acf657cdff5aca321d933bc9c10bc430f0224f287cba0e4b0243ad82ca1e3
+64f594d05c82281faa9a562a19388aa18e01f87e472db0660a23b7086151a83e

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-64f594d05c82281faa9a562a19388aa18e01f87e472db0660a23b7086151a83e
+d92b965383f3a7204a4da09ff5b68e2c378bd56050527977389689640d92edc3

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -70,6 +70,20 @@
 //! This sibling file needs to implement an extension class that is mixed in with the
 //! auto-generated class.
 //! The simplest way to get started is to look at any of the existing examples.
+//!
+//!
+//! #### C++
+//!
+//! Generated C++ code can be manually extended by adding a sibling file with the `_ext.cpp` prefix.
+//! E.g. to extend `vec2d.cpp`, create a `vec2d_ext.cpp`.
+//!
+//! The sibling file is compiled as-is as part of the `rerun_cpp` crate.
+//! In order to extend the generated type declaration in the header,
+//! you can specify a single code-block that you want to be injected into the type declaration by
+//! starting it with `[CODEGEN COPY TO HEADER BEGIN]` and ending it with `[CODEGEN COPY TO HEADER END]`.
+//! Note that it is your responsibility to make sure that the cpp file is valid C++ code -
+//! the code generator & build will not adjust the extension file for you!
+//!
 
 // ---
 

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -74,13 +74,13 @@
 //!
 //! #### C++
 //!
-//! Generated C++ code can be manually extended by adding a sibling file with the `_ext.cpp` prefix.
+//! Generated C++ code can be manually extended by adding a sibling file with the `_ext.cpp` suffix.
 //! E.g. to extend `vec2d.cpp`, create a `vec2d_ext.cpp`.
 //!
 //! The sibling file is compiled as-is as part of the `rerun_cpp` crate.
 //! In order to extend the generated type declaration in the header,
 //! you can specify a single code-block that you want to be injected into the type declaration by
-//! starting it with `[CODEGEN COPY TO HEADER BEGIN]` and ending it with `[CODEGEN COPY TO HEADER END]`.
+//! starting it with `[CODEGEN COPY TO HEADER START]` and ending it with `[CODEGEN COPY TO HEADER END]`.
 //! Note that it is your responsibility to make sure that the cpp file is valid C++ code -
 //! the code generator & build will not adjust the extension file for you!
 //!

--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -69,7 +69,7 @@ pub fn remove_old_files_from_folder(folder_path: Utf8PathBuf, filepaths: &BTreeS
     re_tracing::profile_function!();
     for entry in std::fs::read_dir(folder_path).unwrap().flatten() {
         let filepath = Utf8PathBuf::try_from(entry.path()).unwrap();
-        if filepath.as_str().ends_with("_ext.rs") {
+        if filepath.as_str().ends_with("_ext.rs") || filepath.as_str().ends_with("_ext.cpp") {
             continue;
         }
         if !filepaths.contains(&filepath) {

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -53,10 +53,6 @@ fn string_from_token_stream(token_stream: &TokenStream, source_path: Option<&Utf
         code.push_str(&format!("// Based on {source_path:?}\n"));
     }
 
-    // if source_path.map_or(false, |p| p.as_str().contains("color")) {
-    //     panic!("token_stream: {:?}", token_stream.to_string());
-    // }
-
     code.push('\n');
     code.push_str(
         &token_stream

--- a/docs/code-examples/arrow3d_simple_v2.cpp
+++ b/docs/code-examples/arrow3d_simple_v2.cpp
@@ -19,10 +19,8 @@ int main() {
         float length = log2f(i + 1);
         vectors.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length * cosf(angle)});
 
-        // TODO(andreas): provide `unmultiplied_rgba`
-        uint8_t c = static_cast<uint8_t>((angle / (2.0 * M_PI) * 255.0) + 0.5);
-        uint32_t color = ((255 - c) << 24) + (c << 16) + (128 << 8) + (128 << 0);
-        colors.push_back(color);
+        uint8_t c = static_cast<uint8_t>(angle / (2.0 * M_PI) * 255.0);
+        colors.push_back({static_cast<uint8_t>(255 - c), c, 128, 128});
     }
 
     rr_stream.log("arrows", rr::archetypes::Arrows3D(vectors).with_colors(colors));

--- a/docs/code-examples/arrow3d_simple_v2.cpp
+++ b/docs/code-examples/arrow3d_simple_v2.cpp
@@ -17,7 +17,7 @@ int main() {
     for (int i = 0; i < 100; ++i) {
         float angle = 2.0 * M_PI * i * 0.01f;
         float length = log2f(i + 1);
-        vectors.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length * cosf(angle)});
+        vectors.push_back({length * sinf(angle), 0.0, length * cosf(angle)});
 
         uint8_t c = static_cast<uint8_t>(angle / (2.0 * M_PI) * 255.0);
         colors.push_back({static_cast<uint8_t>(255 - c), c, 128, 128});

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -22,8 +22,7 @@ int main() {
     });
     std::vector<rr::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        // TODO(andreas): provide a `rgb` factory method.
-        return (dist_color(gen) << 24) + (dist_color(gen) << 16) + (dist_color(gen) << 8) + 255;
+        return std::array{dist_color(gen), dist_color(gen), dist_color(gen)};
     });
     std::vector<rr::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -18,11 +18,11 @@ int main() {
 
     std::vector<rr::components::Point3D> points3d(10);
     std::generate(points3d.begin(), points3d.end(), [&] {
-        return rr::datatypes::Vec3D{dist_pos(gen), dist_pos(gen), dist_pos(gen)};
+        return rr::components::Point3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
     });
     std::vector<rr::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return std::array{dist_color(gen), dist_color(gen), dist_color(gen)};
+        return rr::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
     });
     std::vector<rr::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/point3d_simple_v2.cpp
+++ b/docs/code-examples/point3d_simple_v2.cpp
@@ -8,10 +8,5 @@ int main() {
     auto rr_stream = rr::RecordingStream("points3d_simple");
     rr_stream.connect("127.0.0.1:9876");
 
-    rr_stream.log(
-        "points",
-        rr::archetypes::Points3D(
-            {rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f}, rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}}
-        )
-    );
+    rr_stream.log("points", rr::archetypes::Points3D({{0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}}));
 }

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
     rrc::Label c_style_array[3] = {rrc::Label("hello"), rrc::Label("friend"), rrc::Label("yo")};
     rr_stream.log_components(
         "2d/points",
-        std::vector{rrc::Point2D({0.0, 0.0}), rrc::Point2D({1.0, 3.0}), rrc::Point2D({5.0, 5.0})},
+        std::vector{rrc::Point2D(0.0, 0.0), rrc::Point2D(1.0, 3.0), rrc::Point2D(5.0, 5.0)},
         std::array{rrc::Color(0xFF0000FF), rrc::Color(0x00FF00FF), rrc::Color(0x0000FFFF)},
         c_style_array
     );

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -16,13 +16,12 @@ int main(int argc, char** argv) {
     auto rr_stream = rr::RecordingStream("c-example-app");
     rr_stream.connect("127.0.0.1:9876");
 
-    rr_stream.log_archetype(
+    rr_stream.log(
         "3d/points",
-        rr::archetypes::Points3D({rr::datatypes::Vec3D{1.0, 2.0, 3.0},
-                                  rr::datatypes::Vec3D{4.0, 5.0, 6.0}})
+        rr::archetypes::Points3D({{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}})
             .with_radii({0.42, 0.43})
             .with_colors({0xAA0000CC, 0x00BB00DD})
-            .with_labels({std::string("hello"), std::string("friend")})
+            .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
             .with_keypoint_ids({2, 3})
             .with_instance_keys({66, 666})
@@ -31,10 +30,7 @@ int main(int argc, char** argv) {
     rrc::Label c_style_array[3] = {rrc::Label("hello"), rrc::Label("friend"), rrc::Label("yo")};
     rr_stream.log_components(
         "2d/points",
-        std::vector{
-            rrc::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
-            rrc::Point2D(rr::datatypes::Vec2D{1.0, 3.0}),
-            rrc::Point2D(rr::datatypes::Vec2D{5.0, 5.0})},
+        std::vector{rrc::Point2D({0.0, 0.0}), rrc::Point2D({1.0, 3.0}), rrc::Point2D({5.0, 5.0})},
         std::array{rrc::Color(0xFF0000FF), rrc::Color(0x00FF00FF), rrc::Color(0x0000FFFF)},
         c_style_array
     );

--- a/rerun_cpp/src/rerun/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/src/rerun/archetypes/affix_fuzzer1.hpp
@@ -439,7 +439,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2101(rerun::components::AffixFuzzer1 _fuzz2101) {
-                fuzz2101 = std::move(std::vector(1, std::move(_fuzz2101)));
+                fuzz2101 = std::vector(1, std::move(_fuzz2101));
                 return *this;
             }
 
@@ -449,7 +449,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2102(rerun::components::AffixFuzzer2 _fuzz2102) {
-                fuzz2102 = std::move(std::vector(1, std::move(_fuzz2102)));
+                fuzz2102 = std::vector(1, std::move(_fuzz2102));
                 return *this;
             }
 
@@ -459,7 +459,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2103(rerun::components::AffixFuzzer3 _fuzz2103) {
-                fuzz2103 = std::move(std::vector(1, std::move(_fuzz2103)));
+                fuzz2103 = std::vector(1, std::move(_fuzz2103));
                 return *this;
             }
 
@@ -469,7 +469,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2104(rerun::components::AffixFuzzer4 _fuzz2104) {
-                fuzz2104 = std::move(std::vector(1, std::move(_fuzz2104)));
+                fuzz2104 = std::vector(1, std::move(_fuzz2104));
                 return *this;
             }
 
@@ -479,7 +479,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2105(rerun::components::AffixFuzzer5 _fuzz2105) {
-                fuzz2105 = std::move(std::vector(1, std::move(_fuzz2105)));
+                fuzz2105 = std::vector(1, std::move(_fuzz2105));
                 return *this;
             }
 
@@ -489,7 +489,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2106(rerun::components::AffixFuzzer6 _fuzz2106) {
-                fuzz2106 = std::move(std::vector(1, std::move(_fuzz2106)));
+                fuzz2106 = std::vector(1, std::move(_fuzz2106));
                 return *this;
             }
 
@@ -499,7 +499,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2107(rerun::components::AffixFuzzer7 _fuzz2107) {
-                fuzz2107 = std::move(std::vector(1, std::move(_fuzz2107)));
+                fuzz2107 = std::vector(1, std::move(_fuzz2107));
                 return *this;
             }
 
@@ -509,7 +509,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2108(rerun::components::AffixFuzzer8 _fuzz2108) {
-                fuzz2108 = std::move(std::vector(1, std::move(_fuzz2108)));
+                fuzz2108 = std::vector(1, std::move(_fuzz2108));
                 return *this;
             }
 
@@ -519,7 +519,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2109(rerun::components::AffixFuzzer9 _fuzz2109) {
-                fuzz2109 = std::move(std::vector(1, std::move(_fuzz2109)));
+                fuzz2109 = std::vector(1, std::move(_fuzz2109));
                 return *this;
             }
 
@@ -529,7 +529,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2110(rerun::components::AffixFuzzer10 _fuzz2110) {
-                fuzz2110 = std::move(std::vector(1, std::move(_fuzz2110)));
+                fuzz2110 = std::vector(1, std::move(_fuzz2110));
                 return *this;
             }
 
@@ -539,7 +539,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2111(rerun::components::AffixFuzzer11 _fuzz2111) {
-                fuzz2111 = std::move(std::vector(1, std::move(_fuzz2111)));
+                fuzz2111 = std::vector(1, std::move(_fuzz2111));
                 return *this;
             }
 
@@ -549,7 +549,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2112(rerun::components::AffixFuzzer12 _fuzz2112) {
-                fuzz2112 = std::move(std::vector(1, std::move(_fuzz2112)));
+                fuzz2112 = std::vector(1, std::move(_fuzz2112));
                 return *this;
             }
 
@@ -559,7 +559,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2113(rerun::components::AffixFuzzer13 _fuzz2113) {
-                fuzz2113 = std::move(std::vector(1, std::move(_fuzz2113)));
+                fuzz2113 = std::vector(1, std::move(_fuzz2113));
                 return *this;
             }
 
@@ -569,7 +569,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2114(rerun::components::AffixFuzzer14 _fuzz2114) {
-                fuzz2114 = std::move(std::vector(1, std::move(_fuzz2114)));
+                fuzz2114 = std::vector(1, std::move(_fuzz2114));
                 return *this;
             }
 
@@ -579,7 +579,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2115(rerun::components::AffixFuzzer15 _fuzz2115) {
-                fuzz2115 = std::move(std::vector(1, std::move(_fuzz2115)));
+                fuzz2115 = std::vector(1, std::move(_fuzz2115));
                 return *this;
             }
 
@@ -589,7 +589,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2116(rerun::components::AffixFuzzer16 _fuzz2116) {
-                fuzz2116 = std::move(std::vector(1, std::move(_fuzz2116)));
+                fuzz2116 = std::vector(1, std::move(_fuzz2116));
                 return *this;
             }
 
@@ -599,7 +599,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2117(rerun::components::AffixFuzzer17 _fuzz2117) {
-                fuzz2117 = std::move(std::vector(1, std::move(_fuzz2117)));
+                fuzz2117 = std::vector(1, std::move(_fuzz2117));
                 return *this;
             }
 
@@ -609,7 +609,7 @@ namespace rerun {
             }
 
             AffixFuzzer1& with_fuzz2118(rerun::components::AffixFuzzer18 _fuzz2118) {
-                fuzz2118 = std::move(std::vector(1, std::move(_fuzz2118)));
+                fuzz2118 = std::vector(1, std::move(_fuzz2118));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -44,13 +44,10 @@ namespace rerun {
         ///    for (int i = 0; i <100; ++i) {
         ///        float angle = 2.0 * M_PI * i * 0.01f;
         ///        float length = log2f(i + 1);
-        ///        vectors.push_back(rr::datatypes::Vec3D{length * sinf(angle), 0.0, length *
-        ///        cosf(angle)});
+        ///        vectors.push_back({length * sinf(angle), 0.0, length * cosf(angle)});
         ///
-        ///        // TODO(andreas): provide `unmultiplied_rgba`
-        ///        uint8_t c = static_cast<uint8_t>((angle / (2.0 * M_PI) * 255.0) + 0.5);
-        ///        uint32_t color = ((255 - c) <<24) + (c <<16) + (128 <<8) + (128 <<0);
-        ///        colors.push_back(color);
+        ///        uint8_t c = static_cast<uint8_t>(angle / (2.0 * M_PI) * 255.0);
+        ///        colors.push_back({static_cast<uint8_t>(255 - c), c, 128, 128});
         ///    }
         ///
         ///    rr_stream.log(\"arrows\", rr::archetypes::Arrows3D(vectors).with_colors(colors));
@@ -99,7 +96,7 @@ namespace rerun {
 
             /// All the origin points for each arrow in the batch.
             Arrows3D& with_origins(rerun::components::Origin3D _origins) {
-                origins = std::move(std::vector(1, std::move(_origins)));
+                origins = std::vector(1, std::move(_origins));
                 return *this;
             }
 
@@ -117,7 +114,7 @@ namespace rerun {
             /// The shaft is rendered as a line with `radius = 0.5 * radius`.
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
             Arrows3D& with_radii(rerun::components::Radius _radii) {
-                radii = std::move(std::vector(1, std::move(_radii)));
+                radii = std::vector(1, std::move(_radii));
                 return *this;
             }
 
@@ -129,7 +126,7 @@ namespace rerun {
 
             /// Optional colors for the points.
             Arrows3D& with_colors(rerun::components::Color _colors) {
-                colors = std::move(std::vector(1, std::move(_colors)));
+                colors = std::vector(1, std::move(_colors));
                 return *this;
             }
 
@@ -141,7 +138,7 @@ namespace rerun {
 
             /// Optional text labels for the arrows.
             Arrows3D& with_labels(rerun::components::Label _labels) {
-                labels = std::move(std::vector(1, std::move(_labels)));
+                labels = std::vector(1, std::move(_labels));
                 return *this;
             }
 
@@ -157,7 +154,7 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Arrows3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::move(std::vector(1, std::move(_class_ids)));
+                class_ids = std::vector(1, std::move(_class_ids));
                 return *this;
             }
 
@@ -170,7 +167,7 @@ namespace rerun {
 
             /// Unique identifiers for each individual point in the batch.
             Arrows3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::move(std::vector(1, std::move(_instance_keys)));
+                instance_keys = std::vector(1, std::move(_instance_keys));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -74,7 +74,7 @@ namespace rerun {
 
             /// Optional radii for the points, effectively turning them into circles.
             Points2D& with_radii(rerun::components::Radius _radii) {
-                radii = std::move(std::vector(1, std::move(_radii)));
+                radii = std::vector(1, std::move(_radii));
                 return *this;
             }
 
@@ -86,7 +86,7 @@ namespace rerun {
 
             /// Optional colors for the points.
             Points2D& with_colors(rerun::components::Color _colors) {
-                colors = std::move(std::vector(1, std::move(_colors)));
+                colors = std::vector(1, std::move(_colors));
                 return *this;
             }
 
@@ -98,7 +98,7 @@ namespace rerun {
 
             /// Optional text labels for the points.
             Points2D& with_labels(rerun::components::Label _labels) {
-                labels = std::move(std::vector(1, std::move(_labels)));
+                labels = std::vector(1, std::move(_labels));
                 return *this;
             }
 
@@ -123,7 +123,7 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Points2D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::move(std::vector(1, std::move(_class_ids)));
+                class_ids = std::vector(1, std::move(_class_ids));
                 return *this;
             }
 
@@ -147,7 +147,7 @@ namespace rerun {
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
             Points2D& with_keypoint_ids(rerun::components::KeypointId _keypoint_ids) {
-                keypoint_ids = std::move(std::vector(1, std::move(_keypoint_ids)));
+                keypoint_ids = std::vector(1, std::move(_keypoint_ids));
                 return *this;
             }
 
@@ -160,7 +160,7 @@ namespace rerun {
 
             /// Unique identifiers for each individual point in the batch.
             Points2D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::move(std::vector(1, std::move(_instance_keys)));
+                instance_keys = std::vector(1, std::move(_instance_keys));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -35,13 +35,8 @@ namespace rerun {
         ///    auto rr_stream = rr::RecordingStream(\"points3d_simple\");
         ///    rr_stream.connect(\"127.0.0.1:9876\");
         ///
-        ///    rr_stream.log(
-        ///        \"points\",
-        ///        rr::archetypes::Points3D(
-        ///            {rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f},
-        ///            rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}}
-        ///        )
-        ///    );
+        ///    rr_stream.log(\"points\", rr::archetypes::Points3D({{0.0f, 0.0f, 0.0f},
+        ///    {1.0f, 1.0f, 1.0f}}));
         /// }
         ///```
         struct Points3D {
@@ -90,7 +85,7 @@ namespace rerun {
 
             /// Optional radii for the points, effectively turning them into circles.
             Points3D& with_radii(rerun::components::Radius _radii) {
-                radii = std::move(std::vector(1, std::move(_radii)));
+                radii = std::vector(1, std::move(_radii));
                 return *this;
             }
 
@@ -102,7 +97,7 @@ namespace rerun {
 
             /// Optional colors for the points.
             Points3D& with_colors(rerun::components::Color _colors) {
-                colors = std::move(std::vector(1, std::move(_colors)));
+                colors = std::vector(1, std::move(_colors));
                 return *this;
             }
 
@@ -114,7 +109,7 @@ namespace rerun {
 
             /// Optional text labels for the points.
             Points3D& with_labels(rerun::components::Label _labels) {
-                labels = std::move(std::vector(1, std::move(_labels)));
+                labels = std::vector(1, std::move(_labels));
                 return *this;
             }
 
@@ -130,7 +125,7 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Points3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::move(std::vector(1, std::move(_class_ids)));
+                class_ids = std::vector(1, std::move(_class_ids));
                 return *this;
             }
 
@@ -154,7 +149,7 @@ namespace rerun {
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
             Points3D& with_keypoint_ids(rerun::components::KeypointId _keypoint_ids) {
-                keypoint_ids = std::move(std::vector(1, std::move(_keypoint_ids)));
+                keypoint_ids = std::vector(1, std::move(_keypoint_ids));
                 return *this;
             }
 
@@ -167,7 +162,7 @@ namespace rerun {
 
             /// Unique identifiers for each individual point in the batch.
             Points3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::move(std::vector(1, std::move(_instance_keys)));
+                instance_keys = std::vector(1, std::move(_instance_keys));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -20,6 +20,35 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'color_ext.cpp'
+
+            /// Construct Color from unmultiplied RGBA values.
+            Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
+                : Color(static_cast<uint32_t>((r << 24) | (g << 16) | (b << 8) | a)) {}
+
+            /// Construct Color from unmultiplied RGBA values.
+            Color(const uint8_t (&_rgba)[4]) : Color(_rgba[0], _rgba[1], _rgba[2], _rgba[3]) {}
+
+            /// Construct Color from RGB values, setting alpha to 255.
+            Color(const uint8_t (&_rgb)[3]) : Color(_rgb[0], _rgb[1], _rgb[2]) {}
+
+            uint8_t r() const {
+                return (rgba >> 24) & 0xFF;
+            }
+
+            uint8_t g() const {
+                return (rgba >> 16) & 0xFF;
+            }
+
+            uint8_t b() const {
+                return (rgba >> 8) & 0xFF;
+            }
+
+            uint8_t a() const {
+                return rgba & 0xFF;
+            }
+
+          public:
             Color() = default;
 
             Color(uint32_t _rgba) : rgba(std::move(_rgba)) {}

--- a/rerun_cpp/src/rerun/components/color_ext.cpp
+++ b/rerun_cpp/src/rerun/components/color_ext.cpp
@@ -16,16 +16,29 @@ namespace rerun {
 
             /// Construct Color from unmultiplied RGBA values.
             Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
-                : Color((r << 24) | (g << 16) | (b << 8) | a) {}
+                : Color(static_cast<uint32_t>((r << 24) | (g << 16) | (b << 8) | a)) {}
 
             /// Construct Color from unmultiplied RGBA values.
-            Color(uint8_t _rgba[4]) : Color(_rgba[0], _rgba[1], _rgba[2], _rgba[3]) {}
+            Color(const uint8_t (&_rgba)[4]) : Color(_rgba[0], _rgba[1], _rgba[2], _rgba[3]) {}
 
-            /// Construct Color from unmultiplied RGBA array.
-            Color(std::array<uint8_t, 4> _rgba) : Color(_rgba[0], _rgba[1], _rgba[2], _rgba[3]) {}
+            /// Construct Color from RGB values, setting alpha to 255.
+            Color(const uint8_t (&_rgb)[3]) : Color(_rgb[0], _rgb[1], _rgb[2]) {}
 
-            /// Construct Color from an RGB array, with alpha set to 255.
-            Color(std::array<uint8_t, 3> _rgb) : Color(_rgb[0], _rgb[1], _rgb[2]) {}
+            uint8_t r() const {
+                return (rgba >> 24) & 0xFF;
+            }
+
+            uint8_t g() const {
+                return (rgba >> 16) & 0xFF;
+            }
+
+            uint8_t b() const {
+                return (rgba >> 8) & 0xFF;
+            }
+
+            uint8_t a() const {
+                return rgba & 0xFF;
+            }
 
             // [CODEGEN COPY TO HEADER END]
         };

--- a/rerun_cpp/src/rerun/components/color_ext.cpp
+++ b/rerun_cpp/src/rerun/components/color_ext.cpp
@@ -1,0 +1,34 @@
+#include "color.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct ColorExt : public Color {
+            ColorExt(uint32_t _rgba) : Color(_rgba) {}
+
+#define Color ColorExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Color from unmultiplied RGBA values.
+            Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
+                : Color((r << 24) | (g << 16) | (b << 8) | a) {}
+
+            /// Construct Color from unmultiplied RGBA values.
+            Color(uint8_t _rgba[4]) : Color(_rgba[0], _rgba[1], _rgba[2], _rgba[3]) {}
+
+            /// Construct Color from unmultiplied RGBA array.
+            Color(std::array<uint8_t, 4> _rgba) : Color(_rgba[0], _rgba[1], _rgba[2], _rgba[3]) {}
+
+            /// Construct Color from an RGB array, with alpha set to 255.
+            Color(std::array<uint8_t, 3> _rgb) : Color(_rgb[0], _rgb[1], _rgb[2]) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/label.hpp
+++ b/rerun_cpp/src/rerun/components/label.hpp
@@ -20,6 +20,16 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'label_ext.cpp'
+
+            /// Construct Label from c string.
+            Label(const char* str) : value(str) {}
+
+            const char* c_str() const {
+                return value.c_str();
+            }
+
+          public:
             Label() = default;
 
             Label(std::string _value) : value(std::move(_value)) {}

--- a/rerun_cpp/src/rerun/components/label_ext.cpp
+++ b/rerun_cpp/src/rerun/components/label_ext.cpp
@@ -1,4 +1,4 @@
-#include "Label.hpp"
+#include "label.hpp"
 
 // Uncomment for better auto-complete while editing the extension.
 #define EDIT_EXTENSION

--- a/rerun_cpp/src/rerun/components/label_ext.cpp
+++ b/rerun_cpp/src/rerun/components/label_ext.cpp
@@ -1,0 +1,27 @@
+#include "Label.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+#define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct LabelExt {
+            std::string value;
+#define Label LabelExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Label from c string.
+            Label(const char* str) : value(str) {}
+
+            const char* c_str() const {
+                return value.c_str();
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/origin3d.hpp
+++ b/rerun_cpp/src/rerun/components/origin3d.hpp
@@ -20,6 +20,24 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'origin3d_ext.cpp'
+
+            /// Construct Origin3D from x/y/z values.
+            Origin3D(float x, float y, float z) : origin{x, y, z} {}
+
+            float x() const {
+                return origin.x();
+            }
+
+            float y() const {
+                return origin.y();
+            }
+
+            float z() const {
+                return origin.z();
+            }
+
+          public:
             Origin3D() = default;
 
             Origin3D(rerun::datatypes::Vec3D _origin) : origin(std::move(_origin)) {}

--- a/rerun_cpp/src/rerun/components/origin3d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/origin3d_ext.cpp
@@ -1,0 +1,35 @@
+#include "origin3d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Origin3DExt {
+            float origin[3];
+#define Origin3D Origin3DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Origin3D from x/y/z values.
+            Origin3D(float x, float y, float z) : origin{x, y, z} {}
+
+            float x() const {
+                return origin.x();
+            }
+
+            float y() const {
+                return origin.y();
+            }
+
+            float z() const {
+                return origin.z();
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/point2d.hpp
+++ b/rerun_cpp/src/rerun/components/point2d.hpp
@@ -20,6 +20,20 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'point2d_ext.cpp'
+
+            /// Construct Point2D from x/y/z values.
+            Point2D(float x, float y) : xy{x, y} {}
+
+            float x() const {
+                return xy.x();
+            }
+
+            float y() const {
+                return xy.y();
+            }
+
+          public:
             Point2D() = default;
 
             Point2D(rerun::datatypes::Vec2D _xy) : xy(std::move(_xy)) {}

--- a/rerun_cpp/src/rerun/components/point2d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/point2d_ext.cpp
@@ -1,0 +1,31 @@
+#include "point2d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Point2DExt {
+            float xyz[2];
+#define Point2D Point2DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Point2D from x/y/z values.
+            Point2D(float x, float y) : xy{x, y} {}
+
+            float x() const {
+                return xy.x();
+            }
+
+            float y() const {
+                return xy.y();
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/point3d.hpp
+++ b/rerun_cpp/src/rerun/components/point3d.hpp
@@ -20,6 +20,24 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'point3d_ext.cpp'
+
+            /// Construct Point3D from x/y/z values.
+            Point3D(float x, float y, float z) : xyz{x, y, z} {}
+
+            float x() const {
+                return xyz.x();
+            }
+
+            float y() const {
+                return xyz.y();
+            }
+
+            float z() const {
+                return xyz.z();
+            }
+
+          public:
             Point3D() = default;
 
             Point3D(rerun::datatypes::Vec3D _xyz) : xyz(std::move(_xyz)) {}

--- a/rerun_cpp/src/rerun/components/point3d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/point3d_ext.cpp
@@ -1,0 +1,35 @@
+#include "point3d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Point3DExt {
+            float xyz[3];
+#define Point3D Point3DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Point3D from x/y/z values.
+            Point3D(float x, float y, float z) : xyz{x, y, z} {}
+
+            float x() const {
+                return xyz.x();
+            }
+
+            float y() const {
+                return xyz.y();
+            }
+
+            float z() const {
+                return xyz.z();
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -20,6 +20,24 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'vector3d_ext.cpp'
+
+            /// Construct Vector3D from x/y/z values.
+            Vector3D(float x, float y, float z) : vector{x, y, z} {}
+
+            float x() const {
+                return vector.x();
+            }
+
+            float y() const {
+                return vector.y();
+            }
+
+            float z() const {
+                return vector.z();
+            }
+
+          public:
             Vector3D() = default;
 
             Vector3D(rerun::datatypes::Vec3D _vector) : vector(std::move(_vector)) {}

--- a/rerun_cpp/src/rerun/components/vector3d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/vector3d_ext.cpp
@@ -1,0 +1,35 @@
+#include "vector3d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Vector3DExt {
+            float vector[3];
+#define Vector3D Vector3DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Vector3D from x/y/z values.
+            Vector3D(float x, float y, float z) : vector{x, y, z} {}
+
+            float x() const {
+                return vector.x();
+            }
+
+            float y() const {
+                return vector.y();
+            }
+
+            float z() const {
+                return vector.z();
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -15,6 +15,18 @@ namespace rerun {
           public:
             Mat3x3() = default;
 
+            Mat3x3(const float (&_coeffs)[9])
+                : coeffs{
+                      _coeffs[0],
+                      _coeffs[1],
+                      _coeffs[2],
+                      _coeffs[3],
+                      _coeffs[4],
+                      _coeffs[5],
+                      _coeffs[6],
+                      _coeffs[7],
+                      _coeffs[8]} {}
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -15,6 +15,25 @@ namespace rerun {
           public:
             Mat4x4() = default;
 
+            Mat4x4(const float (&_coeffs)[16])
+                : coeffs{
+                      _coeffs[0],
+                      _coeffs[1],
+                      _coeffs[2],
+                      _coeffs[3],
+                      _coeffs[4],
+                      _coeffs[5],
+                      _coeffs[6],
+                      _coeffs[7],
+                      _coeffs[8],
+                      _coeffs[9],
+                      _coeffs[10],
+                      _coeffs[11],
+                      _coeffs[12],
+                      _coeffs[13],
+                      _coeffs[14],
+                      _coeffs[15]} {}
+
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -13,7 +13,31 @@ namespace rerun {
             float xyzw[4];
 
           public:
+            // Extensions to generated type defined in 'quaternion_ext.cpp'
+
+            /// Construct Quaternion from x/y/z/w values.
+            Quaternion(float x, float y, float z, float w) : xyzw{x, y, z, w} {}
+
+            float x() const {
+                return xyzw[0];
+            }
+
+            float y() const {
+                return xyzw[1];
+            }
+
+            float z() const {
+                return xyzw[2];
+            }
+
+            float w() const {
+                return xyzw[3];
+            }
+
+          public:
             Quaternion() = default;
+
+            Quaternion(const float (&_xyzw)[4]) : xyzw{_xyzw[0], _xyzw[1], _xyzw[2], _xyzw[3]} {}
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/quaternion_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion_ext.cpp
@@ -1,0 +1,39 @@
+#include "quaternion.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct QuaternionExt {
+            float xyzw[4];
+#define Quaternion QuaternionExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Quaternion from x/y/z/w values.
+            Quaternion(float x, float y, float z, float w) : xyzw{x, y, z, w} {}
+
+            float x() const {
+                return xyzw[0];
+            }
+
+            float y() const {
+                return xyzw[1];
+            }
+
+            float z() const {
+                return xyzw[2];
+            }
+
+            float w() const {
+                return xyzw[3];
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -13,7 +13,23 @@ namespace rerun {
             float xy[2];
 
           public:
+            // Extensions to generated type defined in 'vec2d_ext.cpp'
+
+            /// Construct Vec2D from x/y values.
+            Vec2D(float x, float y) : xy{x, y} {}
+
+            float x() const {
+                return xy[0];
+            }
+
+            float y() const {
+                return xy[1];
+            }
+
+          public:
             Vec2D() = default;
+
+            Vec2D(const float (&_xy)[2]) : xy{_xy[0], _xy[1]} {}
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/vec2d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d_ext.cpp
@@ -1,0 +1,31 @@
+#include "vec2d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Vec2DExt {
+            float xy[2];
+#define Vec2D Vec2DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Vec2D from x/y values.
+            Vec2D(float x, float y) : xy{x, y} {}
+
+            float x() const {
+                return xy[0];
+            }
+
+            float y() const {
+                return xy[1];
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -13,7 +13,27 @@ namespace rerun {
             float xyz[3];
 
           public:
+            // Extensions to generated type defined in 'vec3d_ext.cpp'
+
+            /// Construct Vec3D from x/y/z values.
+            Vec3D(float x, float y, float z) : xyz{x, y, z} {}
+
+            float x() const {
+                return xyz[0];
+            }
+
+            float y() const {
+                return xyz[1];
+            }
+
+            float z() const {
+                return xyz[2];
+            }
+
+          public:
             Vec3D() = default;
+
+            Vec3D(const float (&_xyz)[3]) : xyz{_xyz[0], _xyz[1], _xyz[2]} {}
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/vec3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d_ext.cpp
@@ -1,0 +1,35 @@
+#include "vec3d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Vec3DExt {
+            float xyz[3];
+#define Vec3D Vec3DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Vec3D from x/y/z values.
+            Vec3D(float x, float y, float z) : xyz{x, y, z} {}
+
+            float x() const {
+                return xyz[0];
+            }
+
+            float y() const {
+                return xyz[1];
+            }
+
+            float z() const {
+                return xyz[2];
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -13,7 +13,31 @@ namespace rerun {
             float xyzw[4];
 
           public:
+            // Extensions to generated type defined in 'vec4d_ext.cpp'
+
+            /// Construct Vec4D from x/y/z/w values.
+            Vec4D(float x, float y, float z, float w) : xyzw{x, y, z, w} {}
+
+            float x() const {
+                return xyzw[0];
+            }
+
+            float y() const {
+                return xyzw[1];
+            }
+
+            float z() const {
+                return xyzw[2];
+            }
+
+            float w() const {
+                return xyzw[3];
+            }
+
+          public:
             Vec4D() = default;
+
+            Vec4D(const float (&_xyzw)[4]) : xyzw{_xyzw[0], _xyzw[1], _xyzw[2], _xyzw[3]} {}
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/vec4d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d_ext.cpp
@@ -1,0 +1,39 @@
+#include "vec4d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct Vec4DExt {
+            float xyzw[4];
+#define Vec4D Vec4DExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            /// Construct Vec4D from x/y/z/w values.
+            Vec4D(float x, float y, float z, float w) : xyzw{x, y, z, w} {}
+
+            float x() const {
+                return xyzw[0];
+            }
+
+            float y() const {
+                return xyzw[1];
+            }
+
+            float z() const {
+                return xyzw[2];
+            }
+
+            float w() const {
+                return xyzw[3];
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/tests/archetype_test.hpp
+++ b/rerun_cpp/tests/archetype_test.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#include <arrow/buffer.h>
+#include <arrow/result.h>
+#pragma GCC diagnostic pop
+
+template <typename T>
+void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
+    THEN("serialization succeeds") {
+        auto from_builder_serialized = from_builder.to_data_cells();
+        REQUIRE(from_builder_serialized.ok());
+
+        auto from_manual_serialized = from_manual.to_data_cells();
+        REQUIRE(from_manual_serialized.ok());
+
+        AND_THEN("the serialized data is the same") {
+            auto from_builder_cells = from_builder_serialized.ValueOrDie();
+            auto from_manual_cells = from_manual_serialized.ValueOrDie();
+
+            CHECK(from_builder_cells.size() == from_manual_cells.size());
+            for (size_t i = 0; i < from_builder_cells.size(); ++i) {
+                CHECK(from_builder_cells[i].component_name == from_manual_cells[i].component_name);
+                CHECK(from_builder_cells[i].buffer->Equals(*from_manual_cells[i].buffer));
+            }
+        }
+    }
+}

--- a/rerun_cpp/tests/arrows3d.cpp
+++ b/rerun_cpp/tests/arrows3d.cpp
@@ -1,0 +1,34 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/arrows3d.hpp>
+
+using namespace rerun::archetypes;
+
+#define TEST_TAG "[arrow3d]"
+
+SCENARIO(
+    "Arrows3D archetype can be serialized with the same result for manually built instances and "
+    "the builder pattern",
+    TEST_TAG
+) {
+    GIVEN("Constructed from builder and manually") {
+        auto from_builder = Arrows3D({{1.0, 2.0, 3.0}, {10.0, 20.0, 30.0}})
+                                .with_origins({{4.0, 5.0, 6.0}, {40.0, 50.0, 60.0}})
+                                .with_radii({1.0, 10.0})
+                                .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
+                                .with_labels({"hello", "friend"})
+                                .with_class_ids({126, 127})
+                                .with_instance_keys({123ull, 124ull});
+
+        Arrows3D from_manual;
+        from_manual.vectors = {{1.0, 2.0, 3.0}, {10.0, 20.0, 30.0}};
+        from_manual.origins = {{4.0, 5.0, 6.0}, {40.0, 50.0, 60.0}};
+        from_manual.radii = {1.0, 10.0};
+        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+        from_manual.labels = {"hello", "friend"};
+        from_manual.class_ids = {126, 127};
+        from_manual.instance_keys = {123ull, 124ull};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+}

--- a/rerun_cpp/tests/color.cpp
+++ b/rerun_cpp/tests/color.cpp
@@ -39,13 +39,14 @@ TEST_CASE("Construct Color in different ways", TEST_TAG) {
         CHECK(c.a() == 4);
     }
 
-    SECTION("Passing RGB to constructor via initializer list") {
-        Color c({1, 2, 3});
-        CHECK(c.r() == 1);
-        CHECK(c.g() == 2);
-        CHECK(c.b() == 3);
-        CHECK(c.a() == 255);
-    }
+    // This builds on Clang but is an ambiguous overload on GCC.
+    // SECTION("Passing RGB to constructor via initializer list") {
+    //     Color c({1, 2, 3});
+    //     CHECK(c.r() == 1);
+    //     CHECK(c.g() == 2);
+    //     CHECK(c.b() == 3);
+    //     CHECK(c.a() == 255);
+    // }
 
     SECTION("Passing RGBA to constructor via c array") {
         uint8_t rgba[4] = {1, 2, 3, 4};

--- a/rerun_cpp/tests/color.cpp
+++ b/rerun_cpp/tests/color.cpp
@@ -2,8 +2,6 @@
 
 #include <rerun/components/color.hpp>
 
-#include <array>
-
 using namespace rerun::components;
 
 #define TEST_TAG "[color]"

--- a/rerun_cpp/tests/color.cpp
+++ b/rerun_cpp/tests/color.cpp
@@ -1,0 +1,69 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <rerun/components/color.hpp>
+
+#include <array>
+
+using namespace rerun::components;
+
+#define TEST_TAG "[color]"
+
+TEST_CASE("Construct Color in different ways", TEST_TAG) {
+    SECTION("Default constructor") {
+        Color c;
+
+        // Not initialized! Access is undefined behavior.
+        // Suppress unused warning.
+        (void)(c);
+    }
+
+    SECTION("Passing RGBA to constructor") {
+        Color c(1, 2, 3, 4);
+        CHECK(c.r() == 1);
+        CHECK(c.g() == 2);
+        CHECK(c.b() == 3);
+        CHECK(c.a() == 4);
+    }
+
+    SECTION("Passing RGB to constructor") {
+        Color c(1, 2, 3);
+        CHECK(c.r() == 1);
+        CHECK(c.g() == 2);
+        CHECK(c.b() == 3);
+        CHECK(c.a() == 255);
+    }
+
+    SECTION("Passing RGBA to constructor via initializer list") {
+        Color c({1, 2, 3, 4});
+        CHECK(c.r() == 1);
+        CHECK(c.g() == 2);
+        CHECK(c.b() == 3);
+        CHECK(c.a() == 4);
+    }
+
+    SECTION("Passing RGB to constructor via initializer list") {
+        Color c({1, 2, 3});
+        CHECK(c.r() == 1);
+        CHECK(c.g() == 2);
+        CHECK(c.b() == 3);
+        CHECK(c.a() == 255);
+    }
+
+    SECTION("Passing RGBA to constructor via c array") {
+        uint8_t rgba[4] = {1, 2, 3, 4};
+        Color c(rgba);
+        CHECK(c.r() == 1);
+        CHECK(c.g() == 2);
+        CHECK(c.b() == 3);
+        CHECK(c.a() == 4);
+    }
+
+    SECTION("Passing RGB to constructor via c array") {
+        uint8_t rgb[3] = {1, 2, 3};
+        Color c(rgb);
+        CHECK(c.r() == 1);
+        CHECK(c.g() == 2);
+        CHECK(c.b() == 3);
+        CHECK(c.a() == 255);
+    }
+}

--- a/rerun_cpp/tests/disconnected_space.cpp
+++ b/rerun_cpp/tests/disconnected_space.cpp
@@ -10,7 +10,7 @@ SCENARIO("disconnected_space archetype can be serialized" TEST_TAG) {
     GIVEN("Constructed from builder and manually") {
         auto from_builder = DisconnectedSpace(true);
 
-        THEN("serialization suceeds") {
+        THEN("serialization succeeds") {
             CHECK(from_builder.to_data_cells().ok());
         }
     }

--- a/rerun_cpp/tests/disconnected_space.cpp
+++ b/rerun_cpp/tests/disconnected_space.cpp
@@ -1,0 +1,17 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/disconnected_space.hpp>
+
+using namespace rerun::archetypes;
+
+#define TEST_TAG "[disconnected_space]"
+
+SCENARIO("disconnected_space archetype can be serialized" TEST_TAG) {
+    GIVEN("Constructed from builder and manually") {
+        auto from_builder = DisconnectedSpace(true);
+
+        THEN("serialization suceeds") {
+            CHECK(from_builder.to_data_cells().ok());
+        }
+    }
+}

--- a/rerun_cpp/tests/points2d.cpp
+++ b/rerun_cpp/tests/points2d.cpp
@@ -1,0 +1,34 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/points2d.hpp>
+
+using namespace rerun::archetypes;
+
+#define TEST_TAG "[points2d]"
+
+SCENARIO(
+    "Points2D archetype can be serialized with the same result for manually built instances and "
+    "the builder pattern",
+    TEST_TAG
+) {
+    GIVEN("Constructed from builder and manually") {
+        auto from_builder = Points2D({{1.0, 2.0}, {10.0, 20.0}})
+                                .with_radii({1.0, 10.0})
+                                .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
+                                .with_labels({"hello", "friend"})
+                                .with_class_ids({126, 127})
+                                .with_keypoint_ids({1, 2})
+                                .with_instance_keys({123ull, 124ull});
+
+        Points2D from_manual;
+        from_manual.points = {{1.0, 2.0}, {10.0, 20.0}};
+        from_manual.radii = {1.0, 10.0};
+        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+        from_manual.labels = {"hello", "friend"};
+        from_manual.keypoint_ids = {1, 2};
+        from_manual.class_ids = {126, 127};
+        from_manual.instance_keys = {123ull, 124ull};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+}

--- a/rerun_cpp/tests/points3d.cpp
+++ b/rerun_cpp/tests/points3d.cpp
@@ -1,0 +1,34 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/points3d.hpp>
+
+using namespace rerun::archetypes;
+
+#define TEST_TAG "[points3d]"
+
+SCENARIO(
+    "Points3D archetype can be serialized with the same result for manually built instances and "
+    "the builder pattern",
+    TEST_TAG
+) {
+    GIVEN("Constructed from builder and manually") {
+        auto from_builder = Points3D({{1.0, 2.0, 3.0}, {10.0, 20.0, 30.0}})
+                                .with_radii({1.0, 10.0})
+                                .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
+                                .with_labels({"hello", "friend"})
+                                .with_class_ids({126, 127})
+                                .with_keypoint_ids({1, 2})
+                                .with_instance_keys({123ull, 124ull});
+
+        Points3D from_manual;
+        from_manual.points = {{1.0, 2.0, 3.0}, {10.0, 20.0, 30.0}};
+        from_manual.radii = {1.0, 10.0};
+        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+        from_manual.labels = {"hello", "friend"};
+        from_manual.keypoint_ids = {1, 2};
+        from_manual.class_ids = {126, 127};
+        from_manual.instance_keys = {123ull, 124ull};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+}

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -151,7 +151,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
 SCENARIO("RecordingStream can log to file", TEST_TAG) {
     const char* test_path = "build/test_output";
     fs::create_directories(test_path);
-    static int counter = 0;
+
     std::string test_rrd0 = std::string(test_path) + "test-file-0.rrd";
     std::string test_rrd1 = std::string(test_path) + "test-file-1.rrd";
     std::remove(test_rrd0.c_str());

--- a/rerun_cpp/tests/vec_and_quaternion.cpp
+++ b/rerun_cpp/tests/vec_and_quaternion.cpp
@@ -5,8 +5,6 @@
 #include <rerun/datatypes/vec3d.hpp>
 #include <rerun/datatypes/vec4d.hpp>
 
-#include <array>
-
 using namespace rerun::datatypes;
 
 #define TEST_TAG "[vec_and_quaternion]"

--- a/rerun_cpp/tests/vec_and_quaternion.cpp
+++ b/rerun_cpp/tests/vec_and_quaternion.cpp
@@ -1,0 +1,104 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <rerun/datatypes/quaternion.hpp>
+#include <rerun/datatypes/vec2d.hpp>
+#include <rerun/datatypes/vec3d.hpp>
+#include <rerun/datatypes/vec4d.hpp>
+
+#include <array>
+
+namespace rr = rerun;
+
+#define TEST_TAG "[vec_and_quaternion]"
+
+void ctor_checks(
+    const rr::datatypes::Vec2D& v2, const rr::datatypes::Vec3D& v3, const rr::datatypes::Vec4D& v4,
+    const rr::datatypes::Quaternion& q
+) {
+    CHECK(v2.x() == 1.0);
+    CHECK(v2.y() == 2.0);
+
+    CHECK(v3.x() == 1.0);
+    CHECK(v3.y() == 2.0);
+    CHECK(v3.z() == 3.0);
+
+    CHECK(v4.x() == 1.0);
+    CHECK(v4.y() == 2.0);
+    CHECK(v4.z() == 3.0);
+    CHECK(v4.w() == 4.0);
+
+    CHECK(q.x() == 1.0);
+    CHECK(q.y() == 2.0);
+    CHECK(q.z() == 3.0);
+    CHECK(q.w() == 4.0);
+}
+
+TEST_CASE("Construct VecND in different ways", TEST_TAG) {
+    SECTION("Default constructor") {
+        rr::datatypes::Vec2D v2;
+        rr::datatypes::Vec3D v3;
+        rr::datatypes::Vec4D v4;
+        rr::datatypes::Quaternion q;
+
+        // Not initialized! Access is undefined behavior.
+        // Suppress unused warnings.
+        (void)(v2);
+        (void)(v3);
+        (void)(v4);
+        (void)(q);
+    }
+
+    SECTION("Passing values to constructor") {
+        rr::datatypes::Vec2D v2(1.0f, 2.0f);
+        rr::datatypes::Vec3D v3(1.0f, 2.0f, 3.0f);
+        rr::datatypes::Vec4D v4(1.0f, 2.0f, 3.0f, 4.0f);
+        rr::datatypes::Quaternion q(1.0f, 2.0f, 3.0f, 4.0f);
+
+        ctor_checks(v2, v3, v4, q);
+    }
+
+    SECTION("Via brace initialization") {
+        rr::datatypes::Vec2D v2{1.0f, 2.0f};
+        rr::datatypes::Vec3D v3{1.0f, 2.0f, 3.0f};
+        rr::datatypes::Vec4D v4{1.0f, 2.0f, 3.0f, 4.0f};
+        rr::datatypes::Quaternion q{1.0f, 2.0f, 3.0f, 4.0f};
+
+        ctor_checks(v2, v3, v4, q);
+    }
+
+    SECTION("Via initializer list") {
+        rr::datatypes::Vec2D v2({1.0f, 2.0f});
+        rr::datatypes::Vec3D v3({1.0f, 2.0f, 3.0f});
+        rr::datatypes::Vec4D v4({1.0f, 2.0f, 3.0f, 4.0f});
+        rr::datatypes::Quaternion q({1.0f, 2.0f, 3.0f, 4.0f});
+
+        ctor_checks(v2, v3, v4, q);
+    }
+
+    // Dropped this since providing an std::array version makes the initializer list version
+    // ambiguous.
+    // SECTION("Via std::array") {
+    //     rr::datatypes::Vec2D v2(std::array<float, 2>{1.0f, 2.0f});
+    //     rr::datatypes::Vec3D v3(std::array<float, 3>{1.0f, 2.0f, 3.0f});
+    //     rr::datatypes::Vec4D v4(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f});
+    //     rr::datatypes::Quaternion q(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f});
+
+    //     ctor_checks(v2, v3, v4, q);
+    // }
+
+    SECTION("Via c-array") {
+        float c_v2[2] = {1.0f, 2.0f};
+        rr::datatypes::Vec2D v2(c_v2);
+
+        float c_v3[3] = {1.0f, 2.0f, 3.0f};
+        rr::datatypes::Vec3D v3(c_v3);
+
+        float c_v4[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+        rr::datatypes::Vec4D v4(c_v4);
+
+        float c_q[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+        rr::datatypes::Quaternion q(c_q);
+
+        ctor_checks(v2, v3, v4, q);
+    }
+}

--- a/rerun_cpp/tests/vec_and_quaternion.cpp
+++ b/rerun_cpp/tests/vec_and_quaternion.cpp
@@ -7,14 +7,11 @@
 
 #include <array>
 
-namespace rr = rerun;
+using namespace rerun::datatypes;
 
 #define TEST_TAG "[vec_and_quaternion]"
 
-void ctor_checks(
-    const rr::datatypes::Vec2D& v2, const rr::datatypes::Vec3D& v3, const rr::datatypes::Vec4D& v4,
-    const rr::datatypes::Quaternion& q
-) {
+void ctor_checks(const Vec2D& v2, const Vec3D& v3, const Vec4D& v4, const Quaternion& q) {
     CHECK(v2.x() == 1.0);
     CHECK(v2.y() == 2.0);
 
@@ -35,10 +32,10 @@ void ctor_checks(
 
 TEST_CASE("Construct VecND in different ways", TEST_TAG) {
     SECTION("Default constructor") {
-        rr::datatypes::Vec2D v2;
-        rr::datatypes::Vec3D v3;
-        rr::datatypes::Vec4D v4;
-        rr::datatypes::Quaternion q;
+        Vec2D v2;
+        Vec3D v3;
+        Vec4D v4;
+        Quaternion q;
 
         // Not initialized! Access is undefined behavior.
         // Suppress unused warnings.
@@ -49,28 +46,28 @@ TEST_CASE("Construct VecND in different ways", TEST_TAG) {
     }
 
     SECTION("Passing values to constructor") {
-        rr::datatypes::Vec2D v2(1.0f, 2.0f);
-        rr::datatypes::Vec3D v3(1.0f, 2.0f, 3.0f);
-        rr::datatypes::Vec4D v4(1.0f, 2.0f, 3.0f, 4.0f);
-        rr::datatypes::Quaternion q(1.0f, 2.0f, 3.0f, 4.0f);
+        Vec2D v2(1.0f, 2.0f);
+        Vec3D v3(1.0f, 2.0f, 3.0f);
+        Vec4D v4(1.0f, 2.0f, 3.0f, 4.0f);
+        Quaternion q(1.0f, 2.0f, 3.0f, 4.0f);
 
         ctor_checks(v2, v3, v4, q);
     }
 
     SECTION("Via brace initialization") {
-        rr::datatypes::Vec2D v2{1.0f, 2.0f};
-        rr::datatypes::Vec3D v3{1.0f, 2.0f, 3.0f};
-        rr::datatypes::Vec4D v4{1.0f, 2.0f, 3.0f, 4.0f};
-        rr::datatypes::Quaternion q{1.0f, 2.0f, 3.0f, 4.0f};
+        Vec2D v2{1.0f, 2.0f};
+        Vec3D v3{1.0f, 2.0f, 3.0f};
+        Vec4D v4{1.0f, 2.0f, 3.0f, 4.0f};
+        Quaternion q{1.0f, 2.0f, 3.0f, 4.0f};
 
         ctor_checks(v2, v3, v4, q);
     }
 
     SECTION("Via initializer list") {
-        rr::datatypes::Vec2D v2({1.0f, 2.0f});
-        rr::datatypes::Vec3D v3({1.0f, 2.0f, 3.0f});
-        rr::datatypes::Vec4D v4({1.0f, 2.0f, 3.0f, 4.0f});
-        rr::datatypes::Quaternion q({1.0f, 2.0f, 3.0f, 4.0f});
+        Vec2D v2({1.0f, 2.0f});
+        Vec3D v3({1.0f, 2.0f, 3.0f});
+        Vec4D v4({1.0f, 2.0f, 3.0f, 4.0f});
+        Quaternion q({1.0f, 2.0f, 3.0f, 4.0f});
 
         ctor_checks(v2, v3, v4, q);
     }
@@ -78,26 +75,26 @@ TEST_CASE("Construct VecND in different ways", TEST_TAG) {
     // Dropped this since providing an std::array version makes the initializer list version
     // ambiguous.
     // SECTION("Via std::array") {
-    //     rr::datatypes::Vec2D v2(std::array<float, 2>{1.0f, 2.0f});
-    //     rr::datatypes::Vec3D v3(std::array<float, 3>{1.0f, 2.0f, 3.0f});
-    //     rr::datatypes::Vec4D v4(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f});
-    //     rr::datatypes::Quaternion q(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f});
+    //     Vec2D v2(std::array<float, 2>{1.0f, 2.0f});
+    //     Vec3D v3(std::array<float, 3>{1.0f, 2.0f, 3.0f});
+    //     Vec4D v4(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f});
+    //     Quaternion q(std::array<float, 4>{1.0f, 2.0f, 3.0f, 4.0f});
 
     //     ctor_checks(v2, v3, v4, q);
     // }
 
     SECTION("Via c-array") {
         float c_v2[2] = {1.0f, 2.0f};
-        rr::datatypes::Vec2D v2(c_v2);
+        Vec2D v2(c_v2);
 
         float c_v3[3] = {1.0f, 2.0f, 3.0f};
-        rr::datatypes::Vec3D v3(c_v3);
+        Vec3D v3(c_v3);
 
         float c_v4[4] = {1.0f, 2.0f, 3.0f, 4.0f};
-        rr::datatypes::Vec4D v4(c_v4);
+        Vec4D v4(c_v4);
 
         float c_q[4] = {1.0f, 2.0f, 3.0f, 4.0f};
-        rr::datatypes::Quaternion q(c_q);
+        Quaternion q(c_q);
 
         ctor_checks(v2, v3, v4, q);
     }

--- a/tests/cpp/roundtrips/arrows3d/main.cpp
+++ b/tests/cpp/roundtrips/arrows3d/main.cpp
@@ -7,13 +7,13 @@ int main(int argc, char** argv) {
     auto rec_stream = rr::RecordingStream("roundtrip_arrows3d");
     rec_stream.save(argv[1]);
 
-    rec_stream.log_archetype(
+    rec_stream.log(
         "arrows3d",
         rr::archetypes::Arrows3D({{4.0f, 5.0f, 6.0f}, {40.0f, 50.0f, 60.0f}})
             .with_origins({{1.0f, 2.0f, 3.0f}, {10.0f, 20.0f, 30.0f}})
             .with_radii({0.1f, 1.0f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
-            .with_labels({std::string("hello"), std::string("friend")})
+            .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
             .with_instance_keys({66, 666})
     );

--- a/tests/cpp/roundtrips/arrows3d/main.cpp
+++ b/tests/cpp/roundtrips/arrows3d/main.cpp
@@ -9,11 +9,8 @@ int main(int argc, char** argv) {
 
     rec_stream.log_archetype(
         "arrows3d",
-        rr::archetypes::Arrows3D({rr::datatypes::Vec3D{4.0f, 5.0f, 6.0f},
-                                  rr::datatypes::Vec3D{40.0f, 50.0f, 60.0f}})
-            .with_origins(
-                {rr::datatypes::Vec3D{1.0f, 2.0f, 3.0f}, rr::datatypes::Vec3D{10.0f, 20.0f, 30.0f}}
-            )
+        rr::archetypes::Arrows3D({{4.0f, 5.0f, 6.0f}, {40.0f, 50.0f, 60.0f}})
+            .with_origins({{1.0f, 2.0f, 3.0f}, {10.0f, 20.0f, 30.0f}})
             .with_radii({0.1f, 1.0f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({std::string("hello"), std::string("friend")})

--- a/tests/cpp/roundtrips/disconnected_space/main.cpp
+++ b/tests/cpp/roundtrips/disconnected_space/main.cpp
@@ -7,5 +7,5 @@ int main(int argc, char** argv) {
     auto rec_stream = rr::RecordingStream("roundtrip_disconnected_space");
     rec_stream.save(argv[1]);
 
-    rec_stream.log_archetype("disconnected_space", rr::archetypes::DisconnectedSpace(true));
+    rec_stream.log("disconnected_space", rr::archetypes::DisconnectedSpace(true));
 }

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -7,12 +7,12 @@ int main(int argc, char** argv) {
     auto rec_stream = rr::RecordingStream("roundtrip_points3d");
     rec_stream.save(argv[1]);
 
-    rec_stream.log_archetype(
+    rec_stream.log(
         "points3d",
         rr::archetypes::Points3D({{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}})
             .with_radii({0.42f, 0.43f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
-            .with_labels({std::string("hello"), std::string("friend")})
+            .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
             .with_keypoint_ids({2, 3})
             .with_instance_keys({66, 666})

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -9,8 +9,7 @@ int main(int argc, char** argv) {
 
     rec_stream.log_archetype(
         "points3d",
-        rr::archetypes::Points3D({rr::datatypes::Vec3D{1.0, 2.0, 3.0},
-                                  rr::datatypes::Vec3D{4.0, 5.0, 6.0}})
+        rr::archetypes::Points3D({{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}})
             .with_radii({0.42f, 0.43f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({std::string("hello"), std::string("friend")})

--- a/tests/cpp/run_all.sh
+++ b/tests/cpp/run_all.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu
+script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$script_path/../.."
+
+echo "------------ Building all C++ Examples ------------"
+/bin/bash ./tests/cpp/build_all_doc_examples.sh
+
+echo "------------ Building & running SDK tests ------------"
+/bin/bash ./rerun_cpp/build_and_run_tests.sh
+
+echo "------------ Building & running minimal example ------------"
+/bin/bash ./examples/cpp/minimal/build_and_run.sh
+
+echo "------------ Running roundtrip tests ------------"
+python ./scripts/ci/run_e2e_roundtrip_tests.py


### PR DESCRIPTION
### What

Introduces a simple extension system for C++ codegen: Add an extra cpp file that will be compiled as part of the SDK. A section between two markes is copied into the generated hpp as part of generation (typically this section is removed from compilation via #ifdef)

Adds extensions to:
* color
* vec2/vec3/vec4
* quaternion
* origin3d
* point2d
* point3d
* arrow3d

... and uses them to simplify examples and test code!

All fully supported archetypes now have a simple test that checks that the base interface works and that we can serialize out to arrow without issues.

Additionally, there's tests for vecN/quaternion/color to check that their various constructors work as expected (not being a C++ expert it's fairly hard to predict)

Extends codegen with single-array-field-constructors.


---------

* part of #2647
* Fixes #2798
* Fixes #2785
* Missing only 2D example: #2789
* Adds to #2791 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2916) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2916)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fcustom-extensions/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fcustom-extensions/examples)