### PR TITLE
Optimize point cloud rendering

### DIFF
--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -362,6 +362,7 @@ impl DataCell {
     pub fn try_to_native<'a, C: Component + Default + 'a>(
         &'a self,
     ) -> DataCellResult<impl Iterator<Item = C> + '_> {
+        re_tracing::profile_function!(C::name().as_str());
         Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?
             .map(C::convert_item_to_self)
             .map(|v| {

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -284,6 +284,7 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_required_component<'a, C: Component + Default + 'a>(
         &'a self,
     ) -> DeserializationResult<impl Iterator<Item = C> + '_> {
+        re_tracing::profile_function!(C::name().as_str());
         debug_assert!(A::required_components()
             .iter()
             .any(|c| c.as_ref() == C::name()));

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -226,11 +226,13 @@ pub struct UiLabel {
 pub fn load_keypoint_connections(
     ent_context: &SpatialSceneEntityContext<'_>,
     ent_path: &re_data_store::EntityPath,
-    keypoints: Keypoints,
+    keypoints: &Keypoints,
 ) {
     if keypoints.is_empty() {
         return;
     }
+
+    re_tracing::profile_function!();
 
     // Generate keypoint connections if any.
     let mut line_builder = ent_context.shared_render_builders.lines();
@@ -242,7 +244,7 @@ pub fn load_keypoint_connections(
     for ((class_id, _time), keypoints_in_class) in keypoints {
         let resolved_class_description = ent_context
             .annotations
-            .resolved_class_description(Some(class_id));
+            .resolved_class_description(Some(*class_id));
 
         let Some(class_description) = resolved_class_description.class_description else {
             continue;

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
@@ -124,6 +125,7 @@ impl Points3DPart {
                 arch_view
                     .iter_required_component::<Point3D>()?
                     .map(glam::Vec3::from)
+                    .collect_vec()
             };
 
             let picking_instance_ids = arch_view
@@ -131,7 +133,7 @@ impl Points3DPart {
                 .map(picking_id_from_instance_key);
             let mut point_range_builder = point_batch.add_points(
                 arch_view.num_instances(),
-                point_positions,
+                point_positions.iter().copied(),
                 radii,
                 colors,
                 picking_instance_ids,
@@ -154,16 +156,14 @@ impl Points3DPart {
                     }
                 }
             }
+
+            self.data.extend_bounding_box_with_points(
+                point_positions.iter().copied(),
+                ent_context.world_from_obj,
+            );
         }
 
-        load_keypoint_connections(ent_context, ent_path, keypoints);
-
-        self.data.extend_bounding_box_with_points(
-            arch_view
-                .iter_required_component::<Point3D>()?
-                .map(glam::Vec3::from),
-            ent_context.world_from_obj,
-        );
+        load_keypoint_connections(ent_context, ent_path, &keypoints);
 
         Ok(())
     }


### PR DESCRIPTION
### What
Makes `open_photogrammetry_format` example ~30% faster by only calling `iter_required_component::<Point3D>()` once per frame instead of twice.

Before: 158 ms/frame:
![image](https://github.com/rerun-io/rerun/assets/1148717/cdfa3906-ac1e-4fd8-8088-7fa71d82f0cb)

After: 119 ms/frame:
![image](https://github.com/rerun-io/rerun/assets/1148717/7570cf74-57d9-4cc3-9dfc-8bb5b878c6d7)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
