### PR TITLE
Uniform icon, pointer, and tooltip for external links

### DIFF
--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -1,8 +1,8 @@
 //! The main Rerun drop-down menu found in the top panel.
 
-use egui::NumExt as _;
+use egui::{NumExt as _, Widget};
 
-use re_ui::UICommand;
+use re_ui::{ReUi, UICommand};
 use re_viewer_context::StoreContext;
 
 use crate::App;
@@ -82,11 +82,21 @@ impl App {
             ui.add_space(spacing);
 
             // dont use `hyperlink_to` for styling reasons
-            if ui.button("Help").clicked() {
+            const HELP_URL: &str = "https://www.rerun.io/docs/getting-started/viewer-walkthrough";
+
+            let texture_id = self
+                .re_ui()
+                .icon_image(&re_ui::icons::EXTERNAL_LINK)
+                .texture_id(ui.ctx());
+            if egui::Button::image_and_text(texture_id, ReUi::small_icon_size(), "Help")
+                .ui(ui)
+                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                .on_hover_text(HELP_URL)
+                .clicked()
+            {
                 ui.ctx().output_mut(|o| {
                     o.open_url = Some(egui::output::OpenUrl {
-                        url: "https://www.rerun.io/docs/getting-started/viewer-walkthrough"
-                            .to_owned(),
+                        url: HELP_URL.to_owned(),
                         new_tab: true,
                     });
                 });

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -166,10 +166,11 @@ fn website_link_ui(ui: &mut egui::Ui, app: &mut App) {
 
     let image_size = icon_image.size_vec2() * (desired_height / icon_image.size_vec2().y);
     let texture_id = icon_image.texture_id(ui.ctx());
+    let url = "https://rerun.io/";
     let response = ui
         .add(egui::ImageButton::new(texture_id, image_size))
-        .on_hover_cursor(egui::CursorIcon::PointingHand);
-    let url = "https://rerun.io/";
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(url);
     if response.clicked() {
         ui.ctx().output_mut(|o| {
             o.open_url = Some(egui::output::OpenUrl {


### PR DESCRIPTION
### What

This PR unifies the behaviour of our external links (welcome screen, help menu item, top rerun.io logo), which should include:
- pointy finger mouse pointer
- external link icon (rerun.io logo is an exception here—it'll be redesigned soon-ish anyway)
- url in tooltip

<img width="1374" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/d26c682e-f409-42d2-b3d8-f75253a4c424">


cc @martenbjork 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3026) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3026)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Funified-link-behaviour/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Funified-link-behaviour/examples)