### PR TITLE
C++ serialization support for most nested types, transform3d roundtrip test

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-0c1bfdb8e73ff615ececbc52b6e9bbaf4fb38e25cbb5aba41a96a49ffcacbe8e
+9c2144405965455ffd11ce2f32d6b05f6428d8a782551751a0c7b3bc838ed635

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -961,7 +961,7 @@ fn fill_arrow_array_builder_method(
     cpp_includes.system.insert("arrow/api.h".to_owned());
 
     let builder = format_ident!("builder");
-    let arrow_builder_type = arrow_array_builder_type_object(&obj, objects);
+    let arrow_builder_type = arrow_array_builder_type_object(obj, objects);
 
     let fill_builder =
         quote_fill_arrow_array_builder(type_ident, obj, objects, &builder, cpp_includes);

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1441,13 +1441,13 @@ fn quote_num_items_per_value(typ: &Type, value_accessor: &TokenStream) -> TokenS
 }
 
 fn quote_field_ptr_access(typ: &Type, field_accessor: TokenStream) -> TokenStream {
-    let (ptr_access, elem_type) = match typ {
-        Type::Array { elem_type, .. } => (field_accessor, elem_type.clone()),
-        Type::Vector { elem_type } => (quote!(#field_accessor.data()), elem_type.clone()),
-        _ => (quote!(&#field_accessor), typ.clone().try_into().unwrap()),
+    let (ptr_access, typ) = match typ {
+        Type::Array { elem_type, .. } => (field_accessor, elem_type.clone().into()),
+        Type::Vector { elem_type } => (quote!(#field_accessor.data()), elem_type.clone().into()),
+        _ => (quote!(&#field_accessor), typ.clone()),
     };
 
-    if elem_type == ElementType::Bool {
+    if typ == Type::Bool {
         // Bool needs a cast because arrow takes it as uint8_t.
         quote!(reinterpret_cast<const uint8_t*>(#ptr_access))
     } else {

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1678,7 +1678,7 @@ fn static_constructor_for_enum_type(
                 for (size_t i = 0; i < #length; i += 1) {
                     #element_assignment
                 }
-                return std::move(self);
+                return self;
             },
             inline: true,
         }
@@ -1691,7 +1691,7 @@ fn static_constructor_for_enum_type(
                 #pascal_case_ident self;
                 self._tag = detail::#tag_typename::#tag_ident;
                 self._data.#snake_case_ident = std::move(#snake_case_ident);
-                return std::move(self);
+                return self;
             },
             inline: true,
         }
@@ -1708,7 +1708,7 @@ fn static_constructor_for_enum_type(
                 #pascal_case_ident self;
                 self._tag = detail::#tag_typename::#tag_ident;
                 new (&self._data.#snake_case_ident) TypeAlias(std::move(#snake_case_ident));
-                return std::move(self);
+                return self;
             },
             inline: true,
         }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1200,21 +1200,21 @@ fn quote_fill_arrow_array_builder(
             let tag_cases = fields
                 .iter()
                 .zip(union_datatypes.iter().skip(1))
-                .map(|(field, arrow_field)| {
+                .map(|(variant, arrow_field)| {
                     let arrow_builder_type = arrow_array_builder_type(arrow_field.data_type());
-                    let field_name = format_ident!("{}", field.name);
+                    let variant_name = format_ident!("{}", variant.name);
 
-                    let field_append = if matches!(field.typ, Type::Vector {..} | Type::Array {..}) {
+                    let variant_append = if variant.typ.is_plural() {
                         quote! { return arrow::Status::NotImplemented("TODO(andreas): list types in unions are not yet supported");}
                     } else {
-                        let element_accessor = quote!(union_instance._data);
-                        quote_append_single_field_to_builder(field, &variant_builder, &element_accessor, includes)
+                        let variant_accessor = quote!(union_instance._data);
+                        quote_append_single_field_to_builder(variant, &variant_builder, &variant_accessor, includes)
                     };
 
                     quote! {
-                        case detail::#tag_name::#field_name: {
+                        case detail::#tag_name::#variant_name: {
                             auto #variant_builder = static_cast<arrow::#arrow_builder_type*>(variant_builder_untyped);
-                            #field_append
+                            #variant_append
                             break;
                         }
                     }

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -900,37 +900,18 @@ impl Type {
 
     /// True if this is some kind of array/vector.
     pub fn is_plural(&self) -> bool {
-        match self {
-            Self::Array {
-                elem_type: _,
-                length: _,
-            }
-            | Self::Vector { elem_type: _ } => true,
-            Self::UInt8
-            | Self::UInt16
-            | Self::UInt32
-            | Self::UInt64
-            | Self::Int8
-            | Self::Int16
-            | Self::Int32
-            | Self::Int64
-            | Self::Bool
-            | Self::Float16
-            | Self::Float32
-            | Self::Float64
-            | Self::String
-            | Self::Object(_) => false,
-        }
+        self.plural_inner().is_some()
     }
 
-    pub fn vector_inner(&self) -> Option<&ElementType> {
+    /// Returns element type for arrays and vectors.
+    pub fn plural_inner(&self) -> Option<&ElementType> {
         match self {
-            Self::Vector { elem_type } => Some(elem_type),
-            Self::Array {
-                elem_type: _,
+            Self::Vector { elem_type }
+            | Self::Array {
+                elem_type,
                 length: _,
-            }
-            | Self::UInt8
+            } => Some(elem_type),
+            Self::UInt8
             | Self::UInt16
             | Self::UInt32
             | Self::UInt64
@@ -945,6 +926,11 @@ impl Type {
             | Self::String
             | Self::Object(_) => None,
         }
+    }
+
+    pub fn vector_inner(&self) -> Option<&ElementType> {
+        self.plural_inner()
+            .filter(|_| matches!(self, Self::Vector { .. }))
     }
 
     /// `Some(fqname)` if this is an `Object` or an `Array`/`Vector` of `Object`s.

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -1077,6 +1077,30 @@ impl ElementType {
     }
 }
 
+impl TryFrom<Type> for ElementType {
+    type Error = ();
+
+    fn try_from(value: Type) -> Result<Self, ()> {
+        match value {
+            Type::UInt8 => Ok(ElementType::UInt8),
+            Type::UInt16 => Ok(ElementType::UInt16),
+            Type::UInt32 => Ok(ElementType::UInt32),
+            Type::UInt64 => Ok(ElementType::UInt64),
+            Type::Int8 => Ok(ElementType::Int8),
+            Type::Int16 => Ok(ElementType::Int16),
+            Type::Int32 => Ok(ElementType::Int32),
+            Type::Int64 => Ok(ElementType::Int64),
+            Type::Bool => Ok(ElementType::Bool),
+            Type::Float16 => Ok(ElementType::Float16),
+            Type::Float32 => Ok(ElementType::Float32),
+            Type::Float64 => Ok(ElementType::Float64),
+            Type::String => Ok(ElementType::String),
+            Type::Array { .. } | Type::Vector { .. } => Err(()),
+            Type::Object(fqname) => Ok(ElementType::Object(fqname)),
+        }
+    }
+}
+
 // --- Common ---
 
 /// A collection of arbitrary attributes.

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -1063,30 +1063,6 @@ impl ElementType {
     }
 }
 
-impl TryFrom<Type> for ElementType {
-    type Error = ();
-
-    fn try_from(value: Type) -> Result<Self, ()> {
-        match value {
-            Type::UInt8 => Ok(ElementType::UInt8),
-            Type::UInt16 => Ok(ElementType::UInt16),
-            Type::UInt32 => Ok(ElementType::UInt32),
-            Type::UInt64 => Ok(ElementType::UInt64),
-            Type::Int8 => Ok(ElementType::Int8),
-            Type::Int16 => Ok(ElementType::Int16),
-            Type::Int32 => Ok(ElementType::Int32),
-            Type::Int64 => Ok(ElementType::Int64),
-            Type::Bool => Ok(ElementType::Bool),
-            Type::Float16 => Ok(ElementType::Float16),
-            Type::Float32 => Ok(ElementType::Float32),
-            Type::Float64 => Ok(ElementType::Float64),
-            Type::String => Ok(ElementType::String),
-            Type::Array { .. } | Type::Vector { .. } => Err(()),
-            Type::Object(fqname) => Ok(ElementType::Object(fqname)),
-        }
-    }
-}
-
 // --- Common ---
 
 /// A collection of arbitrary attributes.

--- a/rerun_cpp/src/rerun/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer11.cpp
@@ -12,8 +12,7 @@ namespace rerun {
         const char *AffixFuzzer11::NAME = "rerun.testing.components.AffixFuzzer11";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer11::to_arrow_datatype() {
-            static const auto datatype =
-                arrow::list(arrow::field("item", arrow::float32(), true, nullptr));
+            static const auto datatype = arrow::list(arrow::field("item", arrow::float32(), false));
             return datatype;
         }
 
@@ -48,7 +47,7 @@ namespace rerun {
                 const auto &element = elements[elem_idx];
                 if (element.many_floats_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        &element.many_floats_optional.value()[0],
+                        element.many_floats_optional.value().data(),
                         element.many_floats_optional.value().size(),
                         nullptr
                     ));

--- a/rerun_cpp/src/rerun/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer12.cpp
@@ -12,8 +12,7 @@ namespace rerun {
         const char *AffixFuzzer12::NAME = "rerun.testing.components.AffixFuzzer12";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer12::to_arrow_datatype() {
-            static const auto datatype =
-                arrow::list(arrow::field("item", arrow::utf8(), false, nullptr));
+            static const auto datatype = arrow::list(arrow::field("item", arrow::utf8(), false));
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer13.cpp
@@ -12,8 +12,7 @@ namespace rerun {
         const char *AffixFuzzer13::NAME = "rerun.testing.components.AffixFuzzer13";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer13::to_arrow_datatype() {
-            static const auto datatype =
-                arrow::list(arrow::field("item", arrow::utf8(), true, nullptr));
+            static const auto datatype = arrow::list(arrow::field("item", arrow::utf8(), false));
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer16.cpp
@@ -10,20 +10,17 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer16::NAME = "rerun.testing.components.AffixFuzzer16";
+        const char *AffixFuzzer16::NAME = "rerun.testing.components.AffixFuzzer16";
 
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer16::to_arrow_datatype() {
-            static const auto datatype = arrow::list(arrow::field(
-                "item",
-                rerun::datatypes::AffixFuzzer3::to_arrow_datatype(),
-                false,
-                nullptr
-            ));
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer16::to_arrow_datatype() {
+            static const auto datatype = arrow::list(
+                arrow::field("item", rerun::datatypes::AffixFuzzer3::to_arrow_datatype(), false)
+            );
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer16::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -36,7 +33,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer16::fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
+            arrow::ListBuilder *builder, const AffixFuzzer16 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -45,18 +42,28 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): custom data types in lists/fixedsizelist are not yet implemented"
-            );
+            auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &element = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                    value_builder,
+                    element.many_required_unions.data(),
+                    element.many_required_unions.size()
+                ));
+                ARROW_RETURN_NOT_OK(builder->Append());
+            }
 
             return arrow::Status::OK();
         }
 
         arrow::Result<rerun::DataCell> AffixFuzzer16::to_data_cell(
-            const AffixFuzzer16* instances, size_t num_instances
+            const AffixFuzzer16 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer16::new_arrow_array_builder(pool));
             if (instances && num_instances > 0) {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer17.cpp
@@ -10,20 +10,17 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer17::NAME = "rerun.testing.components.AffixFuzzer17";
+        const char *AffixFuzzer17::NAME = "rerun.testing.components.AffixFuzzer17";
 
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer17::to_arrow_datatype() {
-            static const auto datatype = arrow::list(arrow::field(
-                "item",
-                rerun::datatypes::AffixFuzzer3::to_arrow_datatype(),
-                true,
-                nullptr
-            ));
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer17::to_arrow_datatype() {
+            static const auto datatype = arrow::list(
+                arrow::field("item", rerun::datatypes::AffixFuzzer3::to_arrow_datatype(), false)
+            );
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer17::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -36,7 +33,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer17::fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
+            arrow::ListBuilder *builder, const AffixFuzzer17 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -45,18 +42,32 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): custom data types in lists/fixedsizelist are not yet implemented"
-            );
+            auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &element = elements[elem_idx];
+                if (element.many_optional_unions.has_value()) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                        value_builder,
+                        element.many_optional_unions.value().data(),
+                        element.many_optional_unions.value().size()
+                    ));
+                    ARROW_RETURN_NOT_OK(builder->Append());
+                } else {
+                    ARROW_RETURN_NOT_OK(builder->AppendNull());
+                }
+            }
 
             return arrow::Status::OK();
         }
 
         arrow::Result<rerun::DataCell> AffixFuzzer17::to_data_cell(
-            const AffixFuzzer17* instances, size_t num_instances
+            const AffixFuzzer17 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer17::new_arrow_array_builder(pool));
             if (instances && num_instances > 0) {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer18.cpp
@@ -10,20 +10,17 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer18::NAME = "rerun.testing.components.AffixFuzzer18";
+        const char *AffixFuzzer18::NAME = "rerun.testing.components.AffixFuzzer18";
 
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer18::to_arrow_datatype() {
-            static const auto datatype = arrow::list(arrow::field(
-                "item",
-                rerun::datatypes::AffixFuzzer4::to_arrow_datatype(),
-                true,
-                nullptr
-            ));
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer18::to_arrow_datatype() {
+            static const auto datatype = arrow::list(
+                arrow::field("item", rerun::datatypes::AffixFuzzer4::to_arrow_datatype(), false)
+            );
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer18::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -36,7 +33,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer18::fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
+            arrow::ListBuilder *builder, const AffixFuzzer18 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -45,18 +42,32 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): custom data types in lists/fixedsizelist are not yet implemented"
-            );
+            auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &element = elements[elem_idx];
+                if (element.many_optional_unions.has_value()) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
+                        value_builder,
+                        element.many_optional_unions.value().data(),
+                        element.many_optional_unions.value().size()
+                    ));
+                    ARROW_RETURN_NOT_OK(builder->Append());
+                } else {
+                    ARROW_RETURN_NOT_OK(builder->AppendNull());
+                }
+            }
 
             return arrow::Status::OK();
         }
 
         arrow::Result<rerun::DataCell> AffixFuzzer18::to_data_cell(
-            const AffixFuzzer18* instances, size_t num_instances
+            const AffixFuzzer18 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer18::new_arrow_array_builder(pool));
             if (instances && num_instances > 0) {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer7.cpp
@@ -10,20 +10,17 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer7::NAME = "rerun.testing.components.AffixFuzzer7";
+        const char *AffixFuzzer7::NAME = "rerun.testing.components.AffixFuzzer7";
 
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer7::to_arrow_datatype() {
-            static const auto datatype = arrow::list(arrow::field(
-                "item",
-                rerun::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                true,
-                nullptr
-            ));
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer7::to_arrow_datatype() {
+            static const auto datatype = arrow::list(
+                arrow::field("item", rerun::datatypes::AffixFuzzer1::to_arrow_datatype(), false)
+            );
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer7::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -36,7 +33,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer7::fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
+            arrow::ListBuilder *builder, const AffixFuzzer7 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -45,18 +42,32 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): custom data types in lists/fixedsizelist are not yet implemented"
-            );
+            auto value_builder = static_cast<arrow::StructBuilder *>(builder->value_builder());
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &element = elements[elem_idx];
+                if (element.many_optional.has_value()) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+                        value_builder,
+                        element.many_optional.value().data(),
+                        element.many_optional.value().size()
+                    ));
+                    ARROW_RETURN_NOT_OK(builder->Append());
+                } else {
+                    ARROW_RETURN_NOT_OK(builder->AppendNull());
+                }
+            }
 
             return arrow::Status::OK();
         }
 
         arrow::Result<rerun::DataCell> AffixFuzzer7::to_data_cell(
-            const AffixFuzzer7* instances, size_t num_instances
+            const AffixFuzzer7 *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer7::new_arrow_array_builder(pool));
             if (instances && num_instances > 0) {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer9.cpp
@@ -37,7 +37,7 @@ namespace rerun {
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].single_string_required));
             }
 

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -10,20 +10,19 @@
 
 namespace rerun {
     namespace components {
-        const char* AnnotationContext::NAME = "rerun.annotation_context";
+        const char *AnnotationContext::NAME = "rerun.annotation_context";
 
-        const std::shared_ptr<arrow::DataType>& AnnotationContext::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &AnnotationContext::to_arrow_datatype() {
             static const auto datatype = arrow::list(arrow::field(
                 "item",
                 rerun::datatypes::ClassDescriptionMapElem::to_arrow_datatype(),
-                false,
-                nullptr
+                false
             ));
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>>
-            AnnotationContext::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            AnnotationContext::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -36,7 +35,7 @@ namespace rerun {
         }
 
         arrow::Status AnnotationContext::fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AnnotationContext* elements, size_t num_elements
+            arrow::ListBuilder *builder, const AnnotationContext *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -45,18 +44,30 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): custom data types in lists/fixedsizelist are not yet implemented"
-            );
+            auto value_builder = static_cast<arrow::StructBuilder *>(builder->value_builder());
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &element = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(
+                    rerun::datatypes::ClassDescriptionMapElem::fill_arrow_array_builder(
+                        value_builder,
+                        element.class_map.data(),
+                        element.class_map.size()
+                    )
+                );
+                ARROW_RETURN_NOT_OK(builder->Append());
+            }
 
             return arrow::Status::OK();
         }
 
         arrow::Result<rerun::DataCell> AnnotationContext::to_data_cell(
-            const AnnotationContext* instances, size_t num_instances
+            const AnnotationContext *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, AnnotationContext::new_arrow_array_builder(pool));
             if (instances && num_instances > 0) {

--- a/rerun_cpp/src/rerun/components/label.cpp
+++ b/rerun_cpp/src/rerun/components/label.cpp
@@ -37,7 +37,7 @@ namespace rerun {
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].value));
             }
 

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -10,17 +10,17 @@
 
 namespace rerun {
     namespace components {
-        const char* LineStrip3D::NAME = "rerun.linestrip3d";
+        const char *LineStrip3D::NAME = "rerun.linestrip3d";
 
-        const std::shared_ptr<arrow::DataType>& LineStrip3D::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &LineStrip3D::to_arrow_datatype() {
             static const auto datatype = arrow::list(
-                arrow::field("item", rerun::datatypes::Vec3D::to_arrow_datatype(), false, nullptr)
+                arrow::field("item", rerun::datatypes::Vec3D::to_arrow_datatype(), false)
             );
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::ListBuilder>> LineStrip3D::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -33,7 +33,7 @@ namespace rerun {
         }
 
         arrow::Status LineStrip3D::fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const LineStrip3D* elements, size_t num_elements
+            arrow::ListBuilder *builder, const LineStrip3D *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -42,18 +42,29 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): custom data types in lists/fixedsizelist are not yet implemented"
-            );
+            auto value_builder =
+                static_cast<arrow::FixedSizeListBuilder *>(builder->value_builder());
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &element = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                    value_builder,
+                    element.points.data(),
+                    element.points.size()
+                ));
+                ARROW_RETURN_NOT_OK(builder->Append());
+            }
 
             return arrow::Status::OK();
         }
 
         arrow::Result<rerun::DataCell> LineStrip3D::to_data_cell(
-            const LineStrip3D* instances, size_t num_instances
+            const LineStrip3D *instances, size_t num_instances
         ) {
             // TODO(andreas): Allow configuring the memory pool.
-            arrow::MemoryPool* pool = arrow::default_memory_pool();
+            arrow::MemoryPool *pool = arrow::default_memory_pool();
 
             ARROW_ASSIGN_OR_RAISE(auto builder, LineStrip3D::new_arrow_array_builder(pool));
             if (instances && num_instances > 0) {

--- a/rerun_cpp/src/rerun/components/string_component.cpp
+++ b/rerun_cpp/src/rerun/components/string_component.cpp
@@ -36,7 +36,7 @@ namespace rerun {
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].value));
             }
 

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.cpp
@@ -11,35 +11,31 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &AffixFuzzer1::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field("single_float_optional", arrow::float32(), true, nullptr),
-                arrow::field("single_string_required", arrow::utf8(), false, nullptr),
-                arrow::field("single_string_optional", arrow::utf8(), true, nullptr),
+                arrow::field("single_float_optional", arrow::float32(), true),
+                arrow::field("single_string_required", arrow::utf8(), false),
+                arrow::field("single_string_optional", arrow::utf8(), true),
                 arrow::field(
                     "many_floats_optional",
-                    arrow::list(arrow::field("item", arrow::float32(), true, nullptr)),
-                    true,
-                    nullptr
+                    arrow::list(arrow::field("item", arrow::float32(), false)),
+                    true
                 ),
                 arrow::field(
                     "many_strings_required",
-                    arrow::list(arrow::field("item", arrow::utf8(), false, nullptr)),
-                    false,
-                    nullptr
+                    arrow::list(arrow::field("item", arrow::utf8(), false)),
+                    false
                 ),
                 arrow::field(
                     "many_strings_optional",
-                    arrow::list(arrow::field("item", arrow::utf8(), true, nullptr)),
-                    true,
-                    nullptr
+                    arrow::list(arrow::field("item", arrow::utf8(), false)),
+                    true
                 ),
