### PR TITLE
C++ resolve `archetypes` namespace within `rerun` namespace by default

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-90e8d17413cd057b17694675789dedd7b01374e419fdcc348354ee1ffd206823
+7f3229bd4b4272102f9f5bced8f57400c5284b743ab084272f9e791325d8ef58

--- a/docs/code-examples/annotation_context_arrows_v2.cpp
+++ b/docs/code-examples/annotation_context_arrows_v2.cpp
@@ -11,7 +11,7 @@ int main() {
     // Log an annotation context to assign a label and color to each class
     rr_stream.log(
         "/",
-        rr::archetypes::AnnotationContext({
+        rr::AnnotationContext({
             rr::datatypes::AnnotationInfo(1, "red", rr::datatypes::Color(255, 0, 0)),
             rr::datatypes::AnnotationInfo(2, "green", rr::datatypes::Color(0, 255, 0)),
         })
@@ -20,6 +20,6 @@ int main() {
     // Log a batch of 2 arrows with different `class_ids`
     rr_stream.log(
         "arrows",
-        rr::archetypes::Arrows3D({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}).with_class_ids({1, 2})
+        rr::Arrows3D({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}).with_class_ids({1, 2})
     );
 }

--- a/docs/code-examples/arrow3d_simple_v2.cpp
+++ b/docs/code-examples/arrow3d_simple_v2.cpp
@@ -23,5 +23,5 @@ int main() {
         colors.push_back({static_cast<uint8_t>(255 - c), c, 128, 128});
     }
 
-    rr_stream.log("arrows", rr::archetypes::Arrows3D(vectors).with_colors(colors));
+    rr_stream.log("arrows", rr::Arrows3D(vectors).with_colors(colors));
 }

--- a/docs/code-examples/disconnected_space_v2.cpp
+++ b/docs/code-examples/disconnected_space_v2.cpp
@@ -9,19 +9,10 @@ int main() {
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
     // These two points can be projected into the same space..
-    rr_stream.log(
-        "world/room1/point",
-        rr::archetypes::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f})
-    );
-    rr_stream.log(
-        "world/room2/point",
-        rr::archetypes::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f})
-    );
+    rr_stream.log("world/room1/point", rr::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f}));
+    rr_stream.log("world/room2/point", rr::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}));
 
     // ..but this one lives in a completely separate space!
-    rr_stream.log("world/wormhole", rr::archetypes::DisconnectedSpace(true));
-    rr_stream.log(
-        "world/wormhole/point",
-        rr::archetypes::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f})
-    );
+    rr_stream.log("world/wormhole", rr::DisconnectedSpace(true));
+    rr_stream.log("world/wormhole/point", rr::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f}));
 }

--- a/docs/code-examples/line_segments2d_simple_v2.cpp
+++ b/docs/code-examples/line_segments2d_simple_v2.cpp
@@ -9,5 +9,5 @@ int main() {
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
     std::vector<rr::datatypes::Vec2D> points = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
-    rr_stream.log("strips", rr::archetypes::LineStrips2D(points));
+    rr_stream.log("strips", rr::LineStrips2D(points));
 }

--- a/docs/code-examples/line_segments3d_simple_v2.cpp
+++ b/docs/code-examples/line_segments3d_simple_v2.cpp
@@ -18,5 +18,5 @@ int main() {
         {0.f, 1.f, 0.f},
         {0.f, 1.f, 1.f},
     };
-    rr_stream.log("segments", rr::archetypes::LineStrips3D(points));
+    rr_stream.log("segments", rr::LineStrips3D(points));
 }

