### PR TITLE
C++ MSVC compilation fixes

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -67,9 +67,9 @@ elseif(UNIX) # if(LINUX) # CMake 3.25
     target_link_libraries(rerun_sdk PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../target/release/librerun_c.a)
     target_link_libraries(rerun_sdk PRIVATE "-lm")
 elseif(WIN32)
-    target_link_libraries(rerun_sdk PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../target/release/librerun_c.a)
-
-    # TODO(andreas): Untested. Almost certainly gonna encounter issues here.
+    # TODO(andreas): Why not static linkage?
+    target_link_libraries(rerun_sdk PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../target/release/rerun_c.lib)
+    target_link_libraries(rerun_sdk PUBLIC ws2_32.dll Bcrypt.dll Userenv.dll)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -14,6 +14,11 @@ namespace rerun {
             case StoreKind::Blueprint:
                 return RERUN_STORE_KIND_BLUEPRINT;
         }
+
+        // This should never happen since if we missed a switch case we'll get a warning on
+        // compilers which compiles as an error on CI. But let's play it safe regardless and default
+        // to recording.
+        return RERUN_STORE_KIND_RECORDING;
     }
 
     RecordingStream::RecordingStream(const char* app_id, StoreKind store_kind)


### PR DESCRIPTION
### What

As kindly supplied by a user on Discord. Didn't get to test them myself yet but makes lot of sense to me regardless.

* Part of #2919
* requires additionally C++20 fixes from #2957
* currently every dependend binary has to know about arrow, should be fixed as part of #2873

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2959) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2959)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fwindows-fixes/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fwindows-fixes/examples)