-                arrow::field("flattened_scalar", arrow::float32(), false, nullptr),
+                arrow::field("flattened_scalar", arrow::float32(), false),
                 arrow::field(
                     "almost_flattened_scalar",
                     rerun::datatypes::FlattenedScalar::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
-                arrow::field("from_parent", arrow::boolean(), true, nullptr),
+                arrow::field("from_parent", arrow::boolean(), true),
             });
             return datatype;
         }
@@ -89,76 +85,132 @@ namespace rerun {
             }
 
             {
-                auto element_builder =
-                    static_cast<arrow::FloatBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
+                auto field_builder = static_cast<arrow::FloatBuilder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.single_float_optional.has_value()) {
                         ARROW_RETURN_NOT_OK(
-                            element_builder->Append(element.single_float_optional.value())
+                            field_builder->Append(element.single_float_optional.value())
                         );
                     } else {
-                        ARROW_RETURN_NOT_OK(element_builder->AppendNull());
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                     }
                 }
             }
             {
-                auto element_builder =
-                    static_cast<arrow::StringBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
-                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(
-                        element_builder->Append(elements[elem_idx].single_string_required)
+                        field_builder->Append(elements[elem_idx].single_string_required)
                     );
                 }
             }
             {
-                auto element_builder =
-                    static_cast<arrow::StringBuilder *>(builder->field_builder(2));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
+                auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(2));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.single_string_optional.has_value()) {
                         ARROW_RETURN_NOT_OK(
-                            element_builder->Append(element.single_string_optional.value())
+                            field_builder->Append(element.single_string_optional.value())
                         );
                     } else {
-                        ARROW_RETURN_NOT_OK(element_builder->AppendNull());
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                     }
                 }
             }
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): lists in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): lists in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): lists in structs are not yet supported"
-            );
             {
-                auto element_builder =
-                    static_cast<arrow::FloatBuilder *>(builder->field_builder(6));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
-                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(element_builder->Append(elements[elem_idx].flattened_scalar)
-                    );
+                auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(3));
+                auto value_builder =
+                    static_cast<arrow::FloatBuilder *>(field_builder->value_builder());
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.many_floats_optional.has_value()) {
+                        ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                            element.many_floats_optional.value().data(),
+                            element.many_floats_optional.value().size(),
+                            nullptr
+                        ));
+                        ARROW_RETURN_NOT_OK(field_builder->Append());
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
                 }
             }
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
             {
-                auto element_builder =
+                auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(4));
+                auto value_builder =
+                    static_cast<arrow::StringBuilder *>(field_builder->value_builder());
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    for (auto item_idx = 0; item_idx < element.many_strings_required.size();
+                         item_idx += 1) {
+                        ARROW_RETURN_NOT_OK(
+                            value_builder->Append(element.many_strings_required[item_idx])
+                        );
+                    }
+                    ARROW_RETURN_NOT_OK(field_builder->Append());
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(5));
+                auto value_builder =
+                    static_cast<arrow::StringBuilder *>(field_builder->value_builder());
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.many_strings_optional.has_value()) {
+                        for (auto item_idx = 0;
+                             item_idx < element.many_strings_optional.value().size();
+                             item_idx += 1) {
+                            ARROW_RETURN_NOT_OK(value_builder->Append(
+                                element.many_strings_optional.value()[item_idx]
+                            ));
+                        }
+                        ARROW_RETURN_NOT_OK(field_builder->Append());
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::FloatBuilder *>(builder->field_builder(6));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].flattened_scalar));
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(7));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::FlattenedScalar::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].almost_flattened_scalar,
+                        1
+                    ));
+                }
+            }
+            {
+                auto field_builder =
                     static_cast<arrow::BooleanBuilder *>(builder->field_builder(8));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.from_parent.has_value()) {
-                        ARROW_RETURN_NOT_OK(element_builder->Append(element.from_parent.value()));
+                        ARROW_RETURN_NOT_OK(field_builder->Append(element.from_parent.value()));
                     } else {
-                        ARROW_RETURN_NOT_OK(element_builder->AppendNull());
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                     }
                 }
             }

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer20.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer20.cpp
@@ -10,26 +10,20 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer20::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer20::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
                 arrow::field(
                     "p",
                     rerun::components::PrimitiveComponent::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
-                arrow::field(
-                    "s",
-                    rerun::components::StringComponent::to_arrow_datatype(),
-                    false,
-                    nullptr
-                ),
+                arrow::field("s", rerun::components::StringComponent::to_arrow_datatype(), false),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer20::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -48,7 +42,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer20::fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
+            arrow::StructBuilder *builder, const AffixFuzzer20 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -57,12 +51,32 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
+            {
+                auto field_builder = static_cast<arrow::UInt32Builder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(
+                        rerun::components::PrimitiveComponent::fill_arrow_array_builder(
+                            field_builder,
+                            &elements[elem_idx].p,
+                            1
+                        )
+                    );
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(
+                        rerun::components::StringComponent::fill_arrow_array_builder(
+                            field_builder,
+                            &elements[elem_idx].s,
+                            1
+                        )
+                    );
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.cpp
@@ -9,37 +9,31 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer3::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer3::to_arrow_datatype() {
             static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
-                arrow::field("degrees", arrow::float32(), false, nullptr),
-                arrow::field("radians", arrow::float32(), false, nullptr),
+                arrow::field("degrees", arrow::float32(), false),
+                arrow::field("radians", arrow::float32(), true),
                 arrow::field(
                     "craziness",
                     arrow::list(arrow::field(
                         "item",
                         rerun::datatypes::AffixFuzzer1::to_arrow_datatype(),
-                        false,
-                        nullptr
+                        false
                     )),
-                    false,
-                    nullptr
+                    false
                 ),
                 arrow::field(
                     "fixed_size_shenanigans",
-                    arrow::fixed_size_list(
-                        arrow::field("item", arrow::float32(), false, nullptr),
-                        3
-                    ),
-                    false,
-                    nullptr
+                    arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 3),
+                    false
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            AffixFuzzer3::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            AffixFuzzer3::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -66,7 +60,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer3::fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
+            arrow::DenseUnionBuilder *builder, const AffixFuzzer3 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -75,10 +69,54 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                const auto& element = elements[elem_idx];
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &union_instance = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+
+                auto variant_index = static_cast<int>(union_instance._tag);
+                auto variant_builder_untyped = builder->child_builder(variant_index).get();
+
+                switch (union_instance._tag) {
+                    case detail::AffixFuzzer3Tag::NONE: {
+                        ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
+                        break;
+                    }
+                    case detail::AffixFuzzer3Tag::degrees: {
+                        auto variant_builder =
+                            static_cast<arrow::FloatBuilder *>(variant_builder_untyped);
+                        ARROW_RETURN_NOT_OK(variant_builder->Append(union_instance._data.degrees));
+                        break;
+                    }
+                    case detail::AffixFuzzer3Tag::radians: {
+                        auto variant_builder =
+                            static_cast<arrow::FloatBuilder *>(variant_builder_untyped);
+                        const auto &element = union_instance._data;
+                        if (element.radians.has_value()) {
+                            ARROW_RETURN_NOT_OK(variant_builder->Append(element.radians.value()));
+                        } else {
+                            ARROW_RETURN_NOT_OK(variant_builder->AppendNull());
+                        }
+                        break;
+                    }
+                    case detail::AffixFuzzer3Tag::craziness: {
+                        auto variant_builder =
+                            static_cast<arrow::ListBuilder *>(variant_builder_untyped);
+                        return arrow::Status::NotImplemented(
+                            "TODO(andreas): list types in unions are not yet supported"
+                        );
+                        break;
+                    }
+                    case detail::AffixFuzzer3Tag::fixed_size_shenanigans: {
+                        auto variant_builder =
+                            static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
+                        return arrow::Status::NotImplemented(
+                            "TODO(andreas): list types in unions are not yet supported"
+                        );
+                        break;
+                    }
+                }
             }
-            return arrow::Status::NotImplemented("TODO(andreas): unions are not yet implemented");
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.hpp
@@ -16,7 +16,7 @@
 namespace rerun {
     namespace datatypes {
         namespace detail {
-            enum class AffixFuzzer3Tag {
+            enum class AffixFuzzer3Tag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We
                 /// need to be able to leave the object in a state which we can run the destructor
                 /// on.
@@ -114,14 +114,14 @@ namespace rerun {
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::degrees;
                 self._data.degrees = std::move(degrees);
-                return std::move(self);
+                return self;
             }
 
             static AffixFuzzer3 radians(std::optional<float> radians) {
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::radians;
                 self._data.radians = std::move(radians);
-                return std::move(self);
+                return self;
             }
 
             static AffixFuzzer3 craziness(std::vector<rerun::datatypes::AffixFuzzer1> craziness) {
@@ -129,7 +129,7 @@ namespace rerun {
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::craziness;
                 new (&self._data.craziness) TypeAlias(std::move(craziness));
-                return std::move(self);
+                return self;
             }
 
             static AffixFuzzer3 fixed_size_shenanigans(float fixed_size_shenanigans[3]) {
@@ -139,7 +139,7 @@ namespace rerun {
                 for (size_t i = 0; i < 3; i += 1) {
                     self._data.fixed_size_shenanigans[i] = std::move(fixed_size_shenanigans[i]);
                 }
-                return std::move(self);
+                return self;
             }
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.cpp
@@ -9,43 +9,38 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer4::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer4::to_arrow_datatype() {
             static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field(
                     "single_required",
                     rerun::datatypes::AffixFuzzer3::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
                 arrow::field(
                     "many_required",
                     arrow::list(arrow::field(
                         "item",
                         rerun::datatypes::AffixFuzzer3::to_arrow_datatype(),
-                        false,
-                        nullptr
+                        false
                     )),
-                    false,
-                    nullptr
+                    false
                 ),
                 arrow::field(
                     "many_optional",
                     arrow::list(arrow::field(
                         "item",
                         rerun::datatypes::AffixFuzzer3::to_arrow_datatype(),
-                        true,
-                        nullptr
+                        false
                     )),
-                    false,
-                    nullptr
+                    true
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            AffixFuzzer4::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            AffixFuzzer4::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -72,7 +67,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer4::fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
+            arrow::DenseUnionBuilder *builder, const AffixFuzzer4 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -81,10 +76,49 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                const auto& element = elements[elem_idx];
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &union_instance = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+
+                auto variant_index = static_cast<int>(union_instance._tag);
+                auto variant_builder_untyped = builder->child_builder(variant_index).get();
+
+                switch (union_instance._tag) {
+                    case detail::AffixFuzzer4Tag::NONE: {
+                        ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
+                        break;
+                    }
+                    case detail::AffixFuzzer4Tag::single_required: {
+                        auto variant_builder =
+                            static_cast<arrow::DenseUnionBuilder *>(variant_builder_untyped);
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                                variant_builder,
+                                &union_instance._data.single_required,
+                                1
+                            )
+                        );
+                        break;
+                    }
+                    case detail::AffixFuzzer4Tag::many_required: {
+                        auto variant_builder =
+                            static_cast<arrow::ListBuilder *>(variant_builder_untyped);
+                        return arrow::Status::NotImplemented(
+                            "TODO(andreas): list types in unions are not yet supported"
+                        );
+                        break;
+                    }
+                    case detail::AffixFuzzer4Tag::many_optional: {
+                        auto variant_builder =
+                            static_cast<arrow::ListBuilder *>(variant_builder_untyped);
+                        return arrow::Status::NotImplemented(
+                            "TODO(andreas): list types in unions are not yet supported"
+                        );
+                        break;
+                    }
+                }
             }
-            return arrow::Status::NotImplemented("TODO(andreas): unions are not yet implemented");
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.hpp
@@ -16,7 +16,7 @@
 namespace rerun {
     namespace datatypes {
         namespace detail {
-            enum class AffixFuzzer4Tag {
+            enum class AffixFuzzer4Tag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We
                 /// need to be able to leave the object in a state which we can run the destructor
                 /// on.
@@ -122,7 +122,7 @@ namespace rerun {
                 AffixFuzzer4 self;
                 self._tag = detail::AffixFuzzer4Tag::single_required;
                 new (&self._data.single_required) TypeAlias(std::move(single_required));
-                return std::move(self);
+                return self;
             }
 
             static AffixFuzzer4 many_required(
@@ -132,7 +132,7 @@ namespace rerun {
                 AffixFuzzer4 self;
                 self._tag = detail::AffixFuzzer4Tag::many_required;
                 new (&self._data.many_required) TypeAlias(std::move(many_required));
-                return std::move(self);
+                return self;
             }
 
             static AffixFuzzer4 many_optional(
@@ -142,7 +142,7 @@ namespace rerun {
                 AffixFuzzer4 self;
                 self._tag = detail::AffixFuzzer4Tag::many_optional;
                 new (&self._data.many_optional) TypeAlias(std::move(many_optional));
-                return std::move(self);
+                return self;
             }
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer5.cpp
@@ -9,20 +9,19 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& AffixFuzzer5::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &AffixFuzzer5::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
                 arrow::field(
                     "single_optional_union",
                     rerun::datatypes::AffixFuzzer4::to_arrow_datatype(),
-                    true,
-                    nullptr
+                    true
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -39,7 +38,7 @@ namespace rerun {
         }
 
         arrow::Status AffixFuzzer5::fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
+            arrow::StructBuilder *builder, const AffixFuzzer5 *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -48,9 +47,25 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
+            {
+                auto field_builder =
+                    static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.single_optional_union.has_value()) {
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
+                                field_builder,
+                                &element.single_optional_union.value(),
+                                1
+                            )
+                        );
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -11,7 +11,7 @@
 namespace rerun {
     namespace datatypes {
         namespace detail {
-            enum class AngleTag {
+            enum class AngleTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We
                 /// need to be able to leave the object in a state which we can run the destructor
                 /// on.
@@ -74,14 +74,14 @@ namespace rerun {
                 Angle self;
                 self._tag = detail::AngleTag::Radians;
                 self._data.radians = std::move(radians);
-                return std::move(self);
+                return self;
             }
 
             static Angle degrees(float degrees) {
                 Angle self;
                 self._tag = detail::AngleTag::Degrees;
                 self._data.degrees = std::move(degrees);
-                return std::move(self);
+                return self;
             }
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
@@ -12,9 +12,9 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &AnnotationInfo::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field("id", arrow::uint16(), false, nullptr),
-                arrow::field("label", rerun::components::Label::to_arrow_datatype(), true, nullptr),
-                arrow::field("color", rerun::components::Color::to_arrow_datatype(), true, nullptr),
+                arrow::field("id", arrow::uint16(), false),
+                arrow::field("label", rerun::components::Label::to_arrow_datatype(), true),
+                arrow::field("color", rerun::components::Color::to_arrow_datatype(), true),
             });
             return datatype;
         }
@@ -47,19 +47,44 @@ namespace rerun {
             }
 
             {
-                auto element_builder =
-                    static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
-                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(element_builder->Append(elements[elem_idx].id));
+                auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].id));
                 }
             }
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
+            {
+                auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.label.has_value()) {
+                        ARROW_RETURN_NOT_OK(rerun::components::Label::fill_arrow_array_builder(
+                            field_builder,
+                            &element.label.value(),
+                            1
+                        ));
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::UInt32Builder *>(builder->field_builder(2));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.color.has_value()) {
+                        ARROW_RETURN_NOT_OK(rerun::components::Color::fill_arrow_array_builder(
+                            field_builder,
+                            &element.color.value(),
+                            1
+                        ));
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/class_description.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.cpp
@@ -10,42 +10,33 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& ClassDescription::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &ClassDescription::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field(
-                    "info",
-                    rerun::datatypes::AnnotationInfo::to_arrow_datatype(),
-                    false,
-                    nullptr
-                ),
+                arrow::field("info", rerun::datatypes::AnnotationInfo::to_arrow_datatype(), false),
                 arrow::field(
                     "keypoint_annotations",
                     arrow::list(arrow::field(
                         "item",
                         rerun::datatypes::AnnotationInfo::to_arrow_datatype(),
-                        false,
-                        nullptr
+                        false
                     )),
-                    false,
-                    nullptr
+                    false
                 ),
                 arrow::field(
                     "keypoint_connections",
                     arrow::list(arrow::field(
                         "item",
                         rerun::datatypes::KeypointPair::to_arrow_datatype(),
-                        false,
-                        nullptr
+                        false
                     )),
-                    false,
-                    nullptr
+                    false
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            ClassDescription::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            ClassDescription::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -71,7 +62,7 @@ namespace rerun {
         }
 
         arrow::Status ClassDescription::fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const ClassDescription* elements, size_t num_elements
+            arrow::StructBuilder *builder, const ClassDescription *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -80,15 +71,51 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): lists in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): lists in structs are not yet supported"
-            );
+            {
+                auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].info,
+                        1
+                    ));
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(1));
+                auto value_builder =
+                    static_cast<arrow::StructBuilder *>(field_builder->value_builder());
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
+                        value_builder,
+                        element.keypoint_annotations.data(),
+                        element.keypoint_annotations.size()
+                    ));
+                    ARROW_RETURN_NOT_OK(field_builder->Append());
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(2));
+                auto value_builder =
+                    static_cast<arrow::StructBuilder *>(field_builder->value_builder());
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointPair::fill_arrow_array_builder(
+                        value_builder,
+                        element.keypoint_connections.data(),
+                        element.keypoint_connections.size()
+                    ));
+                    ARROW_RETURN_NOT_OK(field_builder->Append());
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
@@ -10,26 +10,20 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& ClassDescriptionMapElem::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &ClassDescriptionMapElem::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field(
-                    "class_id",
-                    rerun::components::ClassId::to_arrow_datatype(),
-                    false,
-                    nullptr
-                ),
+                arrow::field("class_id", rerun::components::ClassId::to_arrow_datatype(), false),
                 arrow::field(
                     "class_description",
                     rerun::datatypes::ClassDescription::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            ClassDescriptionMapElem::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            ClassDescriptionMapElem::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -46,7 +40,7 @@ namespace rerun {
         }
 
         arrow::Status ClassDescriptionMapElem::fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const ClassDescriptionMapElem* elements,
+            arrow::StructBuilder *builder, const ClassDescriptionMapElem *elements,
             size_t num_elements
         ) {
             if (!builder) {
@@ -56,12 +50,30 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
+            {
+                auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::components::ClassId::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].class_id,
+                        1
+                    ));
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(
+                        rerun::datatypes::ClassDescription::fill_arrow_array_builder(
+                            field_builder,
+                            &elements[elem_idx].class_description,
+                            1
+                        )
+                    );
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/flattened_scalar.cpp
+++ b/rerun_cpp/src/rerun/datatypes/flattened_scalar.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &FlattenedScalar::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field("value", arrow::float32(), false, nullptr),
+                arrow::field("value", arrow::float32(), false),
             });
             return datatype;
         }
