### PR TITLE
C++ annotation context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,5 +79,6 @@
         "--config",
         "rerun_py/pyproject.toml"
     ],
-    "cmake.buildDirectory" : "${workspaceRoot}/build/"
+    "cmake.buildDirectory": "${workspaceRoot}/build/",
+    "C_Cpp.autoAddFileAssociations": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,4 +79,5 @@
         "--config",
         "rerun_py/pyproject.toml"
     ],
+    "cmake.buildDirectory" : "${workspaceRoot}/build/"
 }

--- a/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
@@ -26,6 +26,12 @@ namespace rerun.archetypes;
 /// \rs ```ignore
 /// \rs \include:../../../../../docs/code-examples/annotation_context_rects.rs
 /// \rs ```
+///
+/// \cpp ## Example
+/// \cpp
+/// \cpp ```
+/// \cpp \include:../../../../../docs/code-examples/annotation_context_arrows_v2.cpp
+/// \cpp ```
 table AnnotationContext (
   "attr.rust.derive": "Eq, PartialEq",
   order: 100

--- a/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
@@ -30,6 +30,7 @@ namespace rerun.archetypes;
 /// \cpp ## Example
 /// \cpp
 /// \cpp ```
+//  \cpp TODO(#2786): implement Rect2D cpp example and link it here instead.
 /// \cpp \include:../../../../../docs/code-examples/annotation_context_arrows_v2.cpp
 /// \cpp ```
 table AnnotationContext (

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-832873ee2d02a0e2fdd611c6846a4ddfd60da5ae44d0cc4059bc3b73c6985013
+532ee926f55626d7536c92551b6ffebc4e0b5bf57e6a0da09b4c1145492859d1

--- a/docs/code-examples/annotation_context_arrows_v2.cpp
+++ b/docs/code-examples/annotation_context_arrows_v2.cpp
@@ -1,0 +1,25 @@
+// Log an annotation context to assign a label and color to each class
+
+#include <rerun.hpp>
+
+namespace rr = rerun;
+
+int main() {
+    auto rr_stream = rr::RecordingStream("annotation_context_rects");
+    rr_stream.connect("127.0.0.1:9876");
+
+    // Log an annotation context to assign a label and color to each class
+    rr_stream.log(
+        "/",
+        rr::archetypes::AnnotationContext({
+            rr::datatypes::AnnotationInfo(1, "red", rr::components::Color(255, 0, 0)),
+            rr::datatypes::AnnotationInfo(2, "green", rr::components::Color(0, 255, 0)),
+        })
+    );
+
+    // Log a batch of 2 arrows with different `class_ids`
+    rr_stream.log(
+        "arrows",
+        rr::archetypes::Arrows3D({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}).with_class_ids({1, 2})
+    );
+}

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -19,6 +19,37 @@ namespace rerun {
         ///`AnnotationContext`. We use the *first* annotation context we find in the
         /// path-hierarchy when searching up through the ancestors of a given entity
         /// path.
+        ///
+        /// ## Example
+        ///
+        ///```
+        ///// Log an annotation context to assign a label and color to each class
+        ///
+        /// #include <rerun.hpp>
+        ///
+        /// namespace rr = rerun;
+        ///
+        /// int main() {
+        ///    auto rr_stream = rr::RecordingStream("annotation_context_rects");
+        ///    rr_stream.connect("127.0.0.1:9876");
+        ///
+        ///    // Log an annotation context to assign a label and color to each class
+        ///    rr_stream.log(
+        ///        "/",
+        ///        rr::archetypes::AnnotationContext({
+        ///            rr::datatypes::AnnotationInfo(1, "red", rr::components::Color(255, 0, 0)),
+        ///            rr::datatypes::AnnotationInfo(2, "green", rr::components::Color(0, 255, 0)),
+        ///        })
+        ///    );
+        ///
+        ///    // Log a batch of 2 arrows with different `class_ids`
+        ///    rr_stream.log(
+        ///        "arrows",
+        ///        rr::archetypes::Arrows3D({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f,
+        ///        0.0f}}).with_class_ids({1, 2})
+        ///    );
+        /// }
+        ///```
         struct AnnotationContext {
             rerun::components::AnnotationContext context;
 

--- a/rerun_cpp/src/rerun/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer11.cpp
@@ -46,12 +46,12 @@ namespace rerun {
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_floats_optional.has_value()) {
+                    ARROW_RETURN_NOT_OK(builder->Append());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                         element.many_floats_optional.value().data(),
                         element.many_floats_optional.value().size(),
                         nullptr
                     ));
-                    ARROW_RETURN_NOT_OK(builder->Append());
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }

--- a/rerun_cpp/src/rerun/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer12.cpp
@@ -45,13 +45,13 @@ namespace rerun {
 
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(builder->Append());
                 for (auto item_idx = 0; item_idx < element.many_strings_required.size();
                      item_idx += 1) {
                     ARROW_RETURN_NOT_OK(
                         value_builder->Append(element.many_strings_required[item_idx])
                     );
                 }
-                ARROW_RETURN_NOT_OK(builder->Append());
             }
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer13.cpp
@@ -46,13 +46,13 @@ namespace rerun {
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_strings_optional.has_value()) {
+                    ARROW_RETURN_NOT_OK(builder->Append());
                     for (auto item_idx = 0; item_idx < element.many_strings_optional.value().size();
                          item_idx += 1) {
                         ARROW_RETURN_NOT_OK(
                             value_builder->Append(element.many_strings_optional.value()[item_idx])
                         );
                     }
-                    ARROW_RETURN_NOT_OK(builder->Append());
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }

--- a/rerun_cpp/src/rerun/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer16.cpp
@@ -48,12 +48,14 @@ namespace rerun {
 
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
-                    value_builder,
-                    element.many_required_unions.data(),
-                    element.many_required_unions.size()
-                ));
                 ARROW_RETURN_NOT_OK(builder->Append());
+                if (element.many_required_unions.data()) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                        value_builder,
+                        element.many_required_unions.data(),
+                        element.many_required_unions.size()
+                    ));
+                }
             }
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer17.cpp
@@ -49,12 +49,16 @@ namespace rerun {
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_optional_unions.has_value()) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
-                        value_builder,
-                        element.many_optional_unions.value().data(),
-                        element.many_optional_unions.value().size()
-                    ));
                     ARROW_RETURN_NOT_OK(builder->Append());
