### PR TITLE
Proof-of-concept: Hand-crafted optimizations to pave the way forward for code-gen

### DIFF
--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -362,6 +362,7 @@ impl DataCell {
     pub fn try_to_native<'a, C: Component + Default + 'a>(
         &'a self,
     ) -> DataCellResult<impl Iterator<Item = C> + '_> {
+        re_tracing::profile_function!(C::name().as_str());
         Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?
             .map(C::convert_item_to_self)
             .map(|v| {

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -363,17 +363,7 @@ impl DataCell {
         &'a self,
     ) -> DataCellResult<impl Iterator<Item = C> + '_> {
         re_tracing::profile_function!(C::name().as_str());
-        Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?
-            .map(C::convert_item_to_self)
-            .map(|v| {
-                // TODO(#2523): This unwrap and the `Default` bounds should go away once we move to fallible iterators
-                v.unwrap_or_else(|| {
-                    re_log::warn_once!(
-                        "Unexpected missing data when iterating non-optional data-cell. Falling back on Default value."
-                    );
-                    C::default()
-                })
-            }))
+        Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?.map(C::convert_item_to_self))
     }
 
     /// Returns the contents of an expected mono-component as an `Option<C>`.
@@ -382,7 +372,7 @@ impl DataCell {
     #[inline]
     pub fn try_to_native_mono<'a, C: Component + 'a>(&'a self) -> DataCellResult<Option<C>> {
         let mut iter =
-            C::try_iter_from_arrow(self.inner.values.as_ref())?.map(C::convert_item_to_self);
+            C::try_iter_from_arrow(self.inner.values.as_ref())?.map(C::convert_item_to_opt_self);
 
         let result = match iter.next() {
             // It's ok to have no result from the iteration: this is what we
@@ -421,7 +411,7 @@ impl DataCell {
     pub fn try_to_native_opt<'a, C: Component + 'a>(
         &'a self,
     ) -> DataCellResult<impl Iterator<Item = Option<C>> + '_> {
-        Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?.map(C::convert_item_to_self))
+        Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?.map(C::convert_item_to_opt_self))
     }
 
     /// Returns the contents of the cell as an iterator of native optional components.

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -411,6 +411,7 @@ impl DataCell {
     pub fn try_to_native_opt<'a, C: Component + 'a>(
         &'a self,
     ) -> DataCellResult<impl Iterator<Item = Option<C>> + '_> {
+        re_tracing::profile_function!(C::name().as_str());
         Ok(C::try_iter_from_arrow(self.inner.values.as_ref())?.map(C::convert_item_to_opt_self))
     }
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -485,7 +485,7 @@ macro_rules! component_legacy_shim {
             }
 
             #[inline]
-            fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+            fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
                 <Self as arrow2_convert::deserialize::ArrowDeserialize>::arrow_deserialize(item)
             }
         }

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -319,21 +319,29 @@ impl<A: Archetype> ArchetypeView<A> {
         let component = self.components.get(&C::name());
 
         if let Some(component) = component {
-            let primary_instance_key_iter = self.iter_instance_keys();
-
-            let mut component_instance_key_iter = component.iter_instance_keys();
-
             let component_value_iter = component.iter_values()?;
 
-            let next_component_instance_key = component_instance_key_iter.next();
+            if component.len() == self.num_instances() {
+                Ok(itertools::Either::Left(itertools::Either::Left(
+                    component_value_iter,
+                )))
+            } else {
+                let primary_instance_key_iter = self.iter_instance_keys();
 
-            Ok(itertools::Either::Left(ComponentJoinedIterator {
-                primary_instance_key_iter,
-                component_instance_key_iter,
-                component_value_iter,
-                next_component_instance_key,
-                splatted_component_value: None,
-            }))
+                let mut component_instance_key_iter = component.iter_instance_keys();
+
+                let next_component_instance_key = component_instance_key_iter.next();
+
+                Ok(itertools::Either::Left(itertools::Either::Right(
+                    ComponentJoinedIterator {
+                        primary_instance_key_iter,
+                        component_instance_key_iter,
+                        component_value_iter,
+                        next_component_instance_key,
+                        splatted_component_value: None,
+                    },
+                )))
+            }
         } else {
             let primary = self.required_comp();
             let nulls = (0..primary.len()).map(|_| None);

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -284,6 +284,7 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_required_component<'a, C: Component + Default + 'a>(
         &'a self,
     ) -> DeserializationResult<impl Iterator<Item = C> + '_> {
+        re_tracing::profile_function!(C::name().as_str());
         debug_assert!(A::required_components()
             .iter()
             .any(|c| c.as_ref() == C::name()));

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -45,15 +45,15 @@ impl Arrows3DPart {
         world_from_obj: glam::Affine3A,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
-            annotation_infos.iter(),
             arch_view.iter_required_component::<Vector3D>()?,
             arch_view.iter_optional_component::<Origin3D>()?,
             arch_view.iter_optional_component::<Label>()?,
             colors,
             instance_path_hashes,
+            annotation_infos.iter().cycle(),
         )
         .filter_map(
-            move |(annotation_info, vector, origin, label, color, labeled_instance)| {
+            move |(vector, origin, label, color, labeled_instance, annotation_info)| {
                 let origin = origin.unwrap_or_default();
                 let label = annotation_info.label(label.as_ref().map(|l| l.as_str()));
                 match (vector, label) {

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -44,14 +44,14 @@ impl Lines2DPart {
         annotation_infos: &'a [ResolvedAnnotationInfo],
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
-            annotation_infos.iter(),
             arch_view.iter_required_component::<LineStrip2D>()?,
             arch_view.iter_optional_component::<Label>()?,
             colors,
             instance_path_hashes,
+            annotation_infos.iter().cycle(),
         )
         .filter_map(
-            move |(annotation_info, strip, label, color, labeled_instance)| {
+            move |(strip, label, color, labeled_instance, annotation_info)| {
                 let label = annotation_info.label(label.as_ref().map(|l| l.as_str()));
                 match (strip, label) {
                     (strip, Some(label)) => {

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -47,14 +47,14 @@ impl Lines3DPart {
         re_tracing::profile_function!();
 
         let labels = itertools::izip!(
-            annotation_infos.iter(),
             arch_view.iter_required_component::<LineStrip3D>()?,
             arch_view.iter_optional_component::<Label>()?,
             colors,
             instance_path_hashes,
+            annotation_infos.iter().cycle(),
         )
         .filter_map(
-            move |(annotation_info, strip, label, color, labeled_instance)| {
+            move |(strip, label, color, labeled_instance, annotation_info)| {
                 let label = annotation_info.label(label.as_ref().map(|l| l.as_str()));
                 match (strip, label) {
                     (strip, Some(label)) => {

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -226,11 +226,13 @@ pub struct UiLabel {
 pub fn load_keypoint_connections(
     ent_context: &SpatialSceneEntityContext<'_>,
     ent_path: &re_data_store::EntityPath,
-    keypoints: Keypoints,
+    keypoints: &Keypoints,
 ) {
     if keypoints.is_empty() {
         return;
     }
+
+    re_tracing::profile_function!();
 
     // Generate keypoint connections if any.
     let mut line_builder = ent_context.shared_render_builders.lines();
@@ -242,7 +244,7 @@ pub fn load_keypoint_connections(
     for ((class_id, _time), keypoints_in_class) in keypoints {
         let resolved_class_description = ent_context
             .annotations
-            .resolved_class_description(Some(class_id));
+            .resolved_class_description(Some(*class_id));
 
         let Some(class_description) = resolved_class_description.class_description else {
             continue;

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -113,10 +113,10 @@ pub fn process_colors<'a, A: Archetype>(
     let default_color = DefaultColor::EntityPath(ent_path);
 
     Ok(itertools::izip!(
-        annotation_infos.iter(),
         arch_view.iter_optional_component::<Color>()?,
+        annotation_infos.iter().cycle(),
     )
-    .map(move |(annotation_info, color)| {
+    .map(move |(color, annotation_info)| {
         annotation_info.color(color.map(move |c| c.to_array()).as_ref(), default_color)
     }))
 }
@@ -170,10 +170,7 @@ where
         let resolved_annotation = annotations
             .resolved_class_description(None)
             .annotation_info();
-        return Ok((
-            vec![resolved_annotation; arch_view.num_instances()],
-            keypoints,
-        ));
+        return Ok((vec![resolved_annotation; 1], keypoints));
     }
 
     let annotation_info = itertools::izip!(

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -46,14 +46,14 @@ impl Points2DPart {
         annotation_infos: &'a [ResolvedAnnotationInfo],
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
-            annotation_infos.iter(),
             arch_view.iter_required_component::<Point2D>()?,
             arch_view.iter_optional_component::<Label>()?,
             colors,
             instance_path_hashes,
+            annotation_infos.iter().cycle(),
         )
         .filter_map(
-            move |(annotation_info, point, label, color, labeled_instance)| {
+            move |(point, label, color, labeled_instance, annotation_info)| {
                 let label = annotation_info.label(label.as_ref().map(|l| l.as_str()));
                 match (point, label) {
                     (point, Some(label)) => Some(UiLabel {

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -46,14 +46,14 @@ impl Points3DPart {
         world_from_obj: glam::Affine3A,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
-            annotation_infos.iter(),
             arch_view.iter_required_component::<Point3D>()?,
             arch_view.iter_optional_component::<Label>()?,
             colors,
             instance_path_hashes,
+            annotation_infos.iter().cycle(),
         )
         .filter_map(
-            move |(annotation_info, point, label, color, labeled_instance)| {
+            move |(point, label, color, labeled_instance, annotation_info)| {
                 let label = annotation_info.label(label.as_ref().map(|l| l.as_str()));
                 match (point, label) {
                     (point, Some(label)) => Some(UiLabel {

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
@@ -124,6 +125,7 @@ impl Points3DPart {
                 arch_view
                     .iter_required_component::<Point3D>()?
                     .map(glam::Vec3::from)
+                    .collect_vec()
             };
 
             let picking_instance_ids = arch_view
@@ -131,7 +133,7 @@ impl Points3DPart {
                 .map(picking_id_from_instance_key);
             let mut point_range_builder = point_batch.add_points(
                 arch_view.num_instances(),
-                point_positions,
+                point_positions.iter().copied(),
                 radii,
                 colors,
                 picking_instance_ids,
@@ -154,16 +156,14 @@ impl Points3DPart {
                     }
                 }
             }
+
+            self.data.extend_bounding_box_with_points(
+                point_positions.iter().copied(),
+                ent_context.world_from_obj,
+            );
         }
 
-        load_keypoint_connections(ent_context, ent_path, keypoints);
-
-        self.data.extend_bounding_box_with_points(
-            arch_view
-                .iter_required_component::<Point3D>()?
-                .map(glam::Vec3::from),
-            ent_context.world_from_obj,
-        );
+        load_keypoint_connections(ent_context, ent_path, &keypoints);
 
         Ok(())
     }

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-196844751442706baa436dac75e5d43760838ec1355b4e170bd48aa9e2a74a30
+498f4b5ab172b3cb50060978de840e09258514443a0e7aed255e092c71d2c127

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -205,7 +205,7 @@ impl crate::Loggable for AnnotationContext {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -132,7 +132,7 @@ impl crate::Loggable for ClassId {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -131,6 +131,7 @@ impl crate::Loggable for Color {
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
+    #[inline]
     fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>>
     where
         Self: Sized,

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -141,7 +141,7 @@ impl crate::Loggable for Color {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -132,7 +132,7 @@ impl crate::Loggable for DisconnectedSpace {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -136,7 +136,7 @@ impl crate::Loggable for DrawOrder {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -130,7 +130,7 @@ impl crate::Loggable for InstanceKey {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -120,6 +120,7 @@ impl crate::Loggable for InstanceKey {
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
+    #[inline]
     fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>>
     where
         Self: Sized,

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -134,7 +134,7 @@ impl crate::Loggable for KeypointId {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -149,7 +149,7 @@ impl crate::Loggable for Label {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -330,7 +330,7 @@ impl crate::Loggable for LineStrip2D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -330,7 +330,7 @@ impl crate::Loggable for LineStrip3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -232,7 +232,7 @@ impl crate::Loggable for Origin3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -38,7 +38,7 @@ impl<'a> From<&'a Point2D> for ::std::borrow::Cow<'a, Point2D> {
 
 impl crate::Loggable for Point2D {
     type Name = crate::ComponentName;
-    type Item<'a> = Option<Self>;
+    type Item<'a> = Self;
     type Iter<'a> = <Vec<Self::Item<'a>> as IntoIterator>::IntoIter;
     #[inline]
     fn name() -> Self::Name {
@@ -221,6 +221,37 @@ impl crate::Loggable for Point2D {
         })?)
     }
 
+    #[allow(unused_imports, clippy::wildcard_imports)]
+    #[inline]
+    fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use crate::Loggable as _;
+        use ::arrow2::{array::*, buffer::*, datatypes::*};
+        Ok({
+            let data = data
+                .as_any()
+                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
+                .unwrap();
+            if data.is_empty() {
+                itertools::Either::Left(std::iter::empty())
+            } else {
+                let data = &**data.values();
+                let data = data
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap()
+                    .values()
+                    .as_slice();
+                let data2: &[[f32; 2]] = bytemuck::cast_slice(data);
+                itertools::Either::Right(data2.iter().map(|v| crate::datatypes::Vec2D(*v)))
+            }
+        }
+        .map(|v| Self(v))
+        .collect::<Vec<_>>())
+    }
+
     #[inline]
     fn try_iter_from_arrow(
         data: &dyn ::arrow2::array::Array,
@@ -228,12 +259,17 @@ impl crate::Loggable for Point2D {
     where
         Self: Sized,
     {
-        Ok(Self::try_from_arrow_opt(data)?.into_iter())
+        Ok(Self::try_from_arrow(data)?.into_iter())
+    }
+
+    #[inline]
+    fn convert_item_to_self(item: Self::Item<'_>) -> Self {
+        item
     }
 
     #[inline]
     fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
-        item
+        Some(item)
     }
 }
 

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -232,7 +232,7 @@ impl crate::Loggable for Point2D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -222,6 +222,7 @@ impl crate::Loggable for Point3D {
     }
 
     #[allow(unused_imports, clippy::wildcard_imports)]
+    #[inline]
     fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>>
     where
         Self: Sized,

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -232,7 +232,7 @@ impl crate::Loggable for Point3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -129,7 +129,7 @@ impl crate::Loggable for Radius {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -154,7 +154,7 @@ impl crate::Loggable for Transform3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -232,7 +232,7 @@ impl crate::Loggable for Vector3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -313,7 +313,7 @@ impl crate::Loggable for Angle {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -341,7 +341,7 @@ impl crate::Loggable for AnnotationInfo {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -421,7 +421,7 @@ impl crate::Loggable for ClassDescription {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -248,7 +248,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -273,7 +273,7 @@ impl crate::Loggable for KeypointPair {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -219,7 +219,7 @@ impl crate::Loggable for Mat3x3 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -219,7 +219,7 @@ impl crate::Loggable for Mat4x4 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -219,7 +219,7 @@ impl crate::Loggable for Quaternion {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -370,7 +370,7 @@ impl crate::Loggable for Rotation3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -311,7 +311,7 @@ impl crate::Loggable for RotationAxisAngle {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -365,7 +365,7 @@ impl crate::Loggable for Scale3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -306,7 +306,7 @@ impl crate::Loggable for Transform3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -412,7 +412,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -382,7 +382,7 @@ impl crate::Loggable for TranslationRotationScale3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -219,7 +219,7 @@ impl crate::Loggable for Vec2D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -219,7 +219,7 @@ impl crate::Loggable for Vec3D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -219,7 +219,7 @@ impl crate::Loggable for Vec4D {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -200,14 +200,9 @@ pub trait Loggable: Sized {
     /// For the non-fallible version, see [`Loggable::from_arrow_opt`].
     #[inline]
     fn try_from_arrow(data: &dyn ::arrow2::array::Array) -> DeserializationResult<Vec<Self>> {
-        Self::try_iter_from_arrow(data)?
-            .map(Self::convert_item_to_opt_self)
-            .map(|v| {
-                v.ok_or_else(|| DeserializationError::MissingData {
-                    backtrace: ::backtrace::Backtrace::new_unresolved(),
-                })
-            })
-            .collect()
+        Ok(Self::try_iter_from_arrow(data)?
+            .map(Self::convert_item_to_self)
+            .collect())
     }
 
     /// Given an Arrow array, deserializes it into a collection of optional [`Loggable`]s.

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -199,7 +199,7 @@ impl crate::Loggable for AffixFuzzer1 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -393,7 +393,7 @@ impl crate::Loggable for AffixFuzzer2 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -587,7 +587,7 @@ impl crate::Loggable for AffixFuzzer3 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -779,7 +779,7 @@ impl crate::Loggable for AffixFuzzer4 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -971,7 +971,7 @@ impl crate::Loggable for AffixFuzzer5 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1163,7 +1163,7 @@ impl crate::Loggable for AffixFuzzer6 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1376,7 +1376,7 @@ impl crate::Loggable for AffixFuzzer7 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1497,7 +1497,7 @@ impl crate::Loggable for AffixFuzzer8 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1639,7 +1639,7 @@ impl crate::Loggable for AffixFuzzer9 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1779,7 +1779,7 @@ impl crate::Loggable for AffixFuzzer10 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1993,7 +1993,7 @@ impl crate::Loggable for AffixFuzzer11 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -2228,7 +2228,7 @@ impl crate::Loggable for AffixFuzzer12 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -2461,7 +2461,7 @@ impl crate::Loggable for AffixFuzzer13 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -2633,7 +2633,7 @@ impl crate::Loggable for AffixFuzzer14 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -2803,7 +2803,7 @@ impl crate::Loggable for AffixFuzzer15 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -3019,7 +3019,7 @@ impl crate::Loggable for AffixFuzzer16 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -3233,7 +3233,7 @@ impl crate::Loggable for AffixFuzzer17 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -3447,7 +3447,7 @@ impl crate::Loggable for AffixFuzzer18 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -3578,7 +3578,7 @@ impl crate::Loggable for AffixFuzzer19 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -3715,7 +3715,7 @@ impl crate::Loggable for AffixFuzzer20 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/testing/components/fuzzy_deps.rs
+++ b/crates/re_types/src/testing/components/fuzzy_deps.rs
@@ -129,7 +129,7 @@ impl crate::Loggable for PrimitiveComponent {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -272,7 +272,7 @@ impl crate::Loggable for StringComponent {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -199,7 +199,7 @@ impl crate::Loggable for FlattenedScalar {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1043,7 +1043,7 @@ impl crate::Loggable for AffixFuzzer1 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1164,7 +1164,7 @@ impl crate::Loggable for AffixFuzzer2 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1516,7 +1516,7 @@ impl crate::Loggable for AffixFuzzer3 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -1831,7 +1831,7 @@ impl crate::Loggable for AffixFuzzer4 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -2031,7 +2031,7 @@ impl crate::Loggable for AffixFuzzer5 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }
@@ -2327,7 +2327,7 @@ impl crate::Loggable for AffixFuzzer20 {
     }
 
     #[inline]
-    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
         item
     }
 }

--- a/crates/re_types_builder/src/codegen/rust.rs
+++ b/crates/re_types_builder/src/codegen/rust.rs
@@ -796,7 +796,7 @@ fn quote_trait_impls_from_obj(
                     }
 
                     #[inline]
-                    fn convert_item_to_self(item: Self::Item<'_>) -> Option<Self> {
+                    fn convert_item_to_opt_self(item: Self::Item<'_>) -> Option<Self> {
                         item
                     }
                 }


### PR DESCRIPTION
### What
Demonstrating that with the right generated deserializer optimizations the new code-gen can out-perform the legacy queries.

There's a couple of performance improvements all rolled in here to really push the envelope:
 - Avoid dealing with Option on non-nullible components
 - Iterate over direct slices from arrow buffers where possible
 - Optimization for matched-length joining iterator (this implementation is incorrect but close enough for this profiling)
 - Fix silly allocations of annotationInfo in the noop case.

Using the photogrammetry example as a stress-test:

Previous Baseline (0.8)
![image](https://github.com/rerun-io/rerun/assets/3312232/2a1ecc88-99f1-4e0f-9f53-b03294cae1bf)

Before (main):
![image](https://github.com/rerun-io/rerun/assets/3312232/971d1a9e-1b90-4a6d-bed7-0a48177e04f7)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/48dcf4c7-b6b0-4032-9abd-8ee7cce7aaeb)


### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
