### PR TITLE
Add default value for `info` argument of `ClassDescription`

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/annotation_info.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/annotation_info.fbs
@@ -12,7 +12,7 @@ namespace rerun.datatypes;
 /// Color and label will be used to annotate entities/keypoints which reference the id.
 /// The id refers either to a class or key-point id
 table AnnotationInfo (
-  "attr.python.aliases": "Tuple[int, str], Tuple[int, str, datatypes.ColorLike]",
+  "attr.python.aliases": "int, Tuple[int, str], Tuple[int, str, datatypes.ColorLike]",
   "attr.rust.derive": "Default, Eq, PartialEq",
   order: 500
 ) {

--- a/crates/re_types/definitions/rerun/datatypes/class_description.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_description.fbs
@@ -21,6 +21,8 @@ namespace rerun.datatypes;
 /// defined, and both keypoints exist within the instance of the class, then the
 /// keypoints should be connected with an edge. The edge should be labeled and
 /// colored as described by the class's `AnnotationInfo`.
+///
+/// The default `info` is an `id=0` with no label or color.
 table ClassDescription (
   "attr.python.aliases": "datatypes.AnnotationInfoLike",
   "attr.rust.derive": "Default, Eq, PartialEq",

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-e52eaba28a92032dfb37a3b2c0eccc8d9fd2ef244df7fffb3e1ecbf693ad7acb
+906964856e0258359678fb9b126226558c0caac81d4d98c36f4e8b30391a51d5

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-906964856e0258359678fb9b126226558c0caac81d4d98c36f4e8b30391a51d5
+28d5cb0fc8ce83c25d7c19429def1bb45436ccdbfebdae483fc3fb8b617ab813

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-39e4d6a894018848a2ef49c36db1635a9bafd5594bf962b1c53f65041b6955bf
+bc4dc84dd4a9c8581e38b94a991cdb80c418f6cbe39e1b530f33cdd0deb20d32

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -26,6 +26,8 @@
 /// defined, and both keypoints exist within the instance of the class, then the
 /// keypoints should be connected with an edge. The edge should be labeled and
 /// colored as described by the class's `AnnotationInfo`.
+///
+/// The default `info` is an `id=0` with no label or color.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ClassDescription {
     /// The `AnnotationInfo` for the class.

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -26,6 +26,8 @@ namespace rerun {
         /// defined, and both keypoints exist within the instance of the class, then the
         /// keypoints should be connected with an edge. The edge should be labeled and
         /// colored as described by the class's `AnnotationInfo`.
+        ///
+        /// The default `info` is an `id=0` with no label or color.
         struct ClassDescription {
             /// The `AnnotationInfo` for the class.
             rerun::datatypes::AnnotationInfo info;

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/annotation_context.py
@@ -29,7 +29,8 @@ if TYPE_CHECKING:
 
 def classdescription_init(
     self: ClassDescription,
-    info: AnnotationInfoLike,
+    *,
+    info: AnnotationInfoLike = 0,
     keypoint_annotations: Sequence[AnnotationInfoLike] = [],
     keypoint_connections: Sequence[KeypointPairLike] = [],
 ) -> None:
@@ -89,6 +90,8 @@ def classdescription_info_converter(
 
     if isinstance(data, AnnotationInfo):
         return data
+    elif isinstance(data, int):
+        return AnnotationInfo(id=data)
     else:
         return AnnotationInfo(*data)
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/annotation_context.py
@@ -29,8 +29,8 @@ if TYPE_CHECKING:
 
 def classdescription_init(
     self: ClassDescription,
-    *,
     info: AnnotationInfoLike = 0,
+    *,
     keypoint_annotations: Sequence[AnnotationInfoLike] = [],
     keypoint_connections: Sequence[KeypointPairLike] = [],
 ) -> None:

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/annotation_info.py
@@ -67,7 +67,7 @@ class AnnotationInfo:
 
 
 if TYPE_CHECKING:
-    AnnotationInfoLike = Union[AnnotationInfo, Tuple[int, str], Tuple[int, str, datatypes.ColorLike]]
+    AnnotationInfoLike = Union[AnnotationInfo, int, Tuple[int, str], Tuple[int, str, datatypes.ColorLike]]
 else:
     AnnotationInfoLike = Any
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description.py
@@ -47,6 +47,8 @@ class ClassDescription:
     defined, and both keypoints exist within the instance of the class, then the
     keypoints should be connected with an edge. The edge should be labeled and
     colored as described by the class's `AnnotationInfo`.
+
+    The default `info` is an `id=0` with no label or color.
     """
 
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]

--- a/tests/python/roundtrips/annotation_context/main.py
+++ b/tests/python/roundtrips/annotation_context/main.py
@@ -16,7 +16,7 @@ def main() -> None:
         [
             (1, "hello"),
             rrd.ClassDescription(
-                (2, "world", [3, 4, 5]),
+                info=(2, "world", [3, 4, 5]),
                 keypoint_annotations=[(17, "head"), (42, "shoulders")],
                 keypoint_connections=[(1, 2), (3, 4)],
             ),


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/2924

Two changes:
* You can now easily specify the `info` without having to also specify label and color, using `info=0`.
* The default info is one with `id=0`, matching 0.7.0 behavior and how `log_points` work


(This took me over an hour to figure out 😭)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3017) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3017)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-annotation-context-default/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-annotation-context-default/examples)