+                    if (element.many_optional_unions.value().data()) {
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                                value_builder,
+                                element.many_optional_unions.value().data(),
+                                element.many_optional_unions.value().size()
+                            )
+                        );
+                    }
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }

--- a/rerun_cpp/src/rerun/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer18.cpp
@@ -49,12 +49,16 @@ namespace rerun {
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_optional_unions.has_value()) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
-                        value_builder,
-                        element.many_optional_unions.value().data(),
-                        element.many_optional_unions.value().size()
-                    ));
                     ARROW_RETURN_NOT_OK(builder->Append());
+                    if (element.many_optional_unions.value().data()) {
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
+                                value_builder,
+                                element.many_optional_unions.value().data(),
+                                element.many_optional_unions.value().size()
+                            )
+                        );
+                    }
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }

--- a/rerun_cpp/src/rerun/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer7.cpp
@@ -49,12 +49,16 @@ namespace rerun {
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_optional.has_value()) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
-                        value_builder,
-                        element.many_optional.value().data(),
-                        element.many_optional.value().size()
-                    ));
                     ARROW_RETURN_NOT_OK(builder->Append());
+                    if (element.many_optional.value().data()) {
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+                                value_builder,
+                                element.many_optional.value().data(),
+                                element.many_optional.value().size()
+                            )
+                        );
+                    }
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -50,14 +50,16 @@ namespace rerun {
 
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(
-                    rerun::datatypes::ClassDescriptionMapElem::fill_arrow_array_builder(
-                        value_builder,
-                        element.class_map.data(),
-                        element.class_map.size()
-                    )
-                );
                 ARROW_RETURN_NOT_OK(builder->Append());
+                if (element.class_map.data()) {
+                    ARROW_RETURN_NOT_OK(
+                        rerun::datatypes::ClassDescriptionMapElem::fill_arrow_array_builder(
+                            value_builder,
+                            element.class_map.data(),
+                            element.class_map.size()
+                        )
+                    );
+                }
             }
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -27,6 +27,18 @@ namespace rerun {
             static const char* NAME;
 
           public:
+            // Extensions to generated type defined in 'annotation_context_ext.cpp'
+
+            AnnotationContext(
+                std::initializer_list<rerun::datatypes::ClassDescription> class_descriptions
+            ) {
+                class_map.reserve(class_descriptions.size());
+                for (const auto& class_description : class_descriptions) {
+                    class_map.emplace_back(std::move(class_description));
+                }
+            }
+
+          public:
             AnnotationContext() = default;
 
             AnnotationContext(std::vector<rerun::datatypes::ClassDescriptionMapElem> _class_map)

--- a/rerun_cpp/src/rerun/components/annotation_context_ext.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context_ext.cpp
@@ -1,0 +1,31 @@
+#include <utility>
+#include "annotation_context.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+#ifdef EDIT_EXTENSION
+        struct AnnotationContextExt {
+            std::vector<rerun::datatypes::ClassDescriptionMapElem> class_map;
+
+#define AnnotationContext AnnotationContextExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            AnnotationContext(
+                std::initializer_list<rerun::datatypes::ClassDescription> class_descriptions
+            ) {
+                class_map.reserve(class_descriptions.size());
+                for (const auto& class_description : class_descriptions) {
+                    class_map.emplace_back(std::move(class_description));
+                }
+            }
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -49,12 +49,14 @@ namespace rerun {
 
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
-                    value_builder,
-                    element.points.data(),
-                    element.points.size()
-                ));
                 ARROW_RETURN_NOT_OK(builder->Append());
