### PR TITLE
Fix major perf regression caused by unoptimized boundchecks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,7 @@ name = "re_types"
 version = "0.9.0-alpha.2"
 dependencies = [
  "anyhow",
+ "array-init",
  "arrow2",
  "arrow2_convert",
  "backtrace",

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -67,6 +67,7 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 # Rerun
 re_string_interner.workspace = true
+array-init = "2.1.0"
 
 [dev-dependencies]
 

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -43,12 +43,13 @@ testing = []
 re_error.workspace = true
 
 # External
+anyhow.workspace = true
+array-init = "2.1"
 arrow2 = { workspace = true, features = [
   "io_ipc",
   "io_print",
   "compute_concatenate",
 ] }
-anyhow.workspace = true
 arrow2_convert.workspace = true
 backtrace = "0.3"
 bytemuck = { version = "1.11", features = ["derive", "extern_crate_alloc"] }
@@ -67,7 +68,6 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 # Rerun
 re_string_interner.workspace = true
-array-init = "2.1.0"
 
 [dev-dependencies]
 

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-ec3be09f454b4916608b2b3d56b33c764dd5ac2faf4b8c0c4867cb567cd4779d
+d3ed38a8c2daefc074b5fbd7fbbf63528837a005b879edf398dcd352eab07cf9

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-2789e31dfc5745ca4d7e375ec6b42f9d57951869af9a89856d0c0d16db530564
+510b1d59ccfc084c7f8c215bad9960d85deeb3383c6ca7553a5ffb014e232884

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-9c2144405965455ffd11ce2f32d6b05f6428d8a782551751a0c7b3bc838ed635
+ec3be09f454b4916608b2b3d56b33c764dd5ac2faf4b8c0c4867cb567cd4779d

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-510b1d59ccfc084c7f8c215bad9960d85deeb3383c6ca7553a5ffb014e232884
+afa8e194d0e3d978baf95d82ba6d5b646c2cc34902b1229dae22e0e84de926ec

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-d3ed38a8c2daefc074b5fbd7fbbf63528837a005b879edf398dcd352eab07cf9
+2789e31dfc5745ca4d7e375ec6b42f9d57951869af9a89856d0c0d16db530564

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -47,7 +47,7 @@ impl<'a> From<&'a AnnotationContext> for ::std::borrow::Cow<'a, AnnotationContex
 impl crate::Loggable for AnnotationContext {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.annotation_context".into()
@@ -201,7 +201,7 @@ impl crate::Loggable for AnnotationContext {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -169,7 +169,10 @@ impl crate::Loggable for AnnotationContext {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -161,14 +161,16 @@ impl crate::Loggable for AnnotationContext {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -36,7 +36,7 @@ impl<'a> From<&'a ClassId> for ::std::borrow::Cow<'a, ClassId> {
 impl crate::Loggable for ClassId {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.class_id".into()
@@ -128,7 +128,7 @@ impl crate::Loggable for ClassId {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -45,7 +45,7 @@ impl<'a> From<&'a Color> for ::std::borrow::Cow<'a, Color> {
 impl crate::Loggable for Color {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.colorrgba".into()
@@ -137,7 +137,7 @@ impl crate::Loggable for Color {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -37,7 +37,7 @@ impl<'a> From<&'a DisconnectedSpace> for ::std::borrow::Cow<'a, DisconnectedSpac
 impl crate::Loggable for DisconnectedSpace {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.disconnected_space".into()
@@ -128,7 +128,7 @@ impl crate::Loggable for DisconnectedSpace {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -40,7 +40,7 @@ impl<'a> From<&'a DrawOrder> for ::std::borrow::Cow<'a, DrawOrder> {
 impl crate::Loggable for DrawOrder {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.draw_order".into()
@@ -132,7 +132,7 @@ impl crate::Loggable for DrawOrder {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -34,7 +34,7 @@ impl<'a> From<&'a InstanceKey> for ::std::borrow::Cow<'a, InstanceKey> {
 impl crate::Loggable for InstanceKey {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.instance_key".into()
@@ -126,7 +126,7 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -38,7 +38,7 @@ impl<'a> From<&'a KeypointId> for ::std::borrow::Cow<'a, KeypointId> {
 impl crate::Loggable for KeypointId {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.keypoint_id".into()
@@ -130,7 +130,7 @@ impl crate::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -34,7 +34,7 @@ impl<'a> From<&'a Label> for ::std::borrow::Cow<'a, Label> {
 impl crate::Loggable for Label {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.label".into()
@@ -145,7 +145,7 @@ impl crate::Loggable for Label {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -258,7 +258,10 @@ impl crate::Loggable for LineStrip2D {
                                             );
                                         }
 
-                                        let data = data.get(start as usize..end as usize).unwrap();
+                                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                        let data = unsafe {
+                                            data.get_unchecked(start as usize..end as usize)
+                                        };
                                         let mut arr = [Default::default(); 2usize];
 
                                         arr.copy_from_slice(data);
@@ -292,7 +295,10 @@ impl crate::Loggable for LineStrip2D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -50,7 +50,7 @@ impl<'a> From<&'a LineStrip2D> for ::std::borrow::Cow<'a, LineStrip2D> {
 impl crate::Loggable for LineStrip2D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.linestrip2d".into()
@@ -326,7 +326,7 @@ impl crate::Loggable for LineStrip2D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -247,22 +247,17 @@ impl crate::Loggable for LineStrip2D {
                                     .as_ref()
                                     .map_or(true, |bitmap| bitmap.get_bit(i))
                                     .then(|| {
-                                        data.get(start as usize..end as usize)
-                                            .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                        let data = data.get(start as usize..end as usize).ok_or(
+                                            crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
                                                 backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                            })?
-                                            .to_vec()
-                                            .try_into()
-                                            .map_err(|_err| {
-                                                crate::DeserializationError::ArrayLengthMismatch {
-                                                    expected: 2usize,
-                                                    got: (end - start) as usize,
-                                                    backtrace:
-                                                        ::backtrace::Backtrace::new_unresolved(),
-                                                }
-                                            })
+                                            },
+                                        )?;
+                                        let mut arr = [Default::default(); 2usize];
+
+                                        arr.copy_from_slice(data);
+                                        Ok(arr)
                                     })
                                     .transpose()
                             })

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -262,9 +262,8 @@ impl crate::Loggable for LineStrip2D {
                                         let data = unsafe {
                                             data.get_unchecked(start as usize..end as usize)
                                         };
-                                        let mut arr = [Default::default(); 2usize];
-
-                                        arr.copy_from_slice(data);
+                                        let arr =
+                                            array_init::from_iter(data.iter().copied()).unwrap();
                                         Ok(arr)
                                     })
                                     .transpose()

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -247,13 +247,18 @@ impl crate::Loggable for LineStrip2D {
                                     .as_ref()
                                     .map_or(true, |bitmap| bitmap.get_bit(i))
                                     .then(|| {
-                                        let data = data.get(start as usize..end as usize).ok_or(
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                            },
-                                        )?;
+                                        if end as usize > data.len() {
+                                            return Err(
+                                                crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace:
+                                                        ::backtrace::Backtrace::new_unresolved(),
+                                                },
+                                            );
+                                        }
+
+                                        let data = data.get(start as usize..end as usize).unwrap();
                                         let mut arr = [Default::default(); 2usize];
 
                                         arr.copy_from_slice(data);
@@ -279,14 +284,16 @@ impl crate::Loggable for LineStrip2D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -258,7 +258,10 @@ impl crate::Loggable for LineStrip3D {
                                             );
                                         }
 
-                                        let data = data.get(start as usize..end as usize).unwrap();
+                                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                        let data = unsafe {
+                                            data.get_unchecked(start as usize..end as usize)
+                                        };
                                         let mut arr = [Default::default(); 3usize];
 
                                         arr.copy_from_slice(data);
@@ -292,7 +295,10 @@ impl crate::Loggable for LineStrip3D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -247,22 +247,17 @@ impl crate::Loggable for LineStrip3D {
                                     .as_ref()
                                     .map_or(true, |bitmap| bitmap.get_bit(i))
                                     .then(|| {
-                                        data.get(start as usize..end as usize)
-                                            .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                        let data = data.get(start as usize..end as usize).ok_or(
+                                            crate::DeserializationError::OffsetsMismatch {
                                                 bounds: (start as usize, end as usize),
                                                 len: data.len(),
                                                 backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                            })?
-                                            .to_vec()
-                                            .try_into()
-                                            .map_err(|_err| {
-                                                crate::DeserializationError::ArrayLengthMismatch {
-                                                    expected: 3usize,
-                                                    got: (end - start) as usize,
-                                                    backtrace:
-                                                        ::backtrace::Backtrace::new_unresolved(),
-                                                }
-                                            })
+                                            },
+                                        )?;
+                                        let mut arr = [Default::default(); 3usize];
+
+                                        arr.copy_from_slice(data);
+                                        Ok(arr)
                                     })
                                     .transpose()
                             })

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -262,9 +262,8 @@ impl crate::Loggable for LineStrip3D {
                                         let data = unsafe {
                                             data.get_unchecked(start as usize..end as usize)
                                         };
-                                        let mut arr = [Default::default(); 3usize];
-
-                                        arr.copy_from_slice(data);
+                                        let arr =
+                                            array_init::from_iter(data.iter().copied()).unwrap();
                                         Ok(arr)
                                     })
                                     .transpose()

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -50,7 +50,7 @@ impl<'a> From<&'a LineStrip3D> for ::std::borrow::Cow<'a, LineStrip3D> {
 impl crate::Loggable for LineStrip3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.linestrip3d".into()
@@ -326,7 +326,7 @@ impl crate::Loggable for LineStrip3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -247,13 +247,18 @@ impl crate::Loggable for LineStrip3D {
                                     .as_ref()
                                     .map_or(true, |bitmap| bitmap.get_bit(i))
                                     .then(|| {
-                                        let data = data.get(start as usize..end as usize).ok_or(
-                                            crate::DeserializationError::OffsetsMismatch {
-                                                bounds: (start as usize, end as usize),
-                                                len: data.len(),
-                                                backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                            },
-                                        )?;
+                                        if end as usize > data.len() {
+                                            return Err(
+                                                crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace:
+                                                        ::backtrace::Backtrace::new_unresolved(),
+                                                },
+                                            );
+                                        }
+
+                                        let data = data.get(start as usize..end as usize).unwrap();
                                         let mut arr = [Default::default(); 3usize];
 
                                         arr.copy_from_slice(data);
@@ -279,14 +284,16 @@ impl crate::Loggable for LineStrip3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -198,9 +198,7 @@ impl crate::Loggable for Origin3D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 3usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -187,21 +187,17 @@ impl crate::Loggable for Origin3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 3usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 3usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Origin3D> for ::std::borrow::Cow<'a, Origin3D> {
 impl crate::Loggable for Origin3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.components.Origin3D".into()
@@ -228,7 +228,7 @@ impl crate::Loggable for Origin3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -195,7 +195,9 @@ impl crate::Loggable for Origin3D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -187,13 +187,15 @@ impl crate::Loggable for Origin3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -195,7 +195,9 @@ impl crate::Loggable for Point2D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 2usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -198,9 +198,7 @@ impl crate::Loggable for Point2D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 2usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -187,13 +187,15 @@ impl crate::Loggable for Point2D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 2usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -187,21 +187,17 @@ impl crate::Loggable for Point2D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 2usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 2usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Point2D> for ::std::borrow::Cow<'a, Point2D> {
 impl crate::Loggable for Point2D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.point2d".into()
@@ -228,7 +228,7 @@ impl crate::Loggable for Point2D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -187,13 +187,15 @@ impl crate::Loggable for Point3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -198,9 +198,7 @@ impl crate::Loggable for Point3D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 3usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -195,7 +195,9 @@ impl crate::Loggable for Point3D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Point3D> for ::std::borrow::Cow<'a, Point3D> {
 impl crate::Loggable for Point3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.point3d".into()
@@ -228,7 +228,7 @@ impl crate::Loggable for Point3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -187,21 +187,17 @@ impl crate::Loggable for Point3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 3usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 3usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Radius> for ::std::borrow::Cow<'a, Radius> {
 impl crate::Loggable for Radius {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.radius".into()
@@ -125,7 +125,7 @@ impl crate::Loggable for Radius {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -42,7 +42,7 @@ impl<'a> From<&'a Transform3D> for ::std::borrow::Cow<'a, Transform3D> {
 impl crate::Loggable for Transform3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.transform3d".into()
@@ -150,7 +150,7 @@ impl crate::Loggable for Transform3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -187,13 +187,15 @@ impl crate::Loggable for Vector3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -187,21 +187,17 @@ impl crate::Loggable for Vector3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 3usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 3usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Vector3D> for ::std::borrow::Cow<'a, Vector3D> {
 impl crate::Loggable for Vector3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.components.Vector3D".into()
@@ -228,7 +228,7 @@ impl crate::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -198,9 +198,7 @@ impl crate::Loggable for Vector3D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 3usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -195,7 +195,9 @@ impl crate::Loggable for Vector3D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -36,7 +36,7 @@ impl<'a> From<&'a Angle> for ::std::borrow::Cow<'a, Angle> {
 impl crate::Loggable for Angle {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Angle".into()
@@ -309,7 +309,7 @@ impl crate::Loggable for Angle {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -253,10 +253,9 @@ impl crate::Loggable for Angle {
                             Ok(None)
                         } else {
                             Ok(Some(match typ {
-                                1i8 => Angle::Radians(
-                                    radians
-                                        .get(offset as usize)
-                                        .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                1i8 => Angle::Radians({
+                                    if offset as usize >= radians.len() {
+                                        return Err(crate::DeserializationError::OffsetsMismatch {
                                             bounds: (offset as usize, offset as usize),
                                             len: radians.len(),
                                             backtrace: ::backtrace::Backtrace::new_unresolved(),
@@ -264,14 +263,14 @@ impl crate::Loggable for Angle {
                                         .map_err(|err| crate::DeserializationError::Context {
                                             location: "rerun.datatypes.Angle#Radians".into(),
                                             source: Box::new(err),
-                                        })?
-                                        .clone()
-                                        .unwrap(),
-                                ),
-                                2i8 => Angle::Degrees(
-                                    degrees
-                                        .get(offset as usize)
-                                        .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                        });
+                                    }
+
+                                    radians.get(offset as usize).unwrap().clone().unwrap()
+                                }),
+                                2i8 => Angle::Degrees({
+                                    if offset as usize >= degrees.len() {
+                                        return Err(crate::DeserializationError::OffsetsMismatch {
                                             bounds: (offset as usize, offset as usize),
                                             len: degrees.len(),
                                             backtrace: ::backtrace::Backtrace::new_unresolved(),
@@ -279,10 +278,11 @@ impl crate::Loggable for Angle {
                                         .map_err(|err| crate::DeserializationError::Context {
                                             location: "rerun.datatypes.Angle#Degrees".into(),
                                             source: Box::new(err),
-                                        })?
-                                        .clone()
-                                        .unwrap(),
-                                ),
+                                        });
+                                    }
+
+                                    degrees.get(offset as usize).unwrap().clone().unwrap()
+                                }),
                                 _ => unreachable!(),
                             }))
                         }

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -266,7 +266,10 @@ impl crate::Loggable for Angle {
                                         });
                                     }
 
-                                    radians.get(offset as usize).unwrap().clone().unwrap()
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { radians.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .unwrap()
                                 }),
                                 2i8 => Angle::Degrees({
                                     if offset as usize >= degrees.len() {
@@ -281,7 +284,10 @@ impl crate::Loggable for Angle {
                                         });
                                     }
 
-                                    degrees.get(offset as usize).unwrap().clone().unwrap()
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { degrees.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .unwrap()
                                 }),
                                 _ => unreachable!(),
                             }))

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -45,7 +45,7 @@ impl<'a> From<&'a AnnotationInfo> for ::std::borrow::Cow<'a, AnnotationInfo> {
 impl crate::Loggable for AnnotationInfo {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.AnnotationInfo".into()
@@ -337,7 +337,7 @@ impl crate::Loggable for AnnotationInfo {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -351,7 +351,9 @@ impl crate::Loggable for ClassDescription {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -378,7 +380,9 @@ impl crate::Loggable for ClassDescription {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -347,9 +347,11 @@ impl crate::Loggable for ClassDescription {
 
 ) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -372,9 +374,11 @@ impl crate::Loggable for ClassDescription {
 
 ) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -55,7 +55,7 @@ impl<'a> From<&'a ClassDescription> for ::std::borrow::Cow<'a, ClassDescription>
 impl crate::Loggable for ClassDescription {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.ClassDescription".into()
@@ -417,7 +417,7 @@ impl crate::Loggable for ClassDescription {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -38,7 +38,7 @@ impl<'a> From<&'a ClassDescriptionMapElem> for ::std::borrow::Cow<'a, ClassDescr
 impl crate::Loggable for ClassDescriptionMapElem {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.ClassDescriptionMapElem".into()
@@ -244,7 +244,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -36,7 +36,7 @@ impl<'a> From<&'a KeypointPair> for ::std::borrow::Cow<'a, KeypointPair> {
 impl crate::Loggable for KeypointPair {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.KeypointPair".into()
@@ -269,7 +269,7 @@ impl crate::Loggable for KeypointPair {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -175,21 +175,17 @@ impl crate::Loggable for Mat3x3 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 9usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 9usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -183,7 +183,9 @@ impl crate::Loggable for Mat3x3 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 9usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -186,9 +186,7 @@ impl crate::Loggable for Mat3x3 {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 9usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -175,13 +175,15 @@ impl crate::Loggable for Mat3x3 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 9usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Mat3x3> for ::std::borrow::Cow<'a, Mat3x3> {
 impl crate::Loggable for Mat3x3 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Mat3x3".into()
@@ -215,7 +215,7 @@ impl crate::Loggable for Mat3x3 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -186,9 +186,7 @@ impl crate::Loggable for Mat4x4 {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 16usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -175,13 +175,15 @@ impl crate::Loggable for Mat4x4 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 16usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Mat4x4> for ::std::borrow::Cow<'a, Mat4x4> {
 impl crate::Loggable for Mat4x4 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Mat4x4".into()
@@ -215,7 +215,7 @@ impl crate::Loggable for Mat4x4 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -183,7 +183,9 @@ impl crate::Loggable for Mat4x4 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 16usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -175,21 +175,17 @@ impl crate::Loggable for Mat4x4 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 16usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 16usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -175,21 +175,17 @@ impl crate::Loggable for Quaternion {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 4usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 4usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Quaternion> for ::std::borrow::Cow<'a, Quaternion> {
 impl crate::Loggable for Quaternion {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Quaternion".into()
@@ -215,7 +215,7 @@ impl crate::Loggable for Quaternion {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -183,7 +183,9 @@ impl crate::Loggable for Quaternion {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 4usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -175,13 +175,15 @@ impl crate::Loggable for Quaternion {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 4usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -186,9 +186,7 @@ impl crate::Loggable for Quaternion {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 4usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -280,9 +280,7 @@ impl crate::Loggable for Rotation3D {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 4usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Quaternion (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -278,7 +278,9 @@ impl crate::Loggable for Rotation3D {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 4usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 4usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 
@@ -323,7 +325,10 @@ impl crate::Loggable for Rotation3D {
                                         });
                                     }
 
-                                    quaternion.get(offset as usize).unwrap().clone().unwrap()
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { quaternion.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .unwrap()
                                 }),
                                 2i8 => Rotation3D::AxisAngle({
                                     if offset as usize >= axis_angle.len() {
@@ -338,7 +343,10 @@ impl crate::Loggable for Rotation3D {
                                         });
                                     }
 
-                                    axis_angle.get(offset as usize).unwrap().clone().unwrap()
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { axis_angle.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .unwrap()
                                 }),
                                 _ => unreachable!(),
                             }))

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -274,11 +274,11 @@ impl crate::Loggable for Rotation3D {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (4usize) . zip ((4usize ..) . step_by (4usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 4usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 4usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Quaternion (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Rotation3D> for ::std::borrow::Cow<'a, Rotation3D> {
 impl crate::Loggable for Rotation3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Rotation3D".into()
@@ -366,7 +366,7 @@ impl crate::Loggable for Rotation3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -43,7 +43,7 @@ impl<'a> From<&'a RotationAxisAngle> for ::std::borrow::Cow<'a, RotationAxisAngl
 impl crate::Loggable for RotationAxisAngle {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.RotationAxisAngle".into()
@@ -307,7 +307,7 @@ impl crate::Loggable for RotationAxisAngle {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -244,7 +244,9 @@ impl crate::Loggable for RotationAxisAngle {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -246,9 +246,7 @@ impl crate::Loggable for RotationAxisAngle {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 3usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -240,9 +240,11 @@ impl crate::Loggable for RotationAxisAngle {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? ; let mut arr = [Default :: default () ; 3usize];
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -240,11 +240,11 @@ impl crate::Loggable for RotationAxisAngle {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 3usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -271,11 +271,11 @@ impl crate::Loggable for Scale3D {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 3usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -277,9 +277,7 @@ impl crate::Loggable for Scale3D {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 3usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -275,7 +275,9 @@ impl crate::Loggable for Scale3D {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 
@@ -318,7 +320,10 @@ impl crate::Loggable for Scale3D {
                                         });
                                     }
 
-                                    three_d.get(offset as usize).unwrap().clone().unwrap()
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { three_d.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .unwrap()
                                 }),
                                 2i8 => Scale3D::Uniform({
                                     if offset as usize >= uniform.len() {
@@ -333,7 +338,10 @@ impl crate::Loggable for Scale3D {
                                         });
                                     }
 
-                                    uniform.get(offset as usize).unwrap().clone().unwrap()
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { uniform.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .unwrap()
                                 }),
                                 _ => unreachable!(),
                             }))

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Scale3D> for ::std::borrow::Cow<'a, Scale3D> {
 impl crate::Loggable for Scale3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Scale3D".into()
@@ -361,7 +361,7 @@ impl crate::Loggable for Scale3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -268,7 +268,9 @@ impl crate::Loggable for Transform3D {
 
 ) ; }
 
- translation_and_mat_3_x_3 . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { translation_and_mat_3_x_3 . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , 2i8 => Transform3D :: TranslationRotationScale ({ if offset as usize >= translation_rotation_scale . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_rotation_scale . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
@@ -276,7 +278,9 @@ impl crate::Loggable for Transform3D {
 
 ) ; }
 
- translation_rotation_scale . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { translation_rotation_scale . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , _ => unreachable ! () , }
 

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a Transform3D> for ::std::borrow::Cow<'a, Transform3D> {
 impl crate::Loggable for Transform3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Transform3D".into()
@@ -302,7 +302,7 @@ impl crate::Loggable for Transform3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -262,15 +262,23 @@ impl crate::Loggable for Transform3D {
 
  if * typ == 0 { Ok (None) }
 
- else { Ok (Some (match typ { 1i8 => Transform3D :: TranslationAndMat3X3 (translation_and_mat_3_x_3 . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_and_mat_3_x_3 . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+ else { Ok (Some (match typ { 1i8 => Transform3D :: TranslationAndMat3X3 ({ if offset as usize >= translation_and_mat_3_x_3 . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_and_mat_3_x_3 . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.Transform3D#TranslationAndMat3x3" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , 2i8 => Transform3D :: TranslationRotationScale (translation_rotation_scale . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_rotation_scale . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ; }
+
+ translation_and_mat_3_x_3 . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , 2i8 => Transform3D :: TranslationRotationScale ({ if offset as usize >= translation_rotation_scale . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_rotation_scale . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.Transform3D#TranslationRotationScale" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , _ => unreachable ! () , }
+) ; }
+
+ translation_rotation_scale . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , _ => unreachable ! () , }
 
 )) }
 

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -324,11 +324,11 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 3usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -347,11 +347,11 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (9usize) . zip ((9usize ..) . step_by (9usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 9usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 9usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Mat3x3 (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -328,7 +328,9 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 
@@ -353,7 +355,9 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 9usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 9usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -45,7 +45,7 @@ impl<'a> From<&'a TranslationAndMat3x3> for ::std::borrow::Cow<'a, TranslationAn
 impl crate::Loggable for TranslationAndMat3x3 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.TranslationAndMat3x3".into()
@@ -408,7 +408,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -330,9 +330,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 3usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -357,9 +355,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 9usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Mat3x3 (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -324,9 +324,11 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? ; let mut arr = [Default :: default () ; 3usize];
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 
@@ -347,9 +349,11 @@ impl crate::Loggable for TranslationAndMat3x3 {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (9usize) . zip ((9usize ..) . step_by (9usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? ; let mut arr = [Default :: default () ; 9usize];
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 9usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -317,9 +317,11 @@ impl crate::Loggable for TranslationRotationScale3D {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? ; let mut arr = [Default :: default () ; 3usize];
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -323,9 +323,7 @@ impl crate::Loggable for TranslationRotationScale3D {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 3usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -317,11 +317,11 @@ impl crate::Loggable for TranslationRotationScale3D {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 3usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -48,7 +48,7 @@ impl<'a> From<&'a TranslationRotationScale3D>
 impl crate::Loggable for TranslationRotationScale3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.TranslationRotationScale3D".into()
@@ -378,7 +378,7 @@ impl crate::Loggable for TranslationRotationScale3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -321,7 +321,9 @@ impl crate::Loggable for TranslationRotationScale3D {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -175,13 +175,15 @@ impl crate::Loggable for Vec2D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 2usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -183,7 +183,9 @@ impl crate::Loggable for Vec2D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 2usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -175,21 +175,17 @@ impl crate::Loggable for Vec2D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 2usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 2usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -186,9 +186,7 @@ impl crate::Loggable for Vec2D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 2usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Vec2D> for ::std::borrow::Cow<'a, Vec2D> {
 impl crate::Loggable for Vec2D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Vec2D".into()
@@ -215,7 +215,7 @@ impl crate::Loggable for Vec2D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -183,7 +183,9 @@ impl crate::Loggable for Vec3D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -175,13 +175,15 @@ impl crate::Loggable for Vec3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 3usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -186,9 +186,7 @@ impl crate::Loggable for Vec3D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 3usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Vec3D> for ::std::borrow::Cow<'a, Vec3D> {
 impl crate::Loggable for Vec3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Vec3D".into()
@@ -215,7 +215,7 @@ impl crate::Loggable for Vec3D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -175,21 +175,17 @@ impl crate::Loggable for Vec3D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 3usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 3usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -175,13 +175,15 @@ impl crate::Loggable for Vec4D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                let data = data.get(start as usize..end as usize).ok_or(
-                                    crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    },
-                                )?;
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap();
                                 let mut arr = [Default::default(); 4usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -186,9 +186,7 @@ impl crate::Loggable for Vec4D {
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data =
                                     unsafe { data.get_unchecked(start as usize..end as usize) };
-                                let mut arr = [Default::default(); 4usize];
-
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap();
                                 Ok(arr)
                             })
                             .transpose()

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -175,21 +175,17 @@ impl crate::Loggable for Vec4D {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                data.get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                let data = data.get(start as usize..end as usize).ok_or(
+                                    crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec()
-                                    .try_into()
-                                    .map_err(|_err| {
-                                        crate::DeserializationError::ArrayLengthMismatch {
-                                            expected: 4usize,
-                                            got: (end - start) as usize,
-                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                        }
-                                    })
+                                    },
+                                )?;
+                                let mut arr = [Default::default(); 4usize];
+
+                                arr.copy_from_slice(data);
+                                Ok(arr)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a Vec4D> for ::std::borrow::Cow<'a, Vec4D> {
 impl crate::Loggable for Vec4D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Vec4D".into()
@@ -215,7 +215,7 @@ impl crate::Loggable for Vec4D {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -183,7 +183,9 @@ impl crate::Loggable for Vec4D {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data =
+                                    unsafe { data.get_unchecked(start as usize..end as usize) };
                                 let mut arr = [Default::default(); 4usize];
 
                                 arr.copy_from_slice(data);

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -38,7 +38,7 @@ impl<'a> From<&'a AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
 impl crate::Loggable for AffixFuzzer1 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer1".into()
@@ -195,7 +195,7 @@ impl crate::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -232,7 +232,7 @@ impl<'a> From<&'a AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
 impl crate::Loggable for AffixFuzzer2 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer2".into()
@@ -389,7 +389,7 @@ impl crate::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -426,7 +426,7 @@ impl<'a> From<&'a AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
 impl crate::Loggable for AffixFuzzer3 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer3".into()
@@ -583,7 +583,7 @@ impl crate::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -620,7 +620,7 @@ impl<'a> From<&'a AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
 impl crate::Loggable for AffixFuzzer4 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer4".into()
@@ -775,7 +775,7 @@ impl crate::Loggable for AffixFuzzer4 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -812,7 +812,7 @@ impl<'a> From<&'a AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
 impl crate::Loggable for AffixFuzzer5 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer5".into()
@@ -967,7 +967,7 @@ impl crate::Loggable for AffixFuzzer5 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1004,7 +1004,7 @@ impl<'a> From<&'a AffixFuzzer6> for ::std::borrow::Cow<'a, AffixFuzzer6> {
 impl crate::Loggable for AffixFuzzer6 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer6".into()
@@ -1159,7 +1159,7 @@ impl crate::Loggable for AffixFuzzer6 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1198,7 +1198,7 @@ impl<'a> From<&'a AffixFuzzer7> for ::std::borrow::Cow<'a, AffixFuzzer7> {
 impl crate::Loggable for AffixFuzzer7 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer7".into()
@@ -1372,7 +1372,7 @@ impl crate::Loggable for AffixFuzzer7 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1403,7 +1403,7 @@ impl<'a> From<&'a AffixFuzzer8> for ::std::borrow::Cow<'a, AffixFuzzer8> {
 impl crate::Loggable for AffixFuzzer8 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer8".into()
@@ -1493,7 +1493,7 @@ impl crate::Loggable for AffixFuzzer8 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1524,7 +1524,7 @@ impl<'a> From<&'a AffixFuzzer9> for ::std::borrow::Cow<'a, AffixFuzzer9> {
 impl crate::Loggable for AffixFuzzer9 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer9".into()
@@ -1635,7 +1635,7 @@ impl crate::Loggable for AffixFuzzer9 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1666,7 +1666,7 @@ impl<'a> From<&'a AffixFuzzer10> for ::std::borrow::Cow<'a, AffixFuzzer10> {
 impl crate::Loggable for AffixFuzzer10 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer10".into()
@@ -1775,7 +1775,7 @@ impl crate::Loggable for AffixFuzzer10 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1806,7 +1806,7 @@ impl<'a> From<&'a AffixFuzzer11> for ::std::borrow::Cow<'a, AffixFuzzer11> {
 impl crate::Loggable for AffixFuzzer11 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer11".into()
@@ -1989,7 +1989,7 @@ impl crate::Loggable for AffixFuzzer11 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -2020,7 +2020,7 @@ impl<'a> From<&'a AffixFuzzer12> for ::std::borrow::Cow<'a, AffixFuzzer12> {
 impl crate::Loggable for AffixFuzzer12 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer12".into()
@@ -2224,7 +2224,7 @@ impl crate::Loggable for AffixFuzzer12 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -2255,7 +2255,7 @@ impl<'a> From<&'a AffixFuzzer13> for ::std::borrow::Cow<'a, AffixFuzzer13> {
 impl crate::Loggable for AffixFuzzer13 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer13".into()
@@ -2457,7 +2457,7 @@ impl crate::Loggable for AffixFuzzer13 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -2494,7 +2494,7 @@ impl<'a> From<&'a AffixFuzzer14> for ::std::borrow::Cow<'a, AffixFuzzer14> {
 impl crate::Loggable for AffixFuzzer14 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer14".into()
@@ -2629,7 +2629,7 @@ impl crate::Loggable for AffixFuzzer14 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -2666,7 +2666,7 @@ impl<'a> From<&'a AffixFuzzer15> for ::std::borrow::Cow<'a, AffixFuzzer15> {
 impl crate::Loggable for AffixFuzzer15 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer15".into()
@@ -2799,7 +2799,7 @@ impl crate::Loggable for AffixFuzzer15 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -2838,7 +2838,7 @@ impl<'a> From<&'a AffixFuzzer16> for ::std::borrow::Cow<'a, AffixFuzzer16> {
 impl crate::Loggable for AffixFuzzer16 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer16".into()
@@ -3015,7 +3015,7 @@ impl crate::Loggable for AffixFuzzer16 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -3054,7 +3054,7 @@ impl<'a> From<&'a AffixFuzzer17> for ::std::borrow::Cow<'a, AffixFuzzer17> {
 impl crate::Loggable for AffixFuzzer17 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer17".into()
@@ -3229,7 +3229,7 @@ impl crate::Loggable for AffixFuzzer17 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -3268,7 +3268,7 @@ impl<'a> From<&'a AffixFuzzer18> for ::std::borrow::Cow<'a, AffixFuzzer18> {
 impl crate::Loggable for AffixFuzzer18 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer18".into()
@@ -3443,7 +3443,7 @@ impl crate::Loggable for AffixFuzzer18 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -3480,7 +3480,7 @@ impl<'a> From<&'a AffixFuzzer19> for ::std::borrow::Cow<'a, AffixFuzzer19> {
 impl crate::Loggable for AffixFuzzer19 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer19".into()
@@ -3574,7 +3574,7 @@ impl crate::Loggable for AffixFuzzer19 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -3611,7 +3611,7 @@ impl<'a> From<&'a AffixFuzzer20> for ::std::borrow::Cow<'a, AffixFuzzer20> {
 impl crate::Loggable for AffixFuzzer20 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer20".into()
@@ -3711,7 +3711,7 @@ impl crate::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -1336,14 +1336,16 @@ impl crate::Loggable for AffixFuzzer7 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })
@@ -1948,14 +1950,16 @@ impl crate::Loggable for AffixFuzzer11 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })
@@ -2174,14 +2178,16 @@ impl crate::Loggable for AffixFuzzer12 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })
@@ -2406,14 +2412,16 @@ impl crate::Loggable for AffixFuzzer13 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })
@@ -2955,14 +2963,16 @@ impl crate::Loggable for AffixFuzzer16 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })
@@ -3168,14 +3178,16 @@ impl crate::Loggable for AffixFuzzer17 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })
@@ -3377,14 +3389,16 @@ impl crate::Loggable for AffixFuzzer18 {
                             .as_ref()
                             .map_or(true, |bitmap| bitmap.get_bit(i))
                             .then(|| {
-                                Ok(data
-                                    .get(start as usize..end as usize)
-                                    .ok_or(crate::DeserializationError::OffsetsMismatch {
+                                if end as usize > data.len() {
+                                    return Err(crate::DeserializationError::OffsetsMismatch {
                                         bounds: (start as usize, end as usize),
                                         len: data.len(),
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
-                                    })?
-                                    .to_vec())
+                                    });
+                                }
+
+                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                Ok(data)
                             })
                             .transpose()
                     })

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -1344,7 +1344,10 @@ impl crate::Loggable for AffixFuzzer7 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()
@@ -1958,7 +1961,10 @@ impl crate::Loggable for AffixFuzzer11 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()
@@ -2186,7 +2192,10 @@ impl crate::Loggable for AffixFuzzer12 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()
@@ -2420,7 +2429,10 @@ impl crate::Loggable for AffixFuzzer13 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()
@@ -2971,7 +2983,10 @@ impl crate::Loggable for AffixFuzzer16 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()
@@ -3186,7 +3201,10 @@ impl crate::Loggable for AffixFuzzer17 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()
@@ -3397,7 +3415,10 @@ impl crate::Loggable for AffixFuzzer18 {
                                     });
                                 }
 
-                                let data = data.get(start as usize..end as usize).unwrap().to_vec();
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe {
+                                    data.get_unchecked(start as usize..end as usize).to_vec()
+                                };
                                 Ok(data)
                             })
                             .transpose()

--- a/crates/re_types/src/testing/components/fuzzy_deps.rs
+++ b/crates/re_types/src/testing/components/fuzzy_deps.rs
@@ -33,7 +33,7 @@ impl<'a> From<&'a PrimitiveComponent> for ::std::borrow::Cow<'a, PrimitiveCompon
 impl crate::Loggable for PrimitiveComponent {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.PrimitiveComponent".into()
@@ -125,7 +125,7 @@ impl crate::Loggable for PrimitiveComponent {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -157,7 +157,7 @@ impl<'a> From<&'a StringComponent> for ::std::borrow::Cow<'a, StringComponent> {
 impl crate::Loggable for StringComponent {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.StringComponent".into()
@@ -268,7 +268,7 @@ impl crate::Loggable for StringComponent {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -911,7 +911,9 @@ impl crate::Loggable for AffixFuzzer1 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -938,7 +940,9 @@ impl crate::Loggable for AffixFuzzer1 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -965,7 +969,9 @@ impl crate::Loggable for AffixFuzzer1 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1411,7 +1417,9 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1430,7 +1438,9 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
+
+ ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 
@@ -1450,7 +1460,9 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ; }
 
- degrees . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { degrees . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , 2i8 => AffixFuzzer3 :: Radians ({ if offset as usize >= radians . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : radians . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
@@ -1458,7 +1470,9 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ; }
 
- radians . get (offset as usize) . unwrap () . clone () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { radians . get_unchecked (offset as usize) }
+
+ . clone () }
 
 ) , 3i8 => AffixFuzzer3 :: Craziness ({ if offset as usize >= craziness . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : craziness . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
@@ -1466,7 +1480,9 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ; }
 
- craziness . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { craziness . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , 4i8 => AffixFuzzer3 :: FixedSizeShenanigans ({ if offset as usize >= fixed_size_shenanigans . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : fixed_size_shenanigans . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
@@ -1474,7 +1490,9 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ; }
 
- fixed_size_shenanigans . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { fixed_size_shenanigans . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , _ => unreachable ! () , }
 
@@ -1722,7 +1740,9 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1745,7 +1765,9 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ; }
 
- let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
+
+ ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1763,7 +1785,9 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ; }
 
- single_required . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { single_required . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , 2i8 => AffixFuzzer4 :: ManyRequired ({ if offset as usize >= many_required . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : many_required . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
@@ -1771,7 +1795,9 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ; }
 
- many_required . get (offset as usize) . unwrap () . clone () . unwrap () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { many_required . get_unchecked (offset as usize) }
+
+ . clone () . unwrap () }
 
 ) , 3i8 => AffixFuzzer4 :: ManyOptional ({ if offset as usize >= many_optional . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : many_optional . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
@@ -1779,7 +1805,9 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ; }
 
- many_optional . get (offset as usize) . unwrap () . clone () }
+ # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { many_optional . get_unchecked (offset as usize) }
+
+ . clone () }
 
 ) , _ => unreachable ! () , }
 

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -1440,9 +1440,7 @@ impl crate::Loggable for AffixFuzzer3 {
 
  # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
 
- ; let mut arr = [Default :: default () ; 3usize];
-
- arr . copy_from_slice (data) ; Ok (arr) }
+ ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -1418,11 +1418,11 @@ impl crate::Loggable for AffixFuzzer3 {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec () . try_into () . map_err (| _err | crate :: DeserializationError :: ArrayLengthMismatch { expected : 3usize , got : (end - start) as usize , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ? ; let mut arr = [Default :: default () ; 3usize];
 
-) }
+ arr . copy_from_slice (data) ; Ok (arr) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -34,7 +34,7 @@ impl<'a> From<&'a FlattenedScalar> for ::std::borrow::Cow<'a, FlattenedScalar> {
 impl crate::Loggable for FlattenedScalar {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.FlattenedScalar".into()
@@ -195,7 +195,7 @@ impl crate::Loggable for FlattenedScalar {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -236,7 +236,7 @@ impl<'a> From<&'a AffixFuzzer1> for ::std::borrow::Cow<'a, AffixFuzzer1> {
 impl crate::Loggable for AffixFuzzer1 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.AffixFuzzer1".into()
@@ -1039,7 +1039,7 @@ impl crate::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1070,7 +1070,7 @@ impl<'a> From<&'a AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
 impl crate::Loggable for AffixFuzzer2 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.AffixFuzzer2".into()
@@ -1160,7 +1160,7 @@ impl crate::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1196,7 +1196,7 @@ impl<'a> From<&'a AffixFuzzer3> for ::std::borrow::Cow<'a, AffixFuzzer3> {
 impl crate::Loggable for AffixFuzzer3 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.AffixFuzzer3".into()
@@ -1512,7 +1512,7 @@ impl crate::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1547,7 +1547,7 @@ impl<'a> From<&'a AffixFuzzer4> for ::std::borrow::Cow<'a, AffixFuzzer4> {
 impl crate::Loggable for AffixFuzzer4 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.AffixFuzzer4".into()
@@ -1827,7 +1827,7 @@ impl crate::Loggable for AffixFuzzer4 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -1868,7 +1868,7 @@ impl<'a> From<&'a AffixFuzzer5> for ::std::borrow::Cow<'a, AffixFuzzer5> {
 impl crate::Loggable for AffixFuzzer5 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.AffixFuzzer5".into()
@@ -2027,7 +2027,7 @@ impl crate::Loggable for AffixFuzzer5 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]
@@ -2061,7 +2061,7 @@ impl<'a> From<&'a AffixFuzzer20> for ::std::borrow::Cow<'a, AffixFuzzer20> {
 impl crate::Loggable for AffixFuzzer20 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
-    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.datatypes.AffixFuzzer20".into()
@@ -2323,7 +2323,7 @@ impl crate::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
-        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+        Ok(Self::try_from_arrow_opt(data)?.into_iter())
     }
 
     #[inline]

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -907,9 +907,11 @@ impl crate::Loggable for AffixFuzzer1 {
 
  ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -932,9 +934,11 @@ impl crate::Loggable for AffixFuzzer1 {
 
  . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -957,9 +961,11 @@ impl crate::Loggable for AffixFuzzer1 {
 
  . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1401,9 +1407,11 @@ impl crate::Loggable for AffixFuzzer3 {
 
 ) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1418,9 +1426,11 @@ impl crate::Loggable for AffixFuzzer3 {
 
  else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { let data = data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? ; let mut arr = [Default :: default () ; 3usize];
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () ; let mut arr = [Default :: default () ; 3usize];
 
  arr . copy_from_slice (data) ; Ok (arr) }
 
@@ -1434,23 +1444,39 @@ impl crate::Loggable for AffixFuzzer3 {
 
  if * typ == 0 { Ok (None) }
 
- else { Ok (Some (match typ { 1i8 => AffixFuzzer3 :: Degrees (degrees . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : degrees . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+ else { Ok (Some (match typ { 1i8 => AffixFuzzer3 :: Degrees ({ if offset as usize >= degrees . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : degrees . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer3#degrees" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , 2i8 => AffixFuzzer3 :: Radians (radians . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : radians . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ; }
+
+ degrees . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , 2i8 => AffixFuzzer3 :: Radians ({ if offset as usize >= radians . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : radians . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer3#radians" . into () , source : Box :: new (err) , }
 
-) ? . clone ()) , 3i8 => AffixFuzzer3 :: Craziness (craziness . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : craziness . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ; }
+
+ radians . get (offset as usize) . unwrap () . clone () }
+
+) , 3i8 => AffixFuzzer3 :: Craziness ({ if offset as usize >= craziness . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : craziness . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer3#craziness" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , 4i8 => AffixFuzzer3 :: FixedSizeShenanigans (fixed_size_shenanigans . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : fixed_size_shenanigans . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ; }
+
+ craziness . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , 4i8 => AffixFuzzer3 :: FixedSizeShenanigans ({ if offset as usize >= fixed_size_shenanigans . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : fixed_size_shenanigans . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer3#fixed_size_shenanigans" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , _ => unreachable ! () , }
+) ; }
+
+ fixed_size_shenanigans . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , _ => unreachable ! () , }
 
 )) }
 
@@ -1692,9 +1718,11 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1713,9 +1741,11 @@ impl crate::Loggable for AffixFuzzer4 {
 
 ) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { Ok (data . get (start as usize .. end as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
-) ? . to_vec ()) }
+) ; }
+
+ let data = data . get (start as usize .. end as usize) . unwrap () . to_vec () ; Ok (data) }
 
 ) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
 
@@ -1727,19 +1757,31 @@ impl crate::Loggable for AffixFuzzer4 {
 
  if * typ == 0 { Ok (None) }
 
- else { Ok (Some (match typ { 1i8 => AffixFuzzer4 :: SingleRequired (single_required . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : single_required . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+ else { Ok (Some (match typ { 1i8 => AffixFuzzer4 :: SingleRequired ({ if offset as usize >= single_required . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : single_required . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer4#single_required" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , 2i8 => AffixFuzzer4 :: ManyRequired (many_required . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : many_required . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ; }
+
+ single_required . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , 2i8 => AffixFuzzer4 :: ManyRequired ({ if offset as usize >= many_required . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : many_required . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer4#many_required" . into () , source : Box :: new (err) , }
 
-) ? . clone () . unwrap ()) , 3i8 => AffixFuzzer4 :: ManyOptional (many_optional . get (offset as usize) . ok_or (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : many_optional . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
+) ; }
+
+ many_required . get (offset as usize) . unwrap () . clone () . unwrap () }
+
+) , 3i8 => AffixFuzzer4 :: ManyOptional ({ if offset as usize >= many_optional . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : many_optional . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
 
 ) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.testing.datatypes.AffixFuzzer4#many_optional" . into () , source : Box :: new (err) , }
 
-) ? . clone ()) , _ => unreachable ! () , }
+) ; }
+
+ many_optional . get (offset as usize) . unwrap () . clone () }
+
+) , _ => unreachable ! () , }
 
 )) }
 

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -746,7 +746,7 @@ fn quote_trait_impls_from_obj(
                 impl crate::Loggable for #name {
                     type Name = crate::#kind_name;
                     type Item<'a> = Option<Self>;
-                    type Iter<'a> = Box<dyn Iterator<Item = Self::Item<'a>> + 'a>;
+                    type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
 
                     #[inline]
                     fn name() -> Self::Name {
@@ -792,7 +792,7 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Sized,
                     {
-                        Ok(Box::new(Self::try_from_arrow_opt(data)?.into_iter()))
+                        Ok(Self::try_from_arrow_opt(data)?.into_iter())
                     }
 
                     #[inline]

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -2171,9 +2171,10 @@ fn quote_arrow_deserializer(
                                     source: Box::new(err),
                                 });
                             }
-                            #quoted_obj_field_name
-                                .get(offset as usize)
-                                .unwrap() // safe: checked above
+
+                            // Safety: all checked above.
+                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                            unsafe { #quoted_obj_field_name.get_unchecked(offset as usize) }
                                 .clone()
                                 #quoted_unwrap
                         })
@@ -2406,7 +2407,9 @@ fn quote_arrow_field_deserializer(
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
                                     });
                                 }
-                                let data = data.get(start as usize .. end as usize).unwrap(); // safe: checked above
+                                // Safety: all checked above.
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe { data.get_unchecked(start as usize .. end as usize) };
 
                                 let mut arr = [Default::default(); #length];
                                 arr.copy_from_slice(data);
@@ -2474,9 +2477,9 @@ fn quote_arrow_field_deserializer(
                                         backtrace: ::backtrace::Backtrace::new_unresolved(),
                                     });
                                 }
-                                let data = data.get(start as usize .. end as usize)
-                                    .unwrap() // safe: checked above
-                                    .to_vec();
+                                // Safety: all checked above.
+                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                let data = unsafe { data.get_unchecked(start as usize .. end as usize).to_vec() };
 
                                 Ok(data)
                             }).transpose()

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -2411,8 +2411,7 @@ fn quote_arrow_field_deserializer(
                                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                 let data = unsafe { data.get_unchecked(start as usize .. end as usize) };
 
-                                let mut arr = [Default::default(); #length];
-                                arr.copy_from_slice(data);
+                                let arr = array_init::from_iter(data.iter().copied()).unwrap(); // safe: checked above
 
                                 Ok(arr)
                             }).transpose()


### PR DESCRIPTION
For some reason, `rustc` is completely choking on some of the boundchecks in the deserialization routines.

Have a look commit by commit to see the evolution of benchmarks for each change.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2945) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2945)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fmajor_perf_boundchecks/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fmajor_perf_boundchecks/examples)