### PR TITLE
Add support for tree to ListItem

### DIFF
--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -1,4 +1,3 @@
-use egui::Widget;
 use re_ui::{toasts, CommandPalette, UICommand, UICommandSender};
 
 /// Sender that queues up the execution of a command.
@@ -305,12 +304,29 @@ impl eframe::App for ExampleApp {
                                         item.with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
                                     };
 
-                                    if item.ui(ui).clicked() {
+                                    if item.show(ui).clicked() {
                                         self.selected_list_item = Some(i);
                                     }
                                 }
                             });
                         });
+
+                    self.re_ui.panel_content(ui, |re_ui, ui| {
+                        re_ui.panel_title_bar(ui, "Another section", None);
+
+                        self.re_ui
+                            .list_item("Collapsing list item with icon")
+                            .with_icon(&re_ui::icons::SPACE_VIEW_2D)
+                            .show_collapsing(ui, true, |_re_ui, ui| {
+                                self.re_ui.list_item("Sub-item").show(ui);
+                                self.re_ui.list_item("Sub-item").show(ui);
+                                self.re_ui
+                                    .list_item("Sub-item with icon")
+                                    .with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
+                                    .show(ui);
+                                self.re_ui.list_item("Sub-item").show(ui);
+                            });
+                    });
                 });
             });
 

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -612,6 +612,13 @@ impl ReUi {
         });
     }
 
+    /// Size for the collapsing triangle icon.
+    ///
+    /// See [`ReUi::paint_collapsing_triangle`] for actually drawing the triangle.
+    pub fn collapsing_triangle_size() -> egui::Vec2 {
+        egui::Vec2::splat(8.0)
+    }
+
     /// Paint a collapsing triangle with rounded corners.
     ///
     /// Alternative to [`egui::collapsing_header::paint_default_icon`].


### PR DESCRIPTION
### What

Pre-requisite for hierarchical display of recordings and for backport to blueprint tree.

Uses the new collapsing triangle (partially addresses #2738).

Note: not deployed in viewer yet, can be tested with re_ui_example

<img width="203" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e4217f8d-55cc-437c-b207-a585e113f48a">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2968) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2968)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fhierarchical-listitem2/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fhierarchical-listitem2/examples)