### PR TITLE
Add upload rerun_c to ci and show artifacts build results & releases

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -85,7 +85,7 @@ jobs:
 
   save-pr-summary:
     name: "Save PR Summary"
-    needs: [upload-web, run-notebook]
+    needs: [upload-web, run-notebook, build-rerun_c-and-upload]
     uses: ./.github/workflows/reusable_pr_summary.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PLATFORM: linux
+      UPLOAD_COMMIT_OVERRIDE: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
   build-web:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -27,6 +27,14 @@ jobs:
       RRD_ARTIFACT_NAME: linux-rrd-fast
     secrets: inherit
 
+  build-rerun_c-and-upload:
+    name: "Build & Upload rerun_c (Linux x64)"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
+    with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
+      PLATFORM: linux
+    secrets: inherit
+
   build-web:
     name: "Build Web"
     uses: ./.github/workflows/reusable_build_web.yml
@@ -90,4 +98,3 @@ jobs:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
-

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -207,8 +207,7 @@ jobs:
           name: "Development Build"
           tag: "prerelease"
           token: ${{ secrets.GITHUB_TOKEN }}
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           allowUpdates: true
           removeArtifacts: true
           replacesArtifacts: true
-

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -68,6 +68,42 @@ jobs:
       MARK_PRERELEASE_FOR_MAINLINE: true
     secrets: inherit
 
+  build-rerun_c-and-upload-linux:
+    needs: [checks]
+    name: "Linux-x64: Build & Upload rerun_c"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
+    with:
+      CONCURRENCY: push-linux-${{ github.ref_name }}
+      PLATFORM: linux
+    secrets: inherit
+
+  build-rerun_c-and-upload-macos-intel:
+    needs: [checks]
+    name: "Mac-Intel: Build & Upload rerun_c"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
+    with:
+      CONCURRENCY: push-macos-intel-${{ github.ref_name }}
+      PLATFORM: macos-intel
+    secrets: inherit
+
+  build-rerun_c-and-upload-macos-arm:
+    needs: [checks]
+    name: "Mac-Arm: Build & Upload rerun_c"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
+    with:
+      CONCURRENCY: push-macos-arm-${{ github.ref_name }}
+      PLATFORM: macos-arm
+    secrets: inherit
+
+  build-rerun_c-and-upload-windows:
+    needs: [checks]
+    name: "Windows-x64: Build & Upload rerun_c"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
+    with:
+      CONCURRENCY: push-windows-${{ github.ref_name }}
+      PLATFORM: windows
+    secrets: inherit
+
   build-linux:
     needs: [checks]
     name: "Linux: Build/Test Wheels"
@@ -203,6 +239,13 @@ jobs:
             ```
             pip install --pre -f https://build.rerun.io/commit/${{ env.SHORT_SHA}}/wheels --upgrade rerun-sdk
             ```
+
+            ## Static libraries for rerun_c
+            * [Windows x64](https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_c/windows/rerun_c.lib)
+            * [Linux x64](https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_c/linux/librerun_c.a)
+            * [Mac Arm64](https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_c/macos-arm/librerun_c.a)
+            * [Mac Intel](https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_c/macos-intel/librerun_c.a)
+
           prerelease: true
           name: "Development Build"
           tag: "prerelease"

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -235,6 +235,9 @@ jobs:
             ## Example Hosted App
             https://app.rerun.io/commit/${{ env.SHORT_SHA }}
 