@@ -40,11 +40,10 @@ namespace rerun {
             }
 
             {
-                auto element_builder =
-                    static_cast<arrow::FloatBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
-                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(element_builder->Append(elements[elem_idx].value));
+                auto field_builder = static_cast<arrow::FloatBuilder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].value));
                 }
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
@@ -9,26 +9,24 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& KeypointPair::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &KeypointPair::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
                 arrow::field(
                     "keypoint0",
                     rerun::components::KeypointId::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
                 arrow::field(
                     "keypoint1",
                     rerun::components::KeypointId::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>> KeypointPair::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -47,7 +45,7 @@ namespace rerun {
         }
 
         arrow::Status KeypointPair::fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const KeypointPair* elements, size_t num_elements
+            arrow::StructBuilder *builder, const KeypointPair *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -56,12 +54,28 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
+            {
+                auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::components::KeypointId::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].keypoint0,
+                        1
+                    ));
+                }
+            }
+            {
+                auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::components::KeypointId::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].keypoint1,
+                        1
+                    ));
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &Mat3x3::to_arrow_datatype() {
             static const auto datatype =
-                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 9);
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 9);
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &Mat4x4::to_arrow_datatype() {
             static const auto datatype =
-                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 16);
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 16);
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &Quaternion::to_arrow_datatype() {
             static const auto datatype =
-                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 4);
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 4);
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
@@ -10,27 +10,25 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& Rotation3D::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &Rotation3D::to_arrow_datatype() {
             static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
                 arrow::field(
                     "Quaternion",
                     rerun::datatypes::Quaternion::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
                 arrow::field(
                     "AxisAngle",
                     rerun::datatypes::RotationAxisAngle::to_arrow_datatype(),
-                    false,
-                    nullptr
+                    false
                 ),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            Rotation3D::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            Rotation3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -48,7 +46,7 @@ namespace rerun {
         }
 
         arrow::Status Rotation3D::fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
+            arrow::DenseUnionBuilder *builder, const Rotation3D *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -57,10 +55,43 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                const auto& element = elements[elem_idx];
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &union_instance = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+
+                auto variant_index = static_cast<int>(union_instance._tag);
+                auto variant_builder_untyped = builder->child_builder(variant_index).get();
+
+                switch (union_instance._tag) {
+                    case detail::Rotation3DTag::NONE: {
+                        ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
+                        break;
+                    }
+                    case detail::Rotation3DTag::Quaternion: {
+                        auto variant_builder =
+                            static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
+                        ARROW_RETURN_NOT_OK(rerun::datatypes::Quaternion::fill_arrow_array_builder(
+                            variant_builder,
+                            &union_instance._data.quaternion,
+                            1
+                        ));
+                        break;
+                    }
+                    case detail::Rotation3DTag::AxisAngle: {
+                        auto variant_builder =
+                            static_cast<arrow::StructBuilder *>(variant_builder_untyped);
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::RotationAxisAngle::fill_arrow_array_builder(
+                                variant_builder,
+                                &union_instance._data.axis_angle,
+                                1
+                            )
+                        );
+                        break;
+                    }
+                }
             }
