### PR TITLE
Fix unable to set camera spinning until camera has moved

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -179,8 +179,11 @@ impl SpatialSpaceViewState {
                     {
                         self.state_3d.reset_camera(&self.scene_bbox_accum, &view_coordinates);
                     }
-                    re_ui.checkbox(ui, &mut self.state_3d.spin, "Spin")
-                        .on_hover_text("Spin camera around the orbit center");
+                    let mut spin = self.state_3d.spin();
+                    if re_ui.checkbox(ui, &mut spin, "Spin")
+                        .on_hover_text("Spin camera around the orbit center").changed() {
+                        self.state_3d.set_spin(spin);
+                    }
                 }
             });
             ui.end_row();

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -47,7 +47,7 @@ pub struct View3DState {
     eye_interpolation: Option<EyeInterpolation>,
 
     // options:
-    pub spin: bool,
+    spin: bool,
     pub show_axes: bool,
     pub show_bbox: bool,
     pub show_accumulated_bbox: bool,
@@ -204,6 +204,15 @@ impl View3DState {
         } else {
             self.orbit_eye = Some(target);
         }
+    }
+
+    pub fn spin(&self) -> bool {
+        self.spin
+    }
+
+    pub fn set_spin(&mut self, spin: bool) {
+        self.spin = spin;
+        self.did_interact_with_eye = true;
     }
 }
 


### PR DESCRIPTION
Fixes #2892

Thought this was related to blueprint system overwriting, but it was something else entirely actually: The "interpolate to"-method would set spin to false and we would interpolate to whatever the latest default position of the camera is until it is moved first.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