--- a/docs/code-examples/line_strip2d_batch_v2.cpp
+++ b/docs/code-examples/line_strip2d_batch_v2.cpp
@@ -13,7 +13,7 @@ int main() {
         {{0.f, 3.f}, {1.f, 4.f}, {2.f, 2.f}, {3.f, 4.f}, {4.f, 2.f}, {5.f, 4.f}, {6.f, 3.f}};
     rr_stream.log(
         "strips",
-        rr::archetypes::LineStrips2D({strip1, strip2})
+        rr::LineStrips2D({strip1, strip2})
             .with_colors({0xFF0000FF, 0x00FF00FF})
             .with_radii({0.025f, 0.005f})
             .with_labels({"one strip here", "and one strip there"})

--- a/docs/code-examples/line_strip2d_simple_v2.cpp
+++ b/docs/code-examples/line_strip2d_simple_v2.cpp
@@ -9,5 +9,5 @@ int main() {
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
     std::vector<rr::datatypes::Vec2D> strip = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
-    rr_stream.log("strips", rr::archetypes::LineStrips2D(strip));
+    rr_stream.log("strips", rr::LineStrips2D(strip));
 }

--- a/docs/code-examples/line_strip3d_batch_v2.cpp
+++ b/docs/code-examples/line_strip3d_batch_v2.cpp
@@ -26,7 +26,7 @@ int main() {
     };
     rr_stream.log(
         "strips",
-        rr::archetypes::LineStrips3D({strip1, strip2})
+        rr::LineStrips3D({strip1, strip2})
             .with_colors({0xFF0000FF, 0x00FF00FF})
             .with_radii({0.025f, 0.005f})
             .with_labels({"one strip here", "and one strip there"})

--- a/docs/code-examples/line_strip3d_simple_v2.cpp
+++ b/docs/code-examples/line_strip3d_simple_v2.cpp
@@ -18,5 +18,5 @@ int main() {
         {0.f, 1.f, 0.f},
         {0.f, 1.f, 1.f},
     };
-    rr_stream.log("strips", rr::archetypes::LineStrips3D(points));
+    rr_stream.log("strips", rr::LineStrips3D(points));
 }

--- a/docs/code-examples/point3d_random_v2.cpp
+++ b/docs/code-examples/point3d_random_v2.cpp
@@ -27,8 +27,5 @@ int main() {
     std::vector<rr::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
 
-    rr_stream.log(
-        "random",
-        rr::archetypes::Points3D(points3d).with_colors(colors).with_radii(radii)
-    );
+    rr_stream.log("random", rr::Points3D(points3d).with_colors(colors).with_radii(radii));
 }

--- a/docs/code-examples/point3d_simple_v2.cpp
+++ b/docs/code-examples/point3d_simple_v2.cpp
@@ -8,5 +8,5 @@ int main() {
     auto rr_stream = rr::RecordingStream("points3d_simple");
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
-    rr_stream.log("points", rr::archetypes::Points3D({{0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}}));
+    rr_stream.log("points", rr::Points3D({{0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}}));
 }

--- a/docs/code-examples/transform3d_simple_v2.cpp
+++ b/docs/code-examples/transform3d_simple_v2.cpp
@@ -13,16 +13,16 @@ int main() {
     auto rr_stream = rr::RecordingStream("transform3d");
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
-    auto arrow = rr::archetypes::Arrows3D({0.0f, 1.0f, 0.0f});
+    auto arrow = rr::Arrows3D({0.0f, 1.0f, 0.0f});
 
     rr_stream.log("base", arrow);
 
-    rr_stream.log("base/translated", rr::archetypes::Transform3D({1.0f, 0.0f, 0.0f}));
+    rr_stream.log("base/translated", rr::Transform3D({1.0f, 0.0f, 0.0f}));
     rr_stream.log("base/translated", arrow);
 
     rr_stream.log(
         "base/rotated_scaled",
-        rr::archetypes::Transform3D(
+        rr::Transform3D(
             rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(pi / 4.0f)),
             2.0f
         )

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -16,9 +16,10 @@ int main(int argc, char** argv) {
     auto rr_stream = rr::RecordingStream("c-example-app");
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
+    // Log points with the archetype api - this is the preferred way of logging.
     rr_stream.log(
         "3d/points",
-        rr::archetypes::Points3D({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}})
+        rr::Points3D({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}})
             .with_radii({0.42f, 0.43f})
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({"hello", "friend"})
@@ -27,6 +28,8 @@ int main(int argc, char** argv) {
             .with_instance_keys({66, 666})
     );
 
+    // Log points with the components api - this is the advanced way of logging components in a
+    // fine-grained matter. It supports passing various types of containers.
     rrc::Label c_style_array[3] = {rrc::Label("hello"), rrc::Label("friend"), rrc::Label("yo")};
     rr_stream.log_components(
         "2d/points",

--- a/rerun_cpp/src/rerun.hpp
+++ b/rerun_cpp/src/rerun.hpp
@@ -11,3 +11,9 @@
 #include "rerun/recording_stream.hpp"
 #include "rerun/result.hpp"
 #include "rerun/sdk_info.hpp"
+
+// Archetypes are the quick-and-easy default way of logging data to Rerun.
+// Make them available in the rerun namespace.
+namespace rerun {
+    using namespace archetypes;
+}

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -37,7 +37,7 @@ namespace rerun {
         ///    // Log an annotation context to assign a label and color to each class
         ///    rr_stream.log(
         ///        "/",
-        ///        rr::archetypes::AnnotationContext({
+        ///        rr::AnnotationContext({
         ///            rr::datatypes::AnnotationInfo(1, "red", rr::datatypes::Color(255, 0, 0)),
         ///            rr::datatypes::AnnotationInfo(2, "green", rr::datatypes::Color(0, 255, 0)),
         ///        })
@@ -46,8 +46,7 @@ namespace rerun {
         ///    // Log a batch of 2 arrows with different `class_ids`
         ///    rr_stream.log(
         ///        "arrows",
-        ///        rr::archetypes::Arrows3D({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f,
-        ///        0.0f}}).with_class_ids({1, 2})
+        ///        rr::Arrows3D({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}}).with_class_ids({1, 2})
         ///    );
         /// }
         ///```

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -51,7 +51,7 @@ namespace rerun {
         ///        colors.push_back({static_cast<uint8_t>(255 - c), c, 128, 128});
         ///    }
         ///
-        ///    rr_stream.log("arrows", rr::archetypes::Arrows3D(vectors).with_colors(colors));
+        ///    rr_stream.log("arrows", rr::Arrows3D(vectors).with_colors(colors));
         /// }
         ///```
         struct Arrows3D {

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -34,21 +34,14 @@ namespace rerun {
         ///    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
         ///
         ///    // These two points can be projected into the same space..
-        ///    rr_stream.log(
-        ///        "world/room1/point",
-        ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f})
-        ///    );
-        ///    rr_stream.log(
-        ///        "world/room2/point",
-        ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f})
-        ///    );
+        ///    rr_stream.log("world/room1/point", rr::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f,
+        ///    0.0f})); rr_stream.log("world/room2/point",
+        ///    rr::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}));
         ///
         ///    // ..but this one lives in a completely separate space!
-        ///    rr_stream.log("world/wormhole", rr::archetypes::DisconnectedSpace(true));
-        ///    rr_stream.log(
-        ///        "world/wormhole/point",
-        ///        rr::archetypes::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f})
-        ///    );
+        ///    rr_stream.log("world/wormhole", rr::DisconnectedSpace(true));
+        ///    rr_stream.log("world/wormhole/point",
+        ///    rr::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f}));
         /// }
         ///```
         struct DisconnectedSpace {

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -43,7 +43,7 @@ namespace rerun {
         ///        {6.f, 3.f}};
         ///    rr_stream.log(
         ///        "strips",
-        ///        rr::archetypes::LineStrips2D({strip1, strip2})
+        ///        rr::LineStrips2D({strip1, strip2})
         ///            .with_colors({0xFF0000FF, 0x00FF00FF})
         ///            .with_radii({0.025f, 0.005f})
         ///            .with_labels({"one strip here", "and one strip there"})
@@ -64,7 +64,7 @@ namespace rerun {
         ///    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
         ///
         ///    std::vector<rr::datatypes::Vec2D> points = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f},
-        ///    {6.f, 0.f}}; rr_stream.log("strips", rr::archetypes::LineStrips2D(points));
+        ///    {6.f, 0.f}}; rr_stream.log("strips", rr::LineStrips2D(points));
         /// }
         ///```
         struct LineStrips2D {

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -54,7 +54,7 @@ namespace rerun {
         ///    };
         ///    rr_stream.log(
         ///        "strips",
-        ///        rr::archetypes::LineStrips3D({strip1, strip2})
+        ///        rr::LineStrips3D({strip1, strip2})
         ///            .with_colors({0xFF0000FF, 0x00FF00FF})
         ///            .with_radii({0.025f, 0.005f})
         ///            .with_labels({"one strip here", "and one strip there"})
@@ -84,7 +84,7 @@ namespace rerun {
         ///        {0.f, 1.f, 0.f},
         ///        {0.f, 1.f, 1.f},
         ///    };
-        ///    rr_stream.log("segments", rr::archetypes::LineStrips3D(points));
+        ///    rr_stream.log("segments", rr::LineStrips3D(points));
         /// }
         ///```
         struct LineStrips3D {

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -36,8 +36,7 @@ namespace rerun {
         ///    auto rr_stream = rr::RecordingStream("points3d_simple");
         ///    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///    rr_stream.log("points", rr::archetypes::Points3D({{0.0f, 0.0f, 0.0f},
-        ///    {1.0f, 1.0f, 1.0f}}));
+        ///    rr_stream.log("points", rr::Points3D({{0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}}));
         /// }
         ///```
         struct Points3D {

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -33,16 +33,16 @@ namespace rerun {
         ///    auto rr_stream = rr::RecordingStream("transform3d");
         ///    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///    auto arrow = rr::archetypes::Arrows3D({0.0f, 1.0f, 0.0f});
+        ///    auto arrow = rr::Arrows3D({0.0f, 1.0f, 0.0f});
         ///
         ///    rr_stream.log("base", arrow);
         ///
-        ///    rr_stream.log("base/translated", rr::archetypes::Transform3D({1.0f, 0.0f, 0.0f}));
+        ///    rr_stream.log("base/translated", rr::Transform3D({1.0f, 0.0f, 0.0f}));
         ///    rr_stream.log("base/translated", arrow);
         ///
         ///    rr_stream.log(
         ///        "base/rotated_scaled",
-        ///        rr::archetypes::Transform3D(
+        ///        rr::Transform3D(
         ///            rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(pi / 4.0f)),
         ///            2.0f
         ///        )


### PR DESCRIPTION
### What
Small QOL change that we discussed a while ago but didn't write down

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3024) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3024)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fusing-namespace-archetype/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fusing-namespace-archetype/examples)