### PR TITLE
Fix big bug in size estimation of array buffers

### DIFF
--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1200,7 +1200,7 @@ impl DataTable {
                 for (c1, c2) in izip!(&cells1.0, &cells2.0) {
                     if c1.total_size_bytes() != c2.total_size_bytes() {
                         size_mismatches.push(format!(
-                            "Sizes don't match! {} ({}) vs. {} ({}) bytes",
+                            "Sizes don't match! {} ({}) vs. {} ({}) bytes. Perhaps the validity differs?",
                             c1.total_size_bytes(),
                             c1.component_name(),
                             c2.total_size_bytes(),

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1229,7 +1229,7 @@ impl DataTable {
                         }
 
                         let c1_bytes = cell_to_bytes(c1.clone());
-                        let c2_bytes = cell_to_bytes(c1.clone());
+                        let c2_bytes = cell_to_bytes(c2.clone());
 
                         size_mismatches.push(format!(
                             "Cell size is {} vs {} bytes",

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1231,10 +1231,16 @@ impl DataTable {
                         let c1_bytes = cell_to_bytes(c1.clone());
                         let c2_bytes = cell_to_bytes(c1.clone());
 
+                        size_mismatches.push(format!(
+                            "Cell size is {} vs {} bytes",
+                            c1_bytes.len(),
+                            c2_bytes.len()
+                        ));
+
                         size_mismatches.push(
                             similar_asserts::SimpleDiff::from_str(
-                                &format!("{c1_bytes:?}"),
-                                &format!("{c2_bytes:?}"),
+                                &format!("{c1_bytes:#?}"),
+                                &format!("{c2_bytes:#?}"),
                                 "cell1_ipc",
                                 "cell2_ipc",
                             )

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-7e553fd1c2a34bd6bc64bba056f27212b7866ebc9f1ac4f821f109fc2844ccc0
+9c88ae405fd592d38f10d10b1dae0003a0f7c7c165fd9bdb831e53b934dbbba1

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-4f4bc40656d9770837ed871649f2a9b1ff6ecf6bc635196a064d315bba26e8a8
+7e553fd1c2a34bd6bc64bba056f27212b7866ebc9f1ac4f821f109fc2844ccc0

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -144,7 +144,15 @@ impl crate::Loggable for LineStrip2D {
                             .flatten()
                             .map(Some)
                             .collect();
-                        let data0_inner_data_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                        let data0_inner_data_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                            data0_inner_bitmap.as_ref().map(|bitmap| {
+                                bitmap
+                                    .iter()
+                                    .map(|i| std::iter::repeat(i).take(2usize))
+                                    .flatten()
+                                    .collect::<Vec<_>>()
+                                    .into()
+                            });
                         FixedSizeListArray::new(
                             {
                                 _ = extension_wrapper;

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -144,7 +144,15 @@ impl crate::Loggable for LineStrip3D {
                             .flatten()
                             .map(Some)
                             .collect();
-                        let data0_inner_data_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                        let data0_inner_data_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                            data0_inner_bitmap.as_ref().map(|bitmap| {
+                                bitmap
+                                    .iter()
+                                    .map(|i| std::iter::repeat(i).take(3usize))
+                                    .flatten()
+                                    .collect::<Vec<_>>()
+                                    .into()
+                            });
                         FixedSizeListArray::new(
                             {
                                 _ = extension_wrapper;

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -102,7 +102,15 @@ impl crate::Loggable for Origin3D {
                     .flatten()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(3usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -102,7 +102,15 @@ impl crate::Loggable for Point2D {
                     .flatten()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(2usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -102,7 +102,15 @@ impl crate::Loggable for Point3D {
                     .flatten()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(3usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -102,7 +102,15 @@ impl crate::Loggable for Vector3D {
                     .flatten()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(3usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -90,7 +90,15 @@ impl crate::Loggable for Mat3x3 {
                     .cloned()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(9usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -90,7 +90,15 @@ impl crate::Loggable for Mat4x4 {
                     .cloned()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(16usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -90,7 +90,15 @@ impl crate::Loggable for Quaternion {
                     .cloned()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(4usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -149,7 +149,15 @@ impl crate::Loggable for Rotation3D {
                                 .flatten()
                                 .map(Some)
                                 .collect();
-                            let quaternion_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                            let quaternion_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                                quaternion_bitmap.as_ref().map(|bitmap| {
+                                    bitmap
+                                        .iter()
+                                        .map(|i| std::iter::repeat(i).take(4usize))
+                                        .flatten()
+                                        .collect::<Vec<_>>()
+                                        .into()
+                                });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -135,7 +135,15 @@ impl crate::Loggable for RotationAxisAngle {
                                 .flatten()
                                 .map(Some)
                                 .collect();
-                            let axis_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                            let axis_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                                axis_bitmap.as_ref().map(|bitmap| {
+                                    bitmap
+                                        .iter()
+                                        .map(|i| std::iter::repeat(i).take(3usize))
+                                        .flatten()
+                                        .collect::<Vec<_>>()
+                                        .into()
+                                });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -147,7 +147,15 @@ impl crate::Loggable for Scale3D {
                                 .flatten()
                                 .map(Some)
                                 .collect();
-                            let three_d_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                            let three_d_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                                three_d_bitmap.as_ref().map(|bitmap| {
+                                    bitmap
+                                        .iter()
+                                        .map(|i| std::iter::repeat(i).take(3usize))
+                                        .flatten()
+                                        .collect::<Vec<_>>()
+                                        .into()
+                                });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -146,7 +146,15 @@ impl crate::Loggable for TranslationAndMat3x3 {
                                 .flatten()
                                 .map(Some)
                                 .collect();
-                            let translation_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                            let translation_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                                translation_bitmap.as_ref().map(|bitmap| {
+                                    bitmap
+                                        .iter()
+                                        .map(|i| std::iter::repeat(i).take(3usize))
+                                        .flatten()
+                                        .collect::<Vec<_>>()
+                                        .into()
+                                });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
@@ -212,7 +220,15 @@ impl crate::Loggable for TranslationAndMat3x3 {
                                 .flatten()
                                 .map(Some)
                                 .collect();
-                            let matrix_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                            let matrix_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                                matrix_bitmap.as_ref().map(|bitmap| {
+                                    bitmap
+                                        .iter()
+                                        .map(|i| std::iter::repeat(i).take(9usize))
+                                        .flatten()
+                                        .collect::<Vec<_>>()
+                                        .into()
+                                });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -157,7 +157,15 @@ impl crate::Loggable for TranslationRotationScale3D {
                                 .flatten()
                                 .map(Some)
                                 .collect();
-                            let translation_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                            let translation_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                                translation_bitmap.as_ref().map(|bitmap| {
+                                    bitmap
+                                        .iter()
+                                        .map(|i| std::iter::repeat(i).take(3usize))
+                                        .flatten()
+                                        .collect::<Vec<_>>()
+                                        .into()
+                                });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -90,7 +90,15 @@ impl crate::Loggable for Vec2D {
                     .cloned()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(2usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -90,7 +90,15 @@ impl crate::Loggable for Vec3D {
                     .cloned()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(3usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -90,7 +90,15 @@ impl crate::Loggable for Vec4D {
                     .cloned()
                     .map(Some)
                     .collect();
-                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                let data0_inner_bitmap: Option<::arrow2::bitmap::Bitmap> =
+                    data0_bitmap.as_ref().map(|bitmap| {
+                        bitmap
+                            .iter()
+                            .map(|i| std::iter::repeat(i).take(4usize))
+                            .flatten()
+                            .collect::<Vec<_>>()
+                            .into()
+                    });
                 FixedSizeListArray::new(
                     {
                         _ = extension_wrapper;

--- a/crates/re_types/src/size_bytes.rs
+++ b/crates/re_types/src/size_bytes.rs
@@ -360,6 +360,7 @@ fn estimated_bytes_size(array: &dyn Array) -> usize {
                 // The range of offsets for a given type id.
                 let mut type_ranges: BTreeMap<i8, Range> = Default::default();
 
+                debug_assert_eq!(array.types().len(), offsets.len());
                 for (&type_id, &offset) in array.types().iter().zip(offsets.iter()) {
                     // Offsets are monotonically increasing
                     type_ranges

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -2182,7 +2182,14 @@ impl crate::Loggable for AffixFuzzer3 {
                                 .collect();
                             let fixed_size_shenanigans_inner_bitmap: Option<
                                 ::arrow2::bitmap::Bitmap,
-                            > = None;
+                            > = fixed_size_shenanigans_bitmap.as_ref().map(|bitmap| {
+                                bitmap
+                                    .iter()
+                                    .map(|i| std::iter::repeat(i).take(3usize))
+                                    .flatten()
+                                    .collect::<Vec<_>>()
+                                    .into()
+                            });
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -1401,7 +1401,7 @@ fn quote_arrow_field(field: &Field) -> String {
     let is_nullable = is_nullable.then_some("True").unwrap_or("False");
     let metadata = quote_metadata_map(metadata);
 
-    format!(r#"pa.field("{name}", {datatype}, {is_nullable}, {metadata})"#)
+    format!(r#"pa.field("{name}", {datatype}, nullable={is_nullable}, metadata={metadata})"#)
 }
 
 fn quote_metadata_map(metadata: &BTreeMap<String, String>) -> String {

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -550,6 +550,34 @@ fn quote_arrow_field_serializer(
                 }
             };
 
+            // TODO(jleibs): The inner types of lists shouldn't be nullable, but both the python and
+            // C++ code-gen end up setting these to null when an outer fixed-sized field does happen
+            // to be null. In order to keep everything aligned at a validation level we match this
+            // behavior and create a validity-mask for the corresponding inner type. We can undo this if
+            // we make the C++ and Python codegen match the rust behavior or make our comparison tests
+            // more lenient.
+            let quoted_inner_bitmap =
+                if let DataType::FixedSizeList(_, count) = datatype.to_logical_type() {
+                    quote! {
+                        let #quoted_inner_bitmap: Option<::arrow2::bitmap::Bitmap>
+                            = #bitmap_src
+                                .as_ref()
+                                .map(|bitmap| {
+                                bitmap
+                                    .iter()
+                                    .map(|i| std::iter::repeat(i).take(#count))
+                                    .flatten()
+                                    .collect::<Vec<_>>()
+                                    .into()
+                                });
+                    }
+                } else {
+                    // TODO(cmc): We don't support intra-list nullability in our IDL at the moment.
+                    quote! {
+                        let #quoted_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                    }
+                };
+
             // TODO(cmc): We should be checking this, but right now we don't because we don't
             // support intra-list nullability.
             _ = is_nullable;
@@ -564,8 +592,7 @@ fn quote_arrow_field_serializer(
                     .map(Some)
                     .collect();
 
-                // TODO(cmc): We don't support intra-list nullability in our IDL at the moment.
-                let #quoted_inner_bitmap: Option<::arrow2::bitmap::Bitmap> = None;
+                #quoted_inner_bitmap
 
                 #quoted_create
             }}

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -550,12 +550,14 @@ fn quote_arrow_field_serializer(
                 }
             };
 
-            // TODO(jleibs): The inner types of lists shouldn't be nullable, but both the python and
-            // C++ code-gen end up setting these to null when an outer fixed-sized field does happen
-            // to be null. In order to keep everything aligned at a validation level we match this
-            // behavior and create a validity-mask for the corresponding inner type. We can undo this if
-            // we make the C++ and Python codegen match the rust behavior or make our comparison tests
-            // more lenient.
+            // TODO(https://github.com/rerun-io/rerun/issues/2993): The inner
+            // types of lists shouldn't be nullable, but both the python and C++
+            // code-gen end up setting these to null when an outer fixed-sized
+            // field does happen to be null. In order to keep everything aligned
+            // at a validation level we match this behavior and create a
+            // validity-mask for the corresponding inner type. We can undo this
+            // if we make the C++ and Python codegen match the rust behavior or
+            // make our comparison tests more lenient.
             let quoted_inner_bitmap =
                 if let DataType::FixedSizeList(_, count) = datatype.to_logical_type() {
                     quote! {

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/annotation_context.py
@@ -59,7 +59,7 @@ class AnnotationContextType(BaseExtensionType):
                     "item",
                     pa.struct(
                         [
-                            pa.field("class_id", pa.uint16(), False, {}),
+                            pa.field("class_id", pa.uint16(), nullable=False, metadata={}),
                             pa.field(
                                 "class_description",
                                 pa.struct(
@@ -68,13 +68,13 @@ class AnnotationContextType(BaseExtensionType):
                                             "info",
                                             pa.struct(
                                                 [
-                                                    pa.field("id", pa.uint16(), False, {}),
-                                                    pa.field("label", pa.utf8(), True, {}),
-                                                    pa.field("color", pa.uint32(), True, {}),
+                                                    pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                                    pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                                    pa.field("color", pa.uint32(), nullable=True, metadata={}),
                                                 ]
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "keypoint_annotations",
@@ -83,17 +83,17 @@ class AnnotationContextType(BaseExtensionType):
                                                     "item",
                                                     pa.struct(
                                                         [
-                                                            pa.field("id", pa.uint16(), False, {}),
-                                                            pa.field("label", pa.utf8(), True, {}),
-                                                            pa.field("color", pa.uint32(), True, {}),
+                                                            pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                                            pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                                            pa.field("color", pa.uint32(), nullable=True, metadata={}),
                                                         ]
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 )
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "keypoint_connections",
@@ -102,26 +102,30 @@ class AnnotationContextType(BaseExtensionType):
                                                     "item",
                                                     pa.struct(
                                                         [
-                                                            pa.field("keypoint0", pa.uint16(), False, {}),
-                                                            pa.field("keypoint1", pa.uint16(), False, {}),
+                                                            pa.field(
+                                                                "keypoint0", pa.uint16(), nullable=False, metadata={}
+                                                            ),
+                                                            pa.field(
+                                                                "keypoint1", pa.uint16(), nullable=False, metadata={}
+                                                            ),
                                                         ]
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 )
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                     ]
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             ),
                         ]
                     ),
-                    False,
-                    {},
+                    nullable=False,
+                    metadata={},
                 )
             ),
             "rerun.annotation_context",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/fuzzy.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/fuzzy.py
@@ -222,30 +222,39 @@ class AffixFuzzer7Type(BaseExtensionType):
                     "item",
                     pa.struct(
                         [
-                            pa.field("single_float_optional", pa.float32(), True, {}),
-                            pa.field("single_string_required", pa.utf8(), False, {}),
-                            pa.field("single_string_optional", pa.utf8(), True, {}),
+                            pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                            pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                            pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                             pa.field(
-                                "many_floats_optional", pa.list_(pa.field("item", pa.float32(), True, {})), True, {}
+                                "many_floats_optional",
+                                pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+                                nullable=True,
+                                metadata={},
                             ),
                             pa.field(
-                                "many_strings_required", pa.list_(pa.field("item", pa.utf8(), False, {})), False, {}
+                                "many_strings_required",
+                                pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                nullable=False,
+                                metadata={},
                             ),
                             pa.field(
-                                "many_strings_optional", pa.list_(pa.field("item", pa.utf8(), True, {})), True, {}
+                                "many_strings_optional",
+                                pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                nullable=True,
+                                metadata={},
                             ),
-                            pa.field("flattened_scalar", pa.float32(), False, {}),
+                            pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
                             pa.field(
                                 "almost_flattened_scalar",
-                                pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                False,
-                                {},
+                                pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                nullable=False,
+                                metadata={},
                             ),
-                            pa.field("from_parent", pa.bool_(), True, {}),
+                            pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                         ]
                     ),
-                    True,
-                    {},
+                    nullable=True,
+                    metadata={},
                 )
             ),
             "rerun.testing.components.AffixFuzzer7",
@@ -399,7 +408,9 @@ AffixFuzzer11ArrayLike = Union[
 class AffixFuzzer11Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), True, {})), "rerun.testing.components.AffixFuzzer11"
+            self,
+            pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+            "rerun.testing.components.AffixFuzzer11",
         )
 
 
@@ -436,7 +447,9 @@ AffixFuzzer12ArrayLike = Union[
 class AffixFuzzer12Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.utf8(), False, {})), "rerun.testing.components.AffixFuzzer12"
+            self,
+            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+            "rerun.testing.components.AffixFuzzer12",
         )
 
 
@@ -473,7 +486,9 @@ AffixFuzzer13ArrayLike = Union[
 class AffixFuzzer13Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.utf8(), True, {})), "rerun.testing.components.AffixFuzzer13"
+            self,
+            pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+            "rerun.testing.components.AffixFuzzer13",
         )
 
 
@@ -550,9 +565,9 @@ class AffixFuzzer16Type(BaseExtensionType):
                     "item",
                     pa.dense_union(
                         [
-                            pa.field("_null_markers", pa.null(), True, {}),
-                            pa.field("degrees", pa.float32(), False, {}),
-                            pa.field("radians", pa.float32(), False, {}),
+                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                            pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                            pa.field("radians", pa.float32(), nullable=False, metadata={}),
                             pa.field(
                                 "craziness",
                                 pa.list_(
@@ -560,54 +575,64 @@ class AffixFuzzer16Type(BaseExtensionType):
                                         "item",
                                         pa.struct(
                                             [
-                                                pa.field("single_float_optional", pa.float32(), True, {}),
-                                                pa.field("single_string_required", pa.utf8(), False, {}),
-                                                pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                pa.field(
+                                                    "single_float_optional", pa.float32(), nullable=True, metadata={}
+                                                ),
+                                                pa.field(
+                                                    "single_string_required", pa.utf8(), nullable=False, metadata={}
+                                                ),
+                                                pa.field(
+                                                    "single_string_optional", pa.utf8(), nullable=True, metadata={}
+                                                ),
                                                 pa.field(
                                                     "many_floats_optional",
-                                                    pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                    True,
-                                                    {},
+                                                    pa.list_(
+                                                        pa.field("item", pa.float32(), nullable=True, metadata={})
+                                                    ),
+                                                    nullable=True,
+                                                    metadata={},
                                                 ),
                                                 pa.field(
                                                     "many_strings_required",
-                                                    pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                    False,
-                                                    {},
+                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
                                                 pa.field(
                                                     "many_strings_optional",
-                                                    pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                    True,
-                                                    {},
+                                                    pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                                    nullable=True,
+                                                    metadata={},
                                                 ),
-                                                pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
                                                 pa.field(
                                                     "almost_flattened_scalar",
-                                                    pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                                    False,
-                                                    {},
+                                                    pa.struct(
+                                                        [pa.field("value", pa.float32(), nullable=False, metadata={})]
+                                                    ),
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
-                                                pa.field("from_parent", pa.bool_(), True, {}),
+                                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                                             ]
                                         ),
-                                        False,
-                                        {},
+                                        nullable=False,
+                                        metadata={},
                                     )
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             ),
                             pa.field(
                                 "fixed_size_shenanigans",
-                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                False,
-                                {},
+                                pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                nullable=False,
+                                metadata={},
                             ),
                         ]
                     ),
-                    False,
-                    {},
+                    nullable=False,
+                    metadata={},
                 )
             ),
             "rerun.testing.components.AffixFuzzer16",
@@ -653,9 +678,9 @@ class AffixFuzzer17Type(BaseExtensionType):
                     "item",
                     pa.dense_union(
                         [
-                            pa.field("_null_markers", pa.null(), True, {}),
-                            pa.field("degrees", pa.float32(), False, {}),
-                            pa.field("radians", pa.float32(), False, {}),
+                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                            pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                            pa.field("radians", pa.float32(), nullable=False, metadata={}),
                             pa.field(
                                 "craziness",
                                 pa.list_(
@@ -663,54 +688,64 @@ class AffixFuzzer17Type(BaseExtensionType):
                                         "item",
                                         pa.struct(
                                             [
-                                                pa.field("single_float_optional", pa.float32(), True, {}),
-                                                pa.field("single_string_required", pa.utf8(), False, {}),
-                                                pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                pa.field(
+                                                    "single_float_optional", pa.float32(), nullable=True, metadata={}
+                                                ),
+                                                pa.field(
+                                                    "single_string_required", pa.utf8(), nullable=False, metadata={}
+                                                ),
+                                                pa.field(
+                                                    "single_string_optional", pa.utf8(), nullable=True, metadata={}
+                                                ),
                                                 pa.field(
                                                     "many_floats_optional",
-                                                    pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                    True,
-                                                    {},
+                                                    pa.list_(
+                                                        pa.field("item", pa.float32(), nullable=True, metadata={})
+                                                    ),
+                                                    nullable=True,
+                                                    metadata={},
                                                 ),
                                                 pa.field(
                                                     "many_strings_required",
-                                                    pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                    False,
-                                                    {},
+                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
                                                 pa.field(
                                                     "many_strings_optional",
-                                                    pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                    True,
-                                                    {},
+                                                    pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                                    nullable=True,
+                                                    metadata={},
                                                 ),
-                                                pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
                                                 pa.field(
                                                     "almost_flattened_scalar",
-                                                    pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                                    False,
-                                                    {},
+                                                    pa.struct(
+                                                        [pa.field("value", pa.float32(), nullable=False, metadata={})]
+                                                    ),
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
-                                                pa.field("from_parent", pa.bool_(), True, {}),
+                                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                                             ]
                                         ),
-                                        False,
-                                        {},
+                                        nullable=False,
+                                        metadata={},
                                     )
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             ),
                             pa.field(
                                 "fixed_size_shenanigans",
-                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                False,
-                                {},
+                                pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                nullable=False,
+                                metadata={},
                             ),
                         ]
                     ),
-                    True,
-                    {},
+                    nullable=True,
+                    metadata={},
                 )
             ),
             "rerun.testing.components.AffixFuzzer17",
@@ -756,14 +791,14 @@ class AffixFuzzer18Type(BaseExtensionType):
                     "item",
                     pa.dense_union(
                         [
-                            pa.field("_null_markers", pa.null(), True, {}),
+                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                             pa.field(
                                 "single_required",
                                 pa.dense_union(
                                     [
-                                        pa.field("_null_markers", pa.null(), True, {}),
-                                        pa.field("degrees", pa.float32(), False, {}),
-                                        pa.field("radians", pa.float32(), False, {}),
+                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                         pa.field(
                                             "craziness",
                                             pa.list_(
@@ -771,54 +806,97 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                     "item",
                                                     pa.struct(
                                                         [
-                                                            pa.field("single_float_optional", pa.float32(), True, {}),
-                                                            pa.field("single_string_required", pa.utf8(), False, {}),
-                                                            pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                            pa.field(
+                                                                "single_float_optional",
+                                                                pa.float32(),
+                                                                nullable=True,
+                                                                metadata={},
+                                                            ),
+                                                            pa.field(
+                                                                "single_string_required",
+                                                                pa.utf8(),
+                                                                nullable=False,
+                                                                metadata={},
+                                                            ),
+                                                            pa.field(
+                                                                "single_string_optional",
+                                                                pa.utf8(),
+                                                                nullable=True,
+                                                                metadata={},
+                                                            ),
                                                             pa.field(
                                                                 "many_floats_optional",
-                                                                pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                                True,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.float32(), nullable=True, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=True,
+                                                                metadata={},
                                                             ),
                                                             pa.field(
                                                                 "many_strings_required",
-                                                                pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                                False,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.utf8(), nullable=False, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=False,
+                                                                metadata={},
                                                             ),
                                                             pa.field(
                                                                 "many_strings_optional",
-                                                                pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                                True,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.utf8(), nullable=True, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=True,
+                                                                metadata={},
                                                             ),
-                                                            pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                            pa.field(
+                                                                "flattened_scalar",
+                                                                pa.float32(),
+                                                                nullable=False,
+                                                                metadata={},
+                                                            ),
                                                             pa.field(
                                                                 "almost_flattened_scalar",
-                                                                pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                                                False,
-                                                                {},
+                                                                pa.struct(
+                                                                    [
+                                                                        pa.field(
+                                                                            "value",
+                                                                            pa.float32(),
+                                                                            nullable=False,
+                                                                            metadata={},
+                                                                        )
+                                                                    ]
+                                                                ),
+                                                                nullable=False,
+                                                                metadata={},
                                                             ),
-                                                            pa.field("from_parent", pa.bool_(), True, {}),
+                                                            pa.field(
+                                                                "from_parent", pa.bool_(), nullable=True, metadata={}
+                                                            ),
                                                         ]
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 )
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                            False,
-                                            {},
+                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                     ]
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             ),
                             pa.field(
                                 "many_required",
@@ -827,9 +905,9 @@ class AffixFuzzer18Type(BaseExtensionType):
                                         "item",
                                         pa.dense_union(
                                             [
-                                                pa.field("_null_markers", pa.null(), True, {}),
-                                                pa.field("degrees", pa.float32(), False, {}),
-                                                pa.field("radians", pa.float32(), False, {}),
+                                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                                 pa.field(
                                                     "craziness",
                                                     pa.list_(
@@ -838,71 +916,114 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                             pa.struct(
                                                                 [
                                                                     pa.field(
-                                                                        "single_float_optional", pa.float32(), True, {}
+                                                                        "single_float_optional",
+                                                                        pa.float32(),
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
-                                                                        "single_string_required", pa.utf8(), False, {}
+                                                                        "single_string_required",
+                                                                        pa.utf8(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
-                                                                        "single_string_optional", pa.utf8(), True, {}
+                                                                        "single_string_optional",
+                                                                        pa.utf8(),
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "many_floats_optional",
                                                                         pa.list_(
-                                                                            pa.field("item", pa.float32(), True, {})
+                                                                            pa.field(
+                                                                                "item",
+                                                                                pa.float32(),
+                                                                                nullable=True,
+                                                                                metadata={},
+                                                                            )
                                                                         ),
-                                                                        True,
-                                                                        {},
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "many_strings_required",
                                                                         pa.list_(
-                                                                            pa.field("item", pa.utf8(), False, {})
+                                                                            pa.field(
+                                                                                "item",
+                                                                                pa.utf8(),
+                                                                                nullable=False,
+                                                                                metadata={},
+                                                                            )
                                                                         ),
-                                                                        False,
-                                                                        {},
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "many_strings_optional",
-                                                                        pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                                        True,
-                                                                        {},
+                                                                        pa.list_(
+                                                                            pa.field(
+                                                                                "item",
+                                                                                pa.utf8(),
+                                                                                nullable=True,
+                                                                                metadata={},
+                                                                            )
+                                                                        ),
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
-                                                                        "flattened_scalar", pa.float32(), False, {}
+                                                                        "flattened_scalar",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "almost_flattened_scalar",
                                                                         pa.struct(
-                                                                            [pa.field("value", pa.float32(), False, {})]
+                                                                            [
+                                                                                pa.field(
+                                                                                    "value",
+                                                                                    pa.float32(),
+                                                                                    nullable=False,
+                                                                                    metadata={},
+                                                                                )
+                                                                            ]
                                                                         ),
-                                                                        False,
-                                                                        {},
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
-                                                                    pa.field("from_parent", pa.bool_(), True, {}),
+                                                                    pa.field(
+                                                                        "from_parent",
+                                                                        pa.bool_(),
+                                                                        nullable=True,
+                                                                        metadata={},
+                                                                    ),
                                                                 ]
                                                             ),
-                                                            False,
-                                                            {},
+                                                            nullable=False,
+                                                            metadata={},
                                                         )
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
                                                 pa.field(
                                                     "fixed_size_shenanigans",
-                                                    pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                    False,
-                                                    {},
+                                                    pa.list_(
+                                                        pa.field("item", pa.float32(), nullable=False, metadata={}), 3
+                                                    ),
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
                                             ]
                                         ),
-                                        False,
-                                        {},
+                                        nullable=False,
+                                        metadata={},
                                     )
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             ),
                             pa.field(
                                 "many_optional",
@@ -911,9 +1032,9 @@ class AffixFuzzer18Type(BaseExtensionType):
                                         "item",
                                         pa.dense_union(
                                             [
-                                                pa.field("_null_markers", pa.null(), True, {}),
-                                                pa.field("degrees", pa.float32(), False, {}),
-                                                pa.field("radians", pa.float32(), False, {}),
+                                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                                 pa.field(
                                                     "craziness",
                                                     pa.list_(
@@ -922,76 +1043,119 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                             pa.struct(
                                                                 [
                                                                     pa.field(
-                                                                        "single_float_optional", pa.float32(), True, {}
+                                                                        "single_float_optional",
+                                                                        pa.float32(),
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
-                                                                        "single_string_required", pa.utf8(), False, {}
+                                                                        "single_string_required",
+                                                                        pa.utf8(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
-                                                                        "single_string_optional", pa.utf8(), True, {}
+                                                                        "single_string_optional",
+                                                                        pa.utf8(),
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "many_floats_optional",
                                                                         pa.list_(
-                                                                            pa.field("item", pa.float32(), True, {})
+                                                                            pa.field(
+                                                                                "item",
+                                                                                pa.float32(),
+                                                                                nullable=True,
+                                                                                metadata={},
+                                                                            )
                                                                         ),
-                                                                        True,
-                                                                        {},
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "many_strings_required",
                                                                         pa.list_(
-                                                                            pa.field("item", pa.utf8(), False, {})
+                                                                            pa.field(
+                                                                                "item",
+                                                                                pa.utf8(),
+                                                                                nullable=False,
+                                                                                metadata={},
+                                                                            )
                                                                         ),
-                                                                        False,
-                                                                        {},
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "many_strings_optional",
-                                                                        pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                                        True,
-                                                                        {},
+                                                                        pa.list_(
+                                                                            pa.field(
+                                                                                "item",
+                                                                                pa.utf8(),
+                                                                                nullable=True,
+                                                                                metadata={},
+                                                                            )
+                                                                        ),
+                                                                        nullable=True,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
-                                                                        "flattened_scalar", pa.float32(), False, {}
+                                                                        "flattened_scalar",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
                                                                     pa.field(
                                                                         "almost_flattened_scalar",
                                                                         pa.struct(
-                                                                            [pa.field("value", pa.float32(), False, {})]
+                                                                            [
+                                                                                pa.field(
+                                                                                    "value",
+                                                                                    pa.float32(),
+                                                                                    nullable=False,
+                                                                                    metadata={},
+                                                                                )
+                                                                            ]
                                                                         ),
-                                                                        False,
-                                                                        {},
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     ),
-                                                                    pa.field("from_parent", pa.bool_(), True, {}),
+                                                                    pa.field(
+                                                                        "from_parent",
+                                                                        pa.bool_(),
+                                                                        nullable=True,
+                                                                        metadata={},
+                                                                    ),
                                                                 ]
                                                             ),
-                                                            False,
-                                                            {},
+                                                            nullable=False,
+                                                            metadata={},
                                                         )
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
                                                 pa.field(
                                                     "fixed_size_shenanigans",
-                                                    pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                    False,
-                                                    {},
+                                                    pa.list_(
+                                                        pa.field("item", pa.float32(), nullable=False, metadata={}), 3
+                                                    ),
+                                                    nullable=False,
+                                                    metadata={},
                                                 ),
                                             ]
                                         ),
-                                        True,
-                                        {},
+                                        nullable=True,
+                                        metadata={},
                                     )
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             ),
                         ]
                     ),
-                    True,
-                    {},
+                    nullable=True,
+                    metadata={},
                 )
             ),
             "rerun.testing.components.AffixFuzzer18",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/line_strip2d.py
@@ -54,7 +54,14 @@ class LineStrip2DType(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.list_(pa.field("item", pa.list_(pa.field("item", pa.float32(), False, {}), 2), False, {})),
+            pa.list_(
+                pa.field(
+                    "item",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2),
+                    nullable=False,
+                    metadata={},
+                )
+            ),
             "rerun.linestrip2d",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/line_strip3d.py
@@ -54,7 +54,14 @@ class LineStrip3DType(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.list_(pa.field("item", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {})),
+            pa.list_(
+                pa.field(
+                    "item",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                    nullable=False,
+                    metadata={},
+                )
+            ),
             "rerun.linestrip3d",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/angle.py
@@ -58,9 +58,9 @@ class AngleType(BaseExtensionType):
             self,
             pa.dense_union(
                 [
-                    pa.field("_null_markers", pa.null(), True, {}),
-                    pa.field("Radians", pa.float32(), False, {}),
-                    pa.field("Degrees", pa.float32(), False, {}),
+                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                    pa.field("Radians", pa.float32(), nullable=False, metadata={}),
+                    pa.field("Degrees", pa.float32(), nullable=False, metadata={}),
                 ]
             ),
             "rerun.datatypes.Angle",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/annotation_info.py
@@ -86,9 +86,9 @@ class AnnotationInfoType(BaseExtensionType):
             self,
             pa.struct(
                 [
-                    pa.field("id", pa.uint16(), False, {}),
-                    pa.field("label", pa.utf8(), True, {}),
-                    pa.field("color", pa.uint32(), True, {}),
+                    pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                    pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                    pa.field("color", pa.uint32(), nullable=True, metadata={}),
                 ]
             ),
             "rerun.datatypes.AnnotationInfo",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description.py
@@ -96,13 +96,13 @@ class ClassDescriptionType(BaseExtensionType):
                         "info",
                         pa.struct(
                             [
-                                pa.field("id", pa.uint16(), False, {}),
-                                pa.field("label", pa.utf8(), True, {}),
-                                pa.field("color", pa.uint32(), True, {}),
+                                pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                pa.field("color", pa.uint32(), nullable=True, metadata={}),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                     pa.field(
                         "keypoint_annotations",
@@ -111,17 +111,17 @@ class ClassDescriptionType(BaseExtensionType):
                                 "item",
                                 pa.struct(
                                     [
-                                        pa.field("id", pa.uint16(), False, {}),
-                                        pa.field("label", pa.utf8(), True, {}),
-                                        pa.field("color", pa.uint32(), True, {}),
+                                        pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                        pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                        pa.field("color", pa.uint32(), nullable=True, metadata={}),
                                     ]
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             )
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                     pa.field(
                         "keypoint_connections",
@@ -130,16 +130,16 @@ class ClassDescriptionType(BaseExtensionType):
                                 "item",
                                 pa.struct(
                                     [
-                                        pa.field("keypoint0", pa.uint16(), False, {}),
-                                        pa.field("keypoint1", pa.uint16(), False, {}),
+                                        pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+                                        pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
                                     ]
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             )
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description_map_elem.py
@@ -62,7 +62,7 @@ class ClassDescriptionMapElemType(BaseExtensionType):
             self,
             pa.struct(
                 [
-                    pa.field("class_id", pa.uint16(), False, {}),
+                    pa.field("class_id", pa.uint16(), nullable=False, metadata={}),
                     pa.field(
                         "class_description",
                         pa.struct(
@@ -71,13 +71,13 @@ class ClassDescriptionMapElemType(BaseExtensionType):
                                     "info",
                                     pa.struct(
                                         [
-                                            pa.field("id", pa.uint16(), False, {}),
-                                            pa.field("label", pa.utf8(), True, {}),
-                                            pa.field("color", pa.uint32(), True, {}),
+                                            pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                            pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                            pa.field("color", pa.uint32(), nullable=True, metadata={}),
                                         ]
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "keypoint_annotations",
@@ -86,17 +86,17 @@ class ClassDescriptionMapElemType(BaseExtensionType):
                                             "item",
                                             pa.struct(
                                                 [
-                                                    pa.field("id", pa.uint16(), False, {}),
-                                                    pa.field("label", pa.utf8(), True, {}),
-                                                    pa.field("color", pa.uint32(), True, {}),
+                                                    pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                                    pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                                    pa.field("color", pa.uint32(), nullable=True, metadata={}),
                                                 ]
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         )
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "keypoint_connections",
@@ -105,21 +105,21 @@ class ClassDescriptionMapElemType(BaseExtensionType):
                                             "item",
                                             pa.struct(
                                                 [
-                                                    pa.field("keypoint0", pa.uint16(), False, {}),
-                                                    pa.field("keypoint1", pa.uint16(), False, {}),
+                                                    pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+                                                    pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
                                                 ]
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         )
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/fuzzy.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/fuzzy.py
@@ -84,7 +84,9 @@ FlattenedScalarArrayLike = Union[
 class FlattenedScalarType(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.struct([pa.field("value", pa.float32(), False, {})]), "rerun.testing.datatypes.FlattenedScalar"
+            self,
+            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+            "rerun.testing.datatypes.FlattenedScalar",
         )
 
 
@@ -141,17 +143,35 @@ class AffixFuzzer1Type(BaseExtensionType):
             self,
             pa.struct(
                 [
-                    pa.field("single_float_optional", pa.float32(), True, {}),
-                    pa.field("single_string_required", pa.utf8(), False, {}),
-                    pa.field("single_string_optional", pa.utf8(), True, {}),
-                    pa.field("many_floats_optional", pa.list_(pa.field("item", pa.float32(), True, {})), True, {}),
-                    pa.field("many_strings_required", pa.list_(pa.field("item", pa.utf8(), False, {})), False, {}),
-                    pa.field("many_strings_optional", pa.list_(pa.field("item", pa.utf8(), True, {})), True, {}),
-                    pa.field("flattened_scalar", pa.float32(), False, {}),
+                    pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                    pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                    pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                     pa.field(
-                        "almost_flattened_scalar", pa.struct([pa.field("value", pa.float32(), False, {})]), False, {}
+                        "many_floats_optional",
+                        pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+                        nullable=True,
+                        metadata={},
                     ),
-                    pa.field("from_parent", pa.bool_(), True, {}),
+                    pa.field(
+                        "many_strings_required",
+                        pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                        nullable=False,
+                        metadata={},
+                    ),
+                    pa.field(
+                        "many_strings_optional",
+                        pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                        nullable=True,
+                        metadata={},
+                    ),
+                    pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                    pa.field(
+                        "almost_flattened_scalar",
+                        pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                        nullable=False,
+                        metadata={},
+                    ),
+                    pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                 ]
             ),
             "rerun.testing.datatypes.AffixFuzzer1",
@@ -254,9 +274,9 @@ class AffixFuzzer3Type(BaseExtensionType):
             self,
             pa.dense_union(
                 [
-                    pa.field("_null_markers", pa.null(), True, {}),
-                    pa.field("degrees", pa.float32(), False, {}),
-                    pa.field("radians", pa.float32(), False, {}),
+                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                    pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                    pa.field("radians", pa.float32(), nullable=False, metadata={}),
                     pa.field(
                         "craziness",
                         pa.list_(
@@ -264,46 +284,49 @@ class AffixFuzzer3Type(BaseExtensionType):
                                 "item",
                                 pa.struct(
                                     [
-                                        pa.field("single_float_optional", pa.float32(), True, {}),
-                                        pa.field("single_string_required", pa.utf8(), False, {}),
-                                        pa.field("single_string_optional", pa.utf8(), True, {}),
+                                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                                         pa.field(
                                             "many_floats_optional",
-                                            pa.list_(pa.field("item", pa.float32(), True, {})),
-                                            True,
-                                            {},
+                                            pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+                                            nullable=True,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "many_strings_required",
-                                            pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                            False,
-                                            {},
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "many_strings_optional",
-                                            pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                            True,
-                                            {},
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                            nullable=True,
+                                            metadata={},
                                         ),
-                                        pa.field("flattened_scalar", pa.float32(), False, {}),
+                                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
                                         pa.field(
                                             "almost_flattened_scalar",
-                                            pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                            False,
-                                            {},
+                                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                            nullable=False,
+                                            metadata={},
                                         ),
-                                        pa.field("from_parent", pa.bool_(), True, {}),
+                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                                     ]
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             )
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                     pa.field(
-                        "fixed_size_shenanigans", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {}
+                        "fixed_size_shenanigans",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),
@@ -365,14 +388,14 @@ class AffixFuzzer4Type(BaseExtensionType):
             self,
             pa.dense_union(
                 [
-                    pa.field("_null_markers", pa.null(), True, {}),
+                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                     pa.field(
                         "single_required",
                         pa.dense_union(
                             [
-                                pa.field("_null_markers", pa.null(), True, {}),
-                                pa.field("degrees", pa.float32(), False, {}),
-                                pa.field("radians", pa.float32(), False, {}),
+                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                 pa.field(
                                     "craziness",
                                     pa.list_(
@@ -380,54 +403,77 @@ class AffixFuzzer4Type(BaseExtensionType):
                                             "item",
                                             pa.struct(
                                                 [
-                                                    pa.field("single_float_optional", pa.float32(), True, {}),
-                                                    pa.field("single_string_required", pa.utf8(), False, {}),
-                                                    pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                    pa.field(
+                                                        "single_float_optional",
+                                                        pa.float32(),
+                                                        nullable=True,
+                                                        metadata={},
+                                                    ),
+                                                    pa.field(
+                                                        "single_string_required", pa.utf8(), nullable=False, metadata={}
+                                                    ),
+                                                    pa.field(
+                                                        "single_string_optional", pa.utf8(), nullable=True, metadata={}
+                                                    ),
                                                     pa.field(
                                                         "many_floats_optional",
-                                                        pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                        True,
-                                                        {},
+                                                        pa.list_(
+                                                            pa.field("item", pa.float32(), nullable=True, metadata={})
+                                                        ),
+                                                        nullable=True,
+                                                        metadata={},
                                                     ),
                                                     pa.field(
                                                         "many_strings_required",
-                                                        pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                        False,
-                                                        {},
+                                                        pa.list_(
+                                                            pa.field("item", pa.utf8(), nullable=False, metadata={})
+                                                        ),
+                                                        nullable=False,
+                                                        metadata={},
                                                     ),
                                                     pa.field(
                                                         "many_strings_optional",
-                                                        pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                        True,
-                                                        {},
+                                                        pa.list_(
+                                                            pa.field("item", pa.utf8(), nullable=True, metadata={})
+                                                        ),
+                                                        nullable=True,
+                                                        metadata={},
                                                     ),
-                                                    pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                    pa.field(
+                                                        "flattened_scalar", pa.float32(), nullable=False, metadata={}
+                                                    ),
                                                     pa.field(
                                                         "almost_flattened_scalar",
-                                                        pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                                        False,
-                                                        {},
+                                                        pa.struct(
+                                                            [
+                                                                pa.field(
+                                                                    "value", pa.float32(), nullable=False, metadata={}
+                                                                )
+                                                            ]
+                                                        ),
+                                                        nullable=False,
+                                                        metadata={},
                                                     ),
-                                                    pa.field("from_parent", pa.bool_(), True, {}),
+                                                    pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                                                 ]
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         )
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "fixed_size_shenanigans",
-                                    pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                    False,
-                                    {},
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                    nullable=False,
+                                    metadata={},
                                 ),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                     pa.field(
                         "many_required",
@@ -436,9 +482,9 @@ class AffixFuzzer4Type(BaseExtensionType):
                                 "item",
                                 pa.dense_union(
                                     [
-                                        pa.field("_null_markers", pa.null(), True, {}),
-                                        pa.field("degrees", pa.float32(), False, {}),
-                                        pa.field("radians", pa.float32(), False, {}),
+                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                         pa.field(
                                             "craziness",
                                             pa.list_(
@@ -446,58 +492,101 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                     "item",
                                                     pa.struct(
                                                         [
-                                                            pa.field("single_float_optional", pa.float32(), True, {}),
-                                                            pa.field("single_string_required", pa.utf8(), False, {}),
-                                                            pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                            pa.field(
+                                                                "single_float_optional",
+                                                                pa.float32(),
+                                                                nullable=True,
+                                                                metadata={},
+                                                            ),
+                                                            pa.field(
+                                                                "single_string_required",
+                                                                pa.utf8(),
+                                                                nullable=False,
+                                                                metadata={},
+                                                            ),
+                                                            pa.field(
+                                                                "single_string_optional",
+                                                                pa.utf8(),
+                                                                nullable=True,
+                                                                metadata={},
+                                                            ),
                                                             pa.field(
                                                                 "many_floats_optional",
-                                                                pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                                True,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.float32(), nullable=True, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=True,
+                                                                metadata={},
                                                             ),
                                                             pa.field(
                                                                 "many_strings_required",
-                                                                pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                                False,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.utf8(), nullable=False, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=False,
+                                                                metadata={},
                                                             ),
                                                             pa.field(
                                                                 "many_strings_optional",
-                                                                pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                                True,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.utf8(), nullable=True, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=True,
+                                                                metadata={},
                                                             ),
-                                                            pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                            pa.field(
+                                                                "flattened_scalar",
+                                                                pa.float32(),
+                                                                nullable=False,
+                                                                metadata={},
+                                                            ),
                                                             pa.field(
                                                                 "almost_flattened_scalar",
-                                                                pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                                                False,
-                                                                {},
+                                                                pa.struct(
+                                                                    [
+                                                                        pa.field(
+                                                                            "value",
+                                                                            pa.float32(),
+                                                                            nullable=False,
+                                                                            metadata={},
+                                                                        )
+                                                                    ]
+                                                                ),
+                                                                nullable=False,
+                                                                metadata={},
                                                             ),
-                                                            pa.field("from_parent", pa.bool_(), True, {}),
+                                                            pa.field(
+                                                                "from_parent", pa.bool_(), nullable=True, metadata={}
+                                                            ),
                                                         ]
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 )
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                            False,
-                                            {},
+                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                     ]
                                 ),
-                                False,
-                                {},
+                                nullable=False,
+                                metadata={},
                             )
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                     pa.field(
                         "many_optional",
@@ -506,9 +595,9 @@ class AffixFuzzer4Type(BaseExtensionType):
                                 "item",
                                 pa.dense_union(
                                     [
-                                        pa.field("_null_markers", pa.null(), True, {}),
-                                        pa.field("degrees", pa.float32(), False, {}),
-                                        pa.field("radians", pa.float32(), False, {}),
+                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                         pa.field(
                                             "craziness",
                                             pa.list_(
@@ -516,58 +605,101 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                     "item",
                                                     pa.struct(
                                                         [
-                                                            pa.field("single_float_optional", pa.float32(), True, {}),
-                                                            pa.field("single_string_required", pa.utf8(), False, {}),
-                                                            pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                            pa.field(
+                                                                "single_float_optional",
+                                                                pa.float32(),
+                                                                nullable=True,
+                                                                metadata={},
+                                                            ),
+                                                            pa.field(
+                                                                "single_string_required",
+                                                                pa.utf8(),
+                                                                nullable=False,
+                                                                metadata={},
+                                                            ),
+                                                            pa.field(
+                                                                "single_string_optional",
+                                                                pa.utf8(),
+                                                                nullable=True,
+                                                                metadata={},
+                                                            ),
                                                             pa.field(
                                                                 "many_floats_optional",
-                                                                pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                                True,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.float32(), nullable=True, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=True,
+                                                                metadata={},
                                                             ),
                                                             pa.field(
                                                                 "many_strings_required",
-                                                                pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                                False,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.utf8(), nullable=False, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=False,
+                                                                metadata={},
                                                             ),
                                                             pa.field(
                                                                 "many_strings_optional",
-                                                                pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                                True,
-                                                                {},
+                                                                pa.list_(
+                                                                    pa.field(
+                                                                        "item", pa.utf8(), nullable=True, metadata={}
+                                                                    )
+                                                                ),
+                                                                nullable=True,
+                                                                metadata={},
                                                             ),
-                                                            pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                            pa.field(
+                                                                "flattened_scalar",
+                                                                pa.float32(),
+                                                                nullable=False,
+                                                                metadata={},
+                                                            ),
                                                             pa.field(
                                                                 "almost_flattened_scalar",
-                                                                pa.struct([pa.field("value", pa.float32(), False, {})]),
-                                                                False,
-                                                                {},
+                                                                pa.struct(
+                                                                    [
+                                                                        pa.field(
+                                                                            "value",
+                                                                            pa.float32(),
+                                                                            nullable=False,
+                                                                            metadata={},
+                                                                        )
+                                                                    ]
+                                                                ),
+                                                                nullable=False,
+                                                                metadata={},
                                                             ),
-                                                            pa.field("from_parent", pa.bool_(), True, {}),
+                                                            pa.field(
+                                                                "from_parent", pa.bool_(), nullable=True, metadata={}
+                                                            ),
                                                         ]
                                                     ),
-                                                    False,
-                                                    {},
+                                                    nullable=False,
+                                                    metadata={},
                                                 )
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                         pa.field(
                                             "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                            False,
-                                            {},
+                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                            nullable=False,
+                                            metadata={},
                                         ),
                                     ]
                                 ),
-                                True,
-                                {},
+                                nullable=True,
+                                metadata={},
                             )
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),
@@ -628,14 +760,14 @@ class AffixFuzzer5Type(BaseExtensionType):
                         "single_optional_union",
                         pa.dense_union(
                             [
-                                pa.field("_null_markers", pa.null(), True, {}),
+                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field(
                                     "single_required",
                                     pa.dense_union(
                                         [
-                                            pa.field("_null_markers", pa.null(), True, {}),
-                                            pa.field("degrees", pa.float32(), False, {}),
-                                            pa.field("radians", pa.float32(), False, {}),
+                                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                            pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                            pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                             pa.field(
                                                 "craziness",
                                                 pa.list_(
@@ -644,59 +776,110 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                         pa.struct(
                                                             [
                                                                 pa.field(
-                                                                    "single_float_optional", pa.float32(), True, {}
+                                                                    "single_float_optional",
+                                                                    pa.float32(),
+                                                                    nullable=True,
+                                                                    metadata={},
                                                                 ),
                                                                 pa.field(
-                                                                    "single_string_required", pa.utf8(), False, {}
+                                                                    "single_string_required",
+                                                                    pa.utf8(),
+                                                                    nullable=False,
+                                                                    metadata={},
                                                                 ),
-                                                                pa.field("single_string_optional", pa.utf8(), True, {}),
+                                                                pa.field(
+                                                                    "single_string_optional",
+                                                                    pa.utf8(),
+                                                                    nullable=True,
+                                                                    metadata={},
+                                                                ),
                                                                 pa.field(
                                                                     "many_floats_optional",
-                                                                    pa.list_(pa.field("item", pa.float32(), True, {})),
-                                                                    True,
-                                                                    {},
+                                                                    pa.list_(
+                                                                        pa.field(
+                                                                            "item",
+                                                                            pa.float32(),
+                                                                            nullable=True,
+                                                                            metadata={},
+                                                                        )
+                                                                    ),
+                                                                    nullable=True,
+                                                                    metadata={},
                                                                 ),
                                                                 pa.field(
                                                                     "many_strings_required",
-                                                                    pa.list_(pa.field("item", pa.utf8(), False, {})),
-                                                                    False,
-                                                                    {},
+                                                                    pa.list_(
+                                                                        pa.field(
+                                                                            "item",
+                                                                            pa.utf8(),
+                                                                            nullable=False,
+                                                                            metadata={},
+                                                                        )
+                                                                    ),
+                                                                    nullable=False,
+                                                                    metadata={},
                                                                 ),
                                                                 pa.field(
                                                                     "many_strings_optional",
-                                                                    pa.list_(pa.field("item", pa.utf8(), True, {})),
-                                                                    True,
-                                                                    {},
+                                                                    pa.list_(
+                                                                        pa.field(
+                                                                            "item",
+                                                                            pa.utf8(),
+                                                                            nullable=True,
+                                                                            metadata={},
+                                                                        )
+                                                                    ),
+                                                                    nullable=True,
+                                                                    metadata={},
                                                                 ),
-                                                                pa.field("flattened_scalar", pa.float32(), False, {}),
+                                                                pa.field(
+                                                                    "flattened_scalar",
+                                                                    pa.float32(),
+                                                                    nullable=False,
+                                                                    metadata={},
+                                                                ),
                                                                 pa.field(
                                                                     "almost_flattened_scalar",
                                                                     pa.struct(
-                                                                        [pa.field("value", pa.float32(), False, {})]
+                                                                        [
+                                                                            pa.field(
+                                                                                "value",
+                                                                                pa.float32(),
+                                                                                nullable=False,
+                                                                                metadata={},
+                                                                            )
+                                                                        ]
                                                                     ),
-                                                                    False,
-                                                                    {},
+                                                                    nullable=False,
+                                                                    metadata={},
                                                                 ),
-                                                                pa.field("from_parent", pa.bool_(), True, {}),
+                                                                pa.field(
+                                                                    "from_parent",
+                                                                    pa.bool_(),
+                                                                    nullable=True,
+                                                                    metadata={},
+                                                                ),
                                                             ]
                                                         ),
-                                                        False,
-                                                        {},
+                                                        nullable=False,
+                                                        metadata={},
                                                     )
                                                 ),
-                                                False,
-                                                {},
+                                                nullable=False,
+                                                metadata={},
                                             ),
                                             pa.field(
                                                 "fixed_size_shenanigans",
-                                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                False,
-                                                {},
+                                                pa.list_(
+                                                    pa.field("item", pa.float32(), nullable=False, metadata={}), 3
+                                                ),
+                                                nullable=False,
+                                                metadata={},
                                             ),
                                         ]
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "many_required",
@@ -705,9 +888,9 @@ class AffixFuzzer5Type(BaseExtensionType):
                                             "item",
                                             pa.dense_union(
                                                 [
-                                                    pa.field("_null_markers", pa.null(), True, {}),
-                                                    pa.field("degrees", pa.float32(), False, {}),
-                                                    pa.field("radians", pa.float32(), False, {}),
+                                                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                                    pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                                    pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                                     pa.field(
                                                         "craziness",
                                                         pa.list_(
@@ -718,84 +901,113 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                         pa.field(
                                                                             "single_float_optional",
                                                                             pa.float32(),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "single_string_required",
                                                                             pa.utf8(),
-                                                                            False,
-                                                                            {},
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "single_string_optional",
                                                                             pa.utf8(),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "many_floats_optional",
                                                                             pa.list_(
-                                                                                pa.field("item", pa.float32(), True, {})
+                                                                                pa.field(
+                                                                                    "item",
+                                                                                    pa.float32(),
+                                                                                    nullable=True,
+                                                                                    metadata={},
+                                                                                )
                                                                             ),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "many_strings_required",
                                                                             pa.list_(
-                                                                                pa.field("item", pa.utf8(), False, {})
+                                                                                pa.field(
+                                                                                    "item",
+                                                                                    pa.utf8(),
+                                                                                    nullable=False,
+                                                                                    metadata={},
+                                                                                )
                                                                             ),
-                                                                            False,
-                                                                            {},
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "many_strings_optional",
                                                                             pa.list_(
-                                                                                pa.field("item", pa.utf8(), True, {})
+                                                                                pa.field(
+                                                                                    "item",
+                                                                                    pa.utf8(),
+                                                                                    nullable=True,
+                                                                                    metadata={},
+                                                                                )
                                                                             ),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
-                                                                            "flattened_scalar", pa.float32(), False, {}
+                                                                            "flattened_scalar",
+                                                                            pa.float32(),
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "almost_flattened_scalar",
                                                                             pa.struct(
                                                                                 [
                                                                                     pa.field(
-                                                                                        "value", pa.float32(), False, {}
+                                                                                        "value",
+                                                                                        pa.float32(),
+                                                                                        nullable=False,
+                                                                                        metadata={},
                                                                                     )
                                                                                 ]
                                                                             ),
-                                                                            False,
-                                                                            {},
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
-                                                                        pa.field("from_parent", pa.bool_(), True, {}),
+                                                                        pa.field(
+                                                                            "from_parent",
+                                                                            pa.bool_(),
+                                                                            nullable=True,
+                                                                            metadata={},
+                                                                        ),
                                                                     ]
                                                                 ),
-                                                                False,
-                                                                {},
+                                                                nullable=False,
+                                                                metadata={},
                                                             )
                                                         ),
-                                                        False,
-                                                        {},
+                                                        nullable=False,
+                                                        metadata={},
                                                     ),
                                                     pa.field(
                                                         "fixed_size_shenanigans",
-                                                        pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                        False,
-                                                        {},
+                                                        pa.list_(
+                                                            pa.field("item", pa.float32(), nullable=False, metadata={}),
+                                                            3,
+                                                        ),
+                                                        nullable=False,
+                                                        metadata={},
                                                     ),
                                                 ]
                                             ),
-                                            False,
-                                            {},
+                                            nullable=False,
+                                            metadata={},
                                         )
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "many_optional",
@@ -804,9 +1016,9 @@ class AffixFuzzer5Type(BaseExtensionType):
                                             "item",
                                             pa.dense_union(
                                                 [
-                                                    pa.field("_null_markers", pa.null(), True, {}),
-                                                    pa.field("degrees", pa.float32(), False, {}),
-                                                    pa.field("radians", pa.float32(), False, {}),
+                                                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                                    pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                                                    pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                                     pa.field(
                                                         "craziness",
                                                         pa.list_(
@@ -817,89 +1029,118 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                         pa.field(
                                                                             "single_float_optional",
                                                                             pa.float32(),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "single_string_required",
                                                                             pa.utf8(),
-                                                                            False,
-                                                                            {},
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "single_string_optional",
                                                                             pa.utf8(),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "many_floats_optional",
                                                                             pa.list_(
-                                                                                pa.field("item", pa.float32(), True, {})
+                                                                                pa.field(
+                                                                                    "item",
+                                                                                    pa.float32(),
+                                                                                    nullable=True,
+                                                                                    metadata={},
+                                                                                )
                                                                             ),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "many_strings_required",
                                                                             pa.list_(
-                                                                                pa.field("item", pa.utf8(), False, {})
+                                                                                pa.field(
+                                                                                    "item",
+                                                                                    pa.utf8(),
+                                                                                    nullable=False,
+                                                                                    metadata={},
+                                                                                )
                                                                             ),
-                                                                            False,
-                                                                            {},
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "many_strings_optional",
                                                                             pa.list_(
-                                                                                pa.field("item", pa.utf8(), True, {})
+                                                                                pa.field(
+                                                                                    "item",
+                                                                                    pa.utf8(),
+                                                                                    nullable=True,
+                                                                                    metadata={},
+                                                                                )
                                                                             ),
-                                                                            True,
-                                                                            {},
+                                                                            nullable=True,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
-                                                                            "flattened_scalar", pa.float32(), False, {}
+                                                                            "flattened_scalar",
+                                                                            pa.float32(),
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
                                                                         pa.field(
                                                                             "almost_flattened_scalar",
                                                                             pa.struct(
                                                                                 [
                                                                                     pa.field(
-                                                                                        "value", pa.float32(), False, {}
+                                                                                        "value",
+                                                                                        pa.float32(),
+                                                                                        nullable=False,
+                                                                                        metadata={},
                                                                                     )
                                                                                 ]
                                                                             ),
-                                                                            False,
-                                                                            {},
+                                                                            nullable=False,
+                                                                            metadata={},
                                                                         ),
-                                                                        pa.field("from_parent", pa.bool_(), True, {}),
+                                                                        pa.field(
+                                                                            "from_parent",
+                                                                            pa.bool_(),
+                                                                            nullable=True,
+                                                                            metadata={},
+                                                                        ),
                                                                     ]
                                                                 ),
-                                                                False,
-                                                                {},
+                                                                nullable=False,
+                                                                metadata={},
                                                             )
                                                         ),
-                                                        False,
-                                                        {},
+                                                        nullable=False,
+                                                        metadata={},
                                                     ),
                                                     pa.field(
                                                         "fixed_size_shenanigans",
-                                                        pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                        False,
-                                                        {},
+                                                        pa.list_(
+                                                            pa.field("item", pa.float32(), nullable=False, metadata={}),
+                                                            3,
+                                                        ),
+                                                        nullable=False,
+                                                        metadata={},
                                                     ),
                                                 ]
                                             ),
-                                            True,
-                                            {},
+                                            nullable=True,
+                                            metadata={},
                                         )
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                             ]
                         ),
-                        True,
-                        {},
+                        nullable=True,
+                        metadata={},
                     )
                 ]
             ),
@@ -956,7 +1197,12 @@ class AffixFuzzer20Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.struct([pa.field("p", pa.uint32(), False, {}), pa.field("s", pa.utf8(), False, {})]),
+            pa.struct(
+                [
+                    pa.field("p", pa.uint32(), nullable=False, metadata={}),
+                    pa.field("s", pa.utf8(), nullable=False, metadata={}),
+                ]
+            ),
             "rerun.testing.datatypes.AffixFuzzer20",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/keypoint_pair.py
@@ -57,7 +57,12 @@ class KeypointPairType(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.struct([pa.field("keypoint0", pa.uint16(), False, {}), pa.field("keypoint1", pa.uint16(), False, {})]),
+            pa.struct(
+                [
+                    pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+                    pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
+                ]
+            ),
             "rerun.datatypes.KeypointPair",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/mat3x3.py
@@ -45,7 +45,7 @@ Mat3x3ArrayLike = Union[
 class Mat3x3Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), False, {}), 9), "rerun.datatypes.Mat3x3"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9), "rerun.datatypes.Mat3x3"
         )
 
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/mat4x4.py
@@ -45,7 +45,7 @@ Mat4x4ArrayLike = Union[
 class Mat4x4Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), False, {}), 16), "rerun.datatypes.Mat4x4"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 16), "rerun.datatypes.Mat4x4"
         )
 
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion.py
@@ -47,7 +47,7 @@ QuaternionArrayLike = Union[
 class QuaternionType(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), False, {}), 4), "rerun.datatypes.Quaternion"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), "rerun.datatypes.Quaternion"
         )
 
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation3d.py
@@ -52,29 +52,39 @@ class Rotation3DType(BaseExtensionType):
             self,
             pa.dense_union(
                 [
-                    pa.field("_null_markers", pa.null(), True, {}),
-                    pa.field("Quaternion", pa.list_(pa.field("item", pa.float32(), False, {}), 4), False, {}),
+                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                    pa.field(
+                        "Quaternion",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4),
+                        nullable=False,
+                        metadata={},
+                    ),
                     pa.field(
                         "AxisAngle",
                         pa.struct(
                             [
-                                pa.field("axis", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {}),
+                                pa.field(
+                                    "axis",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                    nullable=False,
+                                    metadata={},
+                                ),
                                 pa.field(
                                     "angle",
                                     pa.dense_union(
                                         [
-                                            pa.field("_null_markers", pa.null(), True, {}),
-                                            pa.field("Radians", pa.float32(), False, {}),
-                                            pa.field("Degrees", pa.float32(), False, {}),
+                                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                            pa.field("Radians", pa.float32(), nullable=False, metadata={}),
+                                            pa.field("Degrees", pa.float32(), nullable=False, metadata={}),
                                         ]
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation_axis_angle.py
@@ -65,18 +65,23 @@ class RotationAxisAngleType(BaseExtensionType):
             self,
             pa.struct(
                 [
-                    pa.field("axis", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {}),
+                    pa.field(
+                        "axis",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                        nullable=False,
+                        metadata={},
+                    ),
                     pa.field(
                         "angle",
                         pa.dense_union(
                             [
-                                pa.field("_null_markers", pa.null(), True, {}),
-                                pa.field("Radians", pa.float32(), False, {}),
-                                pa.field("Degrees", pa.float32(), False, {}),
+                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                pa.field("Radians", pa.float32(), nullable=False, metadata={}),
+                                pa.field("Degrees", pa.float32(), nullable=False, metadata={}),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/scale3d.py
@@ -65,9 +65,14 @@ class Scale3DType(BaseExtensionType):
             self,
             pa.dense_union(
                 [
-                    pa.field("_null_markers", pa.null(), True, {}),
-                    pa.field("ThreeD", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {}),
-                    pa.field("Uniform", pa.float32(), False, {}),
+                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                    pa.field(
+                        "ThreeD",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                        nullable=False,
+                        metadata={},
+                    ),
+                    pa.field("Uniform", pa.float32(), nullable=False, metadata={}),
                 ]
             ),
             "rerun.datatypes.Scale3D",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/transform3d.py
@@ -54,38 +54,51 @@ class Transform3DType(BaseExtensionType):
             self,
             pa.dense_union(
                 [
-                    pa.field("_null_markers", pa.null(), True, {}),
+                    pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                     pa.field(
                         "TranslationAndMat3x3",
                         pa.struct(
                             [
                                 pa.field(
-                                    "translation", pa.list_(pa.field("item", pa.float32(), False, {}), 3), True, {}
+                                    "translation",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                    nullable=True,
+                                    metadata={},
                                 ),
-                                pa.field("matrix", pa.list_(pa.field("item", pa.float32(), False, {}), 9), True, {}),
-                                pa.field("from_parent", pa.bool_(), False, {}),
+                                pa.field(
+                                    "matrix",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field("from_parent", pa.bool_(), nullable=False, metadata={}),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                     pa.field(
                         "TranslationRotationScale",
                         pa.struct(
                             [
                                 pa.field(
-                                    "translation", pa.list_(pa.field("item", pa.float32(), False, {}), 3), True, {}
+                                    "translation",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                    nullable=True,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "rotation",
                                     pa.dense_union(
                                         [
-                                            pa.field("_null_markers", pa.null(), True, {}),
+                                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                             pa.field(
                                                 "Quaternion",
-                                                pa.list_(pa.field("item", pa.float32(), False, {}), 4),
-                                                False,
-                                                {},
+                                                pa.list_(
+                                                    pa.field("item", pa.float32(), nullable=False, metadata={}), 4
+                                                ),
+                                                nullable=False,
+                                                metadata={},
                                             ),
                                             pa.field(
                                                 "AxisAngle",
@@ -93,54 +106,76 @@ class Transform3DType(BaseExtensionType):
                                                     [
                                                         pa.field(
                                                             "axis",
-                                                            pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                            False,
-                                                            {},
+                                                            pa.list_(
+                                                                pa.field(
+                                                                    "item", pa.float32(), nullable=False, metadata={}
+                                                                ),
+                                                                3,
+                                                            ),
+                                                            nullable=False,
+                                                            metadata={},
                                                         ),
                                                         pa.field(
                                                             "angle",
                                                             pa.dense_union(
                                                                 [
-                                                                    pa.field("_null_markers", pa.null(), True, {}),
-                                                                    pa.field("Radians", pa.float32(), False, {}),
-                                                                    pa.field("Degrees", pa.float32(), False, {}),
+                                                                    pa.field(
+                                                                        "_null_markers",
+                                                                        pa.null(),
+                                                                        nullable=True,
+                                                                        metadata={},
+                                                                    ),
+                                                                    pa.field(
+                                                                        "Radians",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
+                                                                    ),
+                                                                    pa.field(
+                                                                        "Degrees",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
+                                                                    ),
                                                                 ]
                                                             ),
-                                                            False,
-                                                            {},
+                                                            nullable=False,
+                                                            metadata={},
                                                         ),
                                                     ]
                                                 ),
-                                                False,
-                                                {},
+                                                nullable=False,
+                                                metadata={},
                                             ),
                                         ]
                                     ),
-                                    True,
-                                    {},
+                                    nullable=True,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "scale",
                                     pa.dense_union(
                                         [
-                                            pa.field("_null_markers", pa.null(), True, {}),
+                                            pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                             pa.field(
                                                 "ThreeD",
-                                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                False,
-                                                {},
+                                                pa.list_(
+                                                    pa.field("item", pa.float32(), nullable=False, metadata={}), 3
+                                                ),
+                                                nullable=False,
+                                                metadata={},
                                             ),
-                                            pa.field("Uniform", pa.float32(), False, {}),
+                                            pa.field("Uniform", pa.float32(), nullable=False, metadata={}),
                                         ]
                                     ),
-                                    True,
-                                    {},
+                                    nullable=True,
+                                    metadata={},
                                 ),
-                                pa.field("from_parent", pa.bool_(), False, {}),
+                                pa.field("from_parent", pa.bool_(), nullable=False, metadata={}),
                             ]
                         ),
-                        False,
-                        {},
+                        nullable=False,
+                        metadata={},
                     ),
                 ]
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/translation_and_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/translation_and_mat3x3.py
@@ -85,9 +85,19 @@ class TranslationAndMat3x3Type(BaseExtensionType):
             self,
             pa.struct(
                 [
-                    pa.field("translation", pa.list_(pa.field("item", pa.float32(), False, {}), 3), True, {}),
-                    pa.field("matrix", pa.list_(pa.field("item", pa.float32(), False, {}), 9), True, {}),
-                    pa.field("from_parent", pa.bool_(), False, {}),
+                    pa.field(
+                        "translation",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                        nullable=True,
+                        metadata={},
+                    ),
+                    pa.field(
+                        "matrix",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9),
+                        nullable=True,
+                        metadata={},
+                    ),
+                    pa.field("from_parent", pa.bool_(), nullable=False, metadata={}),
                 ]
             ),
             "rerun.datatypes.TranslationAndMat3x3",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/translation_rotation_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/translation_rotation_scale3d.py
@@ -99,14 +99,22 @@ class TranslationRotationScale3DType(BaseExtensionType):
             self,
             pa.struct(
                 [
-                    pa.field("translation", pa.list_(pa.field("item", pa.float32(), False, {}), 3), True, {}),
+                    pa.field(
+                        "translation",
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                        nullable=True,
+                        metadata={},
+                    ),
                     pa.field(
                         "rotation",
                         pa.dense_union(
                             [
-                                pa.field("_null_markers", pa.null(), True, {}),
+                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field(
-                                    "Quaternion", pa.list_(pa.field("item", pa.float32(), False, {}), 4), False, {}
+                                    "Quaternion",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4),
+                                    nullable=False,
+                                    metadata={},
                                 ),
                                 pa.field(
                                     "AxisAngle",
@@ -114,45 +122,54 @@ class TranslationRotationScale3DType(BaseExtensionType):
                                         [
                                             pa.field(
                                                 "axis",
-                                                pa.list_(pa.field("item", pa.float32(), False, {}), 3),
-                                                False,
-                                                {},
+                                                pa.list_(
+                                                    pa.field("item", pa.float32(), nullable=False, metadata={}), 3
+                                                ),
+                                                nullable=False,
+                                                metadata={},
                                             ),
                                             pa.field(
                                                 "angle",
                                                 pa.dense_union(
                                                     [
-                                                        pa.field("_null_markers", pa.null(), True, {}),
-                                                        pa.field("Radians", pa.float32(), False, {}),
-                                                        pa.field("Degrees", pa.float32(), False, {}),
+                                                        pa.field(
+                                                            "_null_markers", pa.null(), nullable=True, metadata={}
+                                                        ),
+                                                        pa.field("Radians", pa.float32(), nullable=False, metadata={}),
+                                                        pa.field("Degrees", pa.float32(), nullable=False, metadata={}),
                                                     ]
                                                 ),
-                                                False,
-                                                {},
+                                                nullable=False,
+                                                metadata={},
                                             ),
                                         ]
                                     ),
-                                    False,
-                                    {},
+                                    nullable=False,
+                                    metadata={},
                                 ),
                             ]
                         ),
-                        True,
-                        {},
+                        nullable=True,
+                        metadata={},
                     ),
                     pa.field(
                         "scale",
                         pa.dense_union(
                             [
-                                pa.field("_null_markers", pa.null(), True, {}),
-                                pa.field("ThreeD", pa.list_(pa.field("item", pa.float32(), False, {}), 3), False, {}),
-                                pa.field("Uniform", pa.float32(), False, {}),
+                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                                pa.field(
+                                    "ThreeD",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                                    nullable=False,
+                                    metadata={},
+                                ),
+                                pa.field("Uniform", pa.float32(), nullable=False, metadata={}),
                             ]
                         ),
-                        True,
-                        {},
+                        nullable=True,
+                        metadata={},
                     ),
-                    pa.field("from_parent", pa.bool_(), False, {}),
+                    pa.field("from_parent", pa.bool_(), nullable=False, metadata={}),
                 ]
             ),
             "rerun.datatypes.TranslationRotationScale3D",

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec2d.py
@@ -46,7 +46,9 @@ Vec2DArrayLike = Union[
 
 class Vec2DType(BaseExtensionType):
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.list_(pa.field("item", pa.float32(), False, {}), 2), "rerun.datatypes.Vec2D")
+        pa.ExtensionType.__init__(
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2), "rerun.datatypes.Vec2D"
+        )
 
 
 class Vec2DArray(BaseExtensionArray[Vec2DArrayLike]):

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec3d.py
@@ -46,7 +46,9 @@ Vec3DArrayLike = Union[
 
 class Vec3DType(BaseExtensionType):
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.list_(pa.field("item", pa.float32(), False, {}), 3), "rerun.datatypes.Vec3D")
+        pa.ExtensionType.__init__(
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3), "rerun.datatypes.Vec3D"
+        )
 
 
 class Vec3DArray(BaseExtensionArray[Vec3DArrayLike]):

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/vec4d.py
@@ -46,7 +46,9 @@ Vec4DArrayLike = Union[
 
 class Vec4DType(BaseExtensionType):
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.list_(pa.field("item", pa.float32(), False, {}), 4), "rerun.datatypes.Vec4D")
+        pa.ExtensionType.__init__(
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), "rerun.datatypes.Vec4D"
+        )
 
 
 class Vec4DArray(BaseExtensionArray[Vec4DArrayLike]):

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -117,7 +117,7 @@ def run_roundtrip_python(arch: str) -> str:
 
     cmd = [python_executable, main_path, "--save", output_path]
 
-    print(f"\n> ${subprocess.list2cmdline(cmd)}")
+    print(f"\n> {subprocess.list2cmdline(cmd)}")
     roundtrip_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = roundtrip_process.wait(timeout=30)
     assert returncode == 0, f"python roundtrip process exited with error code {returncode}"
@@ -129,7 +129,7 @@ def run_roundtrip_rust(arch: str, release: bool, target: str | None, target_dir:
     project_name = f"roundtrip_{arch}"
     output_path = f"tests/rust/roundtrips/{arch}/out.rrd"
 
-    cmd = ["cargo", "r", "-p", project_name]
+    cmd = ["cargo", "run", "--quiet", "-p", project_name]
 
     if target is not None:
         cmd += ["--target", target]
@@ -142,7 +142,7 @@ def run_roundtrip_rust(arch: str, release: bool, target: str | None, target_dir:
 
     cmd += ["--", "--save", output_path]
 
-    print(f"\n> ${subprocess.list2cmdline(cmd)}")
+    print(f"\n> {subprocess.list2cmdline(cmd)}")
     roundtrip_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = roundtrip_process.wait(timeout=12000)
     assert returncode == 0, f"rust roundtrip process exited with error code {returncode}"
@@ -157,7 +157,7 @@ def run_roundtrip_cpp(arch: str, release: bool) -> str:
     cmake_build(target_name, release)
 
     cmd = [f"./build/tests/cpp/roundtrips/{target_name}", output_path]
-    print(f"\n> ${subprocess.list2cmdline(cmd)}")
+    print(f"\n> {subprocess.list2cmdline(cmd)}")
     roundtrip_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = roundtrip_process.wait(timeout=12000)
     assert returncode == 0, f"cpp roundtrip process exited with error code {returncode}"
@@ -181,7 +181,7 @@ def cmake_build(target: str, release: bool) -> None:
         "--parallel",
         str(multiprocessing.cpu_count()),
     ]
-    print(f"\n> ${subprocess.list2cmdline(build_process_args)}")
+    print(f"\n> {subprocess.list2cmdline(build_process_args)}")
     result = subprocess.run(build_process_args, cwd="build")
 
     assert result.returncode == 0, f"cmake build of {target} exited with error code {result.returncode}"
@@ -193,7 +193,7 @@ def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]
 
-    print(f"\n> ${subprocess.list2cmdline(cmd)}")
+    print(f"\n> {subprocess.list2cmdline(cmd)}")
     comparison_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = comparison_process.wait(timeout=30)
     assert returncode == 0, f"comparison process exited with error code {returncode}"

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -56,7 +56,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print("Building rerun-sdk for Python…")
         start_time = time.time()
-        returncode = subprocess.Popen(["just", "py-build"], env=build_env).wait()
+        returncode = subprocess.Popen(["just", "py-build", "--quiet"], env=build_env).wait()
         assert returncode == 0, f"Python rerun-sdk build failed with exit code {returncode}"
         elapsed = time.time() - start_time
         print(f"rerun-sdk for Python built in {elapsed:.1f} seconds")
@@ -73,7 +73,7 @@ def main() -> None:
         if args.release:
             build_type = "Release"
         configure_args = ["cmake", f"-DCMAKE_BUILD_TYPE={build_type}", "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON", ".."]
-        print(subprocess.list2cmdline(configure_args))
+        print("> ${subprocess.list2cmdline(configure_args)}")
         returncode = subprocess.Popen(
             configure_args,
             env=build_env,
@@ -117,7 +117,7 @@ def run_roundtrip_python(arch: str) -> str:
 
     cmd = [python_executable, main_path, "--save", output_path]
 
-    print(cmd)
+    print(f"\n> ${subprocess.list2cmdline(cmd)}")
     roundtrip_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = roundtrip_process.wait(timeout=30)
     assert returncode == 0, f"python roundtrip process exited with error code {returncode}"
@@ -142,7 +142,7 @@ def run_roundtrip_rust(arch: str, release: bool, target: str | None, target_dir:
 
     cmd += ["--", "--save", output_path]
 
-    print(cmd)
+    print(f"\n> ${subprocess.list2cmdline(cmd)}")
     roundtrip_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = roundtrip_process.wait(timeout=12000)
     assert returncode == 0, f"rust roundtrip process exited with error code {returncode}"
@@ -157,7 +157,7 @@ def run_roundtrip_cpp(arch: str, release: bool) -> str:
     cmake_build(target_name, release)
 
     cmd = [f"./build/tests/cpp/roundtrips/{target_name}", output_path]
-    print(cmd)
+    print(f"\n> ${subprocess.list2cmdline(cmd)}")
     roundtrip_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = roundtrip_process.wait(timeout=12000)
     assert returncode == 0, f"cpp roundtrip process exited with error code {returncode}"
@@ -181,7 +181,7 @@ def cmake_build(target: str, release: bool) -> None:
         "--parallel",
         str(multiprocessing.cpu_count()),
     ]
-    print(subprocess.list2cmdline(build_process_args))
+    print(f"\n> ${subprocess.list2cmdline(build_process_args)}")
     result = subprocess.run(build_process_args, cwd="build")
 
     assert result.returncode == 0, f"cmake build of {target} exited with error code {result.returncode}"
@@ -193,7 +193,7 @@ def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]
 
-    print(cmd)
+    print(f"\n> ${subprocess.list2cmdline(cmd)}")
     comparison_process = subprocess.Popen(cmd, env=roundtrip_env())
     returncode = comparison_process.wait(timeout=30)
     assert returncode == 0, f"comparison process exited with error code {returncode}"


### PR DESCRIPTION
An off-by-one bug in `estimated_bytes_size` caused the size estimations of Tensors to completely ignore the actual payload, causing the memory consumption of images to be vastly underestimated.

I decided to rewrite the code to be more clear for future readers.

This discovered a difference in how validity bitmaps are written by Rust and Python+C++, fixed in https://github.com/rerun-io/rerun/pull/2991/commits/a828441c2047e5c70ca382598cc7cc6a62471ca8.

To help find this problem a lot of work was also put into improving the output of `scripts/ci/run_e2e_roundtrip_tests.py`.

* Discovered while working on https://github.com/rerun-io/rerun/issues/2435

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/2991) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/2991)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-size-estimation-bug/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-size-estimation-bug/examples)