+            ## Demo App
+            https://demo.rerun.io/commit/${{ env.SHORT_SHA }}
+
             ## Wheels can be installed with:
             ```
             pip install --pre -f https://build.rerun.io/commit/${{ env.SHORT_SHA}}/wheels --upgrade rerun-sdk

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -207,7 +207,15 @@ jobs:
     concurrency:
       group: push-${{ github.ref_name }}-prerelease
       cancel-in-progress: true
-    needs: [upload-web, generate-pip-index]
+    needs:
+      [
+        upload-web,
+        generate-pip-index,
+        build-rerun_c-and-upload-linux,
+        build-rerun_c-and-upload-macos-intel,
+        build-rerun_c-and-upload-macos-arm,
+        build-rerun_c-and-upload-windows,
+      ]
     runs-on: "ubuntu-latest"
     steps:
       - name: Add SHORT_SHA env property with commit short sha

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Build rerun_c (release)
         uses: actions-rs/cargo@v1
         with:
-          command: run
+          command: build
           args: --locked -p rerun_c -- --release ${{ inputs.EXTRA_FLAGS }}
 
       - id: "auth"

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -186,7 +186,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "./target/release/${{ needs.set-config.outputs.LIB_NAME }}"
-          destination: "rerun-builds/rerun_c/commit/${{ steps.short-sha.outputs.SHORT_SHA }}/${{ inputs.PLATFORM }}"
+          destination: "rerun-builds/commit/${{ steps.short-sha.outputs.SHORT_SHA }}rerun_c/${{ inputs.PLATFORM }}"
           parent: false
 
       - name: "Upload web-viewer (adhoc)"
@@ -194,5 +194,5 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "./target/release/${{ needs.set-config.outputs.LIB_NAME }}"
-          destination: "rerun-builds/rerun_c/adhoc/${{inputs.ADHOC_NAME}}/${{ inputs.PLATFORM }}"
+          destination: "rerun-builds/adhoc/${{inputs.ADHOC_NAME}}/rerun_c/${{ inputs.PLATFORM }}"
           parent: false

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -79,6 +79,10 @@ env:
   # See https://github.com/ericseppanen/cargo-cranky/issues/8
   RUSTDOCFLAGS: --deny warnings --deny rustdoc::missing_crate_level_docs
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   set-config:
     name: Set Config (${{ inputs.PLATFORM }})

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -149,6 +149,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0 # Don't do a shallow clone since we need it for finding the full commit hash
           ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
 
       - name: Set up Rust

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -1,0 +1,202 @@
+name: Reusable Rerun-c Build
+
+on:
+  workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+      PLATFORM:
+        required: true
+        type: string
+      RELEASE_VERSION:
+        required: false
+        type: string
+        default: "prerelease"
+      EXTRA_FLAGS:
+        required: false
+        type: string
+        default: ""
+      RELEASE_COMMIT:
+        required: false
+        type: string
+        default: ""
+      UPLOAD_COMMIT:
+        required: false
+        type: boolean
+        default: true
+      ADHOC_NAME:
+        required: false
+        type: string
+        default: ""
+
+  workflow_dispatch:
+    inputs:
+      ADHOC_NAME:
+        required: true
+        type: string
+        description: "Name of the adhoc build, used for upload directory"
+      PLATFORM:
+        type: choice
+        options:
+          - linux
+          - windows
+          - macos-arm
+          - macos-intel
+        description: "Platform to build for"
+        required: true
+      CONCURRENCY:
+        required: false
+        type: string
+        default: "adhoc"
+      RELEASE_VERSION:
+        required: false
+        type: string
+        default: "prerelease"
+      EXTRA_FLAGS:
+        required: false
+        type: string
+        default: ""
+      RELEASE_COMMIT:
+        required: false
+        type: string
+        default: ""
+      UPLOAD_COMMIT:
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-build-rerun_c
+  cancel-in-progress: true
+
+env:
+  # web_sys_unstable_apis is required to enable the web_sys clipboard API which egui_web uses
+  # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
+  # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
+  RUSTFLAGS: --cfg=web_sys_unstable_apis --deny warnings
+
+  # See https://github.com/ericseppanen/cargo-cranky/issues/8
+  RUSTDOCFLAGS: --deny warnings --deny rustdoc::missing_crate_level_docs
+
+jobs:
+  set-config:
+    name: Set Config (${{ inputs.PLATFORM }})
+    runs-on: ubuntu-latest-16-cores
+    outputs:
+      RUNNER: ${{ steps.set-config.outputs.runner }}
+      TARGET: ${{ steps.set-config.outputs.target }}
+      RUN_TESTS: ${{ steps.set-config.outputs.run_tests }}
+      CONTAINER: ${{ steps.set-config.outputs.container }}
+      LIB_NAME: ${{ steps.set-config.outputs.lib_name }}
+    steps:
+      - name: Set runner and target based on platform
+        id: set-config
+        run: |
+          case "${{ inputs.PLATFORM }}" in
+            linux)
+              runner="ubuntu-latest-16-cores"
+              target="x86_64-unknown-linux-gnu"
+              run_tests="true"
+              container="{'image': 'rerunio/ci_docker:0.8'}"
+              lib_name="librerun_c.a"
+              ;;
+            windows)
+              runner="windows-latest-8-cores"
+              target="x86_64-pc-windows-msvc"
+              run_tests="true"
+              container="null"
+              lib_name="rerun_c.lib"
+              ;;
+            macos-arm)
+              runner="macos-latest"
+              target="aarch64-apple-darwin"
+              run_tests="false"
+              container="null"
+              lib_name="librerun_c.a"
+              ;;
+            macos-intel)
+              runner="macos-latest"
+              target="x86_64-apple-darwin"
+              run_tests="false"
+              container="null"
+              lib_name="librerun_c.a"
+              ;;
+            *) echo "Invalid platform" && exit 1 ;;
+          esac
+          echo "runner=$runner" >> "$GITHUB_OUTPUT"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "run_tests=$run_tests" >> "$GITHUB_OUTPUT"
+          echo "container=$container" >> "$GITHUB_OUTPUT"
+          echo "lib_name=$lib_name" >> "$GITHUB_OUTPUT"
+
+  rs-build-rerun_c:
+    name: Build rerun_c (${{ needs.set-config.outputs.RUNNER }})
+
+    needs: [set-config]
+
+    runs-on: ${{ needs.set-config.outputs.RUNNER }}
+    container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+
+    steps:
+      - name: Show context
+        run: |
+          echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
+          echo "JOB_CONTEXT": $JOB_CONTEXT
+          echo "INPUTS_CONTEXT": $INPUTS_CONTEXT
+          echo "ENV_CONTEXT": $ENV_CONTEXT
+        env:
+          ENV_CONTEXT: ${{ toJson(env) }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          JOB_CONTEXT: ${{ toJson(job) }}
+          INPUTS_CONTEXT: ${{ toJson(inputs) }}
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache_key: "build-${{ inputs.PLATFORM }}"
+          save_cache: false
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Build rerun_c (release)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --locked -p rerun_c -- --release ${{ inputs.EXTRA_FLAGS }}
+
+      - id: "auth"
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Add SHORT_SHA env property with commit short sha
+        id: "short-sha"
+        run: |
+          if [ -z "${{ inputs.RELEASE_COMMIT }}" ]; then
+            USED_SHA=${{ github.sha }}
+          else
+            USED_SHA=${{ inputs.RELEASE_COMMIT }}
+          fi
+          echo "SHORT_SHA=$(echo $USED_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: "Upload web-viewer (commit)"
+        if: ${{ inputs.UPLOAD_COMMIT }}
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "./target/release/${{ needs.set-config.outputs.LIB_NAME }}"
+          destination: "rerun-builds/rerun_c/commit/${{ steps.short-sha.outputs.SHORT_SHA }}/${{ inputs.PLATFORM }}"
+          parent: false
+
+      - name: "Upload web-viewer (adhoc)"
+        if: ${{ inputs.ADHOC_NAME != '' }}
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "./target/release/${{ needs.set-config.outputs.LIB_NAME }}"
+          destination: "rerun-builds/rerun_c/adhoc/${{inputs.ADHOC_NAME}}/${{ inputs.PLATFORM }}"
+          parent: false

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
         default: "prerelease"
-      RELEASE_COMMIT:
+      UPLOAD_COMMIT_OVERRIDE:
         required: false
         type: string
         default: ""
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
         default: "prerelease"
-      RELEASE_COMMIT:
+      UPLOAD_COMMIT_OVERRIDE:
         required: false
         type: string
         default: ""
@@ -148,9 +148,6 @@ jobs:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
 
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Don't do a shallow clone since we need it for finding the full commit hash
-          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -175,10 +172,10 @@ jobs:
       - name: Add SHORT_SHA env property with commit short sha
         id: "short-sha"
         run: |
-          if [ -z "${{ inputs.RELEASE_COMMIT }}" ]; then
+          if [ -z "${{ inputs.UPLOAD_COMMIT_OVERRIDE }}" ]; then
             USED_SHA=${{ github.sha }}
           else
-            USED_SHA=${{ inputs.RELEASE_COMMIT }}
+            USED_SHA=${{ inputs.UPLOAD_COMMIT_OVERRIDE }}
           fi
           echo "SHORT_SHA=$(echo $USED_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -186,7 +186,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: "./target/release/${{ needs.set-config.outputs.LIB_NAME }}"
-          destination: "rerun-builds/commit/${{ steps.short-sha.outputs.SHORT_SHA }}rerun_c/${{ inputs.PLATFORM }}"
+          destination: "rerun-builds/commit/${{ steps.short-sha.outputs.SHORT_SHA }}/rerun_c/${{ inputs.PLATFORM }}"
           parent: false
 
       - name: "Upload web-viewer (adhoc)"

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -13,10 +13,6 @@ on:
         required: false
         type: string
         default: "prerelease"
-      EXTRA_FLAGS:
-        required: false
-        type: string
-        default: ""
       RELEASE_COMMIT:
         required: false
         type: string
@@ -53,10 +49,6 @@ on:
         required: false
         type: string
         default: "prerelease"
-      EXTRA_FLAGS:
-        required: false
-        type: string
-        default: ""
       RELEASE_COMMIT:
         required: false
         type: string
@@ -171,7 +163,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --locked -p rerun_c -- --release ${{ inputs.EXTRA_FLAGS }}
+          args: --locked -p rerun_c --release
 
       - id: "auth"
         uses: google-github-actions/auth@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,7 +4920,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "re_log",
  "re_sdk",
- "re_types",
 ]
 
 [[package]]

--- a/crates/rerun_c/Cargo.toml
+++ b/crates/rerun_c/Cargo.toml
@@ -33,7 +33,6 @@ test = false
 [dependencies]
 re_log.workspace = true
 re_sdk.workspace = true
-re_types.workspace = true
 
 arrow2.workspace = true
 ahash.workspace = true

--- a/scripts/ci/generate_pr_summary.py
+++ b/scripts/ci/generate_pr_summary.py
@@ -51,10 +51,10 @@ def generate_pr_summary(github_token: str, github_repository: str, pr_number: in
 
         # Check if there are rerun_c libraries
         rerun_libraries_blobs = [
-            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/windows/rerun_c.lib"),
-            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/linux/librerun_c.a"),
-            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/macos-arm/librerun_c.a"),
-            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/macos-intel/librerun_c.a"),
+            builds_bucket.blob(f"commit/{commit_short}/rerun_c/windows/rerun_c.lib"),
+            builds_bucket.blob(f"commit/{commit_short}/rerun_c/linux/librerun_c.a"),
+            builds_bucket.blob(f"commit/{commit_short}/rerun_c/macos-arm/librerun_c.a"),
+            builds_bucket.blob(f"commit/{commit_short}/rerun_c/macos-intel/librerun_c.a"),
         ]
         rerun_libraries = [
             f"https://build.rerun.io/commit/{blob.name}" for blob in rerun_libraries_blobs if blob.exists()

--- a/scripts/ci/generate_pr_summary.py
+++ b/scripts/ci/generate_pr_summary.py
@@ -49,6 +49,20 @@ def generate_pr_summary(github_token: str, github_repository: str, pr_number: in
             print(f"Found web assets commit: {commit_short}")
             found["hosted_app"] = f"https://app.rerun.io/commit/{commit_short}"
 
+        # Check if there are rerun_c libraries
+        rerun_libraries_blobs = [
+            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/windows/rerun_c.lib"),
+            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/linux/librerun_c.a"),
+            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/macos-arm/librerun_c.a"),
+            viewer_bucket.blob(f"commit/{commit_short}/rerun_c/macos-intel/librerun_c.a"),
+        ]
+        rerun_libraries = [
+            f"https://build.rerun.io/commit/{blob.name}" for blob in rerun_libraries_blobs if blob.exists()
+        ]
+        if rerun_libraries:
+            print(f"Found rerun_c libraries for commit: {commit_short}")
+            found["rerun_c_libraries"] = rerun_libraries
+
         # Check if there are benchmark results
         bench_blob = builds_bucket.blob(f"commit/{commit_short}/bench_results.txt")
         if bench_blob.exists():

--- a/scripts/ci/generate_pr_summary.py
+++ b/scripts/ci/generate_pr_summary.py
@@ -56,9 +56,7 @@ def generate_pr_summary(github_token: str, github_repository: str, pr_number: in
             builds_bucket.blob(f"commit/{commit_short}/rerun_c/macos-arm/librerun_c.a"),
             builds_bucket.blob(f"commit/{commit_short}/rerun_c/macos-intel/librerun_c.a"),
         ]
-        rerun_libraries = [
-            f"https://build.rerun.io/commit/{blob.name}" for blob in rerun_libraries_blobs if blob.exists()
-        ]
+        rerun_libraries = [f"https://build.rerun.io/{blob.name}" for blob in rerun_libraries_blobs if blob.exists()]
         if rerun_libraries:
             print(f"Found rerun_c libraries for commit: {commit_short}")
             found["rerun_c_libraries"] = rerun_libraries

--- a/scripts/ci/templates/pr_results_summary.html
+++ b/scripts/ci/templates/pr_results_summary.html
@@ -40,7 +40,7 @@
             <h3>Rerun C build:</h3>
             <ul>
                 {% for library in build.rerun_c_libraries %}
-                <li><a href="{{ library }}" target="_blank">{{ library.split('/')[-1] }}</a></li>
+                <li><a href="{{ library }}" target="_blank">{{ library.substr(library.lastIndexOf('rerun_c')) }}</a></li>
                 {% endfor %}
             </ul>
         </div>

--- a/scripts/ci/templates/pr_results_summary.html
+++ b/scripts/ci/templates/pr_results_summary.html
@@ -35,6 +35,16 @@
             <a href="{{ build.hosted_app }}" target="_blank">{{ build.hosted_app }}</a>
         </div>
         {% endif %}
+        {% if build.rerun_c_libraries %}
+        <div class="rerun_c_libraries">
+            <h3>Rerun C build:</h3>
+            <ul>
+                {% for library in build.rerun_c_libraries %}
+                <li><a href="{{ library }}" target="_blank">{{ library.split('/')[-1] }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
         {% if build.bench_results %}
         <h3><a href="{{ build.bench_results }}" target="_blank">Benchmark Results</a></h3>
         {% endif %}

--- a/scripts/ci/templates/pr_results_summary.html
+++ b/scripts/ci/templates/pr_results_summary.html
@@ -16,6 +16,10 @@
             margin-left: 20px;
         }
 
+        .rerun_c-libraries {
+            margin-left: 20px;
+        }
+
         .wheel-list {
             margin-left: 20px;
         }
@@ -36,11 +40,11 @@
         </div>
         {% endif %}
         {% if build.rerun_c_libraries %}
-        <div class="rerun_c_libraries">
+        <div class="rerun_c-libraries">
             <h3>Rerun C build:</h3>
             <ul>
                 {% for library in build.rerun_c_libraries %}
-                <li><a href="{{ library }}" target="_blank">{{ library.substr(library.lastIndexOf('rerun_c')) }}</a></li>
+                <li><a href="{{ library }}" target="_blank">{{ library }}</a></li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/2919

### What

Adds ci jobs to upload rerun_c for linux x64, mac x64, mac aarch64, windows x64 and shows those both on the build summary html as well as the github developer release

Unrelated changes
* remove unnecessary dependency from rerun_c - part of #2905
* no longer show full changelog on Dev releases - this got often very long and isn't all that useful, also doesn't understand our minor releases


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3028) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3028)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Frerun_c-ci-build/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Frerun_c-ci-build/examples)