### PR TITLE
Don't select the spaceview when maximizing it

### DIFF
--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -370,8 +370,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
                 .clicked()
             {
                 *self.maximized = Some(space_view_id);
-                self.ctx
-                    .set_single_selection(&Item::SpaceView(space_view_id));
+                // Just maximize - don't select. See https://github.com/rerun-io/rerun/issues/2861
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/2861

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2988) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2988)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fdont-select-on-maximize/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fdont-select-on-maximize/examples)