### PR TITLE
Add Recordings section to the left panel

### DIFF
--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 use time::OffsetDateTime;
 
 /// A date-time represented as nanoseconds since unix epoch
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Time(i64);
 

--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 use time::OffsetDateTime;
 
 /// A date-time represented as nanoseconds since unix epoch
-#[derive(Copy, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Time(i64);
 

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -222,11 +222,10 @@ impl eframe::App for ExampleApp {
         // RIGHT PANEL
         //
         // This is the "idiomatic" panel structure for Rerun:
-        // - Top level `SidePanel` as a `Frame` with margins = 0.0 and sets the clip rectangle.
-        // - Panel titles (`ReUi::panel_title_bar`) are drawn at the top level of the `SidePanel`'s
-        //   hierarchy.
-        // - Actual content beneath the title bar (including large collapsing headers if used) is
-        //   put inside a sub-`Frame` with `inner_margin` set to `ReUi::view_padding()`.
+        // - A top-level `SidePanel` without inner margins and which sets the clip rectangle.
+        // - A `Frame` is immediately nested with proper inner margins (`ReUi::panel_margins()`).
+        // - All the content (titles, etc.) go inside that nest `Frame`, and use the clip rectangle
+        //   for full-span highlighting.
 
         let panel_frame = egui::Frame {
             fill: egui_ctx.style().visuals.panel_fill,
@@ -238,17 +237,18 @@ impl eframe::App for ExampleApp {
             .show_animated(egui_ctx, self.right_panel, |ui| {
                 ui.set_clip_rect(ui.max_rect());
 
-                self.re_ui.panel_title_bar(
-                    ui,
-                    "Right panel",
-                    Some("This is the title of the right panel"),
-                );
-
+                // inner frame
                 egui::Frame {
-                    inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
+                    inner_margin: re_ui::ReUi::panel_margin(),
                     ..Default::default()
                 }
                 .show(ui, |ui| {
+                    // first section
+                    self.re_ui.panel_title_bar(
+                        ui,
+                        "Right panel",
+                        Some("This is the title of the right panel"),
+                    );
                     self.re_ui
                         .large_collapsing_header(ui, "Large Collapsing Header", true, |ui| {
                             ui.label("Some data here");
@@ -256,15 +256,9 @@ impl eframe::App for ExampleApp {
 
                             selection_buttons(ui);
                         });
-                });
 
-                self.re_ui.panel_title_bar(ui, "Another section", None);
-
-                egui::Frame {
-                    inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
-                    ..Default::default()
-                }
-                .show(ui, |ui| {
+                    // second section
+                    self.re_ui.panel_title_bar(ui, "Another section", None);
                     ui.label("Some data here");
                     ui.label("Some data there");
                 });

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -279,7 +279,7 @@ impl eframe::App for ExampleApp {
                                     let label = if i == 4 {
                                         "That's one heck of a loooooooong label!".to_owned()
                                     } else {
-                                        format!("Some item {}", i)
+                                        format!("Some item {i}")
                                     };
 
                                     let mut item = re_ui

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -219,29 +219,44 @@ impl eframe::App for ExampleApp {
                     });
             });
 
+        // RIGHT PANEL
+        //
+        // This is the "idiomatic" panel structure for Rerun:
+        // - Top level `SidePanel` as a `Frame` with margins = 0.0 and sets the clip rectangle.
+        // - Panel titles (`ReUi::panel_title_bar`) are drawn at the top level of the `SidePanel`'s
+        //   hierarchy.
+        // - Actual content beneath the title bar (including large collapsing headers if used) is
+        //   put inside a sub-`Frame` with `inner_margin` set to `ReUi::view_padding()`.
+
         let panel_frame = egui::Frame {
             fill: egui_ctx.style().visuals.panel_fill,
-            inner_margin: re_ui::ReUi::view_padding().into(),
             ..Default::default()
         };
 
         egui::SidePanel::right("right_panel")
             .frame(panel_frame)
             .show_animated(egui_ctx, self.right_panel, |ui| {
-                // TODO(ab): use the proper `egui::Rect` function when egui 0.23 is released
-                let clip_rect = egui::Rect::from_min_max(
-                    ui.max_rect().min - panel_frame.inner_margin.left_top(),
-                    ui.max_rect().max + panel_frame.inner_margin.right_bottom(),
-                );
-                ui.set_clip_rect(clip_rect);
+                ui.set_clip_rect(ui.max_rect());
 
-                ui.strong("Right panel");
-                selection_buttons(ui);
-                self.re_ui
-                    .large_collapsing_header(ui, "Large Collapsing Header", true, |ui| {
-                        ui.label("Some data here");
-                        ui.label("Some data there");
-                    });
+                self.re_ui.panel_title_bar(
+                    ui,
+                    "Right panel",
+                    Some("This is the title of the right panel"),
+                );
+
+                egui::Frame {
+                    inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
+                    ..Default::default()
+                }
+                .show(ui, |ui| {
+                    self.re_ui
+                        .large_collapsing_header(ui, "Large Collapsing Header", true, |ui| {
+                            ui.label("Some data here");
+                            ui.label("Some data there");
+
+                            selection_buttons(ui);
+                        });
+                });
             });
 
         egui::CentralPanel::default()

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -1,3 +1,4 @@
+use egui::Widget;
 use re_ui::{toasts, CommandPalette, UICommand, UICommandSender};
 
 /// Sender that queues up the execution of a command.
@@ -73,6 +74,8 @@ pub struct ExampleApp {
     right_panel: bool,
     bottom_panel: bool,
 
+    selected_list_item: Option<usize>,
+
     dummy_bool: bool,
 
     cmd_palette: CommandPalette,
@@ -102,6 +105,8 @@ impl ExampleApp {
             left_panel: true,
             right_panel: true,
             bottom_panel: true,
+
+            selected_list_item: None,
 
             dummy_bool: true,
 
@@ -257,10 +262,37 @@ impl eframe::App for ExampleApp {
                             selection_buttons(ui);
                         });
 
-                    // second section
-                    self.re_ui.panel_title_bar(ui, "Another section", None);
-                    ui.label("Some data here");
-                    ui.label("Some data there");
+                    // Second section. It's a list of `list_items`, so we need to remove the default
+                    // spacing.
+                    ui.scope(|ui| {
+                        ui.spacing_mut().item_spacing.y = 0.0;
+
+                        self.re_ui.panel_title_bar(ui, "Another section", None);
+
+                        for i in 0..10 {
+                            let label = if i == 4 {
+                                "That's one heck of a loooooooong label!".to_owned()
+                            } else {
+                                format!("Some item {}", i)
+                            };
+
+                            if self
+                                .re_ui
+                                .list_item(label)
+                                .selected(Some(i) == self.selected_list_item)
+                                .active(i != 3)
+                                .with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
+                                .with_buttons(|re_ui, ui| {
+                                    re_ui.small_icon_button(ui, &re_ui::icons::ADD)
+                                        | re_ui.small_icon_button(ui, &re_ui::icons::REMOVE)
+                                })
+                                .ui(ui)
+                                .clicked()
+                            {
+                                self.selected_list_item = Some(i);
+                            }
+                        }
+                    })
                 });
             });
 

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -257,6 +257,17 @@ impl eframe::App for ExampleApp {
                             selection_buttons(ui);
                         });
                 });
