### PR TITLE
Add support to close a recording

### DIFF
--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -374,4 +374,10 @@ impl StoreDb {
 
         entity_db.purge(&cutoff_times, &drop_row_ids);
     }
+
+    /// Key used for sorting recordings in the UI.
+    pub fn sort_key(&self) -> impl Ord + '_ {
+        self.store_info()
+            .map(|info| (info.application_id.0.as_str(), info.started))
+    }
 }

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -19,6 +19,7 @@ pub enum UICommand {
     Save,
     #[cfg(not(target_arch = "wasm32"))]
     SaveSelection,
+    CloseCurrentRecording,
     #[cfg(not(target_arch = "wasm32"))]
     Quit,
 
@@ -85,6 +86,8 @@ impl UICommand {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Open => ("Open…", "Open a Rerun Data File (.rrd)"),
+
+            UICommand::CloseCurrentRecording => ("Close recording", "Close the current Recording"),
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Quit => ("Quit", "Close the Rerun Viewer"),
@@ -186,6 +189,7 @@ impl UICommand {
             UICommand::SaveSelection => Some(cmd_alt(Key::S)),
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Open => Some(cmd(Key::O)),
+            UICommand::CloseCurrentRecording => None,
 
             #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
             UICommand::Quit => Some(KeyboardShortcut::new(Modifiers::ALT, Key::F4)),

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -87,7 +87,10 @@ impl UICommand {
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Open => ("Open…", "Open a Rerun Data File (.rrd)"),
 
-            UICommand::CloseCurrentRecording => ("Close recording", "Close the current Recording"),
+            UICommand::CloseCurrentRecording => (
+                "Close current Recording",
+                "Close the current Recording (unsaved data will be lost)",
+            ),
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Quit => ("Quit", "Close the Rerun Viewer"),

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -290,6 +290,9 @@ impl App {
             SystemCommand::SetRecordingId(recording_id) => {
                 store_hub.set_recording_id(recording_id);
             }
+            SystemCommand::CloseRecordingId(recording_id) => {
+                store_hub.remove_recording_id(&recording_id);
+            }
             #[cfg(not(target_arch = "wasm32"))]
             SystemCommand::LoadRrd(path) => {
                 let with_notification = true;
@@ -341,6 +344,15 @@ impl App {
                 if let Some(rrd_file) = open_rrd_dialog() {
                     self.command_sender
                         .send_system(SystemCommand::LoadRrd(rrd_file));
+                }
+            }
+            UICommand::CloseCurrentRecording => {
+                let cur_rec = store_context
+                    .and_then(|ctx| ctx.recording)
+                    .map(|rec| rec.store_id());
+                if let Some(cur_rec) = cur_rec {
+                    self.command_sender
+                        .send_system(SystemCommand::CloseRecordingId(cur_rec.clone()));
                 }
             }
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -1,4 +1,3 @@
-use re_data_store::StoreDb;
 use re_viewer_context::{SystemCommand, SystemCommandSender, ViewerContext};
 use time::macros::format_description;
 
@@ -39,13 +38,7 @@ fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         return;
     }
 
-    fn store_db_key(store_db: &StoreDb) -> impl Ord + '_ {
-        store_db
-            .store_info()
-            .map(|info| (info.application_id.0.as_str(), info.started))
-    }
-
-    store_dbs.sort_by_key(|store_db| store_db_key(store_db));
+    store_dbs.sort_by_key(|store_db| store_db.sort_key());
 
     let active_recording = store_context.recording.map(|rec| rec.store_id());
 

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -40,6 +40,8 @@ impl App {
 
                 self.save_buttons_ui(ui, _store_context);
 
+                UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
+
                 ui.add_space(spacing);
 
                 // On the web the browser controls the zoom

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -16,6 +16,9 @@ pub enum SystemCommand {
     /// Change the active recording-id in the `StoreHub`
     SetRecordingId(StoreId),
 
+    /// Close a recording
+    CloseRecordingId(StoreId),
+
     /// Update the blueprint with additional data
     ///
     /// The [`StoreId`] should generally be the currently selected blueprint


### PR DESCRIPTION
### What

This PR adds support to close a recording. Currently, this is available through the Rerun menu and the command palette. A close button will be added to the recording list UI in a subsequent PR.

My choices:
- No warning, etc. This is a rather "lossy" feature.
- No shortcut for the "Close recording" command (the natural one would be cmd-W, but that usually close an actual window).
- When a recording is closed, the next one is selected when sorted by (app ID, recording time). If the closed recording was the last, then the previous one is selected.

<img width="1422" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/81f189e5-890a-45fd-b6ef-4c963d8fc20c">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2972) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2972)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Fclose-recording/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Fclose-recording/examples)