### PR TITLE
C++ Warning fixes, werror on ci, C++17 compliance

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -340,12 +340,12 @@ jobs:
 
       - name: Build and run C++ minimal example
         shell: bash
-        run: ./examples/cpp/minimal/build_and_run.sh
+        run: ./examples/cpp/minimal/build_and_run.sh --werror
 
       - name: Build and run rerun_cpp tests
         shell: bash
-        run: ./rerun_cpp/build_and_run_tests.sh
+        run: ./rerun_cpp/build_and_run_tests.sh --werror
 
       - name: Build code examples
         shell: bash
-        run: ./tests/cpp/build_all_doc_examples.sh
+        run: ./tests/cpp/build_all_doc_examples.sh --werror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,6 @@ function(set_default_warning_settings target)
         # arrow has a bunch of unused parameters in its headers.
         target_compile_options(${target} PRIVATE -Wno-unused-parameter)
     endif()
-
-    # Enable this to fail on warnings.
-    # set_property(TARGET ${target} PROPERTY COMPILE_WARNING_AS_ERROR ON)
 endfunction()
 
 # Use makefiles on linux, otherwise it might use Ninja which isn't installed by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,27 @@ function(set_default_warning_settings target)
     if(MSVC)
         target_compile_options(${target} PRIVATE /W4 /WX)
     else()
-        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wcast-align -Wcast-qual -Wformat=2 -Wmissing-include-dirs -Wnull-dereference -Woverloaded-virtual -Wpointer-arith -Wshadow -Wswitch-enum -Wvla -Wno-sign-compare -Wconversion -Wunused -Wold-style-cast -Wno-missing-braces)
+        # Enabled warnings.
+        target_compile_options(${target} PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wcast-align
+            -Wcast-qual
+            -Wformat=2
+            -Wmissing-include-dirs
+            -Wnull-dereference
+            -Wpointer-arith
+            -Wshadow-all
+            -Wswitch-enum
+            -Wvla
+            -Wold-style-cast
+            -Wnon-gcc
+            -Wgnu
+            -Wc++17-compat-pedantic
+        )
 
+        # Disabled warnings
         # arrow has a bunch of unused parameters in its headers.
         target_compile_options(${target} PRIVATE -Wno-unused-parameter)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ function(set_default_warning_settings target)
         # Disabled warnings
         # arrow has a bunch of unused parameters in its headers.
         target_compile_options(${target} PRIVATE -Wno-unused-parameter)
+
+        # CMAKE_COMPILE_WARNING_AS_ERROR is only directly supported starting in CMake `3.24`
+        # https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html
+        if(${CMAKE_COMPILE_WARNING_AS_ERROR})
+            target_compile_options(${target} PRIVATE -Werror)
+        endif()
     endif()
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,27 +9,27 @@ function(set_default_warning_settings target)
         # Enabled warnings.
         target_compile_options(${target} PRIVATE
             -Wall
-            -Wextra
-            -Wpedantic
             -Wcast-align
             -Wcast-qual
+            -Wextra
             -Wformat=2
             -Wmissing-include-dirs
             -Wnull-dereference
+            -Wold-style-cast
+            -Wpedantic
             -Wpointer-arith
             -Wshadow
             -Wswitch-enum
             -Wvla
-            -Wold-style-cast
         )
 
         if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # match both "Clang" and "AppleClang"
             target_compile_options(${target} PRIVATE
                 -Wc++17-compat-pedantic
-                -Wshadow-all
-                -Wnon-gcc
-                -Wgnu
                 -Wc99-extensions
+                -Wgnu
+                -Wnon-gcc
+                -Wshadow-all
             )
         endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,20 @@ function(set_default_warning_settings target)
             -Wmissing-include-dirs
             -Wnull-dereference
             -Wpointer-arith
-            -Wshadow-all
+            -Wshadow
             -Wswitch-enum
             -Wvla
             -Wold-style-cast
-            -Wnon-gcc
-            -Wgnu
-            -Wc++17-compat-pedantic
         )
+
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # match both "Clang" and "AppleClang"
+            target_compile_options(${target} PRIVATE
+                -Wc++17-compat-pedantic
+                -Wshadow-all
+                -Wnon-gcc
+                -Wgnu
+            )
+        endif()
 
         # Disabled warnings
         # arrow has a bunch of unused parameters in its headers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ function(set_default_warning_settings target)
             -Wswitch-enum
             -Wvla
             -Wold-style-cast
+            -Wc99-extensions
         )
 
         if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # match both "Clang" and "AppleClang"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ function(set_default_warning_settings target)
             -Wswitch-enum
             -Wvla
             -Wold-style-cast
-            -Wc99-extensions
         )
 
         if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # match both "Clang" and "AppleClang"
@@ -30,6 +29,7 @@ function(set_default_warning_settings target)
                 -Wshadow-all
                 -Wnon-gcc
                 -Wgnu