-            return arrow::Status::NotImplemented("TODO(andreas): unions are not yet implemented");
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -14,7 +14,7 @@
 namespace rerun {
     namespace datatypes {
         namespace detail {
-            enum class Rotation3DTag {
+            enum class Rotation3DTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We
                 /// need to be able to leave the object in a state which we can run the destructor
                 /// on.
@@ -80,7 +80,7 @@ namespace rerun {
                 Rotation3D self;
                 self._tag = detail::Rotation3DTag::Quaternion;
                 self._data.quaternion = std::move(quaternion);
-                return std::move(self);
+                return self;
             }
 
             /// Rotation defined with an axis and an angle.
@@ -88,7 +88,7 @@ namespace rerun {
                 Rotation3D self;
                 self._tag = detail::Rotation3DTag::AxisAngle;
                 self._data.axis_angle = std::move(axis_angle);
-                return std::move(self);
+                return self;
             }
 
             /// Rotation defined by a quaternion.

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
@@ -10,16 +10,16 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& RotationAxisAngle::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &RotationAxisAngle::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field("axis", rerun::datatypes::Vec3D::to_arrow_datatype(), false, nullptr),
-                arrow::field("angle", rerun::datatypes::Angle::to_arrow_datatype(), false, nullptr),
+                arrow::field("axis", rerun::datatypes::Vec3D::to_arrow_datatype(), false),
+                arrow::field("angle", rerun::datatypes::Angle::to_arrow_datatype(), false),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            RotationAxisAngle::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+            RotationAxisAngle::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
             }
@@ -35,7 +35,7 @@ namespace rerun {
         }
 
         arrow::Status RotationAxisAngle::fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const RotationAxisAngle* elements, size_t num_elements
+            arrow::StructBuilder *builder, const RotationAxisAngle *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -44,12 +44,30 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
+            {
+                auto field_builder =
+                    static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].axis,
+                        1
+                    ));
+                }
+            }
+            {
+                auto field_builder =
+                    static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::Angle::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].angle,
+                        1
+                    ));
+                }
+            }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -24,6 +24,12 @@ namespace rerun {
             rerun::datatypes::Angle angle;
 
           public:
+            // Extensions to generated type defined in 'rotation_axis_angle_ext.cpp'
+
+            RotationAxisAngle(const Vec3D& _axis, const Angle& _angle)
+                : axis(_axis), angle(_angle) {}
+
+          public:
             RotationAxisAngle() = default;
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle_ext.cpp
@@ -1,0 +1,26 @@
+#include "rotation_axis_angle.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct RotationAxisAngleExt {
+            Vec3D axis;
+            Angle angle;
+
+#define RotationAxisAngle RotationAxisAngleExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            RotationAxisAngle(const Vec3D& _axis, const Angle& _angle)
+                : axis(_axis), angle(_angle) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.cpp
@@ -9,22 +9,17 @@
 
 namespace rerun {
     namespace datatypes {
-        const std::shared_ptr<arrow::DataType>& Scale3D::to_arrow_datatype() {
+        const std::shared_ptr<arrow::DataType> &Scale3D::to_arrow_datatype() {
             static const auto datatype = arrow::dense_union({
                 arrow::field("_null_markers", arrow::null(), true, nullptr),
-                arrow::field(
-                    "ThreeD",
-                    rerun::datatypes::Vec3D::to_arrow_datatype(),
-                    false,
-                    nullptr
-                ),
-                arrow::field("Uniform", arrow::float32(), false, nullptr),
+                arrow::field("ThreeD", rerun::datatypes::Vec3D::to_arrow_datatype(), false),
+                arrow::field("Uniform", arrow::float32(), false),
             });
             return datatype;
         }
 
         arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> Scale3D::new_arrow_array_builder(
-            arrow::MemoryPool* memory_pool
+            arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
                 return arrow::Status::Invalid("Memory pool is null.");
@@ -42,7 +37,7 @@ namespace rerun {
         }
 
         arrow::Status Scale3D::fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
+            arrow::DenseUnionBuilder *builder, const Scale3D *elements, size_t num_elements
         ) {
             if (!builder) {
                 return arrow::Status::Invalid("Passed array builder is null.");
@@ -51,10 +46,37 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                const auto& element = elements[elem_idx];
+            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
+            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto &union_instance = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+
+                auto variant_index = static_cast<int>(union_instance._tag);
+                auto variant_builder_untyped = builder->child_builder(variant_index).get();
+
+                switch (union_instance._tag) {
+                    case detail::Scale3DTag::NONE: {
+                        ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
+                        break;
+                    }
+                    case detail::Scale3DTag::ThreeD: {
+                        auto variant_builder =
+                            static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
+                        ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                            variant_builder,
+                            &union_instance._data.three_d,
+                            1
+                        ));
+                        break;
+                    }
+                    case detail::Scale3DTag::Uniform: {
+                        auto variant_builder =
+                            static_cast<arrow::FloatBuilder *>(variant_builder_untyped);
+                        ARROW_RETURN_NOT_OK(variant_builder->Append(union_instance._data.uniform));
+                        break;
+                    }
+                }
             }
-            return arrow::Status::NotImplemented("TODO(andreas): unions are not yet implemented");
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -13,7 +13,7 @@
 namespace rerun {
     namespace datatypes {
         namespace detail {
-            enum class Scale3DTag {
+            enum class Scale3DTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We
                 /// need to be able to leave the object in a state which we can run the destructor
                 /// on.
@@ -79,7 +79,7 @@ namespace rerun {
                 Scale3D self;
                 self._tag = detail::Scale3DTag::ThreeD;
                 self._data.three_d = std::move(three_d);
-                return std::move(self);
+                return self;
             }
 
             /// Uniform scaling factor along all axis.
@@ -87,7 +87,7 @@ namespace rerun {
                 Scale3D self;
                 self._tag = detail::Scale3DTag::Uniform;
                 self._data.uniform = std::move(uniform);
-                return std::move(self);
+                return self;
             }
 
             /// Individual scaling factors for each axis, distorting the original object.

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -14,7 +14,7 @@
 namespace rerun {
     namespace datatypes {
         namespace detail {
-            enum class Transform3DTag {
+            enum class Transform3DTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We
                 /// need to be able to leave the object in a state which we can run the destructor
                 /// on.
@@ -79,7 +79,7 @@ namespace rerun {
                 Transform3D self;
                 self._tag = detail::Transform3DTag::TranslationAndMat3x3;
                 self._data.translation_and_mat3x3 = std::move(translation_and_mat3x3);
-                return std::move(self);
+                return self;
             }
 
             static Transform3D translation_rotation_scale(
@@ -88,7 +88,7 @@ namespace rerun {
                 Transform3D self;
                 self._tag = detail::Transform3DTag::TranslationRotationScale;
                 self._data.translation_rotation_scale = std::move(translation_rotation_scale);
-                return std::move(self);
+                return self;
             }
 
             Transform3D(rerun::datatypes::TranslationAndMat3x3 translation_and_mat3x3) {

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
@@ -12,19 +12,9 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &TranslationAndMat3x3::to_arrow_datatype() {
             static const auto datatype = arrow::struct_({
-                arrow::field(
-                    "translation",
-                    rerun::datatypes::Vec3D::to_arrow_datatype(),
-                    true,
-                    nullptr
-                ),
-                arrow::field(
-                    "matrix",
-                    rerun::datatypes::Mat3x3::to_arrow_datatype(),
-                    true,
-                    nullptr
-                ),
-                arrow::field("from_parent", arrow::boolean(), false, nullptr),
+                arrow::field("translation", rerun::datatypes::Vec3D::to_arrow_datatype(), true),
+                arrow::field("matrix", rerun::datatypes::Mat3x3::to_arrow_datatype(), true),
+                arrow::field("from_parent", arrow::boolean(), false),
             });
             return datatype;
         }
@@ -56,18 +46,46 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
-            return arrow::Status::NotImplemented(
-                "TODO(andreas): extensions in structs are not yet supported"
-            );
             {
-                auto element_builder =
+                auto field_builder =
+                    static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(0));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.translation.has_value()) {
+                        ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                            field_builder,
+                            &element.translation.value(),
+                            1
+                        ));
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
+                }
+            }
+            {
+                auto field_builder =
+                    static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    const auto &element = elements[elem_idx];
+                    if (element.matrix.has_value()) {
+                        ARROW_RETURN_NOT_OK(rerun::datatypes::Mat3x3::fill_arrow_array_builder(
+                            field_builder,
+                            &element.matrix.value(),
+                            1
+                        ));
+                    } else {
+                        ARROW_RETURN_NOT_OK(field_builder->AppendNull());
+                    }
+                }
+            }
+            {
+                auto field_builder =
                     static_cast<arrow::BooleanBuilder *>(builder->field_builder(2));
-                ARROW_RETURN_NOT_OK(element_builder->Reserve(num_elements));
-                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(element_builder->Append(elements[elem_idx].from_parent));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
+                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].from_parent));
                 }
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -27,6 +27,25 @@ namespace rerun {
             bool from_parent;
 
           public:
+            // Extensions to generated type defined in 'translation_and_mat3x3_ext.cpp'
+
+            static const TranslationAndMat3x3 IDENTITY;
+
+            TranslationAndMat3x3(
+                const std::optional<Vec3D>& _translation, const std::optional<Mat3x3>& _matrix,
+                bool _from_parent
+            )
+                : translation(_translation), matrix(_matrix), from_parent(_from_parent) {}
+
+            /// From rotation only.
+            TranslationAndMat3x3(const Mat3x3& _matrix, bool _from_parent = false)
+                : translation(std::nullopt), matrix(_matrix), from_parent(_from_parent) {}
+
+            /// From translation only.
+            TranslationAndMat3x3(const Vec3D& _translation, bool _from_parent = false)
+                : translation(_translation), matrix(std::nullopt), from_parent(_from_parent) {}
+
+          public:
             TranslationAndMat3x3() = default;
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3_ext.cpp
@@ -1,0 +1,46 @@
+#include "translation_and_mat3x3.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct TranslationAndMat3x3Ext {
+            std::optional<Vec3D> translation;
+            std::optional<Mat3x3> matrix;
+            bool from_parent;
+
+#define TranslationAndMat3x3 TranslationAndMat3x3Ext
+            // [CODEGEN COPY TO HEADER START]
+
+            static const TranslationAndMat3x3 IDENTITY;
+
+            TranslationAndMat3x3(
+                const std::optional<Vec3D>& _translation, const std::optional<Mat3x3>& _matrix,
+                bool _from_parent
+            )
+                : translation(_translation), matrix(_matrix), from_parent(_from_parent) {}
+
+            /// From rotation only.
+            TranslationAndMat3x3(const Mat3x3& _matrix, bool _from_parent = false)
+                : translation(std::nullopt), matrix(_matrix), from_parent(_from_parent) {}
+
+            /// From translation only.
+            TranslationAndMat3x3(const Vec3D& _translation, bool _from_parent = false)
+                : translation(_translation), matrix(std::nullopt), from_parent(_from_parent) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+
+#undef TranslationAndMat3x3
+#else
+#define TranslationAndMat3x3Ext TranslationAndMat3x3
+#endif
+
+        const TranslationAndMat3x3Ext TranslationAndMat3x3Ext::IDENTITY =
+            TranslationAndMat3x3Ext(std::nullopt, std::nullopt, false);
+
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -29,6 +29,54 @@ namespace rerun {
             bool from_parent;
 
           public:
+            // Extensions to generated type defined in 'translation_rotation_scale3d_ext.cpp'
+
+            static const TranslationRotationScale3D IDENTITY;
+
+            TranslationRotationScale3D(
+                const std::optional<Vec3D>& _translation,
+                const std::optional<Rotation3D>& _rotation, const std::optional<Scale3D>& _scale,
+                bool _from_parent
+            )
+                : translation(_translation),
+                  rotation(_rotation),
+                  scale(_scale),
+                  from_parent(_from_parent) {}
+
+            /// From translation & rotation only.
+            TranslationRotationScale3D(
+                const Vec3D& _translation, const Rotation3D& _rotation, bool _from_parent = false
+            )
+                : translation(_translation),
+                  rotation(_rotation),
+                  scale(std::nullopt),
+                  from_parent(_from_parent) {}
+
+            /// From translation & scale only.
+            TranslationRotationScale3D(
+                const Vec3D& _translation, const Scale3D& _scale, bool _from_parent = false
+            )
+                : translation(_translation),
+                  rotation(std::nullopt),
+                  scale(_scale),
+                  from_parent(_from_parent) {}
+
+            /// Creates a new rigid transform (translation & rotation only).
+            static TranslationRotationScale3D rigid(
+                const Vec3D& _translation, const Rotation3D& _rotation, bool _from_parent = false
+            ) {
+                return TranslationRotationScale3D(_translation, _rotation, _from_parent);
+            }
+
+            /// Creates a new affine transform
+            static TranslationRotationScale3D affine(
+                const Vec3D& _translation, const Rotation3D& _rotation, const Scale3D& _scale,
+                bool _from_parent = false
+            ) {
+                return TranslationRotationScale3D(_translation, _rotation, _scale, _from_parent);
+            }
+
+          public:
             TranslationRotationScale3D() = default;
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
@@ -1,0 +1,76 @@
+#include "translation_rotation_scale3d.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct TranslationRotationScale3DExt {
+            std::optional<Vec3D> translation;
+            std::optional<Rotation3D> rotation;
+            std::optional<Scale3D> scale;
+            bool from_parent;
+
+#define TranslationRotationScale3D TranslationRotationScale3DExt
+            // [CODEGEN COPY TO HEADER START]
+
+            static const TranslationRotationScale3D IDENTITY;
+
+            TranslationRotationScale3D(
+                const std::optional<Vec3D>& _translation,
+                const std::optional<Rotation3D>& _rotation, const std::optional<Scale3D>& _scale,
+                bool _from_parent
+            )
+                : translation(_translation),
+                  rotation(_rotation),
+                  scale(_scale),
+                  from_parent(_from_parent) {}
+
+            /// From translation & rotation only.
+            TranslationRotationScale3D(
+                const Vec3D& _translation, const Rotation3D& _rotation, bool _from_parent = false
+            )
+                : translation(_translation),
+                  rotation(_rotation),
+                  scale(std::nullopt),
+                  from_parent(_from_parent) {}
+
+            /// From translation & scale only.
+            TranslationRotationScale3D(
+                const Vec3D& _translation, const Scale3D& _scale, bool _from_parent = false
+            )
+                : translation(_translation),
+                  rotation(std::nullopt),
+                  scale(_scale),
+                  from_parent(_from_parent) {}
+
+            /// Creates a new rigid transform (translation & rotation only).
+            static TranslationRotationScale3D rigid(
+                const Vec3D& _translation, const Rotation3D& _rotation, bool _from_parent = false
+            ) {
+                return TranslationRotationScale3D(_translation, _rotation, _from_parent);
+            }
+
+            /// Creates a new affine transform
+            static TranslationRotationScale3D affine(
+                const Vec3D& _translation, const Rotation3D& _rotation, const Scale3D& _scale,
+                bool _from_parent = false
+            ) {
+                return TranslationRotationScale3D(_translation, _rotation, _scale, _from_parent);
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+
+#undef TranslationAndMat3x3
+#else
+#define TranslationRotationScale3DExt TranslationRotationScale3D
+#endif
+
+        const TranslationRotationScale3DExt TranslationRotationScale3DExt::IDENTITY =
+            TranslationRotationScale3DExt(std::nullopt, std::nullopt, std::nullopt, false);
+
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &Vec2D::to_arrow_datatype() {
             static const auto datatype =
-                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 2);
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 2);
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/datatypes/vec2d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d_ext.cpp
@@ -4,7 +4,7 @@
 // #define EDIT_EXTENSION
 
 namespace rerun {
-    namespace components {
+    namespace datatypes {
 
 #ifdef EDIT_EXTENSION
         struct Vec2DExt {
@@ -27,5 +27,5 @@ namespace rerun {
             // [CODEGEN COPY TO HEADER END]
         };
 #endif
-    } // namespace components
+    } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &Vec3D::to_arrow_datatype() {
             static const auto datatype =
-                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 3);
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 3);
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/datatypes/vec3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d_ext.cpp
@@ -4,7 +4,7 @@
 // #define EDIT_EXTENSION
 
 namespace rerun {
-    namespace components {
+    namespace datatypes {
 
 #ifdef EDIT_EXTENSION
         struct Vec3DExt {
@@ -31,5 +31,5 @@ namespace rerun {
             // [CODEGEN COPY TO HEADER END]
         };
 #endif
-    } // namespace components
+    } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.cpp
@@ -9,7 +9,7 @@ namespace rerun {
     namespace datatypes {
         const std::shared_ptr<arrow::DataType> &Vec4D::to_arrow_datatype() {
             static const auto datatype =
-                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false, nullptr), 4);
+                arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 4);
             return datatype;
         }
 

--- a/rerun_cpp/src/rerun/datatypes/vec4d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d_ext.cpp
@@ -4,7 +4,7 @@
 // #define EDIT_EXTENSION
 
 namespace rerun {
-    namespace components {
+    namespace datatypes {
 
 #ifdef EDIT_EXTENSION
         struct Vec4DExt {
@@ -35,5 +35,5 @@ namespace rerun {
             // [CODEGEN COPY TO HEADER END]
         };
 #endif
-    } // namespace components
+    } // namespace datatypes
 } // namespace rerun

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -26,7 +26,6 @@ cpp_opt_out = [
     "line_strips2d",
     "line_strips3d",
     "points2d",
-    "transform3d",
 ]
 
 

--- a/tests/cpp/roundtrips/transform3d/main.cpp
+++ b/tests/cpp/roundtrips/transform3d/main.cpp
@@ -3,6 +3,8 @@
 #include <rerun/archetypes/transform3d.hpp>
 #include <rerun/recording_stream.hpp>
 
+#include <cmath>
+
 namespace rr = rerun;
 
 int main(int argc, char** argv) {

--- a/tests/cpp/roundtrips/transform3d/main.cpp
+++ b/tests/cpp/roundtrips/transform3d/main.cpp
@@ -1,0 +1,78 @@
+// Logs a `Transform3D` archetype for roundtrip checks.
+
+#include <rerun/archetypes/transform3d.hpp>
+#include <rerun/recording_stream.hpp>
+
+namespace rr = rerun;
+
+int main(int argc, char** argv) {
+    auto rec_stream = rr::RecordingStream("roundtrip_transform3d");
+    rec_stream.save(argv[1]);
+
+    rec_stream.log(
+        "translation_and_mat3x3/identity",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_and_mat3x3(
+            rr::datatypes::TranslationAndMat3x3::IDENTITY
+        ))
+    );
+
+    rec_stream.log(
+        "translation_and_mat3x3/translation",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_and_mat3x3(
+            rr::datatypes::TranslationAndMat3x3({1.0f, 2.0f, 3.0f}, true)
+        ))
+    );
+
+    rec_stream.log(
+        "translation_and_mat3x3/rotation",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_and_mat3x3(
+            rr::datatypes::Mat3x3({1.0f, 4.0f, 7.0f, 2.0f, 5.0f, 8.0f, 3.0f, 6.0f, 9.0f})
+        ))
+    );
+
+    rec_stream.log(
+        "translation_rotation_scale/identity",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_rotation_scale(
+            rr::datatypes::TranslationRotationScale3D::IDENTITY
+        ))
+    );
+
+    rec_stream.log(
+        "translation_rotation_scale/translation_scale",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_rotation_scale(
+            rr::datatypes::TranslationRotationScale3D(
+                {1.0f, 2.0f, 3.0f},
+                rr::datatypes::Scale3D::uniform(42.0f),
+                true
+            )
+        ))
+    );
+
+    rec_stream.log(
+        "translation_rotation_scale/rigid",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_rotation_scale(
+            rr::datatypes::TranslationRotationScale3D::rigid(
+                {1.0f, 2.0f, 3.0f},
+                rr::datatypes::RotationAxisAngle(
+                    {0.2f, 0.2f, 0.8f},
+                    rr::datatypes::Angle::radians(static_cast<float>(M_PI))
+                )
+            )
+        ))
+    );
+
+    rec_stream.log(
+        "translation_rotation_scale/affine",
+        rr::archetypes::Transform3D(rr::datatypes::Transform3D::translation_rotation_scale(
+            rr::datatypes::TranslationRotationScale3D::affine(
+                {1.0f, 2.0f, 3.0f},
+                rr::datatypes::RotationAxisAngle(
+                    {0.2f, 0.2f, 0.8f},
+                    rr::datatypes::Angle::radians(static_cast<float>(M_PI))
+                ),
+                42.0f,
+                true
+            )
+        ))
+    );
+}


### PR DESCRIPTION
Part of:
* #2919 
* #2791

### What

Major facelift of the C++ codegen as it got restructured to support more support more nested kind of serialization and moved away entirely from using the arrow type registry at all (this happened originally due to c&p from Rust without understanding the details; this change makes a lot of the code a lot simpler!)

In order to test the new nested serialization this also enables the transform 3d roundtrip test which required adding some extensions on various datatypes to make the test code readable.
**These are not the transform related final extensions.** More is under way in a future PR to make transform usable.

The resulting transforms can't yet be loaded in the viewer due to #2871

The only remaining cases that don't produce (presumably until tested) correct serialization now are:
* nullable component/datatype inside a transparent component/datatype
* lists/vectors inside as a union variant

(they are not particularly hard to solve, just left out of this PR)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2937) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2937)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Funion-support/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Funion-support/examples)