+
+                self.re_ui.panel_title_bar(ui, "Another section", None);
+
+                egui::Frame {
+                    inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
+                    ..Default::default()
+                }
+                .show(ui, |ui| {
+                    ui.label("Some data here");
+                    ui.label("Some data there");
+                });
             });
 
         egui::CentralPanel::default()

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -246,7 +246,7 @@ impl eframe::App for ExampleApp {
             .show_animated(egui_ctx, self.right_panel, |ui| {
                 ui.set_clip_rect(ui.max_rect());
 
-                // first section - no scroll area, so a global Frame can be used.
+                // first section - no scroll area, so a single outer "panel_content" can be used.
                 self.re_ui.panel_content(ui, |re_ui, ui| {
                     re_ui.panel_title_bar(
                         ui,
@@ -262,7 +262,7 @@ impl eframe::App for ExampleApp {
                 });
 
                 // Second section. It's a list of `list_items`, so we need to remove the default
-                // spacing. Also, it uses a scroll area, so we must use several `Frame`s.
+                // spacing. Also, it uses a scroll area, so we must use several "panel_content".
                 ui.scope(|ui| {
                     ui.spacing_mut().item_spacing.y = 0.0;
 

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -228,9 +228,13 @@ impl eframe::App for ExampleApp {
         //
         // This is the "idiomatic" panel structure for Rerun:
         // - A top-level `SidePanel` without inner margins and which sets the clip rectangle.
-        // - A `Frame` is immediately nested with proper inner margins (`ReUi::panel_margins()`).
-        // - All the content (titles, etc.) go inside that nest `Frame`, and use the clip rectangle
-        //   for full-span highlighting.
+        // - Every piece of content (title bar, lists, etc.) are wrapped in a `Frame` with inner
+        //   margins set to `ReUi::panel_margins()`. That can be done with `ReUi::panel_content()`.
+        // - If/when a scroll area is used, it must be applied without margin and outside of the
+        //   `Frame`.
+        //
+        // This way, the content (titles, etc.) is properly inset and benefits from a properly set
+        // clip rectangle for full-span behaviour, without interference from the scroll areas.
 
         let panel_frame = egui::Frame {
             fill: egui_ctx.style().visuals.panel_fill,
@@ -242,57 +246,71 @@ impl eframe::App for ExampleApp {
             .show_animated(egui_ctx, self.right_panel, |ui| {
                 ui.set_clip_rect(ui.max_rect());
 
-                // inner frame
-                egui::Frame {
-                    inner_margin: re_ui::ReUi::panel_margin(),
-                    ..Default::default()
-                }
-                .show(ui, |ui| {
-                    // first section
-                    self.re_ui.panel_title_bar(
+                // first section - no scroll area, so a global Frame can be used.
+                self.re_ui.panel_content(ui, |re_ui, ui| {
+                    re_ui.panel_title_bar(
                         ui,
                         "Right panel",
                         Some("This is the title of the right panel"),
                     );
-                    self.re_ui
-                        .large_collapsing_header(ui, "Large Collapsing Header", true, |ui| {
-                            ui.label("Some data here");
-                            ui.label("Some data there");
+                    re_ui.large_collapsing_header(ui, "Large Collapsing Header", true, |ui| {
+                        ui.label("Some data here");
+                        ui.label("Some data there");
 
-                            selection_buttons(ui);
+                        selection_buttons(ui);
+                    });
+                });
+
+                // Second section. It's a list of `list_items`, so we need to remove the default
+                // spacing. Also, it uses a scroll area, so we must use several `Frame`s.
+                ui.scope(|ui| {
+                    ui.spacing_mut().item_spacing.y = 0.0;
+
+                    self.re_ui.panel_content(ui, |re_ui, ui| {
+                        re_ui.panel_title_bar(ui, "Another section", None);
+                    });
+
+                    egui::ScrollArea::both()
+                        .id_source("example_right_panel")
+                        .auto_shrink([false, true])
+                        .show(ui, |ui| {
+                            self.re_ui.panel_content(ui, |re_ui, ui| {
+                                for i in 0..10 {
+                                    let label = if i == 4 {
+                                        "That's one heck of a loooooooong label!".to_owned()
+                                    } else {
+                                        format!("Some item {}", i)
+                                    };
+
+                                    let mut item = re_ui
+                                        .list_item(label)
+                                        .selected(Some(i) == self.selected_list_item)
+                                        .active(i != 3)
+                                        .with_buttons(|re_ui, ui| {
+                                            re_ui.small_icon_button(ui, &re_ui::icons::ADD)
+                                                | re_ui.small_icon_button(ui, &re_ui::icons::REMOVE)
+                                        });
+
+                                    // demo custom icon
+                                    item = if i == 6 {
+                                        item.with_icon_fn(|_re_ui, ui, rect, visuals| {
+                                            ui.painter().circle(
+                                                rect.center(),
+                                                rect.width() / 2.0,
+                                                visuals.fg_stroke.color,
+                                                egui::Stroke::NONE,
+                                            );
+                                        })
+                                    } else {
+                                        item.with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
+                                    };
+
+                                    if item.ui(ui).clicked() {
+                                        self.selected_list_item = Some(i);
+                                    }
+                                }
+                            });
                         });
-
-                    // Second section. It's a list of `list_items`, so we need to remove the default
-                    // spacing.
-                    ui.scope(|ui| {
-                        ui.spacing_mut().item_spacing.y = 0.0;
-
-                        self.re_ui.panel_title_bar(ui, "Another section", None);
-
-                        for i in 0..10 {
-                            let label = if i == 4 {
-                                "That's one heck of a loooooooong label!".to_owned()
-                            } else {
-                                format!("Some item {}", i)
-                            };
-
-                            if self
-                                .re_ui
-                                .list_item(label)
-                                .selected(Some(i) == self.selected_list_item)
-                                .active(i != 3)
-                                .with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
-                                .with_buttons(|re_ui, ui| {
-                                    re_ui.small_icon_button(ui, &re_ui::icons::ADD)
-                                        | re_ui.small_icon_button(ui, &re_ui::icons::REMOVE)
-                                })
-                                .ui(ui)
-                                .clicked()
-                            {
-                                self.selected_list_item = Some(i);
-                            }
-                        }
-                    })
                 });
             });
 

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -284,6 +284,14 @@ impl UICommand {
             Default::default()
         }
     }
+
+    pub fn tooltip_with_shortcut(self, egui_ctx: &egui::Context) -> String {
+        format!(
+            "{}{}",
+            self.tooltip(),
+            self.format_shortcut_tooltip_suffix(egui_ctx)
+        )
+    }
 }
 
 #[test]

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -444,6 +444,47 @@ impl ReUi {
         response
     }
 
+    /// Static title bar used to separate panels into section.
+    ///
+    /// Use [`panel_title_bar_with_buttons`] to display buttons in the title bar.
+    pub fn panel_title_bar(&self, ui: &mut egui::Ui, label: &str, hover_text: Option<&str>) {
+        self.panel_title_bar_with_buttons(ui, label, hover_text, |_ui| {});
+    }
+
+    /// Static title bar used to separate panels into section with custom buttons when hovered.
+    #[allow(clippy::unused_self)]
+    pub fn panel_title_bar_with_buttons<R>(
+        &self,
+        ui: &mut egui::Ui,
+        label: &str,
+        hover_text: Option<&str>,
+        add_right_buttons: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> R {
+        egui::TopBottomPanel::top(ui.id().with(label))
+            .exact_height(Self::title_bar_height())
+            .frame(egui::Frame {
+                inner_margin: egui::Margin::symmetric(Self::view_padding(), 0.0),
+                ..Default::default()
+            })
+            .show_inside(ui, |ui| {
+                ui.horizontal_centered(|ui| {
+                    let resp = ui.strong(label);
+                    if let Some(hover_text) = hover_text {
+                        resp.on_hover_text(hover_text);
+                    }
+
+                    ui.allocate_ui_with_layout(
+                        ui.available_size_before_wrap(),
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| add_right_buttons(ui),
+                    )
+                    .inner
+                })
+                .inner
+            })
+            .inner
+    }
+
     /// Show a prominent collapsing header to be used as section delimitation in side panels.
     ///
     /// Note that a clip rect must be set (typically by the panel) to avoid any overdraw.

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -6,6 +6,7 @@ mod design_tokens;
 pub mod egui_helpers;
 pub mod icons;
 mod layout_job_builder;
+pub mod list_item;
 mod static_image_cache;
 pub mod toasts;
 mod toggle_switch;
@@ -50,6 +51,7 @@ use std::{ops::RangeInclusive, sync::Arc};
 
 use parking_lot::Mutex;
 
+use crate::list_item::ListItem;
 use egui::{pos2, Align2, Color32, Mesh, NumExt, Rect, Shape, Vec2};
 
 #[derive(Clone)]
@@ -132,6 +134,10 @@ impl ReUi {
     /// as well as the tab bar height in the viewport view.
     pub fn title_bar_height() -> f32 {
         28.0 // from figma 2022-02-03
+    }
+
+    pub fn list_item_height() -> f32 {
+        24.0
     }
 
     pub fn native_window_rounding() -> f32 {
@@ -647,6 +653,11 @@ impl ReUi {
             texture_id: Default::default(),
         };
         ui.painter().add(shadow);
+    }
+
+    /// Convenience function to create a [`ListItem`] with the given text.
+    pub fn list_item(&self, text: impl Into<egui::WidgetText>) -> ListItem<'_> {
+        ListItem::new(self, text)
     }
 
     pub fn selectable_label_with_icon(

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -91,6 +91,10 @@ impl ReUi {
         12.0
     }
 
+    pub fn panel_margin() -> egui::Margin {
+        egui::Margin::symmetric(Self::view_padding(), 0.0)
+    }
+
     pub fn window_rounding() -> f32 {
         12.0
     }
@@ -446,15 +450,18 @@ impl ReUi {
 
     /// Static title bar used to separate panels into section.
     ///
-    /// Use [`panel_title_bar_with_buttons`] to display buttons in the title bar. Note that a clip
-    /// rect must be set (typically by the panel) to avoid any overdraw.
+    /// This title bar is meant to be used in a panel with proper inner margin and clip rectangle
+    /// set.
+    ///
+    /// Use [`panel_title_bar_with_buttons`] to display buttons in the title bar.
     pub fn panel_title_bar(&self, ui: &mut egui::Ui, label: &str, hover_text: Option<&str>) {
         self.panel_title_bar_with_buttons(ui, label, hover_text, |_ui| {});
     }
 
     /// Static title bar used to separate panels into section with custom buttons when hovered.
     ///
-    /// Note that a clip rect must be set (typically by the panel) to avoid any overdraw.
+    /// This title bar is meant to be used in a panel with proper inner margin and clip rectangle
+    /// set.
     #[allow(clippy::unused_self)]
     pub fn panel_title_bar_with_buttons<R>(
         &self,
@@ -463,41 +470,34 @@ impl ReUi {
         hover_text: Option<&str>,
         add_right_buttons: impl FnOnce(&mut egui::Ui) -> R,
     ) -> R {
-        egui::Frame {
-            inner_margin: egui::Margin::symmetric(Self::view_padding(), 0.0),
-            ..Default::default()
-        }
-        .show(ui, |ui| {
-            ui.allocate_ui_with_layout(
-                egui::vec2(ui.available_width(), Self::title_bar_height()),
-                egui::Layout::left_to_right(egui::Align::Center),
-                |ui| {
-                    // draw horizontal separator lines
-                    let mut rect = ui.available_rect_before_wrap();
-                    let hline_stroke = ui.style().visuals.widgets.noninteractive.bg_stroke;
-                    rect.extend_with_x(ui.clip_rect().right());
-                    rect.extend_with_x(ui.clip_rect().left());
-                    ui.painter().hline(rect.x_range(), rect.top(), hline_stroke);
-                    ui.painter()
-                        .hline(rect.x_range(), rect.bottom(), hline_stroke);
+        ui.allocate_ui_with_layout(
+            egui::vec2(ui.available_width(), Self::title_bar_height()),
+            egui::Layout::left_to_right(egui::Align::Center),
+            |ui| {
+                // draw horizontal separator lines
+                let mut rect = ui.available_rect_before_wrap();
+                let hline_stroke = ui.style().visuals.widgets.noninteractive.bg_stroke;
+                rect.extend_with_x(ui.clip_rect().right());
+                rect.extend_with_x(ui.clip_rect().left());
+                ui.painter().hline(rect.x_range(), rect.top(), hline_stroke);
+                ui.painter()
+                    .hline(rect.x_range(), rect.bottom(), hline_stroke);
 
-                    // draw label
-                    let resp = ui.strong(label);
-                    if let Some(hover_text) = hover_text {
-                        resp.on_hover_text(hover_text);
-                    }
+                // draw label
+                let resp = ui.strong(label);
+                if let Some(hover_text) = hover_text {
+                    resp.on_hover_text(hover_text);
+                }
 
-                    // draw hover buttons
-                    ui.allocate_ui_with_layout(
-                        ui.available_size(),
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| add_right_buttons(ui),
-                    )
-                    .inner
-                },
-            )
-            .inner
-        })
+                // draw hover buttons
+                ui.allocate_ui_with_layout(
+                    ui.available_size(),
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| add_right_buttons(ui),
+                )
+                .inner
+            },
+        )
         .inner
     }
 

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -454,6 +454,19 @@ impl ReUi {
         response
     }
 
+    pub fn panel_content<R>(
+        &self,
+        ui: &mut egui::Ui,
+        add_contents: impl FnOnce(&ReUi, &mut egui::Ui) -> R,
+    ) -> R {
+        egui::Frame {
+            inner_margin: Self::panel_margin(),
+            ..Default::default()
+        }
+        .show(ui, |ui| add_contents(self, ui))
+        .inner
+    }
+
     /// Static title bar used to separate panels into section.
     ///
     /// This title bar is meant to be used in a panel with proper inner margin and clip rectangle

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -453,7 +453,7 @@ impl ReUi {
     /// This title bar is meant to be used in a panel with proper inner margin and clip rectangle
     /// set.
     ///
-    /// Use [`panel_title_bar_with_buttons`] to display buttons in the title bar.
+    /// Use [`ReUi::panel_title_bar_with_buttons`] to display buttons in the title bar.
     pub fn panel_title_bar(&self, ui: &mut egui::Ui, label: &str, hover_text: Option<&str>) {
         self.panel_title_bar_with_buttons(ui, label, hover_text, |_ui| {});
     }

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -512,7 +512,7 @@ impl ReUi {
                 ui.allocate_ui_with_layout(
                     ui.available_size(),
                     egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| add_right_buttons(ui),
+                    add_right_buttons,
                 )
                 .inner
             },
@@ -723,7 +723,7 @@ impl ReUi {
             let image_rect = egui::Rect::from_min_size(
                 ui.painter().round_pos_to_pixels(egui::pos2(
                     rect.min.x.ceil(),
-                    ((rect.min.y + rect.max.y - Self::small_icon_size().y) * 0.5).ceil(),
+                    (rect.center().y - 0.5 * ReUi::small_icon_size().y).ceil(),
                 )),
                 Self::small_icon_size(),
             );

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -150,13 +150,11 @@ impl egui::Widget for ListItem<'_> {
             bg_rect.extend_with_x(ui.clip_rect().left());
             let background_frame = ui.painter().add(egui::Shape::Noop);
 
-            let leftmost_x_pos = rect.min.x.ceil();
-
             // Draw icon
             if let Some(icon_fn) = self.icon_fn {
                 let icon_pos = ui.painter().round_pos_to_pixels(egui::pos2(
-                    leftmost_x_pos,
-                    (rect.center().y - 0.5 * ReUi::small_icon_size().y).ceil(),
+                    rect.min.x,
+                    rect.center().y - 0.5 * ReUi::small_icon_size().y,
                 ));
                 let icon_rect = egui::Rect::from_min_size(icon_pos, ReUi::small_icon_size());
                 icon_fn(self.re_ui, ui, icon_rect, visuals);
@@ -164,7 +162,7 @@ impl egui::Widget for ListItem<'_> {
 
             // Draw text next to the icon.
             let mut text_rect = rect;
-            text_rect.min.x = leftmost_x_pos + icon_extra;
+            text_rect.min.x += icon_extra;
             let text_pos = Align2::LEFT_CENTER
                 .align_size_within_rect(text.size(), text_rect)
                 .min;

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -1,5 +1,5 @@
 use crate::{Icon, ReUi};
-use egui::{Response, Shape, Ui};
+use egui::{NumExt, Response, Shape, Ui};
 
 #[allow(clippy::type_complexity)]
 pub struct ListItem<'a> {
@@ -45,6 +45,10 @@ impl<'a> ListItem<'a> {
         self.buttons = Some(Box::new(buttons));
         self
     }
+
+    pub fn show(self, ui: &mut Ui) -> Response {
+        ui.add(self)
+    }
 }
 
 impl egui::Widget for ListItem<'_> {
@@ -64,7 +68,8 @@ impl egui::Widget for ListItem<'_> {
                 .clone()
                 .into_galley(ui, Some(false), wrap_width, egui::TextStyle::Button);
 
-        let desired_size = egui::vec2(ui.available_width(), ReUi::list_item_height());
+        let desired_size = (padding_extra + text.size() + egui::vec2(icon_extra, 0.0))
+            .at_least(egui::vec2(ui.available_width(), ReUi::list_item_height()));
         let (rect, response) = ui.allocate_at_least(desired_size, egui::Sense::click());
 
         response.widget_info(|| {

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -1,6 +1,26 @@
 use crate::{Icon, ReUi};
 use egui::{NumExt, Response, Shape, Ui};
 
+/// Generic widget for use in lists.
+///
+/// Features:
+/// - selectable
+/// - full span highlighting
+/// - optional icon
+/// - optional on-hover buttons on the right
+///
+/// This widget relies on the clip rectangle to be properly set as it use it for the shape if its
+/// background highlighting. This has a significant impact on the hierarchy of the UI. This is
+/// typically how things should be laid out:
+///
+/// ```text
+/// Panel (no margin, set the clip rectangle)
+/// └── ScrollArea (no margin)
+///     └── Frame (with inner margin)
+///         └── ListItem
+/// ```
+///
+/// See [`ReUi::panel_content`] for an helper to build the [`egui::Frame`] with proper margins.
 #[allow(clippy::type_complexity)]
 pub struct ListItem<'a> {
     text: egui::WidgetText,
@@ -13,6 +33,7 @@ pub struct ListItem<'a> {
 }
 
 impl<'a> ListItem<'a> {
+    /// Create a new [`ListItem`] with the given label.
     pub fn new(re_ui: &'a ReUi, text: impl Into<egui::WidgetText>) -> Self {
         Self {
             text: text.into(),
@@ -24,16 +45,19 @@ impl<'a> ListItem<'a> {
         }
     }
 
+    /// Set the active state the item.
     pub fn active(mut self, active: bool) -> Self {
         self.active = active;
         self
     }
 
+    /// Set the selected state of the item.
     pub fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
         self
     }
 
+    /// Provide an [`Icon`] to be displayed on the left of the item.
     pub fn with_icon(self, icon: &'a Icon) -> Self {
         self.with_icon_fn(|re_ui, ui, rect, visuals| {
             let image = re_ui.icon_image(icon);
@@ -49,6 +73,7 @@ impl<'a> ListItem<'a> {
         })
     }
 
+    /// Provide a custom closure to draw an icon on the left of the item.
     pub fn with_icon_fn(
         mut self,
         icon_fn: impl FnOnce(&ReUi, &mut egui::Ui, egui::Rect, egui::style::WidgetVisuals) + 'a,
@@ -57,6 +82,7 @@ impl<'a> ListItem<'a> {
         self
     }
 
+    /// Provide a closure to display on-hover buttons on the right of the item.
     pub fn with_buttons(
         mut self,
         buttons: impl FnOnce(&ReUi, &mut egui::Ui) -> egui::Response + 'a,
@@ -65,6 +91,7 @@ impl<'a> ListItem<'a> {
         self
     }
 
+    /// Draw the item.
     pub fn show(self, ui: &mut Ui) -> Response {
         ui.add(self)
     }

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -1,0 +1,155 @@
+use crate::{Icon, ReUi};
+use egui::{Response, Shape, Ui};
+
+#[allow(clippy::type_complexity)]
+pub struct ListItem<'a> {
+    text: egui::WidgetText,
+    re_ui: &'a ReUi,
+    active: bool,
+    selected: bool,
+    icon: Option<&'a Icon>,
+    buttons: Option<Box<dyn FnOnce(&ReUi, &mut egui::Ui) -> egui::Response + 'a>>,
+}
+
+impl<'a> ListItem<'a> {
+    pub fn new(re_ui: &'a ReUi, text: impl Into<egui::WidgetText>) -> Self {
+        Self {
+            text: text.into(),
+            re_ui,
+            active: true,
+            selected: false,
+            icon: None,
+            buttons: None,
+        }
+    }
+
+    pub fn active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
+
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    pub fn with_icon(mut self, icon: &'a Icon) -> Self {
+        self.icon = Some(icon);
+        self
+    }
+
+    pub fn with_buttons(
+        mut self,
+        buttons: impl FnOnce(&ReUi, &mut egui::Ui) -> egui::Response + 'a,
+    ) -> Self {
+        self.buttons = Some(Box::new(buttons));
+        self
+    }
+}
+
+impl egui::Widget for ListItem<'_> {
+    fn ui(self, ui: &mut Ui) -> Response {
+        let button_padding = ui.spacing().button_padding;
+        let icon_width_plus_padding = ReUi::small_icon_size().x + ReUi::text_to_icon_padding();
+        let icon_extra = if self.icon.is_some() {
+            icon_width_plus_padding
+        } else {
+            0.0
+        };
+        let padding_extra = button_padding + button_padding;
+        let wrap_width = ui.available_width() - padding_extra.x - icon_extra;
+
+        let text =
+            self.text
+                .clone()
+                .into_galley(ui, Some(false), wrap_width, egui::TextStyle::Button);
+
+        let desired_size = egui::vec2(ui.available_width(), ReUi::list_item_height());
+        let (rect, response) = ui.allocate_at_least(desired_size, egui::Sense::click());
+
+        response.widget_info(|| {
+            egui::WidgetInfo::selected(
+                egui::WidgetType::SelectableLabel,
+                self.selected,
+                text.text(),
+            )
+        });
+
+        if ui.is_rect_visible(rect) {
+            let visuals = if self.active {
+                ui.style().interact_selectable(&response, self.selected)
+            } else {
+                ui.visuals().widgets.inactive
+            };
+
+            let mut bg_rect = rect;
+            bg_rect.extend_with_x(ui.clip_rect().right());
+            bg_rect.extend_with_x(ui.clip_rect().left());
+            let background_frame = ui.painter().add(egui::Shape::Noop);
+
+            let min_pos = ui.painter().round_pos_to_pixels(egui::pos2(
+                rect.min.x.ceil(),
+                ((rect.min.y + rect.max.y - ReUi::small_icon_size().y) * 0.5).ceil(),
+            ));
+
+            // Draw icon
+            if let Some(icon) = self.icon {
+                let icon_rect = egui::Rect::from_min_size(min_pos, ReUi::small_icon_size());
+
+                let image = self.re_ui.icon_image(icon);
+                let texture_id = image.texture_id(ui.ctx());
+                let tint = visuals.fg_stroke.color;
+
+                ui.painter().image(
+                    texture_id,
+                    icon_rect,
+                    egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+                    tint,
+                );
+            }
+
+            // Draw text next to the icon.
+            let mut text_rect = rect;
+            text_rect.min.x = min_pos.x + icon_extra;
+            let text_pos = ui
+                .layout()
+                .align_size_within_rect(text.size(), text_rect)
+                .min;
+            text.paint_with_visuals(ui.painter(), text_pos, &visuals);
+
+            // Handle buttons
+            let button_hovered =
+                if self.active && ui.interact(rect, ui.id(), egui::Sense::hover()).hovered() {
+                    if let Some(buttons) = self.buttons {
+                        let mut ui =
+                            ui.child_ui(rect, egui::Layout::right_to_left(egui::Align::Center));
+                        buttons(self.re_ui, &mut ui).hovered()
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+            // Draw background on interaction.
+            let bg_fill = if button_hovered {
+                Some(visuals.bg_fill)
+            } else if self.selected
+                || response.hovered()
+                || response.highlighted()
+                || response.has_focus()
+            {
+                Some(visuals.weak_bg_fill)
+            } else {
+                None
+            };
+
+            if let Some(bg_fill) = bg_fill {
+                ui.painter()
+                    .set(background_frame, Shape::rect_filled(bg_rect, 0.0, bg_fill));
+            }
+        }
+
+        response
+    }
+}

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -294,7 +294,11 @@ impl App {
             SystemCommand::LoadRrd(path) => {
                 let with_notification = true;
                 if let Some(rrd) = crate::loading::load_file_path(&path, with_notification) {
+                    let store_id = rrd.store_dbs().next().map(|db| db.store_id().clone());
                     store_hub.add_bundle(rrd);
+                    if let Some(store_id) = store_id {
+                        store_hub.set_recording_id(store_id);
+                    }
                 }
             }
             SystemCommand::ResetViewer => self.reset(store_hub, egui_ctx),

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -166,7 +166,7 @@ impl AppState {
                         ui.set_clip_rect(ui.max_rect());
 
                         // TODO(ab): this might be promoted higher in the hierarchy once list item are
-                        //  used in the blueprint panel section
+                        // used in the blueprint panel section.
                         ui.scope(|ui| {
                             ui.spacing_mut().item_spacing.y = 0.0;
                             recordings_panel_ui(&mut ctx, ui);

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -165,12 +165,19 @@ impl AppState {
                         // doesn't have inner margins.
                         ui.set_clip_rect(ui.max_rect());
 
+                        // TODO(ab): this might be promoted higher in the hierarchy once list item are
+                        //  used in the blueprint panel section
+                        ui.scope(|ui| {
+                            ui.spacing_mut().item_spacing.y = 0.0;
+                            recordings_panel_ui(&mut ctx, ui);
+                        });
+
+                        // TODO(ab): remove this frame once the blueprint tree uses list items
                         egui::Frame {
                             inner_margin: re_ui::ReUi::panel_margin(),
                             ..Default::default()
                         }
                         .show(ui, |ui| {
-                            recordings_panel_ui(&mut ctx, ui);
                             blueprint_panel_ui(&mut viewport.blueprint, &mut ctx, ui, &spaces_info);
                         });
                     },

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -165,8 +165,14 @@ impl AppState {
                         // doesn't have inner margins.
                         ui.set_clip_rect(ui.max_rect());
 
-                        recordings_panel_ui(&mut ctx, ui);
-                        blueprint_panel_ui(&mut viewport.blueprint, &mut ctx, ui, &spaces_info);
+                        egui::Frame {
+                            inner_margin: re_ui::ReUi::panel_margin(),
+                            ..Default::default()
+                        }
+                        .show(ui, |ui| {
+                            recordings_panel_ui(&mut ctx, ui);
+                            blueprint_panel_ui(&mut viewport.blueprint, &mut ctx, ui, &spaces_info);
+                        });
                     },
                 );
 

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -9,6 +9,7 @@ use re_viewer_context::{
 };
 use re_viewport::{SpaceInfoCollection, Viewport, ViewportState};
 
+use crate::ui::recordings_panel_ui;
 use crate::{app_blueprint::AppBlueprint, store_hub::StoreHub, ui::blueprint_panel_ui};
 
 const WATERMARK: bool = false; // Nice for recording media material
@@ -146,12 +147,27 @@ impl AppState {
         egui::CentralPanel::default()
             .frame(central_panel_frame)
             .show_inside(ui, |ui| {
-                blueprint_panel_ui(
-                    &mut viewport.blueprint,
-                    &mut ctx,
+                let left_panel = egui::SidePanel::left("blueprint_panel")
+                    .resizable(true)
+                    .frame(egui::Frame {
+                        fill: ui.visuals().panel_fill,
+                        ..Default::default()
+                    })
+                    .min_width(120.0)
+                    .default_width((0.35 * ui.ctx().screen_rect().width()).min(200.0).round());
+
+                left_panel.show_animated_inside(
                     ui,
-                    &spaces_info,
                     app_blueprint.blueprint_panel_expanded,
+                    |ui: &mut egui::Ui| {
+                        // Set the clip rectangle to the panel for the benefit of nested, "full span" widgets like
+                        // large collapsing headers. Here, no need to extend `ui.max_rect()` as the enclosing frame
+                        // doesn't have inner margins.
+                        ui.set_clip_rect(ui.max_rect());
+
+                        recordings_panel_ui(&mut ctx, ui);
+                        blueprint_panel_ui(&mut viewport.blueprint, &mut ctx, ui, &spaces_info);
+                    },
                 );
 
                 let viewport_frame = egui::Frame {

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -18,13 +18,7 @@ pub fn blueprint_panel_ui(
         },
     );
 
-    egui::Frame {
-        inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
-        ..Default::default()
-    }
-    .show(ui, |ui| {
-        blueprint.tree_ui(ctx, ui);
-    });
+    blueprint.tree_ui(ctx, ui);
 }
 
 fn reset_button_ui(

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -1,70 +1,30 @@
 use re_viewer_context::ViewerContext;
 use re_viewport::{SpaceInfoCollection, ViewportBlueprint};
 
-/// Show the left-handle panel based on the current [`ViewportBlueprint`]
+/// Show the Blueprint section of the left panel based on the current [`ViewportBlueprint`]
 pub fn blueprint_panel_ui(
     blueprint: &mut ViewportBlueprint<'_>,
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
-    expanded: bool,
 ) {
-    let screen_width = ui.ctx().screen_rect().width();
+    ctx.re_ui.panel_title_bar_with_buttons(
+        ui,
+        "Blueprint",
+        Some("The Blueprint is where you can configure the Rerun Viewer"),
+        |ui| {
+            blueprint.add_new_spaceview_button_ui(ctx, ui, spaces_info);
+            reset_button_ui(blueprint, ctx, ui, spaces_info);
+        },
+    );
 
-    let panel = egui::SidePanel::left("blueprint_panel")
-        .resizable(true)
-        .frame(egui::Frame {
-            fill: ui.visuals().panel_fill,
-            ..Default::default()
-        })
-        .min_width(120.0)
-        .default_width((0.35 * screen_width).min(200.0).round());
-
-    panel.show_animated_inside(ui, expanded, |ui: &mut egui::Ui| {
-        // Set the clip rectangle to the panel for the benefit of nested, "full span" widgets like
-        // large collapsing headers. Here, no need to extend `ui.max_rect()` as the enclosing frame
-        // doesn't have inner margins.
-        ui.set_clip_rect(ui.max_rect());
-
-        title_bar_ui(blueprint, ctx, ui, spaces_info);
-
-        egui::Frame {
-            inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
-            ..Default::default()
-        }
-        .show(ui, |ui| {
-            blueprint.tree_ui(ctx, ui);
-        });
+    egui::Frame {
+        inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
+        ..Default::default()
+    }
+    .show(ui, |ui| {
+        blueprint.tree_ui(ctx, ui);
     });
-}
-
-fn title_bar_ui(
-    blueprint: &mut ViewportBlueprint<'_>,
-    ctx: &mut ViewerContext<'_>,
-    ui: &mut egui::Ui,
-    spaces_info: &SpaceInfoCollection,
-) {
-    egui::TopBottomPanel::top("blueprint_panel_title_bar")
-        .exact_height(re_ui::ReUi::title_bar_height())
-        .frame(egui::Frame {
-            inner_margin: egui::Margin::symmetric(re_ui::ReUi::view_padding(), 0.0),
-            ..Default::default()
-        })
-        .show_inside(ui, |ui| {
-            ui.horizontal_centered(|ui| {
-                ui.strong("Blueprint")
-                    .on_hover_text("The Blueprint is where you can configure the Rerun Viewer");
-
-                ui.allocate_ui_with_layout(
-                    ui.available_size_before_wrap(),
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        blueprint.add_new_spaceview_button_ui(ctx, ui, spaces_info);
-                        reset_button_ui(blueprint, ctx, ui, spaces_info);
-                    },
-                );
-            });
-        });
 }
 
 fn reset_button_ui(

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -1,5 +1,6 @@
 mod blueprint_panel;
 mod mobile_warning_ui;
+mod recordings_panel;
 mod rerun_menu;
 mod selection_history_ui;
 mod top_panel;
@@ -9,6 +10,7 @@ pub(crate) mod memory_panel;
 pub(crate) mod selection_panel;
 
 pub use blueprint_panel::blueprint_panel_ui;
+pub use recordings_panel::recordings_panel_ui;
 // ----
 
 pub(crate) use {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -1,0 +1,65 @@
+use re_viewer_context::{SystemCommand, SystemCommandSender, ViewerContext};
+
+/// Show the Recordings section of the left panel
+pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
+    ctx.re_ui.panel_title_bar_with_buttons(
+        ui,
+        "Recordings",
+        Some("These are the Recordings currently loaded in the Viewer"),
+        |ui| {
+            add_button_ui(ctx, ui);
+        },
+    );
+
+    let ViewerContext {
+        store_context,
+        command_sender,
+        ..
+    } = ctx;
+
+    egui::Frame {
+        inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
+        ..Default::default()
+    }
+    .show(ui, |ui| {
+        let store_dbs = store_context.alternate_recordings.clone();
+
+        if store_dbs.is_empty() {
+            ui.weak("(empty)");
+            return;
+        }
+
+        let active_recording = store_context.recording.and_then(|rec| Some(rec.store_id()));
+
+        ui.style_mut().wrap = Some(false);
+        for store_db in &store_dbs {
+            let info = if let Some(store_info) = store_db.store_info() {
+                format!(
+                    "{} - {}",
+                    store_info.application_id,
+                    store_info.started.format()
+                )
+            } else {
+                "<UNKNOWN>".to_owned()
+            };
+            if ui
+                .radio(active_recording == Some(store_db.store_id()), info)
+                .clicked()
+            {
+                command_sender
+                    .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
+            }
+        }
+    });
+}
+
+fn add_button_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
+    if ctx
+        .re_ui
+        .small_icon_button(ui, &re_ui::icons::ADD)
+        .on_hover_text("Load a Recording from disk")
+        .clicked()
+    {
+        //TODO(ab)
+    }
+}

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -1,3 +1,4 @@
+use re_ui::UICommandSender;
 use re_viewer_context::{SystemCommand, SystemCommandSender, ViewerContext};
 
 /// Show the Recordings section of the left panel
@@ -8,6 +9,7 @@ pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
             "Recordings",
             Some("These are the Recordings currently loaded in the Viewer"),
             |ui| {
+                #[cfg(not(target_arch = "wasm32"))]
                 add_button_ui(ctx, ui);
             },
         );
@@ -70,13 +72,14 @@ fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn add_button_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
     if ctx
         .re_ui
         .small_icon_button(ui, &re_ui::icons::ADD)
-        .on_hover_text("Load a Recording from disk")
+        .on_hover_text(re_ui::UICommand::Open.text_and_tooltip().1)
         .clicked()
     {
-        //TODO(ab)
+        ctx.command_sender.send_ui(re_ui::UICommand::Open);
     }
 }

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -27,23 +27,30 @@ pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
     let active_recording = store_context.recording.map(|rec| rec.store_id());
 
     ui.style_mut().wrap = Some(false);
-    for store_db in &store_dbs {
-        let info = if let Some(store_info) = store_db.store_info() {
-            format!(
-                "{} - {}",
-                store_info.application_id,
-                store_info.started.format()
-            )
-        } else {
-            "<UNKNOWN>".to_owned()
-        };
-        if ui
-            .radio(active_recording == Some(store_db.store_id()), info)
-            .clicked()
-        {
-            command_sender.send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
-        }
-    }
+
+    egui::ScrollArea::both()
+        .id_source("recordings_scroll_area")
+        .auto_shrink([false, true])
+        .show(ui, |ui| {
+            for store_db in &store_dbs {
+                let info = if let Some(store_info) = store_db.store_info() {
+                    format!(
+                        "{} - {}",
+                        store_info.application_id,
+                        store_info.started.format()
+                    )
+                } else {
+                    "<UNKNOWN>".to_owned()
+                };
+                if ui
+                    .radio(active_recording == Some(store_db.store_id()), info)
+                    .clicked()
+                {
+                    command_sender
+                        .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
+                }
+            }
+        });
 }
 
 fn add_button_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -42,8 +42,11 @@ pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
                 } else {
                     "<UNKNOWN>".to_owned()
                 };
-                if ui
-                    .radio(active_recording == Some(store_db.store_id()), info)
+                if ctx
+                    .re_ui
+                    .list_item(info)
+                    .selected(active_recording == Some(store_db.store_id()))
+                    .show(ui)
                     .clicked()
                 {
                     command_sender

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -24,7 +24,7 @@ pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         return;
     }
 
-    let active_recording = store_context.recording.and_then(|rec| Some(rec.store_id()));
+    let active_recording = store_context.recording.map(|rec| rec.store_id());
 
     ui.style_mut().wrap = Some(false);
     for store_db in &store_dbs {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -2,15 +2,28 @@ use re_viewer_context::{SystemCommand, SystemCommandSender, ViewerContext};
 
 /// Show the Recordings section of the left panel
 pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
-    ctx.re_ui.panel_title_bar_with_buttons(
-        ui,
-        "Recordings",
-        Some("These are the Recordings currently loaded in the Viewer"),
-        |ui| {
-            add_button_ui(ctx, ui);
-        },
-    );
+    ctx.re_ui.panel_content(ui, |re_ui, ui| {
+        re_ui.panel_title_bar_with_buttons(
+            ui,
+            "Recordings",
+            Some("These are the Recordings currently loaded in the Viewer"),
+            |ui| {
+                add_button_ui(ctx, ui);
+            },
+        );
+    });
 
+    egui::ScrollArea::both()
+        .id_source("recordings_scroll_area")
+        .auto_shrink([false, true])
+        .show(ui, |ui| {
+            ctx.re_ui
+                .panel_content(ui, |_re_ui, ui| recording_list_ui(ctx, ui));
+        });
+}
+
+#[allow(clippy::blocks_in_if_conditions)]
+fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
     let ViewerContext {
         store_context,
         command_sender,
@@ -20,40 +33,41 @@ pub fn recordings_panel_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
     let store_dbs = store_context.alternate_recordings.clone();
 
     if store_dbs.is_empty() {
-        ui.weak("(empty)");
         return;
     }
 
     let active_recording = store_context.recording.map(|rec| rec.store_id());
 
-    ui.style_mut().wrap = Some(false);
+    for store_db in &store_dbs {
+        let info = if let Some(store_info) = store_db.store_info() {
+            format!(
+                "{} - {}",
+                store_info.application_id,
+                store_info.started.format()
+            )
+        } else {
+            "<UNKNOWN>".to_owned()
+        };
 
-    egui::ScrollArea::both()
-        .id_source("recordings_scroll_area")
-        .auto_shrink([false, true])
-        .show(ui, |ui| {
-            for store_db in &store_dbs {
-                let info = if let Some(store_info) = store_db.store_info() {
-                    format!(
-                        "{} - {}",
-                        store_info.application_id,
-                        store_info.started.format()
-                    )
+        if ctx
+            .re_ui
+            .list_item(info)
+            .with_icon_fn(|_re_ui, ui, rect, visuals| {
+                let color = if active_recording == Some(store_db.store_id()) {
+                    visuals.fg_stroke.color
                 } else {
-                    "<UNKNOWN>".to_owned()
+                    ui.visuals().widgets.noninteractive.fg_stroke.color
                 };
-                if ctx
-                    .re_ui
-                    .list_item(info)
-                    .selected(active_recording == Some(store_db.store_id()))
-                    .show(ui)
-                    .clicked()
-                {
-                    command_sender
-                        .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
-                }
-            }
-        });
+
+                ui.painter()
+                    .circle(rect.center(), 4.0, color, egui::Stroke::NONE);
+            })
+            .show(ui)
+            .clicked()
+        {
+            command_sender.send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
+        }
+    }
 }
 
 fn add_button_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -10,7 +10,7 @@ use crate::App;
 impl App {
     pub fn rerun_menu_button_ui(
         &mut self,
-        store_context: Option<&StoreContext<'_>>,
+        #[allow(unused_variables)] store_context: Option<&StoreContext<'_>>,
         ui: &mut egui::Ui,
         frame: &mut eframe::Frame,
     ) {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -3,7 +3,7 @@
 use egui::NumExt as _;
 
 use re_ui::UICommand;
-use re_viewer_context::{StoreContext, SystemCommand, SystemCommandSender};
+use re_viewer_context::StoreContext;
 
 use crate::App;
 
@@ -73,12 +73,6 @@ impl App {
 
             ui.add_space(spacing);
 
-            {
-                ui.menu_button("Recordings", |ui| {
-                    self.recordings_menu(ui, store_context);
-                });
-            }
-
             ui.menu_button("Options", |ui| {
                 self.options_menu_ui(ui, frame);
             });
@@ -140,39 +134,6 @@ impl App {
         LLVM {llvm_version}\n\
         Built {datetime}",
         ));
-    }
-
-    fn recordings_menu(&self, ui: &mut egui::Ui, store_context: Option<&StoreContext<'_>>) {
-        let store_dbs = store_context.map_or(vec![], |ctx| ctx.alternate_recordings.clone());
-
-        if store_dbs.is_empty() {
-            ui.weak("(empty)");
-            return;
-        }
-
-        let active_recording = store_context
-            .and_then(|ctx| ctx.recording)
-            .map(|rec| rec.store_id());
-
-        ui.style_mut().wrap = Some(false);
-        for store_db in &store_dbs {
-            let info = if let Some(store_info) = store_db.store_info() {
-                format!(
-                    "{} - {}",
-                    store_info.application_id,
-                    store_info.started.format()
-                )
-            } else {
-                "<UNKNOWN>".to_owned()
-            };
-            if ui
-                .radio(active_recording == Some(store_db.store_id()), info)
-                .clicked()
-            {
-                self.command_sender
-                    .send_system(SystemCommand::SetRecordingId(store_db.store_id().clone()));
-            }
-        }
     }
 
     fn options_menu_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -10,7 +10,7 @@ use crate::App;
 impl App {
     pub fn rerun_menu_button_ui(
         &mut self,
-        #[allow(unused_variables)] store_context: Option<&StoreContext<'_>>,
+        _store_context: Option<&StoreContext<'_>>,
         ui: &mut egui::Ui,
         frame: &mut eframe::Frame,
     ) {
@@ -38,7 +38,7 @@ impl App {
             {
                 UICommand::Open.menu_button_ui(ui, &self.command_sender);
 
-                self.save_buttons_ui(ui, store_context);
+                self.save_buttons_ui(ui, _store_context);
 
                 ui.add_space(spacing);
 

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -17,19 +17,9 @@ impl SelectionHistoryUi {
         blueprint: &ViewportBlueprint<'_>,
         history: &mut SelectionHistory,
     ) -> Option<ItemCollection> {
-        ui.horizontal_centered(|ui| {
-            ui.strong("Selection").on_hover_text("The Selection View contains information and options about the currently selected object(s)");
-
-            // TODO(emilk): an egui helper for right-to-left
-            ui.allocate_ui_with_layout(
-                ui.available_size_before_wrap(),
-                egui::Layout::right_to_left(egui::Align::Center),
-                |ui| {
-                    let next = self.next_button_ui(re_ui, ui, blueprint, history);
-                    let prev = self.prev_button_ui(re_ui, ui, blueprint, history);
-                    prev.or(next)
-                }).inner
-        }).inner
+        let next = self.next_button_ui(re_ui, ui, blueprint, history);
+        let prev = self.prev_button_ui(re_ui, ui, blueprint, history);
+        prev.or(next)
     }
 
     fn prev_button_ui(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -45,35 +45,31 @@ impl SelectionPanel {
             // enclosing frame doesn't have inner margins.
             ui.set_clip_rect(ui.max_rect());
 
-            egui::TopBottomPanel::top("selection_panel_title_bar")
-                .exact_height(re_ui::ReUi::title_bar_height())
-                .frame(egui::Frame {
-                    inner_margin: egui::Margin::symmetric(re_ui::ReUi::view_padding(), 0.0),
-                    ..Default::default()
-                })
-                .show_inside(ui, |ui| {
-                    if let Some(selection) = self.selection_state_ui.selection_ui(
-                        ctx.re_ui,
-                        ui,
-                        &viewport.blueprint,
-                        &mut ctx.selection_state_mut().history,
-                    ) {
-                        ctx.selection_state_mut()
-                            .set_selection(selection.iter().cloned());
-                    }
-                });
+            egui::Frame {
+                inner_margin: re_ui::ReUi::panel_margin(),
+                ..Default::default()
+            }
+            .show(ui, |ui| {
+                let hover = "The Selection View contains information and options about the currently selected object(s)";
+                ctx.re_ui
+                    .panel_title_bar_with_buttons(ui, "Selection", Some(hover), |ui| {
+                        if let Some(selection) = self.selection_state_ui.selection_ui(
+                            ctx.re_ui,
+                            ui,
+                            &viewport.blueprint,
+                            &mut ctx.selection_state_mut().history,
+                        ) {
+                            ctx.selection_state_mut()
+                                .set_selection(selection.iter().cloned());
+                        }
+                    });
 
-            egui::ScrollArea::both()
-                .auto_shrink([false; 2])
-                .show(ui, |ui| {
-                    egui::Frame {
-                        inner_margin: egui::Margin::same(re_ui::ReUi::view_padding()),
-                        ..Default::default()
-                    }
+                egui::ScrollArea::both()
+                    .auto_shrink([false; 2])
                     .show(ui, |ui| {
                         self.contents(ctx, ui, viewport);
                     });
-                });
+            });
         });
     }
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -22,6 +22,7 @@ impl ViewportBlueprint<'_> {
         re_tracing::profile_function!();
 
         egui::ScrollArea::both()
+            .id_source("blueprint_tree_scroll_area")
             .auto_shrink([true, false])
             .show(ui, |ui| {
                 if let Some(root) = self.tree.root() {


### PR DESCRIPTION
### What

Add Recordings section to the left panel.

Fixes #2298

Also:
- [x] created a brand new `ListItem` widget to be used across the UI
  - full-span highlight
  - icon support (`Icon` or closure)
  - hover button support
- [x] created a proper "panel_title_bar" widget in ReUi
- [x] removed the recordings submenu from the rerun menu
- [x] updated re_ui_example.rs to illustrate the "proper" panel hierarchy and demo the new widgets
- [x] `+` button in title to open new recording

Deferred to follow-up PRs:
- hierarchical display
- minus hover button to close the recording

<img width="1412" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/dd761936-bd5d-4161-b7c2-353652cf1897">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/2938) (if applicable)~~ best tested on a native build and throwing lots of example at it, e.g. `for run in {1..4}; do python examples/python/dna/main.py --connect; done`

- [PR Build Summary](https://build.rerun.io/pr/2938)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fnew-recording-ui-2298/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fnew-recording-ui-2298/examples)