### PR TITLE
Fix the Streams UI when the recording is empty

### DIFF
--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -28,7 +28,7 @@ use time_ranges_ui::TimeRangesUi;
 #[derive(serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct TimePanel {
-    data_dentity_graph_painter: data_density_graph::DataDensityGraphPainter,
+    data_density_graph_painter: data_density_graph::DataDensityGraphPainter,
 
     /// Width of the entity name columns previous frame.
     prev_col_width: f32,
@@ -48,7 +48,7 @@ pub struct TimePanel {
 impl Default for TimePanel {
     fn default() -> Self {
         Self {
-            data_dentity_graph_painter: Default::default(),
+            data_density_graph_painter: Default::default(),
             prev_col_width: 400.0,
             next_col_right: 0.0,
             time_ranges_ui: Default::default(),
@@ -189,7 +189,7 @@ impl TimePanel {
     fn expanded_ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
         re_tracing::profile_function!();
 
-        self.data_dentity_graph_painter.begin_frame(ui.ctx());
+        self.data_density_graph_painter.begin_frame(ui.ctx());
 
         //               |timeline            |
         // ------------------------------------
@@ -201,7 +201,8 @@ impl TimePanel {
 
         let time_x_left =
             (ui.min_rect().left() + self.prev_col_width + ui.spacing().item_spacing.x)
-                .at_most(ui.max_rect().right() - 100.0);
+                .at_most(ui.max_rect().right() - 100.0)
+                .at_least(80.); // cover the empty recording case
 
         // Where the time will be shown.
         let time_bg_x_range = Rangef::new(time_x_left, ui.max_rect().right());
@@ -235,7 +236,7 @@ impl TimePanel {
             })
             .response
             .on_hover_text(
-                "A hierarchial view of the paths used during logging.\n\
+                "A hierarchical view of the paths used during logging.\n\
                         \n\
                         On the right you can see when there was a log event for a stream.",
             );
@@ -413,7 +414,7 @@ impl TimePanel {
         let response_rect = response.rect;
         self.next_col_right = self.next_col_right.max(response_rect.right());
 
-        // From the left of the label, all the way to the rigthmost of the time panel
+        // From the left of the label, all the way to the rightmost of the time panel
         let full_width_rect = Rect::from_x_y_ranges(
             response_rect.left()..=ui.max_rect().right(),
             response_rect.y_range(),
@@ -440,7 +441,7 @@ impl TimePanel {
                 Rect::from_x_y_ranges(time_area_response.rect.x_range(), response_rect.y_range());
 
             data_density_graph::data_density_graph_ui(
-                &mut self.data_dentity_graph_painter,
+                &mut self.data_density_graph_painter,
                 ctx,
                 time_area_response,
                 time_area_painter,
@@ -505,7 +506,7 @@ impl TimePanel {
 
                 self.next_col_right = self.next_col_right.max(response_rect.right());
 
-                // From the left of the label, all the way to the rigthmost of the time panel
+                // From the left of the label, all the way to the rightmost of the time panel
                 let full_width_rect = Rect::from_x_y_ranges(
                     response_rect.left()..=ui.max_rect().right(),
                     response_rect.y_range(),
@@ -536,7 +537,7 @@ impl TimePanel {
                     );
 
                     data_density_graph::data_density_graph_ui(
-                        &mut self.data_dentity_graph_painter,
+                        &mut self.data_density_graph_painter,
                         ctx,
                         time_area_response,
                         time_area_painter,


### PR DESCRIPTION
### What

As the title says. Also fixed a bunch of typos around there.

Before:
<img width="216" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/c1e61eea-b8a5-4d3c-83cf-bb92df266d4d">

<br/>

After:
<img width="220" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3b2430d8-26e2-4af4-865b-ee67652efe51">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3027) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3027)
- [Docs preview](https://rerun.io/preview/pr%3Aantoine%2Ffix-stream-ui-empty-rec/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aantoine%2Ffix-stream-ui-empty-rec/examples)