### PR TITLE
Enable debug symbols in build scripts (`build.rs`) in dev mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,9 @@ wgpu-core = { version = "0.16.1" }
 opt-level = 1   # Make debug builds run faster
 panic = "abort" # This leads to better optimizations and smaller binaries (and is the default in Wasm anyways).
 
+[profile.dev.build-override]
+debug = true # enable debug symbols for build scripts when building in dev (codegen backtraces!)
+
 # Optimize all dependencies even in debug builds (does not affect workspace packages):
 [profile.dev.package."*"]
 opt-level = 2


### PR DESCRIPTION
Before:
```
  thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', crates/re_types_builder/src/codegen/python.rs:693:39
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:579:5
     1: core::panicking::panic_fmt
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:64:14
     2: core::panicking::panic
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:114:5
     3: core::option::Option<T>::unwrap
     4: re_types_builder::codegen::python::QuotedObject::from_union
     5: re_types_builder::codegen::python::quote_objects
     6: <re_types_builder::codegen::python::PythonCodeGenerator as re_types_builder::codegen::CodeGenerator>::generate
     7: re_types_builder::generate_python_code
     8: build_script_build::main::{{ closure }}
     9: rayon_core::join::join::call::{{ closure }}
    10: rayon_core::join::join_context::call_b::{{ closure }}
    11: rayon_core::job::JobResult<T>::call::{{ closure }}
    12: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
    13: std::panicking::try::do_call
    14: __rust_try
    15: std::panicking::try
    16: std::panic::catch_unwind
    17: rayon_core::unwind::halt_unwinding
    18: rayon_core::job::JobResult<T>::call
    19: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
    20: rayon_core::registry::WorkerThread::wait_until_cold
    21: rayon_core::registry::ThreadBuilder::run
```

After:
```
  thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', crates/re_types_builder/src/codegen/python.rs:693:39
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:579:5
     1: core::panicking::panic_fmt
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:64:14
     2: core::panicking::panic
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:114:5
     3: core::option::Option<T>::unwrap
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/option.rs:942:21
     4: re_types_builder::codegen::python::QuotedObject::from_union
               at /home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/python.rs:693:13
     5: re_types_builder::codegen::python::quote_objects
               at /home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/python.rs:228:13
     6: <re_types_builder::codegen::python::PythonCodeGenerator as re_types_builder::codegen::CodeGenerator>::generate
               at /home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/codegen/python.rs:99:13
     7: re_types_builder::generate_python_code
               at /home/cmc/dev/rerun-io/rerun/crates/re_types_builder/src/lib.rs:363:21
     8: build_script_build::main::{{ closure }}
               at ./build.rs:113:13
     9: rayon_core::join::join::call::{{ closure }}
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/join/mod.rs:102:18
    10: rayon_core::join::join_context::call_b::{{ closure }}
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/join/mod.rs:129:25
    11: rayon_core::job::JobResult<T>::call::{{ closure }}
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/job.rs:218:41
    12: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panic/unwind_safe.rs:271:9
    13: std::panicking::try::do_call
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:487:40
    14: __rust_try
    15: std::panicking::try
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:451:19
    16: std::panic::catch_unwind
               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panic.rs:140:14
    17: rayon_core::unwind::halt_unwinding
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/unwind.rs:17:5
    18: rayon_core::job::JobResult<T>::call
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/job.rs:218:15
    19: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/job.rs:120:32
    20: rayon_core::registry::WorkerThread::wait_until_cold
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/job.rs:64:9
    21: rayon_core::registry::ThreadBuilder::run
               at /home/cmc/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.11.0/src/registry.rs:803:13
```


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2962) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2962)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Fcodegen_backtraces/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Fcodegen_backtraces/examples)