### PR TITLE
`generate_changelog.py`: ignore PRs with label `exclude from changelog`

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -29,5 +29,5 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, , 🟦 blueprint, 🪳 bug, C/C++ SDK, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, , 🟦 blueprint, 🪳 bug, C/C++ SDK, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
 """
-Summarizes recent PRs based on their GitHub labels.
+Summarizes PRs since `latest` tag, grouping them based on their GitHub labels.
 
-The result can be copy-pasted into CHANGELOG.md, though it often needs some manual editing too.
+If the result is not satisfactory, you can edit the orginal PR titles and labels.
+You can add the `exclude from changelog` label to minor PRs that are not of interest to our users.
+
+Finally, copy-paste the output into `CHANGELOG.md` and add a high-level summary to the top.
 """
 from __future__ import annotations
 
@@ -165,6 +168,9 @@ def main() -> None:
         else:
             title = pr_info.pr_title if pr_info else title  # We prefer the PR title if available
             labels = pr_info.labels if pr_info else []
+
+            if "exclude from changelog" in labels:
+                continue
 
             summary = f"{title} [#{pr_number}](https://github.com/{OWNER}/{REPO}/pull/{pr_number})"
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -3,7 +3,7 @@
 """
 Summarizes PRs since `latest` tag, grouping them based on their GitHub labels.
 
-If the result is not satisfactory, you can edit the orginal PR titles and labels.
+If the result is not satisfactory, you can edit the original PR titles and labels.
 You can add the `exclude from changelog` label to minor PRs that are not of interest to our users.
 
 Finally, copy-paste the output into `CHANGELOG.md` and add a high-level summary to the top.


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/2955

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2958) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2958)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fexclude-from-changelog-label/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fexclude-from-changelog-label/examples)