### PR TITLE
Be more explicit in our `AnnotationContext` python API

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/class_description.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_description.fbs
@@ -21,8 +21,6 @@ namespace rerun.datatypes;
 /// defined, and both keypoints exist within the instance of the class, then the
 /// keypoints should be connected with an edge. The edge should be labeled and
 /// colored as described by the class's `AnnotationInfo`.
-///
-/// The default `info` is an `id=0` with no label or color.
 table ClassDescription (
   "attr.python.aliases": "datatypes.AnnotationInfoLike",
   "attr.rust.derive": "Default, Eq, PartialEq",

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-bc4dc84dd4a9c8581e38b94a991cdb80c418f6cbe39e1b530f33cdd0deb20d32
+47b42cfa1631843bf5c91684b73e1eb459dde762b4edf74f26725420f1c3d548

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -26,8 +26,6 @@
 /// defined, and both keypoints exist within the instance of the class, then the
 /// keypoints should be connected with an edge. The edge should be labeled and
 /// colored as described by the class's `AnnotationInfo`.
-///
-/// The default `info` is an `id=0` with no label or color.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ClassDescription {
     /// The `AnnotationInfo` for the class.

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -116,7 +116,9 @@ class FaceDetectorLogger:
         # With this annotation, the viewer will connect the keypoints with some lines to improve visibility.
         rr.log_annotation_context(
             "video/detector",
-            rr.ClassDescription(keypoint_connections=[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4), (1, 5)]),
+            rr.ClassDescription(
+                info=rr.AnnotationInfo(id=0), keypoint_connections=[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4), (1, 5)]
+            ),
         )
 
     def detect_and_log(self, image: npt.NDArray[np.uint8], frame_time_nano: int) -> None:

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -26,8 +26,6 @@ namespace rerun {
         /// defined, and both keypoints exist within the instance of the class, then the
         /// keypoints should be connected with an edge. The edge should be labeled and
         /// colored as described by the class's `AnnotationInfo`.
-        ///
-        /// The default `info` is an `id=0` with no label or color.
         struct ClassDescription {
             /// The `AnnotationInfo` for the class.
             rerun::datatypes::AnnotationInfo info;

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/annotation_context.py
@@ -29,8 +29,8 @@ if TYPE_CHECKING:
 
 def classdescription_init(
     self: ClassDescription,
-    info: AnnotationInfoLike = 0,
     *,
+    info: AnnotationInfoLike,
     keypoint_annotations: Sequence[AnnotationInfoLike] = [],
     keypoint_connections: Sequence[KeypointPairLike] = [],
 ) -> None:

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/class_description.py
@@ -47,8 +47,6 @@ class ClassDescription:
     defined, and both keypoints exist within the instance of the class, then the
     keypoints should be connected with an edge. The edge should be labeled and
     colored as described by the class's `AnnotationInfo`.
-
-    The default `info` is an `id=0` with no label or color.
     """
 
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]

--- a/rerun_py/tests/unit/test_annotation_context.py
+++ b/rerun_py/tests/unit/test_annotation_context.py
@@ -92,18 +92,21 @@ ANNOTATION_CONTEXT_INPUTS = [
         (2, "label2", [4, 5, 6]),
     ],
     [
-        rr_dt.ClassDescription((1, "label1", [1, 2, 3]), keypoint_annotations=[(3, "kp_label1", [7, 8, 9])]),
-        rr_dt.ClassDescription((2, "label2", [4, 5, 6]), keypoint_annotations=[(4, "kp_label2", [10, 11, 12])]),
+        rr_dt.ClassDescription(info=(1, "label1", [1, 2, 3]), keypoint_annotations=[(3, "kp_label1", [7, 8, 9])]),
+        rr_dt.ClassDescription(info=(2, "label2", [4, 5, 6]), keypoint_annotations=[(4, "kp_label2", [10, 11, 12])]),
     ],
     [
         rr_dt.AnnotationInfo(1, "label1"),
         rr_dt.AnnotationInfo(2, color=[4, 5, 6]),
     ],
     [
-        rr_dt.ClassDescription((1, "label1"), keypoint_annotations=[(3, "kp_label1")]),
-        rr_dt.ClassDescription((2, "label2", [4, 5, 6]), keypoint_annotations=[(4, "kp_label2", [10, 11, 12])]),
+        rr_dt.ClassDescription(info=(1, "label1"), keypoint_annotations=[(3, "kp_label1")]),
+        rr_dt.ClassDescription(info=(2, "label2", [4, 5, 6]), keypoint_annotations=[(4, "kp_label2", [10, 11, 12])]),
     ],
-    [rr_dt.ClassDescription((1, "label1"), keypoint_connections=[(1, 2)]), rr_dt.ClassDescription((2, "label2"))],
+    [
+        rr_dt.ClassDescription(info=(1, "label1"), keypoint_connections=[(1, 2)]),
+        rr_dt.ClassDescription(info=(2, "label2")),
+    ],
 ]
 
 
@@ -113,13 +116,13 @@ def assert_correct_annotation_context(ctx: rr_cmp.AnnotationContext) -> None:
         rr_dt.ClassDescriptionMapElem(
             class_id=1,
             class_description=rr_dt.ClassDescription(
-                (1, "label1", [1, 2, 3]), keypoint_annotations=[(3, "kp_label1", [7, 8, 9])]
+                info=(1, "label1", [1, 2, 3]), keypoint_annotations=[(3, "kp_label1", [7, 8, 9])]
             ),
         ),
         rr_dt.ClassDescriptionMapElem(
             class_id=2,
             class_description=rr_dt.ClassDescription(
-                (2, "label2", [4, 5, 6]), keypoint_annotations=[(4, "kp_label2", [10, 11, 12])]
+                info=(2, "label2", [4, 5, 6]), keypoint_annotations=[(4, "kp_label2", [10, 11, 12])]
             ),
         ),
     ]
@@ -145,7 +148,7 @@ def test_annotation_context_component(ctx: Sequence[rr_dt.ClassDescriptionMapEle
 
 
 ANNOTATION_ARCH_INPUTS = [
-    rr_dt.ClassDescription((1, "label1", [1, 2, 3])),
+    rr_dt.ClassDescription(info=(1, "label1", [1, 2, 3])),
 ] + ANNOTATION_CONTEXT_INPUTS
 
 


### PR DESCRIPTION
Maybe?
Should we do the same for `log_points` to match?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
- [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