+                -Wc99-extensions
             )
         endif()
 

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-fff196de71e8f8f9e00a30610dd5f32fd73b1a0f88d8df9ab523541bacb12881
+4f4bc40656d9770837ed871649f2a9b1ff6ecf6bc635196a064d315bba26e8a8

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -788,8 +788,8 @@ impl QuotedObject {
             }
 
             let trivial_memcpy = quote! {
-                const void *otherbytes = reinterpret_cast<const void *>(&other._data);
-                void *thisbytes = reinterpret_cast<void *>(&this->_data);
+                const void* otherbytes = reinterpret_cast<const void*>(&other._data);
+                void* thisbytes = reinterpret_cast<void*>(&this->_data);
                 std::memcpy(thisbytes, otherbytes, sizeof(detail::#data_typename));
             };
 

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -794,6 +794,8 @@ impl QuotedObject {
                 quote!(#pascal_case_ident(const #pascal_case_ident& other) : _tag(other._tag) {
                     switch (other._tag) {
                         #(#copy_match_arms)*
+
+                        case detail::#tag_typename::NONE:
                         #(#default_match_arms)*
                             memcpy(&this->_data, &other._data, sizeof(detail::#data_typename));
                             break;

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -831,9 +831,11 @@ impl QuotedObject {
                                 #NEWLINE_TOKEN
                                 #swap_comment
                                 char temp[sizeof(#data_typename)];
-                                std::memcpy(temp, this, sizeof(#data_typename));
-                                std::memcpy(this, &other, sizeof(#data_typename));
-                                std::memcpy(&other, temp, sizeof(#data_typename));
+                                void* otherbytes = reinterpret_cast<void*>(&other);
+                                void* thisbytes = reinterpret_cast<void*>(this);
+                                std::memcpy(temp, thisbytes, sizeof(#data_typename));
+                                std::memcpy(thisbytes, otherbytes, sizeof(#data_typename));
+                                std::memcpy(otherbytes, temp, sizeof(#data_typename));
                             }
                         };
 

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1245,7 +1245,10 @@ fn quote_fill_arrow_array_builder(
         let field = &obj.fields[0];
         if let Type::Object(fqname) = &field.typ {
             if field.is_nullable {
-                quote!(return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));)
+                quote! {
+                    (void)num_elements;
+                    return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
+                }
             } else {
                 // Trivial forwarding to inner type.
                 let quoted_fqname = quote_fqname_as_type_path(includes, fqname);
@@ -1315,7 +1318,7 @@ fn quote_fill_arrow_array_builder(
                 quote! {
                     #NEWLINE_TOKEN
                     ARROW_RETURN_NOT_OK(#builder->Reserve(static_cast<int64_t>(num_elements)));
-                    for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                         const auto& union_instance = elements[elem_idx];
                         ARROW_RETURN_NOT_OK(#builder->Append(static_cast<int8_t>(union_instance._tag)));
                         #NEWLINE_TOKEN
@@ -1408,7 +1411,7 @@ fn quote_append_field_to_builder(
             if field.is_nullable {
                 quote! {
                     #setup
-                    for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                         const auto& element = elements[elem_idx];
                         if (element.#field_name.has_value()) {
                             ARROW_RETURN_NOT_OK(#builder->Append());
@@ -1421,7 +1424,7 @@ fn quote_append_field_to_builder(
             } else {
                 quote! {
                     #setup
-                    for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                    for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                         const auto& element = elements[elem_idx];
                         ARROW_RETURN_NOT_OK(#builder->Append());
                         #append_value
@@ -1443,7 +1446,7 @@ fn quote_append_field_to_builder(
             quote_append_single_field_to_builder(field, builder, &element_accessor, includes);
         quote! {
             ARROW_RETURN_NOT_OK(#builder->Reserve(static_cast<int64_t>(num_elements)));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 #single_append
             }
         }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -786,9 +786,16 @@ impl QuotedObject {
                     });
                 }
             }
+
+            let trivial_memcpy = quote! {
+                const void *otherbytes = reinterpret_cast<const void *>(&other._data);
+                void *thisbytes = reinterpret_cast<void *>(&this->_data);
+                std::memcpy(thisbytes, otherbytes, sizeof(detail::#data_typename));
+            };
+
             if copy_match_arms.is_empty() {
                 quote!(#pascal_case_ident(const #pascal_case_ident& other) : _tag(other._tag) {
-                    memcpy(&this->_data, &other._data, sizeof(detail::#data_typename));
+                    #trivial_memcpy
                 })
             } else {
                 quote!(#pascal_case_ident(const #pascal_case_ident& other) : _tag(other._tag) {
@@ -797,7 +804,7 @@ impl QuotedObject {
 
                         case detail::#tag_typename::NONE:
                         #(#default_match_arms)*
-                            memcpy(&this->_data, &other._data, sizeof(detail::#data_typename));
+                        #trivial_memcpy
                             break;
                     }
                 })

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -64,7 +64,7 @@ struct rr_data_cell {
 
     /// The number of bytes in the `bytes` field.
     /// Must be a multiple of 8.
-    const uint64_t num_bytes;
+    uint64_t num_bytes;
 
     /// Data in the Arrow IPC encapsulated message format.
     ///

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -19,12 +19,12 @@ extern "C" {
 /// Special value for `rr_recording_stream` methods to indicate the most appropriate
 /// globally available recording stream for recordings.
 /// (i.e. thread-local first, then global scope)
-#define RERUN_REC_STREAM_CURRENT_RECORDING 0xFFFFFFFF
+#define RERUN_REC_STREAM_CURRENT_RECORDING ((rr_recording_stream)0xFFFFFFFF)
 
 /// Special value for `rr_recording_stream` methods to indicate the most appropriate
 /// globally available recording stream for blueprints.
 /// (i.e. thread-local first, then global scope)
-#define RERUN_REC_STREAM_CURRENT_BLUEPRINT 0xFFFFFFFE
+#define RERUN_REC_STREAM_CURRENT_BLUEPRINT ((rr_recording_stream)0xFFFFFFFE)
 
 /// A unique handle for a recording stream.
 /// A recording stream handles everything related to logging data into Rerun.

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -48,7 +48,7 @@ extern "C" {
 ///
 /// TODO(andreas): The only way of having two instances of a `RecordingStream` is currently to
 /// set it as a the global.
-typedef int32_t rr_recording_stream;
+typedef uint32_t rr_recording_stream;
 
 struct rr_store_info {
     /// The user-chosen name of the application doing the logging.

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -11,6 +11,5 @@ endif()
 
 add_executable(rerun_example main.cpp)
 
-# TODO(andreas): Fix warnings and enable this.
-# set_default_warning_settings(rerun_example)
+set_default_warning_settings(rerun_example)
 target_link_libraries(rerun_example PRIVATE loguru::loguru rerun_sdk)

--- a/examples/cpp/minimal/build_and_run.sh
+++ b/examples/cpp/minimal/build_and_run.sh
@@ -5,11 +5,31 @@ script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/../../.."
 set -x
 
+WERROR=false
+
+while test $# -gt 0; do
+  case "$1" in
+    --werror)
+      shift
+      WERROR=true
+      ;;
+
+    *)
+      break
+      ;;
+  esac
+done
+
+
 num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    if [ ${WERROR} = true ]; then
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ..
+    else
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+    fi
     cmake --build . --config Debug --target rerun_example -j ${num_threads}
 popd
 

--- a/examples/cpp/minimal/build_and_run.sh
+++ b/examples/cpp/minimal/build_and_run.sh
@@ -15,7 +15,8 @@ while test $# -gt 0; do
       ;;
 
     *)
-      break
+      echo "Unknown option: $1"
+      exit 1
       ;;
   esac
 done

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -18,8 +18,8 @@ int main(int argc, char** argv) {
 
     rr_stream.log(
         "3d/points",
-        rr::archetypes::Points3D({{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}})
-            .with_radii({0.42, 0.43})
+        rr::archetypes::Points3D({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}})
+            .with_radii({0.42f, 0.43f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
     rrc::Label c_style_array[3] = {rrc::Label("hello"), rrc::Label("friend"), rrc::Label("yo")};
     rr_stream.log_components(
         "2d/points",
-        std::vector{rrc::Point2D(0.0, 0.0), rrc::Point2D(1.0, 3.0), rrc::Point2D(5.0, 5.0)},
+        std::vector{rrc::Point2D(0.0f, 0.0f), rrc::Point2D(1.0f, 3.0f), rrc::Point2D(5.0f, 5.0f)},
         std::array{rrc::Color(0xFF0000FF), rrc::Color(0x00FF00FF), rrc::Color(0x0000FFFF)},
         c_style_array
     );

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -13,8 +13,7 @@ file(GLOB_RECURSE rerun_sdk_SRC CONFIGURE_DEPENDS
 
 add_library(rerun_sdk ${rerun_sdk_SRC})
 
-# TODO(andreas): Fix all warnings and enable this.
-# set_default_warning_settings(rerun_sdk)
+set_default_warning_settings(rerun_sdk)
 
 # ------------------------------------------------------------------------------
 

--- a/rerun_cpp/build_and_run_tests.sh
+++ b/rerun_cpp/build_and_run_tests.sh
@@ -15,7 +15,8 @@ while test $# -gt 0; do
       ;;
 
     *)
-      break
+      echo "Unknown option: $1"
+      exit 1
       ;;
   esac
 done

--- a/rerun_cpp/build_and_run_tests.sh
+++ b/rerun_cpp/build_and_run_tests.sh
@@ -5,11 +5,31 @@ script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/.."
 set -x
 
+WERROR=false
+
+while test $# -gt 0; do
+  case "$1" in
+    --werror)
+      shift
+      WERROR=true
+      ;;
+
+    *)
+      break
+      ;;
+  esac
+done
+
+
 num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    if [ ${WERROR} = true ]; then
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ..
+    else
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+    fi
     cmake --build . --config Debug --target rerun_sdk_tests -j ${num_threads}
 popd
 

--- a/rerun_cpp/src/rerun/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer10.cpp
@@ -36,8 +36,8 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.single_string_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append(element.single_string_optional.value()));

--- a/rerun_cpp/src/rerun/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer11.cpp
@@ -40,16 +40,16 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_floats_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                         element.many_floats_optional.value().data(),
-                        element.many_floats_optional.value().size(),
+                        static_cast<int64_t>(element.many_floats_optional.value().size()),
                         nullptr
                     ));
                 } else {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer12.cpp
@@ -40,13 +40,13 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::StringBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
-                for (auto item_idx = 0; item_idx < element.many_strings_required.size();
+                for (size_t item_idx = 0; item_idx < element.many_strings_required.size();
                      item_idx += 1) {
                     ARROW_RETURN_NOT_OK(
                         value_builder->Append(element.many_strings_required[item_idx])

--- a/rerun_cpp/src/rerun/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer13.cpp
@@ -40,14 +40,15 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::StringBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_strings_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());
-                    for (auto item_idx = 0; item_idx < element.many_strings_optional.value().size();
+                    for (size_t item_idx = 0;
+                         item_idx < element.many_strings_optional.value().size();
                          item_idx += 1) {
                         ARROW_RETURN_NOT_OK(
                             value_builder->Append(element.many_strings_optional.value()[item_idx])

--- a/rerun_cpp/src/rerun/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer15.cpp
@@ -38,6 +38,7 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
+            (void)num_elements;
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer16.cpp
@@ -43,10 +43,10 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.many_required_unions.data()) {

--- a/rerun_cpp/src/rerun/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer17.cpp
@@ -43,10 +43,10 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_optional_unions.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());

--- a/rerun_cpp/src/rerun/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer18.cpp
@@ -43,10 +43,10 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_optional_unions.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());

--- a/rerun_cpp/src/rerun/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer4.cpp
@@ -39,6 +39,7 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
+            (void)num_elements;
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer5.cpp
@@ -39,6 +39,7 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
+            (void)num_elements;
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer6.cpp
@@ -39,6 +39,7 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
+            (void)num_elements;
             return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer7.cpp
@@ -43,10 +43,10 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::StructBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 if (element.many_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());

--- a/rerun_cpp/src/rerun/components/affix_fuzzer8.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer8.cpp
@@ -36,8 +36,8 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.single_float_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append(element.single_float_optional.value()));

--- a/rerun_cpp/src/rerun/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/src/rerun/components/affix_fuzzer9.cpp
@@ -36,8 +36,8 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].single_string_required));
             }
 

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -45,10 +45,10 @@ namespace rerun {
             }
 
             auto value_builder = static_cast<arrow::StructBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.class_map.data()) {

--- a/rerun_cpp/src/rerun/components/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.cpp
@@ -38,7 +38,7 @@ namespace rerun {
             static_assert(sizeof(*elements) == sizeof(elements->is_disconnected));
             ARROW_RETURN_NOT_OK(builder->AppendValues(
                 reinterpret_cast<const uint8_t *>(&elements->is_disconnected),
-                num_elements
+                static_cast<int64_t>(num_elements)
             ));
 
             return arrow::Status::OK();

--- a/rerun_cpp/src/rerun/components/draw_order.cpp
+++ b/rerun_cpp/src/rerun/components/draw_order.cpp
@@ -37,7 +37,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->value, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/components/instance_key.cpp
+++ b/rerun_cpp/src/rerun/components/instance_key.cpp
@@ -37,7 +37,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->value, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -44,10 +44,10 @@ namespace rerun {
 
             auto value_builder =
                 static_cast<arrow::FixedSizeListBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.points.data()) {

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -44,10 +44,10 @@ namespace rerun {
 
             auto value_builder =
                 static_cast<arrow::FixedSizeListBuilder *>(builder->value_builder());
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.points.data()) {

--- a/rerun_cpp/src/rerun/components/radius.cpp
+++ b/rerun_cpp/src/rerun/components/radius.cpp
@@ -37,7 +37,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->value, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer1.cpp
@@ -86,8 +86,8 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::FloatBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.single_float_optional.has_value()) {
                         ARROW_RETURN_NOT_OK(
@@ -100,8 +100,8 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(
                         field_builder->Append(elements[elem_idx].single_string_required)
                     );
@@ -109,8 +109,8 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(2));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.single_string_optional.has_value()) {
                         ARROW_RETURN_NOT_OK(
@@ -125,16 +125,16 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(3));
                 auto value_builder =
                     static_cast<arrow::FloatBuilder *>(field_builder->value_builder());
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.many_floats_optional.has_value()) {
                         ARROW_RETURN_NOT_OK(field_builder->Append());
                         ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                             element.many_floats_optional.value().data(),
-                            element.many_floats_optional.value().size(),
+                            static_cast<int64_t>(element.many_floats_optional.value().size()),
                             nullptr
                         ));
                     } else {
@@ -146,13 +146,13 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(4));
                 auto value_builder =
                     static_cast<arrow::StringBuilder *>(field_builder->value_builder());
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     ARROW_RETURN_NOT_OK(field_builder->Append());
-                    for (auto item_idx = 0; item_idx < element.many_strings_required.size();
+                    for (size_t item_idx = 0; item_idx < element.many_strings_required.size();
                          item_idx += 1) {
                         ARROW_RETURN_NOT_OK(
                             value_builder->Append(element.many_strings_required[item_idx])
@@ -164,14 +164,14 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(5));
                 auto value_builder =
                     static_cast<arrow::StringBuilder *>(field_builder->value_builder());
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 1));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 1)));
 
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.many_strings_optional.has_value()) {
                         ARROW_RETURN_NOT_OK(field_builder->Append());
-                        for (auto item_idx = 0;
+                        for (size_t item_idx = 0;
                              item_idx < element.many_strings_optional.value().size();
                              item_idx += 1) {
                             ARROW_RETURN_NOT_OK(value_builder->Append(
@@ -185,15 +185,15 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::FloatBuilder *>(builder->field_builder(6));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].flattened_scalar));
                 }
             }
             {
                 auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(7));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::FlattenedScalar::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].almost_flattened_scalar,
@@ -204,8 +204,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::BooleanBuilder *>(builder->field_builder(8));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.from_parent.has_value()) {
                         ARROW_RETURN_NOT_OK(field_builder->Append(element.from_parent.value()));
@@ -214,7 +214,7 @@ namespace rerun {
                     }
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer2.cpp
@@ -32,8 +32,8 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.single_float_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append(element.single_float_optional.value()));

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer20.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer20.cpp
@@ -49,8 +49,8 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::UInt32Builder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(
                         rerun::datatypes::PrimitiveComponent::fill_arrow_array_builder(
                             field_builder,
@@ -62,8 +62,8 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::StringComponent::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].s,
@@ -71,7 +71,7 @@ namespace rerun {
                     ));
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer3.cpp
@@ -69,10 +69,10 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &union_instance = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
 
                 auto variant_index = static_cast<int>(union_instance._tag);
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
@@ -102,6 +102,7 @@ namespace rerun {
                     case detail::AffixFuzzer3Tag::craziness: {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder *>(variant_builder_untyped);
+                        (void)variant_builder;
                         return arrow::Status::NotImplemented(
                             "TODO(andreas): list types in unions are not yet supported"
                         );
@@ -110,6 +111,7 @@ namespace rerun {
                     case detail::AffixFuzzer3Tag::fixed_size_shenanigans: {
                         auto variant_builder =
                             static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
+                        (void)variant_builder;
                         return arrow::Status::NotImplemented(
                             "TODO(andreas): list types in unions are not yet supported"
                         );

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer4.cpp
@@ -76,10 +76,10 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &union_instance = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
 
                 auto variant_index = static_cast<int>(union_instance._tag);
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
@@ -104,6 +104,7 @@ namespace rerun {
                     case detail::AffixFuzzer4Tag::many_required: {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder *>(variant_builder_untyped);
+                        (void)variant_builder;
                         return arrow::Status::NotImplemented(
                             "TODO(andreas): list types in unions are not yet supported"
                         );
@@ -112,6 +113,7 @@ namespace rerun {
                     case detail::AffixFuzzer4Tag::many_optional: {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder *>(variant_builder_untyped);
+                        (void)variant_builder;
                         return arrow::Status::NotImplemented(
                             "TODO(andreas): list types in unions are not yet supported"
                         );

--- a/rerun_cpp/src/rerun/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/src/rerun/datatypes/affix_fuzzer5.cpp
@@ -50,8 +50,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.single_optional_union.has_value()) {
                         ARROW_RETURN_NOT_OK(
@@ -66,7 +66,7 @@ namespace rerun {
                     }
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.cpp
@@ -44,10 +44,10 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &union_instance = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
 
                 auto variant_index = static_cast<int>(union_instance._tag);
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -29,13 +29,15 @@ namespace rerun {
 
                 ~AngleData() {}
 
-                void swap(AngleData& other) noexcept {
+                void swap(AngleData &other) noexcept {
                     // This bitwise swap would fail for self-referential types, but we don't have
                     // any of those.
                     char temp[sizeof(AngleData)];
-                    std::memcpy(temp, this, sizeof(AngleData));
-                    std::memcpy(this, &other, sizeof(AngleData));
-                    std::memcpy(&other, temp, sizeof(AngleData));
+                    void *otherbytes = reinterpret_cast<void *>(&other);
+                    void *thisbytes = reinterpret_cast<void *>(this);
+                    std::memcpy(temp, thisbytes, sizeof(AngleData));
+                    std::memcpy(thisbytes, otherbytes, sizeof(AngleData));
+                    std::memcpy(otherbytes, temp, sizeof(AngleData));
                 }
             };
         } // namespace detail
@@ -44,26 +46,28 @@ namespace rerun {
         struct Angle {
             Angle() : _tag(detail::AngleTag::NONE) {}
 
-            Angle(const Angle& other) : _tag(other._tag) {
-                memcpy(&this->_data, &other._data, sizeof(detail::AngleData));
+            Angle(const Angle &other) : _tag(other._tag) {
+                const void *otherbytes = reinterpret_cast<const void *>(&other._data);
+                void *thisbytes = reinterpret_cast<void *>(&this->_data);
+                std::memcpy(thisbytes, otherbytes, sizeof(detail::AngleData));
             }
 
-            Angle& operator=(const Angle& other) noexcept {
+            Angle &operator=(const Angle &other) noexcept {
                 Angle tmp(other);
                 this->swap(tmp);
                 return *this;
             }
 
-            Angle(Angle&& other) noexcept : _tag(detail::AngleTag::NONE) {
+            Angle(Angle &&other) noexcept : _tag(detail::AngleTag::NONE) {
                 this->swap(other);
             }
 
-            Angle& operator=(Angle&& other) noexcept {
+            Angle &operator=(Angle &&other) noexcept {
                 this->swap(other);
                 return *this;
             }
 
-            void swap(Angle& other) noexcept {
+            void swap(Angle &other) noexcept {
                 auto tag_temp = this->_tag;
                 this->_tag = other._tag;
                 other._tag = tag_temp;
@@ -85,16 +89,16 @@ namespace rerun {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
-                arrow::MemoryPool* memory_pool
+                arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
-                arrow::DenseUnionBuilder* builder, const Angle* elements, size_t num_elements
+                arrow::DenseUnionBuilder *builder, const Angle *elements, size_t num_elements
             );
 
           private:

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
@@ -48,15 +48,15 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].id));
                 }
             }
             {
                 auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.label.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Label::fill_arrow_array_builder(
@@ -71,8 +71,8 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::UInt32Builder *>(builder->field_builder(2));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.color.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Color::fill_arrow_array_builder(
@@ -85,7 +85,7 @@ namespace rerun {
                     }
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/class_description.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.cpp
@@ -73,8 +73,8 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].info,
@@ -86,10 +86,10 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(1));
                 auto value_builder =
                     static_cast<arrow::StructBuilder *>(field_builder->value_builder());
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     ARROW_RETURN_NOT_OK(field_builder->Append());
                     if (element.keypoint_annotations.data()) {
@@ -107,10 +107,10 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(2));
                 auto value_builder =
                     static_cast<arrow::StructBuilder *>(field_builder->value_builder());
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                ARROW_RETURN_NOT_OK(value_builder->Reserve(num_elements * 2));
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     ARROW_RETURN_NOT_OK(field_builder->Append());
                     if (element.keypoint_connections.data()) {
@@ -124,7 +124,7 @@ namespace rerun {
                     }
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
@@ -52,8 +52,8 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].class_id,
@@ -63,8 +63,8 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(
                         rerun::datatypes::ClassDescription::fill_arrow_array_builder(
                             field_builder,
@@ -74,7 +74,7 @@ namespace rerun {
                     );
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/class_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.cpp
@@ -33,7 +33,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->id));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->id, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->id, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/color.cpp
+++ b/rerun_cpp/src/rerun/datatypes/color.cpp
@@ -33,7 +33,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->rgba));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->rgba, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->rgba, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/flattened_scalar.cpp
+++ b/rerun_cpp/src/rerun/datatypes/flattened_scalar.cpp
@@ -41,12 +41,12 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::FloatBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].value));
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
@@ -33,7 +33,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->id));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->id, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->id, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
@@ -46,8 +46,8 @@ namespace rerun {
 
             {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].keypoint0,
@@ -57,8 +57,8 @@ namespace rerun {
             }
             {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].keypoint1,
@@ -66,7 +66,7 @@ namespace rerun {
                     ));
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/label.cpp
+++ b/rerun_cpp/src/rerun/datatypes/label.cpp
@@ -32,8 +32,8 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].value));
             }
 

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -39,11 +39,13 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
             static_assert(sizeof(elements[0].coeffs) == sizeof(elements[0]));
-            ARROW_RETURN_NOT_OK(
-                value_builder->AppendValues(elements[0].coeffs, num_elements * 9, nullptr)
-            );
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                elements[0].coeffs,
+                static_cast<int64_t>(num_elements * 9),
+                nullptr
+            ));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -39,11 +39,13 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
             static_assert(sizeof(elements[0].coeffs) == sizeof(elements[0]));
-            ARROW_RETURN_NOT_OK(
-                value_builder->AppendValues(elements[0].coeffs, num_elements * 16, nullptr)
-            );
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                elements[0].coeffs,
+                static_cast<int64_t>(num_elements * 16),
+                nullptr
+            ));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/primitive_component.cpp
+++ b/rerun_cpp/src/rerun/datatypes/primitive_component.cpp
@@ -32,7 +32,9 @@ namespace rerun {
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
-            ARROW_RETURN_NOT_OK(builder->AppendValues(&elements->value, num_elements));
+            ARROW_RETURN_NOT_OK(
+                builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
+            );
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.cpp
@@ -38,11 +38,13 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
             static_assert(sizeof(elements[0].xyzw) == sizeof(elements[0]));
-            ARROW_RETURN_NOT_OK(
-                value_builder->AppendValues(elements[0].xyzw, num_elements * 4, nullptr)
-            );
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                elements[0].xyzw,
+                static_cast<int64_t>(num_elements * 4),
+                nullptr
+            ));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
@@ -55,10 +55,10 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &union_instance = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
 
                 auto variant_index = static_cast<int>(union_instance._tag);
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -34,13 +34,15 @@ namespace rerun {
 
                 ~Rotation3DData() {}
 
-                void swap(Rotation3DData& other) noexcept {
+                void swap(Rotation3DData &other) noexcept {
                     // This bitwise swap would fail for self-referential types, but we don't have
                     // any of those.
                     char temp[sizeof(Rotation3DData)];
-                    std::memcpy(temp, this, sizeof(Rotation3DData));
-                    std::memcpy(this, &other, sizeof(Rotation3DData));
-                    std::memcpy(&other, temp, sizeof(Rotation3DData));
+                    void *otherbytes = reinterpret_cast<void *>(&other);
+                    void *thisbytes = reinterpret_cast<void *>(this);
+                    std::memcpy(temp, thisbytes, sizeof(Rotation3DData));
+                    std::memcpy(thisbytes, otherbytes, sizeof(Rotation3DData));
+                    std::memcpy(otherbytes, temp, sizeof(Rotation3DData));
                 }
             };
         } // namespace detail
@@ -49,26 +51,28 @@ namespace rerun {
         struct Rotation3D {
             Rotation3D() : _tag(detail::Rotation3DTag::NONE) {}
 
-            Rotation3D(const Rotation3D& other) : _tag(other._tag) {
-                memcpy(&this->_data, &other._data, sizeof(detail::Rotation3DData));
+            Rotation3D(const Rotation3D &other) : _tag(other._tag) {
+                const void *otherbytes = reinterpret_cast<const void *>(&other._data);
+                void *thisbytes = reinterpret_cast<void *>(&this->_data);
+                std::memcpy(thisbytes, otherbytes, sizeof(detail::Rotation3DData));
             }
 
-            Rotation3D& operator=(const Rotation3D& other) noexcept {
+            Rotation3D &operator=(const Rotation3D &other) noexcept {
                 Rotation3D tmp(other);
                 this->swap(tmp);
                 return *this;
             }
 
-            Rotation3D(Rotation3D&& other) noexcept : _tag(detail::Rotation3DTag::NONE) {
+            Rotation3D(Rotation3D &&other) noexcept : _tag(detail::Rotation3DTag::NONE) {
                 this->swap(other);
             }
 
-            Rotation3D& operator=(Rotation3D&& other) noexcept {
+            Rotation3D &operator=(Rotation3D &&other) noexcept {
                 this->swap(other);
                 return *this;
             }
 
-            void swap(Rotation3D& other) noexcept {
+            void swap(Rotation3D &other) noexcept {
                 auto tag_temp = this->_tag;
                 this->_tag = other._tag;
                 other._tag = tag_temp;
@@ -102,16 +106,16 @@ namespace rerun {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
-                arrow::MemoryPool* memory_pool
+                arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
-                arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
+                arrow::DenseUnionBuilder *builder, const Rotation3D *elements, size_t num_elements
             );
 
           private:

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
@@ -47,8 +47,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].axis,
@@ -59,8 +59,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(rerun::datatypes::Angle::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].angle,
@@ -68,7 +68,7 @@ namespace rerun {
                     ));
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.cpp
@@ -46,10 +46,10 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &union_instance = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
 
                 auto variant_index = static_cast<int>(union_instance._tag);
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -33,13 +33,15 @@ namespace rerun {
 
                 ~Scale3DData() {}
 
-                void swap(Scale3DData& other) noexcept {
+                void swap(Scale3DData &other) noexcept {
                     // This bitwise swap would fail for self-referential types, but we don't have
                     // any of those.
                     char temp[sizeof(Scale3DData)];
-                    std::memcpy(temp, this, sizeof(Scale3DData));
-                    std::memcpy(this, &other, sizeof(Scale3DData));
-                    std::memcpy(&other, temp, sizeof(Scale3DData));
+                    void *otherbytes = reinterpret_cast<void *>(&other);
+                    void *thisbytes = reinterpret_cast<void *>(this);
+                    std::memcpy(temp, thisbytes, sizeof(Scale3DData));
+                    std::memcpy(thisbytes, otherbytes, sizeof(Scale3DData));
+                    std::memcpy(otherbytes, temp, sizeof(Scale3DData));
                 }
             };
         } // namespace detail
@@ -48,26 +50,28 @@ namespace rerun {
         struct Scale3D {
             Scale3D() : _tag(detail::Scale3DTag::NONE) {}
 
-            Scale3D(const Scale3D& other) : _tag(other._tag) {
-                memcpy(&this->_data, &other._data, sizeof(detail::Scale3DData));
+            Scale3D(const Scale3D &other) : _tag(other._tag) {
+                const void *otherbytes = reinterpret_cast<const void *>(&other._data);
+                void *thisbytes = reinterpret_cast<void *>(&this->_data);
+                std::memcpy(thisbytes, otherbytes, sizeof(detail::Scale3DData));
             }
 
-            Scale3D& operator=(const Scale3D& other) noexcept {
+            Scale3D &operator=(const Scale3D &other) noexcept {
                 Scale3D tmp(other);
                 this->swap(tmp);
                 return *this;
             }
 
-            Scale3D(Scale3D&& other) noexcept : _tag(detail::Scale3DTag::NONE) {
+            Scale3D(Scale3D &&other) noexcept : _tag(detail::Scale3DTag::NONE) {
                 this->swap(other);
             }
 
-            Scale3D& operator=(Scale3D&& other) noexcept {
+            Scale3D &operator=(Scale3D &&other) noexcept {
                 this->swap(other);
                 return *this;
             }
 
-            void swap(Scale3D& other) noexcept {
+            void swap(Scale3D &other) noexcept {
                 auto tag_temp = this->_tag;
                 this->_tag = other._tag;
                 other._tag = tag_temp;
@@ -101,16 +105,16 @@ namespace rerun {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
-                arrow::MemoryPool* memory_pool
+                arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
-                arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
+                arrow::DenseUnionBuilder *builder, const Scale3D *elements, size_t num_elements
             );
 
           private:

--- a/rerun_cpp/src/rerun/datatypes/string_component.cpp
+++ b/rerun_cpp/src/rerun/datatypes/string_component.cpp
@@ -31,8 +31,8 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].value));
             }
 

--- a/rerun_cpp/src/rerun/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.cpp
@@ -58,10 +58,10 @@ namespace rerun {
                 return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
             }
 
-            ARROW_RETURN_NOT_OK(builder->Reserve(num_elements));
-            for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+            ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto &union_instance = elements[elem_idx];
-                ARROW_RETURN_NOT_OK(builder->Append(static_cast<uint8_t>(union_instance._tag)));
+                ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
 
                 auto variant_index = static_cast<int>(union_instance._tag);
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -32,13 +32,15 @@ namespace rerun {
 
                 ~Transform3DData() {}
 
-                void swap(Transform3DData& other) noexcept {
+                void swap(Transform3DData &other) noexcept {
                     // This bitwise swap would fail for self-referential types, but we don't have
                     // any of those.
                     char temp[sizeof(Transform3DData)];
-                    std::memcpy(temp, this, sizeof(Transform3DData));
-                    std::memcpy(this, &other, sizeof(Transform3DData));
-                    std::memcpy(&other, temp, sizeof(Transform3DData));
+                    void *otherbytes = reinterpret_cast<void *>(&other);
+                    void *thisbytes = reinterpret_cast<void *>(this);
+                    std::memcpy(temp, thisbytes, sizeof(Transform3DData));
+                    std::memcpy(thisbytes, otherbytes, sizeof(Transform3DData));
+                    std::memcpy(otherbytes, temp, sizeof(Transform3DData));
                 }
             };
         } // namespace detail
@@ -47,26 +49,28 @@ namespace rerun {
         struct Transform3D {
             Transform3D() : _tag(detail::Transform3DTag::NONE) {}
 
-            Transform3D(const Transform3D& other) : _tag(other._tag) {
-                memcpy(&this->_data, &other._data, sizeof(detail::Transform3DData));
+            Transform3D(const Transform3D &other) : _tag(other._tag) {
+                const void *otherbytes = reinterpret_cast<const void *>(&other._data);
+                void *thisbytes = reinterpret_cast<void *>(&this->_data);
+                std::memcpy(thisbytes, otherbytes, sizeof(detail::Transform3DData));
             }
 
-            Transform3D& operator=(const Transform3D& other) noexcept {
+            Transform3D &operator=(const Transform3D &other) noexcept {
                 Transform3D tmp(other);
                 this->swap(tmp);
                 return *this;
             }
 
-            Transform3D(Transform3D&& other) noexcept : _tag(detail::Transform3DTag::NONE) {
+            Transform3D(Transform3D &&other) noexcept : _tag(detail::Transform3DTag::NONE) {
                 this->swap(other);
             }
 
-            Transform3D& operator=(Transform3D&& other) noexcept {
+            Transform3D &operator=(Transform3D &&other) noexcept {
                 this->swap(other);
                 return *this;
             }
 
-            void swap(Transform3D& other) noexcept {
+            void swap(Transform3D &other) noexcept {
                 auto tag_temp = this->_tag;
                 this->_tag = other._tag;
                 other._tag = tag_temp;
@@ -101,16 +105,16 @@ namespace rerun {
             }
 
             /// Returns the arrow data type this type corresponds to.
-            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
+            static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
             static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
-                arrow::MemoryPool* memory_pool
+                arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
             static arrow::Status fill_arrow_array_builder(
-                arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
+                arrow::DenseUnionBuilder *builder, const Transform3D *elements, size_t num_elements
             );
 
           private:

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
@@ -49,8 +49,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.translation.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
@@ -66,8 +66,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.matrix.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Mat3x3::fill_arrow_array_builder(
@@ -83,12 +83,12 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::BooleanBuilder *>(builder->field_builder(2));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].from_parent));
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
@@ -53,8 +53,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(0));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.translation.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
@@ -70,8 +70,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(1));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.rotation.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Rotation3D::fill_arrow_array_builder(
@@ -87,8 +87,8 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(2));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.scale.has_value()) {
                         ARROW_RETURN_NOT_OK(rerun::datatypes::Scale3D::fill_arrow_array_builder(
@@ -104,12 +104,12 @@ namespace rerun {
             {
                 auto field_builder =
                     static_cast<arrow::BooleanBuilder *>(builder->field_builder(3));
-                ARROW_RETURN_NOT_OK(field_builder->Reserve(num_elements));
-                for (auto elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+                for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     ARROW_RETURN_NOT_OK(field_builder->Append(elements[elem_idx].from_parent));
                 }
             }
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements, nullptr));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.cpp
@@ -39,11 +39,13 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
             static_assert(sizeof(elements[0].xy) == sizeof(elements[0]));
-            ARROW_RETURN_NOT_OK(
-                value_builder->AppendValues(elements[0].xy, num_elements * 2, nullptr)
-            );
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                elements[0].xy,
+                static_cast<int64_t>(num_elements * 2),
+                nullptr
+            ));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.cpp
@@ -39,11 +39,13 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
             static_assert(sizeof(elements[0].xyz) == sizeof(elements[0]));
-            ARROW_RETURN_NOT_OK(
-                value_builder->AppendValues(elements[0].xyz, num_elements * 3, nullptr)
-            );
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                elements[0].xyz,
+                static_cast<int64_t>(num_elements * 3),
+                nullptr
+            ));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.cpp
@@ -39,11 +39,13 @@ namespace rerun {
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
-            ARROW_RETURN_NOT_OK(builder->AppendValues(num_elements));
+            ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
             static_assert(sizeof(elements[0].xyzw) == sizeof(elements[0]));
-            ARROW_RETURN_NOT_OK(
-                value_builder->AppendValues(elements[0].xyzw, num_elements * 4, nullptr)
-            );
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                elements[0].xyzw,
+                static_cast<int64_t>(num_elements * 4),
+                nullptr
+            ));
 
             return arrow::Status::OK();
         }

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -44,19 +44,20 @@ namespace rerun {
 
     RecordingStream& RecordingStream::current(StoreKind store_kind) {
         switch (store_kind) {
-            case StoreKind::Recording: {
-                static RecordingStream current_recording(
-                    RERUN_REC_STREAM_CURRENT_RECORDING,
-                    StoreKind::Recording
-                );
-                return current_recording;
-            }
             case StoreKind::Blueprint: {
                 static RecordingStream current_blueprint(
                     RERUN_REC_STREAM_CURRENT_BLUEPRINT,
                     StoreKind::Blueprint
                 );
                 return current_blueprint;
+            }
+            case StoreKind::Recording:
+            default: {
+                static RecordingStream current_recording(
+                    RERUN_REC_STREAM_CURRENT_RECORDING,
+                    StoreKind::Recording
+                );
+                return current_recording;
             }
         }
     }

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -78,22 +78,19 @@ namespace rerun {
         const DataCell* data_cells
     ) {
         // Map to C API:
-        std::vector<rr_data_cell> c_data_cells;
-        c_data_cells.reserve(num_data_cells);
-        for (size_t i = 0; i < num_data_cells; ++i) {
-            c_data_cells.push_back({
-                .component_name = data_cells[i].component_name,
-                .num_bytes = static_cast<uint64_t>(data_cells[i].buffer->size()),
-                .bytes = data_cells[i].buffer->data(),
-            });
+        std::unique_ptr<rr_data_cell[]> c_data_cells =
+            std::make_unique<rr_data_cell[]>(num_data_cells);
+        for (size_t i = 0; i < num_data_cells; i++) {
+            c_data_cells[i].component_name = data_cells[i].component_name;
+            c_data_cells[i].num_bytes = static_cast<uint64_t>(data_cells[i].buffer->size());
+            c_data_cells[i].bytes = data_cells[i].buffer->data();
         }
 
-        const rr_data_row c_data_row = {
-            .entity_path = entity_path,
-            .num_instances = static_cast<uint32_t>(num_instances),
-            .num_data_cells = static_cast<uint32_t>(num_data_cells),
-            .data_cells = c_data_cells.data(),
-        };
+        rr_data_row c_data_row;
+        c_data_row.entity_path = entity_path,
+        c_data_row.num_instances = static_cast<uint32_t>(num_instances);
+        c_data_row.num_data_cells = static_cast<uint32_t>(num_data_cells);
+        c_data_row.data_cells = c_data_cells.get();
 
         rr_log(_id, &c_data_row, true);
     }

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -78,8 +78,7 @@ namespace rerun {
         const DataCell* data_cells
     ) {
         // Map to C API:
-        std::unique_ptr<rr_data_cell[]> c_data_cells =
-            std::make_unique<rr_data_cell[]>(num_data_cells);
+        std::vector<rr_data_cell> c_data_cells(num_data_cells);
         for (size_t i = 0; i < num_data_cells; i++) {
             c_data_cells[i].component_name = data_cells[i].component_name;
             c_data_cells[i].num_bytes = static_cast<uint64_t>(data_cells[i].buffer->size());
@@ -90,7 +89,7 @@ namespace rerun {
         c_data_row.entity_path = entity_path,
         c_data_row.num_instances = static_cast<uint32_t>(num_instances);
         c_data_row.num_data_cells = static_cast<uint32_t>(num_data_cells);
-        c_data_row.data_cells = c_data_cells.get();
+        c_data_row.data_cells = c_data_cells.data();
 
         rr_log(_id, &c_data_row, true);
     }

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -220,9 +220,9 @@ namespace rerun {
 
         static void push_data_cells(std::vector<DataCell>&) {}
 
-        RecordingStream(int32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
+        RecordingStream(uint32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
 
-        int32_t _id;
+        uint32_t _id;
         StoreKind _store_kind;
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -220,9 +220,9 @@ namespace rerun {
 
         static void push_data_cells(std::vector<DataCell>&) {}
 
-        RecordingStream(uint32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
+        RecordingStream(int32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
 
-        uint32_t _id;
+        int32_t _id;
         StoreKind _store_kind;
     };
 } // namespace rerun

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -69,10 +69,10 @@ def main() -> None:
         print("Build rerun_c & rerun_cpp…")
         start_time = time.time()
         os.makedirs("build", exist_ok=True)
+        build_type = "Debug"
         if args.release:
-            configure_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release", ".."]
-        else:
-            configure_args = ["cmake", "-DCMAKE_BUILD_TYPE=Debug", ".."]
+            build_type = "Release"
+        configure_args = ["cmake", f"-DCMAKE_BUILD_TYPE={build_type}", "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON", ".."]
         print(subprocess.list2cmdline(configure_args))
         returncode = subprocess.Popen(
             configure_args,

--- a/scripts/publish_crates.sh
+++ b/scripts/publish_crates.sh
@@ -24,7 +24,8 @@ while test $# -gt 0; do
       ;;
 
     *)
-      break
+      echo "Unknown option: $1"
+      exit 1
       ;;
   esac
 done

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -18,8 +18,7 @@ foreach(SOURCE_PATH ${sources_list})
 
     add_executable(${EXAMPLE_TARGET} ${SOURCE_PATH})
 
-    # TODO(andreas): Fix warnings and enable this.
-    # set_default_warning_settings(rerun_example)
+    set_default_warning_settings(rerun_example)
     target_link_libraries(${EXAMPLE_TARGET} PRIVATE rerun_sdk)
 
     add_dependencies(doc_examples ${EXAMPLE_TARGET})

--- a/tests/cpp/build_all_doc_examples.sh
+++ b/tests/cpp/build_all_doc_examples.sh
@@ -9,6 +9,6 @@ num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_BUILD_WARNINGS_AS_ERRORS=On ..
     cmake --build . --config Debug --target doc_examples -j ${num_threads}
 popd

--- a/tests/cpp/build_all_doc_examples.sh
+++ b/tests/cpp/build_all_doc_examples.sh
@@ -16,7 +16,8 @@ while test $# -gt 0; do
       ;;
 
     *)
-      break
+      echo "Unknown option: $1"
+      exit 1
       ;;
   esac
 done

--- a/tests/cpp/build_all_doc_examples.sh
+++ b/tests/cpp/build_all_doc_examples.sh
@@ -5,10 +5,31 @@ script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/../.."
 set -x
 
+
+WERROR=false
+
+while test $# -gt 0; do
+  case "$1" in
+    --werror)
+      shift
+      WERROR=true
+      ;;
+
+    *)
+      break
+      ;;
+  esac
+done
+
+
 num_threads=$(getconf _NPROCESSORS_ONLN)
 
 mkdir -p build
 pushd build
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_BUILD_WARNINGS_AS_ERRORS=On ..
+    if [ ${WERROR} = true ]; then
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON ..
+    else
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+    fi
     cmake --build . --config Debug --target doc_examples -j ${num_threads}
 popd

--- a/tests/cpp/run_all.sh
+++ b/tests/cpp/run_all.sh
@@ -5,13 +5,13 @@ script_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$script_path/../.."
 
 echo "------------ Building all C++ Examples ------------"
-/bin/bash ./tests/cpp/build_all_doc_examples.sh
+/bin/bash ./tests/cpp/build_all_doc_examples.sh $@
 
 echo "------------ Building & running SDK tests ------------"
-/bin/bash ./rerun_cpp/build_and_run_tests.sh
+/bin/bash ./rerun_cpp/build_and_run_tests.sh $@
 
 echo "------------ Building & running minimal example ------------"
-/bin/bash ./examples/cpp/minimal/build_and_run.sh
+/bin/bash ./examples/cpp/minimal/build_and_run.sh $@
 
 echo "------------ Running roundtrip tests ------------"
 python ./scripts/ci/run_e2e_roundtrip_tests.py


### PR DESCRIPTION
### What

* Fixes #2903 
* Part of #2919
* currate warning list for gcc/clang
* enable warnings as errors on CI, for simplicity it's always active on roundtrip tests
* enable standard set of warning settings on all C++ targets
* fix warnings in codegen'ed code and manually written code
* fix accidental C++20 (should have been caught in theory by warnings but it didn't trigger for unknown reason)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2957) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2957)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fwarning-fixes-and-ci-werror/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fwarning-fixes-and-ci-werror/examples)