+                if (element.points.data()) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+                        value_builder,
+                        element.points.data(),
+                        element.points.size()
+                    ));
+                }
             }
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -49,12 +49,14 @@ namespace rerun {
 
             for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
-                    value_builder,
-                    element.points.data(),
-                    element.points.size()
-                ));
                 ARROW_RETURN_NOT_OK(builder->Append());
+                if (element.points.data()) {
+                    ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                        value_builder,
+                        element.points.data(),
+                        element.points.size()
+                    ));
+                }
             }
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.cpp
@@ -131,12 +131,12 @@ namespace rerun {
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.many_floats_optional.has_value()) {
+                        ARROW_RETURN_NOT_OK(field_builder->Append());
                         ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                             element.many_floats_optional.value().data(),
                             element.many_floats_optional.value().size(),
                             nullptr
                         ));
-                        ARROW_RETURN_NOT_OK(field_builder->Append());
                     } else {
                         ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                     }
@@ -151,13 +151,13 @@ namespace rerun {
 
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
+                    ARROW_RETURN_NOT_OK(field_builder->Append());
                     for (auto item_idx = 0; item_idx < element.many_strings_required.size();
                          item_idx += 1) {
                         ARROW_RETURN_NOT_OK(
                             value_builder->Append(element.many_strings_required[item_idx])
                         );
                     }
-                    ARROW_RETURN_NOT_OK(field_builder->Append());
                 }
             }
             {
@@ -170,6 +170,7 @@ namespace rerun {
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.many_strings_optional.has_value()) {
+                        ARROW_RETURN_NOT_OK(field_builder->Append());
                         for (auto item_idx = 0;
                              item_idx < element.many_strings_optional.value().size();
                              item_idx += 1) {
@@ -177,7 +178,6 @@ namespace rerun {
                                 element.many_strings_optional.value()[item_idx]
                             ));
                         }
-                        ARROW_RETURN_NOT_OK(field_builder->Append());
                     } else {
                         ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                     }

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -9,6 +9,7 @@
 #include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <utility>
 
 namespace rerun {
     namespace datatypes {
@@ -25,6 +26,18 @@ namespace rerun {
 
             /// The color that will be applied to the annotated entity.
             std::optional<rerun::components::Color> color;
+
+          public:
+            // Extensions to generated type defined in 'annotation_info_ext.cpp'
+
+            AnnotationInfo(
+                uint16_t _id, std::optional<std::string> _label = std::nullopt,
+                std::optional<components::Color> _color = std::nullopt
+            )
+                : id(_id), label(std::move(_label)), color(_color) {}
+
+            AnnotationInfo(uint16_t _id, components::Color _color)
+                : id(_id), label(std::nullopt), color(_color) {}
 
           public:
             AnnotationInfo() = default;

--- a/rerun_cpp/src/rerun/datatypes/annotation_info_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info_ext.cpp
@@ -1,0 +1,44 @@
+#include <utility>
+#include "annotation_info.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct AnnotationInfoExt {
+            uint16_t id;
+            std::optional<components::Label> label;
+            std::optional<components::Color> color;
+
+#define AnnotationInfo AnnotationInfoExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            AnnotationInfo(
+                uint16_t _id, std::optional<std::string> _label = std::nullopt,
+                std::optional<components::Color> _color = std::nullopt
+            )
+                : id(_id), label(std::move(_label)), color(_color) {}
+
+            AnnotationInfo(uint16_t _id, components::Color _color)
+                : id(_id), label(std::nullopt), color(_color) {}
+
+            AnnotationInfo(std::pair<uint16_t, std::string> id_and_label)
+                : id(id_and_label.first),
+                  label(std::move(id_and_label.second)),
+                  color(std::nullopt) {}
+
+            AnnotationInfo(std::pair<uint16_t, components::Color> id_and_color)
+                : id(id_and_color.first),
+                  label(std::nullopt),
+                  color(std::move(id_and_color.second)) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/annotation_info_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info_ext.cpp
@@ -26,16 +26,6 @@ namespace rerun {
             AnnotationInfo(uint16_t _id, components::Color _color)
                 : id(_id), label(std::nullopt), color(_color) {}
 
-            AnnotationInfo(std::pair<uint16_t, std::string> id_and_label)
-                : id(id_and_label.first),
-                  label(std::move(id_and_label.second)),
-                  color(std::nullopt) {}
-
-            AnnotationInfo(std::pair<uint16_t, components::Color> id_and_color)
-                : id(id_and_color.first),
-                  label(std::nullopt),
-                  color(std::move(id_and_color.second)) {}
-
             // [CODEGEN COPY TO HEADER END]
         };
 #endif

--- a/rerun_cpp/src/rerun/datatypes/class_description.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.cpp
@@ -91,12 +91,16 @@ namespace rerun {
 
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
-                        value_builder,
-                        element.keypoint_annotations.data(),
-                        element.keypoint_annotations.size()
-                    ));
                     ARROW_RETURN_NOT_OK(field_builder->Append());
+                    if (element.keypoint_annotations.data()) {
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
+                                value_builder,
+                                element.keypoint_annotations.data(),
+                                element.keypoint_annotations.size()
+                            )
+                        );
+                    }
                 }
             }
             {
@@ -108,12 +112,16 @@ namespace rerun {
 
                 for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointPair::fill_arrow_array_builder(
-                        value_builder,
-                        element.keypoint_connections.data(),
-                        element.keypoint_connections.size()
-                    ));
                     ARROW_RETURN_NOT_OK(field_builder->Append());
+                    if (element.keypoint_connections.data()) {
+                        ARROW_RETURN_NOT_OK(
+                            rerun::datatypes::KeypointPair::fill_arrow_array_builder(
+                                value_builder,
+                                element.keypoint_connections.data(),
+                                element.keypoint_connections.size()
+                            )
+                        );
+                    }
                 }
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -37,6 +37,17 @@ namespace rerun {
             std::vector<rerun::datatypes::KeypointPair> keypoint_connections;
 
           public:
+            // Extensions to generated type defined in 'class_description_ext.cpp'
+
+            ClassDescription(
+                AnnotationInfo _info, std::vector<AnnotationInfo> _keypoint_annotations = {},
+                std::vector<KeypointPair> _keypoint_connections = {}
+            )
+                : info(std::move(_info)),
+                  keypoint_annotations(std::move(_keypoint_annotations)),
+                  keypoint_connections(std::move(_keypoint_connections)) {}
+
+          public:
             ClassDescription() = default;
 
             /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/class_description_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_ext.cpp
@@ -1,0 +1,32 @@
+#include "class_description.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct ClassDescriptionExt {
+            AnnotationInfo info;
+            std::vector<AnnotationInfo> keypoint_annotations;
+            std::vector<KeypointPair> keypoint_connections;
+
+#define ClassDescription ClassDescriptionExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            ClassDescription(
+                AnnotationInfo _info, std::vector<AnnotationInfo> _keypoint_annotations = {},
+                std::vector<KeypointPair> _keypoint_connections = {}
+            )
+                : info(std::move(_info)),
+                  keypoint_annotations(std::move(_keypoint_annotations)),
+                  keypoint_connections(std::move(_keypoint_connections)) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -8,6 +8,7 @@
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
+#include <utility>
 
 namespace rerun {
     namespace datatypes {
@@ -18,6 +19,13 @@ namespace rerun {
             rerun::components::ClassId class_id;
 
             rerun::datatypes::ClassDescription class_description;
+
+          public:
+            // Extensions to generated type defined in 'class_description_map_elem_ext.cpp'
+
+            ClassDescriptionMapElem(ClassDescription _class_description)
+                : class_id(_class_description.info.id),
+                  class_description(std::move(_class_description)) {}
 
           public:
             ClassDescriptionMapElem() = default;

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem_ext.cpp
@@ -1,0 +1,28 @@
+#include <utility>
+#include "class_description_map_elem.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct ClassDescriptionMapElemExt {
+            components::ClassId class_id;
+            ClassDescription class_description;
+
+#define ClassDescriptionMapElem ClassDescriptionMapElemExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            ClassDescriptionMapElem(ClassDescription _class_description)
+                : class_id(_class_description.info.id),
+                  class_description(std::move(_class_description)) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+#endif
+
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -7,6 +7,7 @@
 
 #include <arrow/type_fwd.h>
 #include <cstdint>
+#include <utility>
 
 namespace rerun {
     namespace datatypes {
@@ -15,6 +16,15 @@ namespace rerun {
             rerun::components::KeypointId keypoint0;
 
             rerun::components::KeypointId keypoint1;
+
+          public:
+            // Extensions to generated type defined in 'keypoint_pair_ext.cpp'
+
+            KeypointPair(uint16_t _keypoint0, uint16_t _keypoint1)
+                : keypoint0(_keypoint0), keypoint1(_keypoint1) {}
+
+            KeypointPair(std::pair<uint16_t, uint16_t> pair)
+                : keypoint0(pair.first), keypoint1(pair.second) {}
 
           public:
             KeypointPair() = default;

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair_ext.cpp
@@ -1,0 +1,30 @@
+#include <utility>
+#include "keypoint_pair.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct KeypointPairExt {
+            rerun::components::KeypointId keypoint0;
+            rerun::components::KeypointId keypoint1;
+
+#define KeypointPair KeypointPairExt
+
+            // [CODEGEN COPY TO HEADER START]
+
+            KeypointPair(uint16_t _keypoint0, uint16_t _keypoint1)
+                : keypoint0(_keypoint0), keypoint1(_keypoint1) {}
+
+            KeypointPair(std::pair<uint16_t, uint16_t> pair)
+                : keypoint0(pair.first), keypoint1(pair.second) {}
+
+            // [CODEGEN COPY TO HEADER END]
+        };
+
+#endif
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -39,11 +39,11 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
+            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
             static_assert(sizeof(elements[0].coeffs) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(
                 value_builder->AppendValues(elements[0].coeffs, num_elements * 9, nullptr)
             );
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -39,11 +39,11 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
+            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
             static_assert(sizeof(elements[0].coeffs) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(
                 value_builder->AppendValues(elements[0].coeffs, num_elements * 16, nullptr)
             );
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.cpp
@@ -38,11 +38,11 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
+            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
             static_assert(sizeof(elements[0].xyzw) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(
                 value_builder->AppendValues(elements[0].xyzw, num_elements * 4, nullptr)
             );
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.cpp
@@ -39,11 +39,11 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
+            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
             static_assert(sizeof(elements[0].xy) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(
                 value_builder->AppendValues(elements[0].xy, num_elements * 2, nullptr)
             );
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.cpp
@@ -39,11 +39,11 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
+            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
             static_assert(sizeof(elements[0].xyz) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(
                 value_builder->AppendValues(elements[0].xyz, num_elements * 3, nullptr)
             );
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.cpp
@@ -39,11 +39,11 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
+            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
             static_assert(sizeof(elements[0].xyzw) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(
                 value_builder->AppendValues(elements[0].xyzw, num_elements * 4, nullptr)
             );
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/tests/annotation_context.cpp
+++ b/rerun_cpp/tests/annotation_context.cpp
@@ -1,0 +1,86 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/annotation_context.hpp>
+
+namespace rr = rerun;
+using namespace rr::archetypes;
+
+#define TEST_TAG "[annotation_context]"
+
+SCENARIO(
+    "AnnotationContext archetype's class descriptions can be constructed in various ways and "
+    "serialized",
+    TEST_TAG
+) {
+    GIVEN("A annotation context created with various utilities and one manual step by step") {
+        rr::archetypes::AnnotationContext from_utilities({
+            rr::datatypes::ClassDescription({1, "hello"}),
+            rr::datatypes::ClassDescription(rr::datatypes::AnnotationInfo(1, "hello")),
+            rr::datatypes::ClassDescription(
+                {2, "world", rr::components::Color(3, 4, 5)},
+                {{17, "head"}, {42, "shoulders"}},
+                {
+                    {1, 2},
+                    {3, 4},
+                }
+            ),
+            rr::datatypes::ClassDescription(
+                rr::datatypes::AnnotationInfo(2, "world", rr::components::Color(3, 4, 5)),
+                {
+                    rr::datatypes::AnnotationInfo(17, "head"),
+                    rr::datatypes::AnnotationInfo(42, "shoulders"),
+                },
+                {
+                    std::pair<uint16_t, uint16_t>(1, 2),
+                    std::pair<uint16_t, uint16_t>(3, 4),
+                }
+            ),
+        });
+
+        AnnotationContext manual_archetype;
+        auto& class_map = manual_archetype.context.class_map;
+        {
+            rr::datatypes::ClassDescriptionMapElem element;
+            rr::datatypes::KeypointPair pair;
+            rr::datatypes::AnnotationInfo keypoint_annotation;
+
+            {
+                element.class_id = 1;
+                element.class_description.info.id = 1;
+                element.class_description.info.color = std::nullopt;
+                element.class_description.info.label = "hello";
+                class_map.push_back(element);
+                class_map.push_back(element);
+            }
+            {
+                element.class_id = 2;
+                element.class_description.info.id = 2;
+                element.class_description.info.color = rr::components::Color(3, 4, 5);
+                element.class_description.info.label = "world";
+
+                keypoint_annotation.id = 17;
+                keypoint_annotation.color = std::nullopt;
+                keypoint_annotation.label = "head";
+                element.class_description.keypoint_annotations.push_back(keypoint_annotation);
+
+                keypoint_annotation.id = 42;
+                keypoint_annotation.color = std::nullopt;
+                keypoint_annotation.label = "shoulders";
+                element.class_description.keypoint_annotations.push_back(keypoint_annotation);
+
+                pair.keypoint0 = 1;
+                pair.keypoint1 = 2;
+                element.class_description.keypoint_connections.push_back(pair);
+
+                pair.keypoint0 = 3;
+                pair.keypoint1 = 4;
+                element.class_description.keypoint_connections.push_back(pair);
+
+                class_map.push_back(element);
+                class_map.push_back(element);
+            }
+        }
+
+        test_serialization_for_manual_and_builder(from_utilities, manual_archetype);
+    }
+}

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -22,7 +22,6 @@ ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 
 # TODO(andreas): Remove these
 cpp_opt_out = [
-    "annotation_context",
     "line_strips2d",
     "line_strips3d",
     "points2d",

--- a/tests/cpp/roundtrips/annotation_context/main.cpp
+++ b/tests/cpp/roundtrips/annotation_context/main.cpp
@@ -4,7 +4,7 @@
 namespace rr = rerun;
 
 int main(int argc, char** argv) {
-    auto rec_stream = rr::RecordingStream("roundtrip_arrows3d");
+    auto rec_stream = rr::RecordingStream("roundtrip_annotation_context");
     rec_stream.save(argv[1]);
 
     rec_stream.log(

--- a/tests/cpp/roundtrips/annotation_context/main.cpp
+++ b/tests/cpp/roundtrips/annotation_context/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
         rr::archetypes::AnnotationContext({
             rr::datatypes::ClassDescription({1, "hello"}),
             rr::datatypes::ClassDescription(
-                {2, "world", rr::components::Color(2, 3, 5)},
+                {2, "world", rr::components::Color(3, 4, 5)},
                 {{17, "head"}, {42, "shoulders"}},
                 {
                     {1, 2},

--- a/tests/cpp/roundtrips/annotation_context/main.cpp
+++ b/tests/cpp/roundtrips/annotation_context/main.cpp
@@ -1,0 +1,24 @@
+#include <rerun/archetypes/annotation_context.hpp>
+#include <rerun/recording_stream.hpp>
+
+namespace rr = rerun;
+
+int main(int argc, char** argv) {
+    auto rec_stream = rr::RecordingStream("roundtrip_arrows3d");
+    rec_stream.save(argv[1]);
+
+    rec_stream.log(
+        "annotation_context",
+        rr::archetypes::AnnotationContext({
+            rr::datatypes::ClassDescription({1, "hello"}),
+            rr::datatypes::ClassDescription(
+                {2, "world", rr::components::Color(2, 3, 5)},
+                {{17, "head"}, {42, "shoulders"}},
+                {
+                    {1, 2},
+                    {3, 4},
+                }
+            ),
+        })
+    );
+}


### PR DESCRIPTION
### What


* Fixes #2794
* Part of #2919 

Small codegen fix for nested array serialization was required.
Adds example & test & roundtrip test for annotation context to C++

Sneaked in: Fixes a few annoyances with VSCode Cpp/CMake config.

<img width="1016" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/31a764bc-cb51-4420-a75f-0da0eb6bfd39">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2948) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2948)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fannotation-context/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fannotation-context/examples)