### PR TITLE
`scripts/highlight_issues.py`: print issues with no comments

### DIFF
--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -107,7 +107,7 @@ def main() -> None:
         state = issue["state"]
         labels = [label["name"] for label in issue["labels"]]
 
-        if '👀 needs triage' in labels:
+        if "👀 needs triage" in labels:
             print(f"{html_url} by {author} needs triage")
         elif len(labels) == 0:
             print(f"{html_url} by {author} has no labels")

--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -18,6 +18,7 @@ OFFICIAL_RERUN_DEVS = [
     "jondo2010",
     "jprochazk",
     "karimo87",
+    "martenbjork",
     "nikolausWest",
     "roym899",
     "teh-cmc",
@@ -104,7 +105,13 @@ def main() -> None:
         html_url = issue["html_url"]
         comments = issue["comments"]
         state = issue["state"]
-        if comments == 0 and state == "open" and author not in OFFICIAL_RERUN_DEVS:
+        labels = [label["name"] for label in issue["labels"]]
+
+        if '👀 needs triage' in labels:
+            print(f"{html_url} by {author} needs triage")
+        elif len(labels) == 0:
+            print(f"{html_url} by {author} has no labels")
+        elif comments == 0 and state == "open" and author not in OFFICIAL_RERUN_DEVS:
             print(f"{html_url} by {author} has {comments} comments")
 
 


### PR DESCRIPTION
`scripts/highlight_issues.py` is useful for finding issues that needs attention

Previously it would only print external issues with no comments. Not it will also print issues marked as "needs triage" as well as issues lacking labels

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2939) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2939)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fimprove-issues-script/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fimprove-issues-script/examples)