### PR TITLE
Automatically select user timeline if no timeline was explicitly selected yet

### DIFF
--- a/crates/re_data_store/src/editable_auto_value.rs
+++ b/crates/re_data_store/src/editable_auto_value.rs
@@ -20,6 +20,7 @@ where
     T: std::fmt::Debug + Clone + Default + PartialEq + serde::Serialize,
     for<'de2> T: serde::Deserialize<'de2>,
 {
+    #[inline]
     fn default() -> Self {
         EditableAutoValue::Auto(T::default())
     }
@@ -30,11 +31,13 @@ where
     T: std::fmt::Debug + Clone + Default + PartialEq + serde::Serialize,
     for<'de2> T: serde::Deserialize<'de2>,
 {
+    #[inline]
     pub fn is_auto(&self) -> bool {
         matches!(self, EditableAutoValue::Auto(_))
     }
 
     /// Gets the value, disregarding if it was user edited or determined by a heuristic.
+    #[inline]
     pub fn get(&self) -> &T {
         match self {
             EditableAutoValue::Auto(v) | EditableAutoValue::UserEdited(v) => v,
@@ -42,6 +45,7 @@ where
     }
 
     /// Returns other if self is auto, self otherwise.
+    #[inline]
     pub fn or<'a>(&'a self, other: &'a EditableAutoValue<T>) -> &'a EditableAutoValue<T> {
         if self.is_auto() {
             other
@@ -52,11 +56,25 @@ where
 
     /// Determine whether this `EditableAutoValue` has user-edits relative to another `EditableAutoValue`
     /// If both values are `Auto`, then it is not considered edited.
+    #[inline]
     pub fn has_edits(&self, other: &Self) -> bool {
         match (self, other) {
             (EditableAutoValue::UserEdited(s), EditableAutoValue::UserEdited(o)) => s != o,
             (EditableAutoValue::Auto(_), EditableAutoValue::Auto(_)) => false,
             _ => true,
         }
+    }
+}
+
+impl<T> std::ops::Deref for EditableAutoValue<T>
+where
+    T: std::fmt::Debug + Clone + Default + PartialEq + serde::Serialize,
+    for<'de2> T: serde::Deserialize<'de2>,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.get()
     }
 }

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -400,13 +400,12 @@ impl TimeControl {
             false
         }
 
-        if !self.timeline.is_auto() && is_timeline_valid(self.timeline.get(), times_per_timeline) {
-            return;
+        // If the timeline is auto refresh it every frame, otherwise only pick a new one if invalid.
+        if self.timeline.is_auto() || !is_timeline_valid(self.timeline.get(), times_per_timeline) {
+            self.timeline = EditableAutoValue::Auto(
+                default_timeline(times_per_timeline.timelines()).map_or(Default::default(), |t| *t),
+            );
         }
-
-        self.timeline = EditableAutoValue::Auto(
-            default_timeline(times_per_timeline.timelines()).map_or(Default::default(), |t| *t),
-        );
     }
 
     /// The currently selected timeline


### PR DESCRIPTION
* Fixes #2186

Slight deviation from the desired behavior from the ticket: We'll always select the user timeline which is _alphabetically first_. I deem this good enough though and an improvement in any case!

Going back the the "auto select" state is not possible explicitely, but will happen if for whatever reason no user timeline is available anymore.

Tested as seen in the video and then confirmed separately the described alphabetic behavior


https://github.com/rerun-io/rerun/assets/1220815/0d3303d7-7b19-4854-993d-0523b3e35cbb



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2986) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2986)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-timeline-auto-select/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Ffix-timeline-auto-select/examples)