### PR TITLE
Use `prettyplease` to improve formatting of generated Rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -456,7 +456,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -473,7 +473,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -650,7 +650,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -831,7 +831,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1255,7 +1255,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1549,7 +1549,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1560,7 +1560,7 @@ checksum = "48016319042fb7c87b78d2993084a831793a897a5cd1a2a67cab9d1eeb4b7d76"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1887,7 +1887,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3595,6 +3595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3666,7 +3676,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
@@ -3798,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -4589,6 +4599,7 @@ dependencies = [
  "flatbuffers",
  "indent",
  "itertools 0.11.0",
+ "prettyplease 0.2.12",
  "proc-macro2",
  "quote",
  "rayon",
@@ -4596,7 +4607,7 @@ dependencies = [
  "re_log",
  "re_tracing",
  "rust-format",
- "syn 2.0.16",
+ "syn 2.0.28",
  "unindent",
  "xshell",
 ]
@@ -5244,7 +5255,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5266,7 +5277,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5538,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5654,7 +5665,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5792,7 +5803,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5880,7 +5891,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -6178,7 +6189,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -6244,7 +6255,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-196844751442706baa436dac75e5d43760838ec1355b4e170bd48aa9e2a74a30
+832873ee2d02a0e2fdd611c6846a4ddfd60da5ae44d0cc4059bc3b73c6985013

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -75,10 +75,13 @@ pub struct AnnotationContext {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.annotation_context".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.annotation_context".into()]);
 

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -80,8 +80,10 @@ pub struct Arrows3D {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.Vector3D".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.Origin3D".into()]);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
@@ -92,6 +94,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]
             "rerun.instance_key".into(),
         ]
     });
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -56,10 +56,13 @@ pub struct DisconnectedSpace {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.disconnected_space".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.disconnected_space".into()]);
 

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -112,8 +112,10 @@ pub struct LineStrips2D {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.linestrip2d".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
@@ -123,6 +125,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]
             "rerun.instance_key".into(),
         ]
     });
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -107,8 +107,10 @@ pub struct LineStrips3D {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.linestrip3d".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
@@ -117,6 +119,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]
             "rerun.instance_key".into(),
         ]
     });
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -80,8 +80,10 @@ pub struct Points2D {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.point2d".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
@@ -92,6 +94,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]
             "rerun.instance_key".into(),
         ]
     });
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -65,8 +65,10 @@ pub struct Points3D {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.point3d".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
@@ -76,6 +78,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]
             "rerun.instance_key".into(),
         ]
     });
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -74,10 +74,13 @@ pub struct Transform3D {
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.transform3d".into()]);
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.transform3d".into()]);
 

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -48,6 +48,7 @@ impl crate::Loggable for AnnotationContext {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.annotation_context".into()
@@ -108,13 +109,38 @@ impl crate::Loggable for AnnotationContext {
                 )
                 .unwrap()
                 .into();
-                ListArray :: new ({ _ = extension_wrapper ; DataType :: Extension ("rerun.components.AnnotationContext" . to_owned () , Box :: new (DataType :: List (Box :: new (Field { name : "item" . to_owned () , data_type : < crate :: datatypes :: ClassDescriptionMapElem > :: to_arrow_datatype () , is_nullable : false , metadata : [] . into () , }
-
-))) , None) . to_logical_type () . clone () }
-
- , offsets , { _ = data0_inner_bitmap ; _ = extension_wrapper ; crate :: datatypes :: ClassDescriptionMapElem :: try_to_arrow_opt (data0_inner_data , Some ("rerun.components.AnnotationContext")) ? }
-
- , data0_bitmap ,) . boxed ()
+                ListArray::new(
+                        {
+                            _ = extension_wrapper;
+                            DataType::Extension(
+                                    "rerun.components.AnnotationContext".to_owned(),
+                                    Box::new(
+                                        DataType::List(
+                                            Box::new(Field {
+                                                name: "item".to_owned(),
+                                                data_type: <crate::datatypes::ClassDescriptionMapElem>::to_arrow_datatype(),
+                                                is_nullable: false,
+                                                metadata: [].into(),
+                                            }),
+                                        ),
+                                    ),
+                                    None,
+                                )
+                                .to_logical_type()
+                                .clone()
+                        },
+                        offsets,
+                        {
+                            _ = data0_inner_bitmap;
+                            _ = extension_wrapper;
+                            crate::datatypes::ClassDescriptionMapElem::try_to_arrow_opt(
+                                data0_inner_data,
+                                Some("rerun.components.AnnotationContext"),
+                            )?
+                        },
+                        data0_bitmap,
+                    )
+                    .boxed()
             }
         })
     }

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -37,6 +37,7 @@ impl crate::Loggable for ClassId {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.class_id".into()

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -46,6 +46,7 @@ impl crate::Loggable for Color {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.colorrgba".into()

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -38,6 +38,7 @@ impl crate::Loggable for DisconnectedSpace {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.disconnected_space".into()

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -41,6 +41,7 @@ impl crate::Loggable for DrawOrder {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.draw_order".into()

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -35,6 +35,7 @@ impl crate::Loggable for InstanceKey {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.instance_key".into()

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -39,6 +39,7 @@ impl crate::Loggable for KeypointId {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.keypoint_id".into()

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -35,6 +35,7 @@ impl crate::Loggable for Label {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.label".into()
@@ -83,6 +84,7 @@ impl crate::Loggable for Label {
                 )
                 .unwrap()
                 .into();
+
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {
                     Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -51,6 +51,7 @@ impl crate::Loggable for LineStrip2D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.linestrip2d".into()

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -51,6 +51,7 @@ impl crate::Loggable for LineStrip3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.linestrip3d".into()

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -40,6 +40,7 @@ impl crate::Loggable for Origin3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.components.Origin3D".into()

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -40,6 +40,7 @@ impl crate::Loggable for Point2D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.point2d".into()

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -40,6 +40,7 @@ impl crate::Loggable for Point3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.point3d".into()

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Radius {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.radius".into()

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -43,6 +43,7 @@ impl crate::Loggable for Transform3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.transform3d".into()

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -40,6 +40,7 @@ impl crate::Loggable for Vector3D {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.components.Vector3D".into()

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -37,6 +37,7 @@ impl crate::Loggable for Angle {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Angle".into()
@@ -176,13 +177,11 @@ impl crate::Loggable for Angle {
                                 nulls_offset += 1;
                                 offset
                             }
-
                             Some(Angle::Radians(_)) => {
                                 let offset = radians_offset;
                                 radians_offset += 1;
                                 offset
                             }
-
                             Some(Angle::Degrees(_)) => {
                                 let offset = degrees_offset;
                                 degrees_offset += 1;
@@ -225,7 +224,6 @@ impl crate::Loggable for Angle {
                     (data.types(), data.fields(), data.offsets().unwrap());
                 let radians = {
                     let data = &*data_arrays[1usize];
-
                     data.as_any()
                         .downcast_ref::<Float32Array>()
                         .unwrap()
@@ -235,7 +233,6 @@ impl crate::Loggable for Angle {
                 };
                 let degrees = {
                     let data = &*data_arrays[2usize];
-
                     data.as_any()
                         .downcast_ref::<Float32Array>()
                         .unwrap()
@@ -248,7 +245,6 @@ impl crate::Loggable for Angle {
                     .enumerate()
                     .map(|(i, typ)| {
                         let offset = data_offsets[i];
-
                         if *typ == 0 {
                             Ok(None)
                         } else {

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -46,6 +46,7 @@ impl crate::Loggable for AnnotationInfo {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.AnnotationInfo".into()
@@ -176,6 +177,7 @@ impl crate::Loggable for AnnotationInfo {
                             )
                             .unwrap()
                             .into();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
@@ -271,7 +273,6 @@ impl crate::Loggable for AnnotationInfo {
                     .collect();
                 let id = {
                     let data = &**arrays_by_name["id"];
-
                     data.as_any()
                         .downcast_ref::<UInt16Array>()
                         .unwrap()
@@ -280,7 +281,6 @@ impl crate::Loggable for AnnotationInfo {
                 };
                 let label = {
                     let data = &**arrays_by_name["label"];
-
                     {
                         let downcast = data.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
                         let offsets = downcast.offsets();
@@ -294,7 +294,6 @@ impl crate::Loggable for AnnotationInfo {
                 };
                 let color = {
                     let data = &**arrays_by_name["color"];
-
                     data.as_any()
                         .downcast_ref::<UInt32Array>()
                         .unwrap()

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -56,6 +56,7 @@ impl crate::Loggable for ClassDescription {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.ClassDescription".into()
@@ -323,7 +324,6 @@ impl crate::Loggable for ClassDescription {
                     .collect();
                 let info = {
                     let data = &**arrays_by_name["info"];
-
                     crate::datatypes::AnnotationInfo::try_from_arrow_opt(data)
                         .map_err(|err| crate::DeserializationError::Context {
                             location: "rerun.datatypes.ClassDescription#info".into(),
@@ -333,79 +333,163 @@ impl crate::Loggable for ClassDescription {
                 };
                 let keypoint_annotations = {
                     let data = &**arrays_by_name["keypoint_annotations"];
-
                     {
                         let data = data
                             .as_any()
                             .downcast_ref::<::arrow2::array::ListArray<i32>>()
                             .unwrap();
-                        if data . is_empty () { Vec :: new () }
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = crate::datatypes::AnnotationInfo::try_from_arrow_opt(
+                                    data,
+                                )
+                                .map_err(|err| crate::DeserializationError::Context {
+                                    location: "rerun.datatypes.ClassDescription#keypoint_annotations"
+                                        .into(),
+                                    source: Box::new(err),
+                                })?
+                                .into_iter()
+                                .map(|v| {
+                                    v
+                                        .ok_or_else(|| crate::DeserializationError::MissingData {
+                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                        })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            if end as usize > data.len() {
+                                                return Err(crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                });
+                                            }
 
- else { let bitmap = data . validity () . cloned () ; let offsets = { let offsets = data . offsets () ; offsets . iter () . copied () . zip (offsets . iter () . copied () . skip (1)) }
-
- ; let data = & * * data . values () ; let data = crate :: datatypes :: AnnotationInfo :: try_from_arrow_opt (data) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescription#keypoint_annotations" . into () , source : Box :: new (err) , }
-
-) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
-
- ; Ok (data) }
-
-) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
-
- . into_iter ()
+                                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                            let data = unsafe {
+                                                data.get_unchecked(start as usize..end as usize).to_vec()
+                                            };
+                                            Ok(data)
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                            .into_iter()
                     }
                 };
                 let keypoint_connections = {
                     let data = &**arrays_by_name["keypoint_connections"];
-
                     {
                         let data = data
                             .as_any()
                             .downcast_ref::<::arrow2::array::ListArray<i32>>()
                             .unwrap();
-                        if data . is_empty () { Vec :: new () }
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = {
+                                let offsets = data.offsets();
+                                offsets.iter().copied().zip(offsets.iter().copied().skip(1))
+                            };
+                            let data = &**data.values();
+                            let data = crate::datatypes::KeypointPair::try_from_arrow_opt(
+                                    data,
+                                )
+                                .map_err(|err| crate::DeserializationError::Context {
+                                    location: "rerun.datatypes.ClassDescription#keypoint_connections"
+                                        .into(),
+                                    source: Box::new(err),
+                                })?
+                                .into_iter()
+                                .map(|v| {
+                                    v
+                                        .ok_or_else(|| crate::DeserializationError::MissingData {
+                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                        })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            if end as usize > data.len() {
+                                                return Err(crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                });
+                                            }
 
- else { let bitmap = data . validity () . cloned () ; let offsets = { let offsets = data . offsets () ; offsets . iter () . copied () . zip (offsets . iter () . copied () . skip (1)) }
-
- ; let data = & * * data . values () ; let data = crate :: datatypes :: KeypointPair :: try_from_arrow_opt (data) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescription#keypoint_connections" . into () , source : Box :: new (err) , }
-
-) ? . into_iter () . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) . to_vec () }
-
- ; Ok (data) }
-
-) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
-
- . into_iter ()
+                                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                            let data = unsafe {
+                                                data.get_unchecked(start as usize..end as usize).to_vec()
+                                            };
+                                            Ok(data)
+                                        })
+                                        .transpose()
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                            .into_iter()
                     }
                 };
-                :: itertools :: izip ! (info , keypoint_annotations , keypoint_connections) . enumerate () . map (| (i , (info , keypoint_annotations , keypoint_connections)) | is_valid (i) . then (|| Ok (Self { info : info . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescription#info" . into () , source : Box :: new (err) , }
-
-) ? , keypoint_annotations : keypoint_annotations . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescription#keypoint_annotations" . into () , source : Box :: new (err) , }
-
-) ? , keypoint_connections : keypoint_connections . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescription#keypoint_connections" . into () , source : Box :: new (err) , }
-
-) ? , }
-
-)) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < _ >> > () . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescription" . into () , source : Box :: new (err) , }
-
-) ?
+                ::itertools::izip!(info, keypoint_annotations, keypoint_connections)
+                    .enumerate()
+                    .map(|(i, (info, keypoint_annotations, keypoint_connections))| {
+                        is_valid(i)
+                            .then(|| Ok(Self {
+                                info: info
+                                    .ok_or_else(|| crate::DeserializationError::MissingData {
+                                        backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                    })
+                                    .map_err(|err| crate::DeserializationError::Context {
+                                        location: "rerun.datatypes.ClassDescription#info".into(),
+                                        source: Box::new(err),
+                                    })?,
+                                keypoint_annotations: keypoint_annotations
+                                    .ok_or_else(|| crate::DeserializationError::MissingData {
+                                        backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                    })
+                                    .map_err(|err| crate::DeserializationError::Context {
+                                        location: "rerun.datatypes.ClassDescription#keypoint_annotations"
+                                            .into(),
+                                        source: Box::new(err),
+                                    })?,
+                                keypoint_connections: keypoint_connections
+                                    .ok_or_else(|| crate::DeserializationError::MissingData {
+                                        backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                    })
+                                    .map_err(|err| crate::DeserializationError::Context {
+                                        location: "rerun.datatypes.ClassDescription#keypoint_connections"
+                                            .into(),
+                                        source: Box::new(err),
+                                    })?,
+                            }))
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()
+                    .map_err(|err| crate::DeserializationError::Context {
+                        location: "rerun.datatypes.ClassDescription".into(),
+                        source: Box::new(err),
+                    })?
             }
         })
     }

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -39,6 +39,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.ClassDescriptionMapElem".into()
@@ -202,7 +203,6 @@ impl crate::Loggable for ClassDescriptionMapElem {
                     .collect();
                 let class_id = {
                     let data = &**arrays_by_name["class_id"];
-
                     data.as_any()
                         .downcast_ref::<UInt16Array>()
                         .unwrap()
@@ -211,7 +211,6 @@ impl crate::Loggable for ClassDescriptionMapElem {
                 };
                 let class_description = {
                     let data = &**arrays_by_name["class_description"];
-
                     crate::datatypes::ClassDescription::try_from_arrow_opt(data)
                         .map_err(|err| crate::DeserializationError::Context {
                             location: "rerun.datatypes.ClassDescriptionMapElem#class_description"
@@ -220,19 +219,37 @@ impl crate::Loggable for ClassDescriptionMapElem {
                         })?
                         .into_iter()
                 };
-                :: itertools :: izip ! (class_id , class_description) . enumerate () . map (| (i , (class_id , class_description)) | is_valid (i) . then (|| Ok (Self { class_id : class_id . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescriptionMapElem#class_id" . into () , source : Box :: new (err) , }
-
-) ? , class_description : class_description . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescriptionMapElem#class_description" . into () , source : Box :: new (err) , }
-
-) ? , }
-
-)) . transpose ()) . collect :: < crate :: DeserializationResult < Vec < _ >> > () . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.ClassDescriptionMapElem" . into () , source : Box :: new (err) , }
-
-) ?
+                ::itertools::izip!(class_id, class_description)
+                    .enumerate()
+                    .map(|(i, (class_id, class_description))| {
+                        is_valid(i)
+                            .then(|| Ok(Self {
+                                class_id: class_id
+                                    .ok_or_else(|| crate::DeserializationError::MissingData {
+                                        backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                    })
+                                    .map_err(|err| crate::DeserializationError::Context {
+                                        location: "rerun.datatypes.ClassDescriptionMapElem#class_id"
+                                            .into(),
+                                        source: Box::new(err),
+                                    })?,
+                                class_description: class_description
+                                    .ok_or_else(|| crate::DeserializationError::MissingData {
+                                        backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                    })
+                                    .map_err(|err| crate::DeserializationError::Context {
+                                        location: "rerun.datatypes.ClassDescriptionMapElem#class_description"
+                                            .into(),
+                                        source: Box::new(err),
+                                    })?,
+                            }))
+                            .transpose()
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()
+                    .map_err(|err| crate::DeserializationError::Context {
+                        location: "rerun.datatypes.ClassDescriptionMapElem".into(),
+                        source: Box::new(err),
+                    })?
             }
         })
     }

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -37,6 +37,7 @@ impl crate::Loggable for KeypointPair {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.KeypointPair".into()
@@ -209,7 +210,6 @@ impl crate::Loggable for KeypointPair {
                     .collect();
                 let keypoint0 = {
                     let data = &**arrays_by_name["keypoint0"];
-
                     data.as_any()
                         .downcast_ref::<UInt16Array>()
                         .unwrap()
@@ -218,7 +218,6 @@ impl crate::Loggable for KeypointPair {
                 };
                 let keypoint1 = {
                     let data = &**arrays_by_name["keypoint1"];
-
                     data.as_any()
                         .downcast_ref::<UInt16Array>()
                         .unwrap()

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Mat3x3 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Mat3x3".into()

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Mat4x4 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Mat4x4".into()

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Quaternion {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Quaternion".into()

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -44,6 +44,7 @@ impl crate::Loggable for RotationAxisAngle {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.RotationAxisAngle".into()
@@ -230,32 +231,67 @@ impl crate::Loggable for RotationAxisAngle {
                     .collect();
                 let axis = {
                     let data = &**arrays_by_name["axis"];
-
                     {
                         let data = data
                             .as_any()
                             .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                             .unwrap();
-                        if data . is_empty () { Vec :: new () }
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = (0..)
+                                .step_by(3usize)
+                                .zip((3usize..).step_by(3usize).take(data.len()));
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Float32Array>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.copied())
+                                .map(|v| {
+                                    v
+                                        .ok_or_else(|| crate::DeserializationError::MissingData {
+                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                        })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            if end as usize > data.len() {
+                                                return Err(crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                });
+                                            }
 
- else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
-
- ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
-
-) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
-
- . into_iter ()
+                                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                            let data = unsafe {
+                                                data.get_unchecked(start as usize..end as usize)
+                                            };
+                                            let arr = array_init::from_iter(data.iter().copied())
+                                                .unwrap();
+                                            Ok(arr)
+                                        })
+                                        .transpose()
+                                })
+                                .map(|res| {
+                                    res.map(|opt| opt.map(|v| crate::datatypes::Vec3D(v)))
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                            .into_iter()
                     }
                 };
                 let angle = {
                     let data = &**arrays_by_name["angle"];
-
                     crate::datatypes::Angle::try_from_arrow_opt(data)
                         .map_err(|err| crate::DeserializationError::Context {
                             location: "rerun.datatypes.RotationAxisAngle#angle".into(),

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -40,6 +40,7 @@ impl crate::Loggable for Scale3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Scale3D".into()
@@ -217,13 +218,11 @@ impl crate::Loggable for Scale3D {
                                 nulls_offset += 1;
                                 offset
                             }
-
                             Some(Scale3D::ThreeD(_)) => {
                                 let offset = three_d_offset;
                                 three_d_offset += 1;
                                 offset
                             }
-
                             Some(Scale3D::Uniform(_)) => {
                                 let offset = uniform_offset;
                                 uniform_offset += 1;
@@ -266,28 +265,68 @@ impl crate::Loggable for Scale3D {
                     (data.types(), data.fields(), data.offsets().unwrap());
                 let three_d = {
                     let data = &*data_arrays[1usize];
+                    {
+                        let data = data
+                            .as_any()
+                            .downcast_ref::<::arrow2::array::FixedSizeListArray>()
+                            .unwrap();
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = (0..)
+                                .step_by(3usize)
+                                .zip((3usize..).step_by(3usize).take(data.len()));
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Float32Array>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.copied())
+                                .map(|v| {
+                                    v
+                                        .ok_or_else(|| crate::DeserializationError::MissingData {
+                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                        })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            if end as usize > data.len() {
+                                                return Err(crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                });
+                                            }
 
-                    { let data = data . as_any () . downcast_ref :: < :: arrow2 :: array :: FixedSizeListArray > () . unwrap () ; if data . is_empty () { Vec :: new () }
-
- else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
-
- ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
-
-) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
-
- . into_iter () }
-
- . collect :: < Vec < _ >> ()
+                                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                            let data = unsafe {
+                                                data.get_unchecked(start as usize..end as usize)
+                                            };
+                                            let arr = array_init::from_iter(data.iter().copied())
+                                                .unwrap();
+                                            Ok(arr)
+                                        })
+                                        .transpose()
+                                })
+                                .map(|res| {
+                                    res.map(|opt| opt.map(|v| crate::datatypes::Vec3D(v)))
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                            .into_iter()
+                    }
+                        .collect::<Vec<_>>()
                 };
                 let uniform = {
                     let data = &*data_arrays[2usize];
-
                     data.as_any()
                         .downcast_ref::<Float32Array>()
                         .unwrap()
@@ -300,7 +339,6 @@ impl crate::Loggable for Scale3D {
                     .enumerate()
                     .map(|(i, typ)| {
                         let offset = data_offsets[i];
-
                         if *typ == 0 {
                             Ok(None)
                         } else {

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -40,6 +40,7 @@ impl crate::Loggable for Transform3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Transform3D".into()
@@ -189,13 +190,11 @@ impl crate::Loggable for Transform3D {
                                 nulls_offset += 1;
                                 offset
                             }
-
                             Some(Transform3D::TranslationAndMat3X3(_)) => {
                                 let offset = translation_and_mat_3_x_3_offset;
                                 translation_and_mat_3_x_3_offset += 1;
                                 offset
                             }
-
                             Some(Transform3D::TranslationRotationScale(_)) => {
                                 let offset = translation_rotation_scale_offset;
                                 translation_rotation_scale_offset += 1;
@@ -238,7 +237,6 @@ impl crate::Loggable for Transform3D {
                     (data.types(), data.fields(), data.offsets().unwrap());
                 let translation_and_mat_3_x_3 = {
                     let data = &*data_arrays[1usize];
-
                     crate::datatypes::TranslationAndMat3x3::try_from_arrow_opt(data)
                         .map_err(|err| crate::DeserializationError::Context {
                             location: "rerun.datatypes.Transform3D#TranslationAndMat3x3".into(),
@@ -249,7 +247,6 @@ impl crate::Loggable for Transform3D {
                 };
                 let translation_rotation_scale = {
                     let data = &*data_arrays[2usize];
-
                     crate::datatypes::TranslationRotationScale3D::try_from_arrow_opt(data)
                         .map_err(|err| crate::DeserializationError::Context {
                             location: "rerun.datatypes.Transform3D#TranslationRotationScale".into(),
@@ -258,39 +255,74 @@ impl crate::Loggable for Transform3D {
                         .into_iter()
                         .collect::<Vec<_>>()
                 };
-                data_types . iter () . enumerate () . map (| (i , typ) | { let offset = data_offsets [i];
+                data_types
+                    .iter()
+                    .enumerate()
+                    .map(|(i, typ)| {
+                        let offset = data_offsets[i];
+                        if *typ == 0 {
+                            Ok(None)
+                        } else {
+                            Ok(
+                                Some(
+                                    match typ {
+                                        1i8 => {
+                                            Transform3D::TranslationAndMat3X3({
+                                                if offset as usize >= translation_and_mat_3_x_3.len() {
+                                                    return Err(crate::DeserializationError::OffsetsMismatch {
+                                                            bounds: (offset as usize, offset as usize),
+                                                            len: translation_and_mat_3_x_3.len(),
+                                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                        })
+                                                        .map_err(|err| crate::DeserializationError::Context {
+                                                            location: "rerun.datatypes.Transform3D#TranslationAndMat3x3"
+                                                                .into(),
+                                                            source: Box::new(err),
+                                                        });
+                                                }
 
- if * typ == 0 { Ok (None) }
+                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                                unsafe {
+                                                    translation_and_mat_3_x_3.get_unchecked(offset as usize)
+                                                }
+                                                    .clone()
+                                                    .unwrap()
+                                            })
+                                        }
+                                        2i8 => {
+                                            Transform3D::TranslationRotationScale({
+                                                if offset as usize >= translation_rotation_scale.len() {
+                                                    return Err(crate::DeserializationError::OffsetsMismatch {
+                                                            bounds: (offset as usize, offset as usize),
+                                                            len: translation_rotation_scale.len(),
+                                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                        })
+                                                        .map_err(|err| crate::DeserializationError::Context {
+                                                            location: "rerun.datatypes.Transform3D#TranslationRotationScale"
+                                                                .into(),
+                                                            source: Box::new(err),
+                                                        });
+                                                }
 
- else { Ok (Some (match typ { 1i8 => Transform3D :: TranslationAndMat3X3 ({ if offset as usize >= translation_and_mat_3_x_3 . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_and_mat_3_x_3 . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.Transform3D#TranslationAndMat3x3" . into () , source : Box :: new (err) , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { translation_and_mat_3_x_3 . get_unchecked (offset as usize) }
-
- . clone () . unwrap () }
-
-) , 2i8 => Transform3D :: TranslationRotationScale ({ if offset as usize >= translation_rotation_scale . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (offset as usize , offset as usize) , len : translation_rotation_scale . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.Transform3D#TranslationRotationScale" . into () , source : Box :: new (err) , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] unsafe { translation_rotation_scale . get_unchecked (offset as usize) }
-
- . clone () . unwrap () }
-
-) , _ => unreachable ! () , }
-
-)) }
-
- }
-
-) . collect :: < crate :: DeserializationResult < Vec < _ >> > () . map_err (| err | crate :: DeserializationError :: Context { location : "rerun.datatypes.Transform3D" . into () , source : Box :: new (err) , }
-
-) ?
+                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                                unsafe {
+                                                    translation_rotation_scale.get_unchecked(offset as usize)
+                                                }
+                                                    .clone()
+                                                    .unwrap()
+                                            })
+                                        }
+                                        _ => unreachable!(),
+                                    },
+                                ),
+                            )
+                        }
+                    })
+                    .collect::<crate::DeserializationResult<Vec<_>>>()
+                    .map_err(|err| crate::DeserializationError::Context {
+                        location: "rerun.datatypes.Transform3D".into(),
+                        source: Box::new(err),
+                    })?
             }
         })
     }

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -46,6 +46,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.TranslationAndMat3x3".into()
@@ -314,57 +315,128 @@ impl crate::Loggable for TranslationAndMat3x3 {
                     .collect();
                 let translation = {
                     let data = &**arrays_by_name["translation"];
-
                     {
                         let data = data
                             .as_any()
                             .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                             .unwrap();
-                        if data . is_empty () { Vec :: new () }
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = (0..)
+                                .step_by(3usize)
+                                .zip((3usize..).step_by(3usize).take(data.len()));
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Float32Array>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.copied())
+                                .map(|v| {
+                                    v
+                                        .ok_or_else(|| crate::DeserializationError::MissingData {
+                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                        })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            if end as usize > data.len() {
+                                                return Err(crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                });
+                                            }
 
- else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (3usize) . zip ((3usize ..) . step_by (3usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
-
- ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
-
-) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Vec3D (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
-
- . into_iter ()
+                                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                            let data = unsafe {
+                                                data.get_unchecked(start as usize..end as usize)
+                                            };
+                                            let arr = array_init::from_iter(data.iter().copied())
+                                                .unwrap();
+                                            Ok(arr)
+                                        })
+                                        .transpose()
+                                })
+                                .map(|res| {
+                                    res.map(|opt| opt.map(|v| crate::datatypes::Vec3D(v)))
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                            .into_iter()
                     }
                 };
                 let matrix = {
                     let data = &**arrays_by_name["matrix"];
-
                     {
                         let data = data
                             .as_any()
                             .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                             .unwrap();
-                        if data . is_empty () { Vec :: new () }
+                        if data.is_empty() {
+                            Vec::new()
+                        } else {
+                            let bitmap = data.validity().cloned();
+                            let offsets = (0..)
+                                .step_by(9usize)
+                                .zip((9usize..).step_by(9usize).take(data.len()));
+                            let data = &**data.values();
+                            let data = data
+                                .as_any()
+                                .downcast_ref::<Float32Array>()
+                                .unwrap()
+                                .into_iter()
+                                .map(|v| v.copied())
+                                .map(|v| {
+                                    v
+                                        .ok_or_else(|| crate::DeserializationError::MissingData {
+                                            backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                        })
+                                })
+                                .collect::<crate::DeserializationResult<Vec<_>>>()?;
+                            offsets
+                                .enumerate()
+                                .map(move |(i, (start, end))| {
+                                    bitmap
+                                        .as_ref()
+                                        .map_or(true, |bitmap| bitmap.get_bit(i))
+                                        .then(|| {
+                                            if end as usize > data.len() {
+                                                return Err(crate::DeserializationError::OffsetsMismatch {
+                                                    bounds: (start as usize, end as usize),
+                                                    len: data.len(),
+                                                    backtrace: ::backtrace::Backtrace::new_unresolved(),
+                                                });
+                                            }
 
- else { let bitmap = data . validity () . cloned () ; let offsets = (0 ..) . step_by (9usize) . zip ((9usize ..) . step_by (9usize) . take (data . len ())) ; let data = & * * data . values () ; let data = data . as_any () . downcast_ref :: < Float32Array > () . unwrap () . into_iter () . map (| v | v . copied ()) . map (| v | v . ok_or_else (|| crate :: DeserializationError :: MissingData { backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-)) . collect :: < crate :: DeserializationResult < Vec < _ >> > () ? ; offsets . enumerate () . map (move | (i , (start , end)) | bitmap . as_ref () . map_or (true , | bitmap | bitmap . get_bit (i)) . then (|| { if end as usize > data . len () { return Err (crate :: DeserializationError :: OffsetsMismatch { bounds : (start as usize , end as usize) , len : data . len () , backtrace : :: backtrace :: Backtrace :: new_unresolved () , }
-
-) ; }
-
- # [allow (unsafe_code , clippy :: undocumented_unsafe_blocks)] let data = unsafe { data . get_unchecked (start as usize .. end as usize) }
-
- ; let arr = array_init :: from_iter (data . iter () . copied ()) . unwrap () ; Ok (arr) }
-
-) . transpose ()) . map (| res | res . map (| opt | opt . map (| v | crate :: datatypes :: Mat3x3 (v)))) . collect :: < crate :: DeserializationResult < Vec < Option < _ >> >> () ? }
-
- . into_iter ()
+                                            #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                            let data = unsafe {
+                                                data.get_unchecked(start as usize..end as usize)
+                                            };
+                                            let arr = array_init::from_iter(data.iter().copied())
+                                                .unwrap();
+                                            Ok(arr)
+                                        })
+                                        .transpose()
+                                })
+                                .map(|res| {
+                                    res.map(|opt| opt.map(|v| crate::datatypes::Mat3x3(v)))
+                                })
+                                .collect::<crate::DeserializationResult<Vec<Option<_>>>>()?
+                        }
+                            .into_iter()
                     }
                 };
                 let from_parent = {
                     let data = &**arrays_by_name["from_parent"];
-
                     data.as_any()
                         .downcast_ref::<BooleanArray>()
                         .unwrap()

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Vec2D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Vec2D".into()

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Vec3D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Vec3D".into()

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for Vec4D {
     type Name = crate::DatatypeName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.datatypes.Vec4D".into()

--- a/crates/re_types/src/testing/archetypes/fuzzy.rs
+++ b/crates/re_types/src/testing/archetypes/fuzzy.rs
@@ -133,8 +133,10 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 38usize
             "rerun.testing.components.AffixFuzzer18".into(),
         ]
     });
+
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
+
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize]> =
     once_cell::sync::Lazy::new(|| {
         [
@@ -176,6 +178,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize
             "rerun.testing.components.AffixFuzzer18".into(),
         ]
     });
+
 static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 74usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -39,6 +39,7 @@ impl crate::Loggable for AffixFuzzer1 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer1".into()
@@ -233,6 +234,7 @@ impl crate::Loggable for AffixFuzzer2 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer2".into()
@@ -427,6 +429,7 @@ impl crate::Loggable for AffixFuzzer3 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer3".into()
@@ -621,6 +624,7 @@ impl crate::Loggable for AffixFuzzer4 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer4".into()
@@ -813,6 +817,7 @@ impl crate::Loggable for AffixFuzzer5 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer5".into()
@@ -1005,6 +1010,7 @@ impl crate::Loggable for AffixFuzzer6 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer6".into()
@@ -1199,6 +1205,7 @@ impl crate::Loggable for AffixFuzzer7 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer7".into()
@@ -1404,6 +1411,7 @@ impl crate::Loggable for AffixFuzzer8 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer8".into()
@@ -1525,6 +1533,7 @@ impl crate::Loggable for AffixFuzzer9 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer9".into()
@@ -1573,6 +1582,7 @@ impl crate::Loggable for AffixFuzzer9 {
                 )
                 .unwrap()
                 .into();
+
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {
                     Utf8Array::<i32>::new_unchecked(
@@ -1667,6 +1677,7 @@ impl crate::Loggable for AffixFuzzer10 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer10".into()
@@ -1717,6 +1728,7 @@ impl crate::Loggable for AffixFuzzer10 {
                 )
                 .unwrap()
                 .into();
+
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {
                     Utf8Array::<i32>::new_unchecked(
@@ -1807,6 +1819,7 @@ impl crate::Loggable for AffixFuzzer11 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer11".into()
@@ -2021,6 +2034,7 @@ impl crate::Loggable for AffixFuzzer12 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer12".into()
@@ -2111,6 +2125,7 @@ impl crate::Loggable for AffixFuzzer12 {
                         )
                         .unwrap()
                         .into();
+
                         #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                         unsafe {
                             Utf8Array::<i32>::new_unchecked(
@@ -2256,6 +2271,7 @@ impl crate::Loggable for AffixFuzzer13 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer13".into()
@@ -2348,6 +2364,7 @@ impl crate::Loggable for AffixFuzzer13 {
                         )
                         .unwrap()
                         .into();
+
                         #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                         unsafe {
                             Utf8Array::<i32>::new_unchecked(
@@ -2495,6 +2512,7 @@ impl crate::Loggable for AffixFuzzer14 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer14".into()
@@ -2667,6 +2685,7 @@ impl crate::Loggable for AffixFuzzer15 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer15".into()
@@ -2839,6 +2858,7 @@ impl crate::Loggable for AffixFuzzer16 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer16".into()
@@ -3055,6 +3075,7 @@ impl crate::Loggable for AffixFuzzer17 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer17".into()
@@ -3269,6 +3290,7 @@ impl crate::Loggable for AffixFuzzer18 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer18".into()
@@ -3481,6 +3503,7 @@ impl crate::Loggable for AffixFuzzer19 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer19".into()
@@ -3612,6 +3635,7 @@ impl crate::Loggable for AffixFuzzer20 {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.AffixFuzzer20".into()

--- a/crates/re_types/src/testing/components/fuzzy_deps.rs
+++ b/crates/re_types/src/testing/components/fuzzy_deps.rs
@@ -34,6 +34,7 @@ impl crate::Loggable for PrimitiveComponent {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.PrimitiveComponent".into()
@@ -158,6 +159,7 @@ impl crate::Loggable for StringComponent {
     type Name = crate::ComponentName;
     type Item<'a> = Option<Self>;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
+
     #[inline]
     fn name() -> Self::Name {
         "rerun.testing.components.StringComponent".into()
@@ -206,6 +208,7 @@ impl crate::Loggable for StringComponent {
                 )
                 .unwrap()
                 .into();
+
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {
                     Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types_builder/Cargo.toml
+++ b/crates/re_types_builder/Cargo.toml
@@ -30,6 +30,7 @@ convert_case = "0.6"
 flatbuffers = "23.0"
 indent = "0.1"
 itertools.workspace = true
+prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }
 quote = "1.0"
 rayon.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -44,14 +44,14 @@ deny = [
 ]
 
 skip = [
-  { name = "ahash" },      # Popular crate + fast release schedule = lots of crates still using old versions
-  { name = "base64" },     # Too popular
-  { name = "libloading" }, # wgpu pulls in two different versions. It is a small crate though.
-  { name = "memoffset" },  # Small crate
-  { name = "nix" },        # difficult to avoid :(
+  { name = "ahash" },        # Popular crate + fast release schedule = lots of crates still using old versions
+  { name = "base64" },       # Too popular
+  { name = "libloading" },   # wgpu pulls in two different versions. It is a small crate though.
+  { name = "memoffset" },    # Small crate
+  { name = "nix" },          # difficult to avoid :(
   { name = "prettyplease" }, # Old version being used by prost
-  { name = "time" },       # Too popular
-  { name = "windows" },    # wgpu and rfd are sometimes on different versions
+  { name = "time" },         # Too popular
+  { name = "windows" },      # wgpu and rfd are sometimes on different versions
 ]
 skip-tree = [
   { name = "cargo-run-wasm" }, # Dev-tool

--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,7 @@ skip = [
   { name = "libloading" }, # wgpu pulls in two different versions. It is a small crate though.
   { name = "memoffset" },  # Small crate
   { name = "nix" },        # difficult to avoid :(
+  { name = "prettyplease" }, # Old version being used by prost
   { name = "time" },       # Too popular
   { name = "windows" },    # wgpu and rfd are sometimes on different versions
 ]


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/2947

### What
Use [`prettyplease`](https://github.com/dtolnay/prettyplease ) to format our generated Rust code, before also running `cargo fmt` on it. Yes, we need both.

Example of the resulting improvement:

![image](https://github.com/rerun-io/rerun/assets/1148717/77b24ed7-8ac5-4e35-9918-c8cb7aa1c49a)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2949) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2949)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fprettyplease/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fprettyplease/examples)