### PR TITLE
Fix quotes in generated C++ doc strings

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-fdd82e3ebb854d36a480e96f1c556fa9ad202200bcba8416cd18ac23005d4d74
+196844751442706baa436dac75e5d43760838ec1355b4e170bd48aa9e2a74a30

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -35,8 +35,8 @@ namespace rerun {
         /// namespace rr = rerun;
         ///
         /// int main() {
-        ///    auto rr_stream = rr::RecordingStream(\"arrow3d\");
-        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///    auto rr_stream = rr::RecordingStream("arrow3d");
+        ///    rr_stream.connect("127.0.0.1:9876");
         ///
         ///    std::vector<rr::components::Vector3D> vectors;
         ///    std::vector<rr::components::Color> colors;
@@ -50,7 +50,7 @@ namespace rerun {
         ///        colors.push_back({static_cast<uint8_t>(255 - c), c, 128, 128});
         ///    }
         ///
-        ///    rr_stream.log(\"arrows\", rr::archetypes::Arrows3D(vectors).with_colors(colors));
+        ///    rr_stream.log("arrows", rr::archetypes::Arrows3D(vectors).with_colors(colors));
         /// }
         ///```
         struct Arrows3D {

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -29,23 +29,23 @@ namespace rerun {
         /// namespace rr = rerun;
         ///
         /// int main() {
-        ///    auto rr_stream = rr::RecordingStream(\"disconnected_space\");
-        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///    auto rr_stream = rr::RecordingStream("disconnected_space");
+        ///    rr_stream.connect("127.0.0.1:9876");
         ///
         ///    // These two points can be projected into the same space..
         ///    rr_stream.log(
-        ///        \"world/room1/point\",
+        ///        "world/room1/point",
         ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f})
         ///    );
         ///    rr_stream.log(
-        ///        \"world/room2/point\",
+        ///        "world/room2/point",
         ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f})
         ///    );
         ///
         ///    // ..but this one lives in a completely separate space!
-        ///    rr_stream.log(\"world/wormhole\", rr::archetypes::DisconnectedSpace(true));
+        ///    rr_stream.log("world/wormhole", rr::archetypes::DisconnectedSpace(true));
         ///    rr_stream.log(
-        ///        \"world/wormhole/point\",
+        ///        "world/wormhole/point",
         ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f})
         ///    );
         /// }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -32,10 +32,10 @@ namespace rerun {
         /// namespace rr = rerun;
         ///
         /// int main() {
-        ///    auto rr_stream = rr::RecordingStream(\"points3d_simple\");
-        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///    auto rr_stream = rr::RecordingStream("points3d_simple");
+        ///    rr_stream.connect("127.0.0.1:9876");
         ///
-        ///    rr_stream.log(\"points\", rr::archetypes::Points3D({{0.0f, 0.0f, 0.0f},
+        ///    rr_stream.log("points", rr::archetypes::Points3D({{0.0f, 0.0f, 0.0f},
         ///    {1.0f, 1.0f, 1.0f}}));
         /// }
         ///```

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -29,24 +29,24 @@ namespace rerun {
         /// const float pi = static_cast<float>(M_PI);
         ///
         /// int main() {
-        ///    auto rr_stream = rr::RecordingStream(\"transform3d\");
-        ///    rr_stream.connect(\"127.0.0.1:9876\");
+        ///    auto rr_stream = rr::RecordingStream("transform3d");
+        ///    rr_stream.connect("127.0.0.1:9876");
         ///
         ///    auto arrow = rr::archetypes::Arrows3D({0.0f, 1.0f, 0.0f});
         ///
-        ///    rr_stream.log(\"base\", arrow);
+        ///    rr_stream.log("base", arrow);
         ///
-        ///    rr_stream.log(\"base/translated\", rr::archetypes::Transform3D({1.0f, 0.0f, 0.0f}));
-        ///    rr_stream.log(\"base/translated\", arrow);
+        ///    rr_stream.log("base/translated", rr::archetypes::Transform3D({1.0f, 0.0f, 0.0f}));
+        ///    rr_stream.log("base/translated", arrow);
         ///
         ///    rr_stream.log(
-        ///        \"base/rotated_scaled\",
+        ///        "base/rotated_scaled",
         ///        rr::archetypes::Transform3D(
         ///            rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(pi / 4.0f)),
         ///            2.0f
         ///        )
         ///    );
-        ///    rr_stream.log(\"base/rotated_scaled\", arrow);
+        ///    rr_stream.log("base/rotated_scaled", arrow);
         /// }
         ///```
         struct Transform3D {

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -7,7 +7,6 @@
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
-#include <utility>
 
 namespace rerun {
     namespace datatypes {
@@ -16,15 +15,6 @@ namespace rerun {
             rerun::components::KeypointId keypoint0;
 
             rerun::components::KeypointId keypoint1;
-
-          public:
-            // Extensions to generated type defined in 'keypoint_pair_ext.cpp'
-
-            KeypointPair(uint16_t _keypoint0, uint16_t _keypoint1)
-                : keypoint0(_keypoint0), keypoint1(_keypoint1) {}
-
-            KeypointPair(std::pair<uint16_t, uint16_t> pair)
-                : keypoint0(pair.first), keypoint1(pair.second) {}
 
           public:
             KeypointPair() = default;


### PR DESCRIPTION
### What

Check codegen'd files why this was necessary :)
Came up on #2940 but was a pre-existing problem

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2943) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2943)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Ffix-escaped-doc-comments/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Ffix-escaped-doc-comments/examples)