### PR TITLE
Reduce code bloat from generated Rust code: reuse datatype definition

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-dc5dd028bea512a97b80ac015bd95f455d926962c3aca60384e27d1d8b0bd275
+c9bfb9cc436f0845f9fff020244f9e5d83beb89d4db080d6cd640e220bfb1a4a

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-dcbcb70a5509902f5c6cdf7405e3af253de84885ff2b91a68115dfa0aa364310
+c936b6348ce416721174519bea2f6b613a4937b7b247a904732a9bc5782a3a2d

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-c936b6348ce416721174519bea2f6b613a4937b7b247a904732a9bc5782a3a2d
+dc5dd028bea512a97b80ac015bd95f455d926962c3aca60384e27d1d8b0bd275

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -110,37 +110,28 @@ impl crate::Loggable for AnnotationContext {
                 .unwrap()
                 .into();
                 ListArray::new(
-                        {
-                            _ = extension_wrapper;
-                            DataType::Extension(
-                                    "rerun.components.AnnotationContext".to_owned(),
-                                    Box::new(
-                                        DataType::List(
-                                            Box::new(Field {
-                                                name: "item".to_owned(),
-                                                data_type: <crate::datatypes::ClassDescriptionMapElem>::to_arrow_datatype(),
-                                                is_nullable: false,
-                                                metadata: [].into(),
-                                            }),
-                                        ),
-                                    ),
-                                    None,
-                                )
-                                .to_logical_type()
-                                .clone()
-                        },
-                        offsets,
-                        {
-                            _ = data0_inner_bitmap;
-                            _ = extension_wrapper;
-                            crate::datatypes::ClassDescriptionMapElem::try_to_arrow_opt(
-                                data0_inner_data,
-                                Some("rerun.components.AnnotationContext"),
-                            )?
-                        },
-                        data0_bitmap,
-                    )
-                    .boxed()
+                    {
+                        _ = extension_wrapper;
+                        DataType::Extension(
+                            "rerun.components.AnnotationContext".to_owned(),
+                            Box::new(Self::to_arrow_datatype()),
+                            None,
+                        )
+                        .to_logical_type()
+                        .clone()
+                    },
+                    offsets,
+                    {
+                        _ = data0_inner_bitmap;
+                        _ = extension_wrapper;
+                        crate::datatypes::ClassDescriptionMapElem::try_to_arrow_opt(
+                            data0_inner_data,
+                            Some("rerun.components.AnnotationContext"),
+                        )?
+                    },
+                    data0_bitmap,
+                )
+                .boxed()
             }
         })
     }

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for ClassId {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.ClassId".to_owned(),
-                        Box::new(DataType::UInt16),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -96,7 +96,7 @@ impl crate::Loggable for Color {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.Color".to_owned(),
-                        Box::new(DataType::UInt32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -82,7 +82,7 @@ impl crate::Loggable for DisconnectedSpace {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.DisconnectedSpace".to_owned(),
-                        Box::new(DataType::Boolean),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -85,7 +85,7 @@ impl crate::Loggable for DrawOrder {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.DrawOrder".to_owned(),
-                        Box::new(DataType::Float32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -79,7 +79,7 @@ impl crate::Loggable for InstanceKey {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.InstanceKey".to_owned(),
-                        Box::new(DataType::UInt64),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -89,7 +89,7 @@ impl crate::Loggable for KeypointId {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.KeypointId".to_owned(),
-                        Box::new(DataType::UInt16),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/label.rs
+++ b/crates/re_types/src/components/label.rs
@@ -108,7 +108,7 @@ impl crate::Loggable for Label {
                             _ = extension_wrapper;
                             DataType::Extension(
                                 "rerun.components.Label".to_owned(),
-                                Box::new(DataType::Utf8),
+                                Box::new(Self::to_arrow_datatype()),
                                 None,
                             )
                             .to_logical_type()

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -117,12 +117,7 @@ impl crate::Loggable for LineStrip2D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.components.LineStrip2D".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: <crate::datatypes::Vec2D>::to_arrow_datatype(),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -117,12 +117,7 @@ impl crate::Loggable for LineStrip3D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.components.LineStrip3D".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -116,15 +116,7 @@ impl crate::Loggable for Origin3D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.components.Origin3D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                3usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/components/point2d.rs
+++ b/crates/re_types/src/components/point2d.rs
@@ -116,15 +116,7 @@ impl crate::Loggable for Point2D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.components.Point2D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                2usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/components/point3d.rs
+++ b/crates/re_types/src/components/point3d.rs
@@ -116,15 +116,7 @@ impl crate::Loggable for Point3D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.components.Point3D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                3usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -78,7 +78,7 @@ impl crate::Loggable for Radius {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.components.Radius".to_owned(),
-                        Box::new(DataType::Float32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -116,15 +116,7 @@ impl crate::Loggable for Vector3D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.components.Vector3D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                3usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -132,7 +132,7 @@ impl crate::Loggable for Angle {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             radians.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             radians_bitmap,
@@ -158,7 +158,7 @@ impl crate::Loggable for Angle {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             degrees.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             degrees_bitmap,
@@ -246,30 +246,7 @@ impl crate::Loggable for Angle {
                     .offsets()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Union(
-                                vec![
-                                    Field {
-                                        name: "_null_markers".to_owned(),
-                                        data_type: DataType::Null,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "Radians".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "Degrees".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                ],
-                                Some(vec![0i32, 1i32, 2i32]),
-                                UnionMode::Dense,
-                            ),
+                            Self::to_arrow_datatype(),
                             data.data_type().clone(),
                         )
                     })
@@ -358,30 +335,7 @@ impl crate::Loggable for Angle {
                                 }),
                                 _ => {
                                     return Err(crate::DeserializationError::missing_union_arm(
-                                        DataType::Union(
-                                            vec![
-                                                Field {
-                                                    name: "_null_markers".to_owned(),
-                                                    data_type: DataType::Null,
-                                                    is_nullable: true,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "Radians".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                                Field {
-                                                    name: "Degrees".to_owned(),
-                                                    data_type: DataType::Float32,
-                                                    is_nullable: false,
-                                                    metadata: [].into(),
-                                                },
-                                            ],
-                                            Some(vec![0i32, 1i32, 2i32]),
-                                            UnionMode::Dense,
-                                        ),
+                                        Self::to_arrow_datatype(),
                                         "<invalid>",
                                         *typ as _,
                                     ))

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -132,7 +132,7 @@ impl crate::Loggable for Angle {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             radians.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             radians_bitmap,
@@ -158,7 +158,7 @@ impl crate::Loggable for Angle {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             degrees.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             degrees_bitmap,

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -131,7 +131,7 @@ impl crate::Loggable for AnnotationInfo {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::UInt16.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             id.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             id_bitmap,
@@ -177,13 +177,12 @@ impl crate::Loggable for AnnotationInfo {
                             )
                             .unwrap()
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8.to_logical_type().clone()
+                                        Self::to_arrow_datatype().to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -214,7 +213,7 @@ impl crate::Loggable for AnnotationInfo {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::UInt32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             color
                                 .into_iter()
@@ -289,26 +288,7 @@ impl crate::Loggable for AnnotationInfo {
                 let id = {
                     if !arrays_by_name.contains_key("id") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "id".to_owned(),
-                                    data_type: DataType::UInt16,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "label".to_owned(),
-                                    data_type: <crate::datatypes::Label>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "color".to_owned(),
-                                    data_type: <crate::datatypes::Color>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "id",
                         ))
                         .with_context("rerun.datatypes.AnnotationInfo");
@@ -329,26 +309,7 @@ impl crate::Loggable for AnnotationInfo {
                 let label = {
                     if !arrays_by_name.contains_key("label") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "id".to_owned(),
-                                    data_type: DataType::UInt16,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "label".to_owned(),
-                                    data_type: <crate::datatypes::Label>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "color".to_owned(),
-                                    data_type: <crate::datatypes::Color>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "label",
                         ))
                         .with_context("rerun.datatypes.AnnotationInfo");
@@ -401,26 +362,7 @@ impl crate::Loggable for AnnotationInfo {
                 let color = {
                     if !arrays_by_name.contains_key("color") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "id".to_owned(),
-                                    data_type: DataType::UInt16,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "label".to_owned(),
-                                    data_type: <crate::datatypes::Label>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "color".to_owned(),
-                                    data_type: <crate::datatypes::Color>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "color",
                         ))
                         .with_context("rerun.datatypes.AnnotationInfo");

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -131,7 +131,7 @@ impl crate::Loggable for AnnotationInfo {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::UInt16.to_logical_type().clone()
                             },
                             id.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             id_bitmap,
@@ -177,12 +177,13 @@ impl crate::Loggable for AnnotationInfo {
                             )
                             .unwrap()
                             .into();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        Self::to_arrow_datatype().to_logical_type().clone()
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -213,7 +214,7 @@ impl crate::Loggable for AnnotationInfo {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::UInt32.to_logical_type().clone()
                             },
                             color
                                 .into_iter()

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -196,15 +196,7 @@ impl crate::Loggable for ClassDescription {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    }))
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -260,15 +252,7 @@ impl crate::Loggable for ClassDescription {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::KeypointPair>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    }))
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -354,39 +338,7 @@ impl crate::Loggable for ClassDescription {
                 let info = {
                     if !arrays_by_name.contains_key("info") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "info".to_owned(),
-                                    data_type:
-                                        <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint_annotations".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint_connections".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::KeypointPair>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "info",
                         ))
                         .with_context("rerun.datatypes.ClassDescription");
@@ -399,39 +351,7 @@ impl crate::Loggable for ClassDescription {
                 let keypoint_annotations = {
                     if !arrays_by_name.contains_key("keypoint_annotations") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "info".to_owned(),
-                                    data_type:
-                                        <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint_annotations".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint_connections".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::KeypointPair>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "keypoint_annotations",
                         ))
                         .with_context("rerun.datatypes.ClassDescription");
@@ -505,39 +425,7 @@ impl crate::Loggable for ClassDescription {
                 let keypoint_connections = {
                     if !arrays_by_name.contains_key("keypoint_connections") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "info".to_owned(),
-                                    data_type:
-                                        <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint_annotations".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint_connections".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type:
-                                            <crate::datatypes::KeypointPair>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    })),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "keypoint_connections",
                         ))
                         .with_context("rerun.datatypes.ClassDescription");

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -196,7 +196,15 @@ impl crate::Loggable for ClassDescription {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type:
+                                            <crate::datatypes::AnnotationInfo>::to_arrow_datatype(),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -252,7 +260,15 @@ impl crate::Loggable for ClassDescription {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type:
+                                            <crate::datatypes::KeypointPair>::to_arrow_datatype(),
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -118,7 +118,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::UInt16.to_logical_type().clone()
                             },
                             class_id
                                 .into_iter()

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -118,7 +118,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::UInt16.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             class_id
                                 .into_iter()
@@ -214,21 +214,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
                 let class_id = {
                     if !arrays_by_name.contains_key("class_id") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "class_id".to_owned(),
-                                    data_type: <crate::datatypes::ClassId>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "class_description".to_owned(),
-                                    data_type:
-                                        <crate::datatypes::ClassDescription>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "class_id",
                         ))
                         .with_context("rerun.datatypes.ClassDescriptionMapElem");
@@ -250,21 +236,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
                 let class_description = {
                     if !arrays_by_name.contains_key("class_description") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "class_id".to_owned(),
-                                    data_type: <crate::datatypes::ClassId>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "class_description".to_owned(),
-                                    data_type:
-                                        <crate::datatypes::ClassDescription>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "class_description",
                         ))
                         .with_context("rerun.datatypes.ClassDescriptionMapElem");

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -82,7 +82,7 @@ impl crate::Loggable for ClassId {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.datatypes.ClassId".to_owned(),
-                        Box::new(DataType::UInt16),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/datatypes/color.rs
+++ b/crates/re_types/src/datatypes/color.rs
@@ -90,7 +90,7 @@ impl crate::Loggable for Color {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.datatypes.Color".to_owned(),
-                        Box::new(DataType::UInt32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -84,7 +84,7 @@ impl crate::Loggable for KeypointId {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.datatypes.KeypointId".to_owned(),
-                        Box::new(DataType::UInt16),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -116,7 +116,7 @@ impl crate::Loggable for KeypointPair {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::UInt16.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             keypoint0
                                 .into_iter()
@@ -151,7 +151,7 @@ impl crate::Loggable for KeypointPair {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::UInt16.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             keypoint1
                                 .into_iter()
@@ -220,20 +220,7 @@ impl crate::Loggable for KeypointPair {
                 let keypoint0 = {
                     if !arrays_by_name.contains_key("keypoint0") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "keypoint0".to_owned(),
-                                    data_type: <crate::datatypes::KeypointId>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint1".to_owned(),
-                                    data_type: <crate::datatypes::KeypointId>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "keypoint0",
                         ))
                         .with_context("rerun.datatypes.KeypointPair");
@@ -255,20 +242,7 @@ impl crate::Loggable for KeypointPair {
                 let keypoint1 = {
                     if !arrays_by_name.contains_key("keypoint1") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "keypoint0".to_owned(),
-                                    data_type: <crate::datatypes::KeypointId>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "keypoint1".to_owned(),
-                                    data_type: <crate::datatypes::KeypointId>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "keypoint1",
                         ))
                         .with_context("rerun.datatypes.KeypointPair");

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -116,7 +116,7 @@ impl crate::Loggable for KeypointPair {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::UInt16.to_logical_type().clone()
                             },
                             keypoint0
                                 .into_iter()
@@ -151,7 +151,7 @@ impl crate::Loggable for KeypointPair {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::UInt16.to_logical_type().clone()
                             },
                             keypoint1
                                 .into_iter()

--- a/crates/re_types/src/datatypes/label.rs
+++ b/crates/re_types/src/datatypes/label.rs
@@ -92,7 +92,7 @@ impl crate::Loggable for Label {
                             _ = extension_wrapper;
                             DataType::Extension(
                                 "rerun.datatypes.Label".to_owned(),
-                                Box::new(DataType::Utf8),
+                                Box::new(Self::to_arrow_datatype()),
                                 None,
                             )
                             .to_logical_type()

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -104,15 +104,7 @@ impl crate::Loggable for Mat3x3 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.datatypes.Mat3x3".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                9usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -104,15 +104,7 @@ impl crate::Loggable for Mat4x4 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.datatypes.Mat4x4".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                16usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -104,15 +104,7 @@ impl crate::Loggable for Quaternion {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.datatypes.Quaternion".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                4usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -161,7 +161,17 @@ impl crate::Loggable for Rotation3D {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        4usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -147,17 +147,7 @@ impl crate::Loggable for RotationAxisAngle {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::FixedSizeList(
-                                        Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }),
-                                        3usize,
-                                    )
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -249,20 +239,7 @@ impl crate::Loggable for RotationAxisAngle {
                 let axis = {
                     if !arrays_by_name.contains_key("axis") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "axis".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "angle".to_owned(),
-                                    data_type: <crate::datatypes::Angle>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "axis",
                         ))
                         .with_context("rerun.datatypes.RotationAxisAngle");
@@ -346,20 +323,7 @@ impl crate::Loggable for RotationAxisAngle {
                 let angle = {
                     if !arrays_by_name.contains_key("angle") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "axis".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "angle".to_owned(),
-                                    data_type: <crate::datatypes::Angle>::to_arrow_datatype(),
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "angle",
                         ))
                         .with_context("rerun.datatypes.RotationAxisAngle");

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -147,7 +147,17 @@ impl crate::Loggable for RotationAxisAngle {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -159,7 +159,17 @@ impl crate::Loggable for Scale3D {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -197,7 +207,7 @@ impl crate::Loggable for Scale3D {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             uniform.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             uniform_bitmap,

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -159,17 +159,7 @@ impl crate::Loggable for Scale3D {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::FixedSizeList(
-                                        Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }),
-                                        3usize,
-                                    )
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -207,7 +197,7 @@ impl crate::Loggable for Scale3D {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             uniform.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             uniform_bitmap,
@@ -295,30 +285,7 @@ impl crate::Loggable for Scale3D {
                     .offsets()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Union(
-                                vec![
-                                    Field {
-                                        name: "_null_markers".to_owned(),
-                                        data_type: DataType::Null,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "ThreeD".to_owned(),
-                                        data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                    Field {
-                                        name: "Uniform".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    },
-                                ],
-                                Some(vec![0i32, 1i32, 2i32]),
-                                UnionMode::Dense,
-                            ),
+                            Self::to_arrow_datatype(),
                             data.data_type().clone(),
                         )
                     })
@@ -437,72 +404,46 @@ impl crate::Loggable for Scale3D {
                         if *typ == 0 {
                             Ok(None)
                         } else {
-                            Ok(
-                                Some(
-                                    match typ {
-                                        1i8 => {
-                                            Scale3D::ThreeD({
-                                                if offset as usize >= three_d.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                three_d.len(),
-                                                            ),
-                                                        )
-                                                        .with_context("rerun.datatypes.Scale3D#ThreeD");
-                                                }
+                            Ok(Some(match typ {
+                                1i8 => Scale3D::ThreeD({
+                                    if offset as usize >= three_d.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            three_d.len(),
+                                        ))
+                                        .with_context("rerun.datatypes.Scale3D#ThreeD");
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe { three_d.get_unchecked(offset as usize) }
-                                                    .clone()
-                                                    .ok_or_else(crate::DeserializationError::missing_data)
-                                                    .with_context("rerun.datatypes.Scale3D#ThreeD")?
-                                            })
-                                        }
-                                        2i8 => {
-                                            Scale3D::Uniform({
-                                                if offset as usize >= uniform.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                uniform.len(),
-                                                            ),
-                                                        )
-                                                        .with_context("rerun.datatypes.Scale3D#Uniform");
-                                                }
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { three_d.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .ok_or_else(crate::DeserializationError::missing_data)
+                                        .with_context("rerun.datatypes.Scale3D#ThreeD")?
+                                }),
+                                2i8 => Scale3D::Uniform({
+                                    if offset as usize >= uniform.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            uniform.len(),
+                                        ))
+                                        .with_context("rerun.datatypes.Scale3D#Uniform");
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe { uniform.get_unchecked(offset as usize) }
-                                                    .clone()
-                                                    .ok_or_else(crate::DeserializationError::missing_data)
-                                                    .with_context("rerun.datatypes.Scale3D#Uniform")?
-                                            })
-                                        }
-                                        _ => {
-                                            return Err(
-                                                    crate::DeserializationError::missing_union_arm(
-                                                        DataType::Union(
-                                                            vec![
-                                                                Field { name : "_null_markers".to_owned(), data_type :
-                                                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                                                Field { name : "ThreeD".to_owned(), data_type : < crate
-                                                                ::datatypes::Vec3D > ::to_arrow_datatype(), is_nullable :
-                                                                false, metadata : [].into(), }, Field { name : "Uniform"
-                                                                .to_owned(), data_type : DataType::Float32, is_nullable :
-                                                                false, metadata : [].into(), },
-                                                            ],
-                                                            Some(vec![0i32, 1i32, 2i32,]),
-                                                            UnionMode::Dense,
-                                                        ),
-                                                        "<invalid>",
-                                                        *typ as _,
-                                                    ),
-                                                )
-                                                .with_context("rerun.datatypes.Scale3D");
-                                        }
-                                    },
-                                ),
-                            )
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { uniform.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .ok_or_else(crate::DeserializationError::missing_data)
+                                        .with_context("rerun.datatypes.Scale3D#Uniform")?
+                                }),
+                                _ => {
+                                    return Err(crate::DeserializationError::missing_union_arm(
+                                        Self::to_arrow_datatype(),
+                                        "<invalid>",
+                                        *typ as _,
+                                    ))
+                                    .with_context("rerun.datatypes.Scale3D");
+                                }
+                            }))
                         }
                     })
                     .collect::<crate::DeserializationResult<Vec<_>>>()

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -251,22 +251,7 @@ impl crate::Loggable for Transform3D {
                     .offsets()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Union(
-                                vec![
-                                Field { name : "_null_markers".to_owned(), data_type :
-                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                Field { name : "TranslationAndMat3x3".to_owned(), data_type
-                                : < crate ::datatypes::TranslationAndMat3x3 >
-                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                .into(), }, Field { name : "TranslationRotationScale"
-                                .to_owned(), data_type : < crate
-                                ::datatypes::TranslationRotationScale3D >
-                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                .into(), },
-                            ],
-                                Some(vec![0i32, 1i32, 2i32]),
-                                UnionMode::Dense,
-                            ),
+                            Self::to_arrow_datatype(),
                             data.data_type().clone(),
                         )
                     })
@@ -306,87 +291,58 @@ impl crate::Loggable for Transform3D {
                         if *typ == 0 {
                             Ok(None)
                         } else {
-                            Ok(
-                                Some(
-                                    match typ {
-                                        1i8 => {
-                                            Transform3D::TranslationAndMat3X3({
-                                                if offset as usize >= translation_and_mat_3_x_3.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                translation_and_mat_3_x_3.len(),
-                                                            ),
-                                                        )
-                                                        .with_context(
-                                                            "rerun.datatypes.Transform3D#TranslationAndMat3x3",
-                                                        );
-                                                }
+                            Ok(Some(match typ {
+                                1i8 => Transform3D::TranslationAndMat3X3({
+                                    if offset as usize >= translation_and_mat_3_x_3.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            translation_and_mat_3_x_3.len(),
+                                        ))
+                                        .with_context(
+                                            "rerun.datatypes.Transform3D#TranslationAndMat3x3",
+                                        );
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe {
-                                                    translation_and_mat_3_x_3.get_unchecked(offset as usize)
-                                                }
-                                                    .clone()
-                                                    .ok_or_else(crate::DeserializationError::missing_data)
-                                                    .with_context(
-                                                        "rerun.datatypes.Transform3D#TranslationAndMat3x3",
-                                                    )?
-                                            })
-                                        }
-                                        2i8 => {
-                                            Transform3D::TranslationRotationScale({
-                                                if offset as usize >= translation_rotation_scale.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                translation_rotation_scale.len(),
-                                                            ),
-                                                        )
-                                                        .with_context(
-                                                            "rerun.datatypes.Transform3D#TranslationRotationScale",
-                                                        );
-                                                }
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe {
+                                        translation_and_mat_3_x_3.get_unchecked(offset as usize)
+                                    }
+                                    .clone()
+                                    .ok_or_else(crate::DeserializationError::missing_data)
+                                    .with_context(
+                                        "rerun.datatypes.Transform3D#TranslationAndMat3x3",
+                                    )?
+                                }),
+                                2i8 => Transform3D::TranslationRotationScale({
+                                    if offset as usize >= translation_rotation_scale.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            translation_rotation_scale.len(),
+                                        ))
+                                        .with_context(
+                                            "rerun.datatypes.Transform3D#TranslationRotationScale",
+                                        );
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe {
-                                                    translation_rotation_scale.get_unchecked(offset as usize)
-                                                }
-                                                    .clone()
-                                                    .ok_or_else(crate::DeserializationError::missing_data)
-                                                    .with_context(
-                                                        "rerun.datatypes.Transform3D#TranslationRotationScale",
-                                                    )?
-                                            })
-                                        }
-                                        _ => {
-                                            return Err(
-                                                    crate::DeserializationError::missing_union_arm(
-                                                        DataType::Union(
-                                                            vec![
-                                                                Field { name : "_null_markers".to_owned(), data_type :
-                                                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                                                Field { name : "TranslationAndMat3x3".to_owned(), data_type
-                                                                : < crate ::datatypes::TranslationAndMat3x3 >
-                                                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                                                .into(), }, Field { name : "TranslationRotationScale"
-                                                                .to_owned(), data_type : < crate
-                                                                ::datatypes::TranslationRotationScale3D >
-                                                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                                                .into(), },
-                                                            ],
-                                                            Some(vec![0i32, 1i32, 2i32,]),
-                                                            UnionMode::Dense,
-                                                        ),
-                                                        "<invalid>",
-                                                        *typ as _,
-                                                    ),
-                                                )
-                                                .with_context("rerun.datatypes.Transform3D");
-                                        }
-                                    },
-                                ),
-                            )
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe {
+                                        translation_rotation_scale.get_unchecked(offset as usize)
+                                    }
+                                    .clone()
+                                    .ok_or_else(crate::DeserializationError::missing_data)
+                                    .with_context(
+                                        "rerun.datatypes.Transform3D#TranslationRotationScale",
+                                    )?
+                                }),
+                                _ => {
+                                    return Err(crate::DeserializationError::missing_union_arm(
+                                        Self::to_arrow_datatype(),
+                                        "<invalid>",
+                                        *typ as _,
+                                    ))
+                                    .with_context("rerun.datatypes.Transform3D");
+                                }
+                            }))
                         }
                     })
                     .collect::<crate::DeserializationResult<Vec<_>>>()

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -158,17 +158,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::FixedSizeList(
-                                        Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }),
-                                        3usize,
-                                    )
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -232,17 +222,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::FixedSizeList(
-                                        Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }),
-                                        9usize,
-                                    )
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -279,7 +259,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                         BooleanArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Boolean.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             from_parent
                                 .into_iter()
@@ -347,26 +327,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                 let translation = {
                     if !arrays_by_name.contains_key("translation") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "matrix".to_owned(),
-                                    data_type: <crate::datatypes::Mat3x3>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "translation",
                         ))
                         .with_context("rerun.datatypes.TranslationAndMat3x3");
@@ -452,26 +413,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                 let matrix = {
                     if !arrays_by_name.contains_key("matrix") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "matrix".to_owned(),
-                                    data_type: <crate::datatypes::Mat3x3>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "matrix",
                         ))
                         .with_context("rerun.datatypes.TranslationAndMat3x3");
@@ -555,26 +497,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                 let from_parent = {
                     if !arrays_by_name.contains_key("from_parent") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "matrix".to_owned(),
-                                    data_type: <crate::datatypes::Mat3x3>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "from_parent",
                         ))
                         .with_context("rerun.datatypes.TranslationAndMat3x3");

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -158,7 +158,17 @@ impl crate::Loggable for TranslationAndMat3x3 {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -222,7 +232,17 @@ impl crate::Loggable for TranslationAndMat3x3 {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        9usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -259,7 +279,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
                         BooleanArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Boolean.to_logical_type().clone()
                             },
                             from_parent
                                 .into_iter()

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -169,7 +169,17 @@ impl crate::Loggable for TranslationRotationScale3D {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -254,7 +264,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                         BooleanArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Boolean.to_logical_type().clone()
                             },
                             from_parent
                                 .into_iter()

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -169,17 +169,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::FixedSizeList(
-                                        Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }),
-                                        3usize,
-                                    )
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -264,7 +254,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                         BooleanArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Boolean.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             from_parent
                                 .into_iter()
@@ -338,32 +328,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                 let translation = {
                     if !arrays_by_name.contains_key("translation") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "rotation".to_owned(),
-                                    data_type: <crate::datatypes::Rotation3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "scale".to_owned(),
-                                    data_type: <crate::datatypes::Scale3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "translation",
                         ))
                         .with_context("rerun.datatypes.TranslationRotationScale3D");
@@ -450,32 +415,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                 let rotation = {
                     if !arrays_by_name.contains_key("rotation") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "rotation".to_owned(),
-                                    data_type: <crate::datatypes::Rotation3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "scale".to_owned(),
-                                    data_type: <crate::datatypes::Scale3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "rotation",
                         ))
                         .with_context("rerun.datatypes.TranslationRotationScale3D");
@@ -488,32 +428,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                 let scale = {
                     if !arrays_by_name.contains_key("scale") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "rotation".to_owned(),
-                                    data_type: <crate::datatypes::Rotation3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "scale".to_owned(),
-                                    data_type: <crate::datatypes::Scale3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "scale",
                         ))
                         .with_context("rerun.datatypes.TranslationRotationScale3D");
@@ -526,32 +441,7 @@ impl crate::Loggable for TranslationRotationScale3D {
                 let from_parent = {
                     if !arrays_by_name.contains_key("from_parent") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![
-                                Field {
-                                    name: "translation".to_owned(),
-                                    data_type: <crate::datatypes::Vec3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "rotation".to_owned(),
-                                    data_type: <crate::datatypes::Rotation3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "scale".to_owned(),
-                                    data_type: <crate::datatypes::Scale3D>::to_arrow_datatype(),
-                                    is_nullable: true,
-                                    metadata: [].into(),
-                                },
-                                Field {
-                                    name: "from_parent".to_owned(),
-                                    data_type: DataType::Boolean,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                },
-                            ]),
+                            Self::to_arrow_datatype(),
                             "from_parent",
                         ))
                         .with_context("rerun.datatypes.TranslationRotationScale3D");

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -104,15 +104,7 @@ impl crate::Loggable for Vec2D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.datatypes.Vec2D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                2usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -104,15 +104,7 @@ impl crate::Loggable for Vec3D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.datatypes.Vec3D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                3usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -104,15 +104,7 @@ impl crate::Loggable for Vec4D {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.datatypes.Vec4D".to_owned(),
-                            Box::new(DataType::FixedSizeList(
-                                Box::new(Field {
-                                    name: "item".to_owned(),
-                                    data_type: DataType::Float32,
-                                    is_nullable: false,
-                                    metadata: [].into(),
-                                }),
-                                4usize,
-                            )),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/testing/components/fuzzy.rs
+++ b/crates/re_types/src/testing/components/fuzzy.rs
@@ -1231,13 +1231,7 @@ impl crate::Loggable for AffixFuzzer7 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer7".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type:
-                                    <crate::testing::datatypes::AffixFuzzer1>::to_arrow_datatype(),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()
@@ -1419,7 +1413,7 @@ impl crate::Loggable for AffixFuzzer8 {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.testing.components.AffixFuzzer8".to_owned(),
-                        Box::new(DataType::Float32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()
@@ -1556,7 +1550,7 @@ impl crate::Loggable for AffixFuzzer9 {
                             _ = extension_wrapper;
                             DataType::Extension(
                                 "rerun.testing.components.AffixFuzzer9".to_owned(),
-                                Box::new(DataType::Utf8),
+                                Box::new(Self::to_arrow_datatype()),
                                 None,
                             )
                             .to_logical_type()
@@ -1727,7 +1721,7 @@ impl crate::Loggable for AffixFuzzer10 {
                             _ = extension_wrapper;
                             DataType::Extension(
                                 "rerun.testing.components.AffixFuzzer10".to_owned(),
-                                Box::new(DataType::Utf8),
+                                Box::new(Self::to_arrow_datatype()),
                                 None,
                             )
                             .to_logical_type()
@@ -1908,12 +1902,7 @@ impl crate::Loggable for AffixFuzzer11 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer11".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()
@@ -2129,12 +2118,7 @@ impl crate::Loggable for AffixFuzzer12 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer12".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()
@@ -2406,12 +2390,7 @@ impl crate::Loggable for AffixFuzzer13 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer13".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Utf8,
-                                is_nullable: true,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()
@@ -3019,13 +2998,7 @@ impl crate::Loggable for AffixFuzzer16 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer16".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type:
-                                    <crate::testing::datatypes::AffixFuzzer3>::to_arrow_datatype(),
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()
@@ -3239,13 +3212,7 @@ impl crate::Loggable for AffixFuzzer17 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer17".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type:
-                                    <crate::testing::datatypes::AffixFuzzer3>::to_arrow_datatype(),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()
@@ -3459,13 +3426,7 @@ impl crate::Loggable for AffixFuzzer18 {
                         _ = extension_wrapper;
                         DataType::Extension(
                             "rerun.testing.components.AffixFuzzer18".to_owned(),
-                            Box::new(DataType::List(Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type:
-                                    <crate::testing::datatypes::AffixFuzzer4>::to_arrow_datatype(),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            }))),
+                            Box::new(Self::to_arrow_datatype()),
                             None,
                         )
                         .to_logical_type()

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -105,7 +105,7 @@ impl crate::Loggable for FlattenedScalar {
                     PrimitiveArray::new(
                         {
                             _ = extension_wrapper;
-                            DataType::Float32.to_logical_type().clone()
+                            Self::to_arrow_datatype().to_logical_type().clone()
                         },
                         value.into_iter().map(|v| v.unwrap_or_default()).collect(),
                         value_bitmap,
@@ -155,12 +155,7 @@ impl crate::Loggable for FlattenedScalar {
                 let value = {
                     if !arrays_by_name.contains_key("value") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![Field {
-                                name: "value".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }]),
+                            Self::to_arrow_datatype(),
                             "value",
                         ))
                         .with_context("rerun.testing.datatypes.FlattenedScalar");
@@ -389,7 +384,7 @@ impl crate::Loggable for AffixFuzzer1 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             single_float_optional
                                 .into_iter()
@@ -435,7 +430,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8.to_logical_type().clone()
+                                        Self::to_arrow_datatype().to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -484,7 +479,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8.to_logical_type().clone()
+                                        Self::to_arrow_datatype().to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -539,14 +534,7 @@ impl crate::Loggable for AffixFuzzer1 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Float32,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    }))
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 PrimitiveArray::new(
@@ -603,14 +591,7 @@ impl crate::Loggable for AffixFuzzer1 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: false,
-                                        metadata: [].into(),
-                                    }))
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -692,14 +673,7 @@ impl crate::Loggable for AffixFuzzer1 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field {
-                                        name: "item".to_owned(),
-                                        data_type: DataType::Utf8,
-                                        is_nullable: true,
-                                        metadata: [].into(),
-                                    }))
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -758,7 +732,7 @@ impl crate::Loggable for AffixFuzzer1 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             flattened_scalar
                                 .into_iter()
@@ -816,7 +790,7 @@ impl crate::Loggable for AffixFuzzer1 {
                         BooleanArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Boolean.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             from_parent
                                 .into_iter()
@@ -892,45 +866,11 @@ impl crate::Loggable for AffixFuzzer1 {
                     .collect();
                 let single_float_optional = {
                     if !arrays_by_name.contains_key("single_float_optional") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "single_float_optional",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "single_float_optional",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["single_float_optional"];
                     data.as_any()
@@ -947,45 +887,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let single_string_required = {
                     if !arrays_by_name.contains_key("single_string_required") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "single_string_required",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "single_string_required",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["single_string_required"];
                     {
@@ -1036,45 +942,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let single_string_optional = {
                     if !arrays_by_name.contains_key("single_string_optional") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "single_string_optional",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "single_string_optional",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["single_string_optional"];
                     {
@@ -1125,45 +997,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let many_floats_optional = {
                     if !arrays_by_name.contains_key("many_floats_optional") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "many_floats_optional",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "many_floats_optional",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["many_floats_optional"];
                     {
@@ -1236,45 +1074,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let many_strings_required = {
                     if !arrays_by_name.contains_key("many_strings_required") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "many_strings_required",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "many_strings_required",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["many_strings_required"];
                     {
@@ -1390,45 +1194,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let many_strings_optional = {
                     if !arrays_by_name.contains_key("many_strings_optional") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "many_strings_optional",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "many_strings_optional",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["many_strings_optional"];
                     {
@@ -1544,45 +1314,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let flattened_scalar = {
                     if !arrays_by_name.contains_key("flattened_scalar") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "flattened_scalar",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "flattened_scalar",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["flattened_scalar"];
                     data.as_any()
@@ -1599,45 +1335,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let almost_flattened_scalar = {
                     if !arrays_by_name.contains_key("almost_flattened_scalar") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "almost_flattened_scalar",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "almost_flattened_scalar",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["almost_flattened_scalar"];
                     crate::testing::datatypes::FlattenedScalar::try_from_arrow_opt(data)
@@ -1648,45 +1350,11 @@ impl crate::Loggable for AffixFuzzer1 {
                 };
                 let from_parent = {
                     if !arrays_by_name.contains_key("from_parent") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "single_float_optional".to_owned(), data_type
-                                            : DataType::Float32, is_nullable : true, metadata : []
-                                            .into(), }, Field { name : "single_string_required"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), }, Field { name :
-                                            "single_string_optional".to_owned(), data_type :
-                                            DataType::Utf8, is_nullable : true, metadata : [].into(), },
-                                            Field { name : "many_floats_optional".to_owned(), data_type
-                                            : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Float32, is_nullable : true, metadata
-                                            : [].into(), })), is_nullable : true, metadata : [].into(),
-                                            }, Field { name : "many_strings_required".to_owned(),
-                                            data_type : DataType::List(Box::new(Field { name : "item"
-                                            .to_owned(), data_type : DataType::Utf8, is_nullable :
-                                            false, metadata : [].into(), })), is_nullable : false,
-                                            metadata : [].into(), }, Field { name :
-                                            "many_strings_optional".to_owned(), data_type :
-                                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                                            data_type : DataType::Utf8, is_nullable : true, metadata :
-                                            [].into(), })), is_nullable : true, metadata : [].into(), },
-                                            Field { name : "flattened_scalar".to_owned(), data_type :
-                                            DataType::Float32, is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "almost_flattened_scalar"
-                                            .to_owned(), data_type : < crate
-                                            ::testing::datatypes::FlattenedScalar >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "from_parent".to_owned(),
-                                            data_type : DataType::Boolean, is_nullable : true, metadata
-                                            : [].into(), },
-                                        ],
-                                    ),
-                                    "from_parent",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer1");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "from_parent",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer1");
                     }
                     let data = &**arrays_by_name["from_parent"];
                     data.as_any()
@@ -1843,7 +1511,7 @@ impl crate::Loggable for AffixFuzzer2 {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.testing.datatypes.AffixFuzzer2".to_owned(),
-                        Box::new(DataType::Float32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()
@@ -2052,7 +1720,7 @@ impl crate::Loggable for AffixFuzzer3 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             degrees.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             degrees_bitmap,
@@ -2081,7 +1749,7 @@ impl crate::Loggable for AffixFuzzer3 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::Float32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             radians.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             radians_bitmap,
@@ -2126,10 +1794,7 @@ impl crate::Loggable for AffixFuzzer3 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field { name : "item".to_owned(),
-                        data_type : < crate ::testing::datatypes::AffixFuzzer1 >
-                        ::to_arrow_datatype(), is_nullable : false, metadata : [].into(),
-                        })).to_logical_type().clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -2188,17 +1853,7 @@ impl crate::Loggable for AffixFuzzer3 {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::FixedSizeList(
-                                        Box::new(Field {
-                                            name: "item".to_owned(),
-                                            data_type: DataType::Float32,
-                                            is_nullable: false,
-                                            metadata: [].into(),
-                                        }),
-                                        3usize,
-                                    )
-                                    .to_logical_type()
-                                    .clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -2308,28 +1963,7 @@ impl crate::Loggable for AffixFuzzer3 {
                     .offsets()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Union(
-                                vec![
-                                Field { name : "_null_markers".to_owned(), data_type :
-                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                Field { name : "degrees".to_owned(), data_type :
-                                DataType::Float32, is_nullable : false, metadata : []
-                                .into(), }, Field { name : "radians".to_owned(), data_type :
-                                DataType::Float32, is_nullable : false, metadata : []
-                                .into(), }, Field { name : "craziness".to_owned(), data_type
-                                : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                data_type : < crate ::testing::datatypes::AffixFuzzer1 >
-                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                .into(), })), is_nullable : false, metadata : [].into(), },
-                                Field { name : "fixed_size_shenanigans".to_owned(),
-                                data_type : DataType::FixedSizeList(Box::new(Field { name :
-                                "item".to_owned(), data_type : DataType::Float32,
-                                is_nullable : false, metadata : [].into(), }), 3usize),
-                                is_nullable : false, metadata : [].into(), },
-                            ],
-                                Some(vec![0i32, 1i32, 2i32, 3i32, 4i32]),
-                                UnionMode::Dense,
-                            ),
+                            Self::to_arrow_datatype(),
                             data.data_type().clone(),
                         )
                     })
@@ -2637,28 +2271,7 @@ impl crate::Loggable for AffixFuzzer3 {
                                         _ => {
                                             return Err(
                                                     crate::DeserializationError::missing_union_arm(
-                                                        DataType::Union(
-                                                            vec![
-                                                                Field { name : "_null_markers".to_owned(), data_type :
-                                                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                                                Field { name : "degrees".to_owned(), data_type :
-                                                                DataType::Float32, is_nullable : false, metadata : []
-                                                                .into(), }, Field { name : "radians".to_owned(), data_type :
-                                                                DataType::Float32, is_nullable : false, metadata : []
-                                                                .into(), }, Field { name : "craziness".to_owned(), data_type
-                                                                : DataType::List(Box::new(Field { name : "item".to_owned(),
-                                                                data_type : < crate ::testing::datatypes::AffixFuzzer1 >
-                                                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                                                .into(), })), is_nullable : false, metadata : [].into(), },
-                                                                Field { name : "fixed_size_shenanigans".to_owned(),
-                                                                data_type : DataType::FixedSizeList(Box::new(Field { name :
-                                                                "item".to_owned(), data_type : DataType::Float32,
-                                                                is_nullable : false, metadata : [].into(), }), 3usize),
-                                                                is_nullable : false, metadata : [].into(), },
-                                                            ],
-                                                            Some(vec![0i32, 1i32, 2i32, 3i32, 4i32,]),
-                                                            UnionMode::Dense,
-                                                        ),
+                                                        Self::to_arrow_datatype(),
                                                         "<invalid>",
                                                         *typ as _,
                                                     ),
@@ -2877,10 +2490,7 @@ impl crate::Loggable for AffixFuzzer4 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field { name : "item".to_owned(),
-                        data_type : < crate ::testing::datatypes::AffixFuzzer3 >
-                        ::to_arrow_datatype(), is_nullable : false, metadata : [].into(),
-                        })).to_logical_type().clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -2935,10 +2545,7 @@ impl crate::Loggable for AffixFuzzer4 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    DataType::List(Box::new(Field { name : "item".to_owned(),
-                        data_type : < crate ::testing::datatypes::AffixFuzzer3 >
-                        ::to_arrow_datatype(), is_nullable : true, metadata : [].into(),
-                        })).to_logical_type().clone()
+                                    Self::to_arrow_datatype().to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -3039,28 +2646,7 @@ impl crate::Loggable for AffixFuzzer4 {
                     .offsets()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Union(
-                                vec![
-                                Field { name : "_null_markers".to_owned(), data_type :
-                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                Field { name : "single_required".to_owned(), data_type : <
-                                crate ::testing::datatypes::AffixFuzzer3 >
-                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                .into(), }, Field { name : "many_required".to_owned(),
-                                data_type : DataType::List(Box::new(Field { name : "item"
-                                .to_owned(), data_type : < crate
-                                ::testing::datatypes::AffixFuzzer3 > ::to_arrow_datatype(),
-                                is_nullable : false, metadata : [].into(), })), is_nullable
-                                : false, metadata : [].into(), }, Field { name :
-                                "many_optional".to_owned(), data_type :
-                                DataType::List(Box::new(Field { name : "item".to_owned(),
-                                data_type : < crate ::testing::datatypes::AffixFuzzer3 >
-                                ::to_arrow_datatype(), is_nullable : true, metadata : []
-                                .into(), })), is_nullable : false, metadata : [].into(), },
-                            ],
-                                Some(vec![0i32, 1i32, 2i32, 3i32]),
-                                UnionMode::Dense,
-                            ),
+                            Self::to_arrow_datatype(),
                             data.data_type().clone(),
                         )
                     })
@@ -3240,108 +2826,68 @@ impl crate::Loggable for AffixFuzzer4 {
                         if *typ == 0 {
                             Ok(None)
                         } else {
-                            Ok(
-                                Some(
-                                    match typ {
-                                        1i8 => {
-                                            AffixFuzzer4::SingleRequired({
-                                                if offset as usize >= single_required.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                single_required.len(),
-                                                            ),
-                                                        )
-                                                        .with_context(
-                                                            "rerun.testing.datatypes.AffixFuzzer4#single_required",
-                                                        );
-                                                }
+                            Ok(Some(match typ {
+                                1i8 => AffixFuzzer4::SingleRequired({
+                                    if offset as usize >= single_required.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            single_required.len(),
+                                        ))
+                                        .with_context(
+                                            "rerun.testing.datatypes.AffixFuzzer4#single_required",
+                                        );
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe { single_required.get_unchecked(offset as usize) }
-                                                    .clone()
-                                                    .ok_or_else(crate::DeserializationError::missing_data)
-                                                    .with_context(
-                                                        "rerun.testing.datatypes.AffixFuzzer4#single_required",
-                                                    )?
-                                            })
-                                        }
-                                        2i8 => {
-                                            AffixFuzzer4::ManyRequired({
-                                                if offset as usize >= many_required.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                many_required.len(),
-                                                            ),
-                                                        )
-                                                        .with_context(
-                                                            "rerun.testing.datatypes.AffixFuzzer4#many_required",
-                                                        );
-                                                }
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { single_required.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .ok_or_else(crate::DeserializationError::missing_data)
+                                        .with_context(
+                                            "rerun.testing.datatypes.AffixFuzzer4#single_required",
+                                        )?
+                                }),
+                                2i8 => AffixFuzzer4::ManyRequired({
+                                    if offset as usize >= many_required.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            many_required.len(),
+                                        ))
+                                        .with_context(
+                                            "rerun.testing.datatypes.AffixFuzzer4#many_required",
+                                        );
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe { many_required.get_unchecked(offset as usize) }
-                                                    .clone()
-                                                    .ok_or_else(crate::DeserializationError::missing_data)
-                                                    .with_context(
-                                                        "rerun.testing.datatypes.AffixFuzzer4#many_required",
-                                                    )?
-                                            })
-                                        }
-                                        3i8 => {
-                                            AffixFuzzer4::ManyOptional({
-                                                if offset as usize >= many_optional.len() {
-                                                    return Err(
-                                                            crate::DeserializationError::offset_oob(
-                                                                offset as _,
-                                                                many_optional.len(),
-                                                            ),
-                                                        )
-                                                        .with_context(
-                                                            "rerun.testing.datatypes.AffixFuzzer4#many_optional",
-                                                        );
-                                                }
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { many_required.get_unchecked(offset as usize) }
+                                        .clone()
+                                        .ok_or_else(crate::DeserializationError::missing_data)
+                                        .with_context(
+                                            "rerun.testing.datatypes.AffixFuzzer4#many_required",
+                                        )?
+                                }),
+                                3i8 => AffixFuzzer4::ManyOptional({
+                                    if offset as usize >= many_optional.len() {
+                                        return Err(crate::DeserializationError::offset_oob(
+                                            offset as _,
+                                            many_optional.len(),
+                                        ))
+                                        .with_context(
+                                            "rerun.testing.datatypes.AffixFuzzer4#many_optional",
+                                        );
+                                    }
 
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe { many_optional.get_unchecked(offset as usize) }
-                                                    .clone()
-                                            })
-                                        }
-                                        _ => {
-                                            return Err(
-                                                    crate::DeserializationError::missing_union_arm(
-                                                        DataType::Union(
-                                                            vec![
-                                                                Field { name : "_null_markers".to_owned(), data_type :
-                                                                DataType::Null, is_nullable : true, metadata : [].into(), },
-                                                                Field { name : "single_required".to_owned(), data_type : <
-                                                                crate ::testing::datatypes::AffixFuzzer3 >
-                                                                ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                                                .into(), }, Field { name : "many_required".to_owned(),
-                                                                data_type : DataType::List(Box::new(Field { name : "item"
-                                                                .to_owned(), data_type : < crate
-                                                                ::testing::datatypes::AffixFuzzer3 > ::to_arrow_datatype(),
-                                                                is_nullable : false, metadata : [].into(), })), is_nullable
-                                                                : false, metadata : [].into(), }, Field { name :
-                                                                "many_optional".to_owned(), data_type :
-                                                                DataType::List(Box::new(Field { name : "item".to_owned(),
-                                                                data_type : < crate ::testing::datatypes::AffixFuzzer3 >
-                                                                ::to_arrow_datatype(), is_nullable : true, metadata : []
-                                                                .into(), })), is_nullable : false, metadata : [].into(), },
-                                                            ],
-                                                            Some(vec![0i32, 1i32, 2i32, 3i32,]),
-                                                            UnionMode::Dense,
-                                                        ),
-                                                        "<invalid>",
-                                                        *typ as _,
-                                                    ),
-                                                )
-                                                .with_context("rerun.testing.datatypes.AffixFuzzer4");
-                                        }
-                                    },
-                                ),
-                            )
+                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+                                    unsafe { many_optional.get_unchecked(offset as usize) }.clone()
+                                }),
+                                _ => {
+                                    return Err(crate::DeserializationError::missing_union_arm(
+                                        Self::to_arrow_datatype(),
+                                        "<invalid>",
+                                        *typ as _,
+                                    ))
+                                    .with_context("rerun.testing.datatypes.AffixFuzzer4");
+                                }
+                            }))
                         }
                     })
                     .collect::<crate::DeserializationResult<Vec<_>>>()
@@ -3525,13 +3071,7 @@ impl crate::Loggable for AffixFuzzer5 {
                 let single_optional_union = {
                     if !arrays_by_name.contains_key("single_optional_union") {
                         return Err(crate::DeserializationError::missing_struct_field(
-                            DataType::Struct(vec![Field {
-                                name: "single_optional_union".to_owned(),
-                                data_type:
-                                    <crate::testing::datatypes::AffixFuzzer4>::to_arrow_datatype(),
-                                is_nullable: true,
-                                metadata: [].into(),
-                            }]),
+                            Self::to_arrow_datatype(),
                             "single_optional_union",
                         ))
                         .with_context("rerun.testing.datatypes.AffixFuzzer5");
@@ -3680,7 +3220,7 @@ impl crate::Loggable for AffixFuzzer20 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                DataType::UInt32.to_logical_type().clone()
+                                Self::to_arrow_datatype().to_logical_type().clone()
                             },
                             p.into_iter()
                                 .map(|datum| {
@@ -3741,7 +3281,7 @@ impl crate::Loggable for AffixFuzzer20 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        DataType::Utf8.to_logical_type().clone()
+                                        Self::to_arrow_datatype().to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -3797,23 +3337,11 @@ impl crate::Loggable for AffixFuzzer20 {
                     .collect();
                 let p = {
                     if !arrays_by_name.contains_key("p") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "p".to_owned(), data_type : < crate
-                                            ::testing::datatypes::PrimitiveComponent >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "s".to_owned(), data_type : <
-                                            crate ::testing::datatypes::StringComponent >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), },
-                                        ],
-                                    ),
-                                    "p",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer20");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "p",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer20");
                     }
                     let data = &**arrays_by_name["p"];
                     data.as_any()
@@ -3833,23 +3361,11 @@ impl crate::Loggable for AffixFuzzer20 {
                 };
                 let s = {
                     if !arrays_by_name.contains_key("s") {
-                        return Err(
-                                crate::DeserializationError::missing_struct_field(
-                                    DataType::Struct(
-                                        vec![
-                                            Field { name : "p".to_owned(), data_type : < crate
-                                            ::testing::datatypes::PrimitiveComponent >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), }, Field { name : "s".to_owned(), data_type : <
-                                            crate ::testing::datatypes::StringComponent >
-                                            ::to_arrow_datatype(), is_nullable : false, metadata : []
-                                            .into(), },
-                                        ],
-                                    ),
-                                    "s",
-                                ),
-                            )
-                            .with_context("rerun.testing.datatypes.AffixFuzzer20");
+                        return Err(crate::DeserializationError::missing_struct_field(
+                            Self::to_arrow_datatype(),
+                            "s",
+                        ))
+                        .with_context("rerun.testing.datatypes.AffixFuzzer20");
                     }
                     let data = &**arrays_by_name["s"];
                     {

--- a/crates/re_types/src/testing/datatypes/fuzzy.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy.rs
@@ -105,7 +105,7 @@ impl crate::Loggable for FlattenedScalar {
                     PrimitiveArray::new(
                         {
                             _ = extension_wrapper;
-                            Self::to_arrow_datatype().to_logical_type().clone()
+                            DataType::Float32.to_logical_type().clone()
                         },
                         value.into_iter().map(|v| v.unwrap_or_default()).collect(),
                         value_bitmap,
@@ -384,7 +384,7 @@ impl crate::Loggable for AffixFuzzer1 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             single_float_optional
                                 .into_iter()
@@ -430,7 +430,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        Self::to_arrow_datatype().to_logical_type().clone()
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -479,7 +479,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        Self::to_arrow_datatype().to_logical_type().clone()
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,
@@ -534,7 +534,14 @@ impl crate::Loggable for AffixFuzzer1 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Float32,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 PrimitiveArray::new(
@@ -591,7 +598,14 @@ impl crate::Loggable for AffixFuzzer1 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: false,
+                                        metadata: [].into(),
+                                    }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -673,7 +687,14 @@ impl crate::Loggable for AffixFuzzer1 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field {
+                                        name: "item".to_owned(),
+                                        data_type: DataType::Utf8,
+                                        is_nullable: true,
+                                        metadata: [].into(),
+                                    }))
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 offsets,
                                 {
@@ -732,7 +753,7 @@ impl crate::Loggable for AffixFuzzer1 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             flattened_scalar
                                 .into_iter()
@@ -790,7 +811,7 @@ impl crate::Loggable for AffixFuzzer1 {
                         BooleanArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Boolean.to_logical_type().clone()
                             },
                             from_parent
                                 .into_iter()
@@ -1720,7 +1741,7 @@ impl crate::Loggable for AffixFuzzer3 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             degrees.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             degrees_bitmap,
@@ -1749,7 +1770,7 @@ impl crate::Loggable for AffixFuzzer3 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::Float32.to_logical_type().clone()
                             },
                             radians.into_iter().map(|v| v.unwrap_or_default()).collect(),
                             radians_bitmap,
@@ -1794,7 +1815,10 @@ impl crate::Loggable for AffixFuzzer3 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field { name : "item".to_owned(),
+                        data_type : < crate ::testing::datatypes::AffixFuzzer1 >
+                        ::to_arrow_datatype(), is_nullable : false, metadata : [].into(),
+                        })).to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -1853,7 +1877,17 @@ impl crate::Loggable for AffixFuzzer3 {
                             FixedSizeListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::FixedSizeList(
+                                        Box::new(Field {
+                                            name: "item".to_owned(),
+                                            data_type: DataType::Float32,
+                                            is_nullable: false,
+                                            metadata: [].into(),
+                                        }),
+                                        3usize,
+                                    )
+                                    .to_logical_type()
+                                    .clone()
                                 },
                                 PrimitiveArray::new(
                                     {
@@ -2490,7 +2524,10 @@ impl crate::Loggable for AffixFuzzer4 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field { name : "item".to_owned(),
+                        data_type : < crate ::testing::datatypes::AffixFuzzer3 >
+                        ::to_arrow_datatype(), is_nullable : false, metadata : [].into(),
+                        })).to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -2545,7 +2582,10 @@ impl crate::Loggable for AffixFuzzer4 {
                             ListArray::new(
                                 {
                                     _ = extension_wrapper;
-                                    Self::to_arrow_datatype().to_logical_type().clone()
+                                    DataType::List(Box::new(Field { name : "item".to_owned(),
+                        data_type : < crate ::testing::datatypes::AffixFuzzer3 >
+                        ::to_arrow_datatype(), is_nullable : true, metadata : [].into(),
+                        })).to_logical_type().clone()
                                 },
                                 offsets,
                                 {
@@ -3220,7 +3260,7 @@ impl crate::Loggable for AffixFuzzer20 {
                         PrimitiveArray::new(
                             {
                                 _ = extension_wrapper;
-                                Self::to_arrow_datatype().to_logical_type().clone()
+                                DataType::UInt32.to_logical_type().clone()
                             },
                             p.into_iter()
                                 .map(|datum| {
@@ -3281,7 +3321,7 @@ impl crate::Loggable for AffixFuzzer20 {
                                 Utf8Array::<i32>::new_unchecked(
                                     {
                                         _ = extension_wrapper;
-                                        Self::to_arrow_datatype().to_logical_type().clone()
+                                        DataType::Utf8.to_logical_type().clone()
                                     },
                                     offsets,
                                     inner_data,

--- a/crates/re_types/src/testing/datatypes/fuzzy_deps.rs
+++ b/crates/re_types/src/testing/datatypes/fuzzy_deps.rs
@@ -78,7 +78,7 @@ impl crate::Loggable for PrimitiveComponent {
                     _ = extension_wrapper;
                     DataType::Extension(
                         "rerun.testing.datatypes.PrimitiveComponent".to_owned(),
-                        Box::new(DataType::UInt32),
+                        Box::new(Self::to_arrow_datatype()),
                         None,
                     )
                     .to_logical_type()
@@ -216,7 +216,7 @@ impl crate::Loggable for StringComponent {
                             _ = extension_wrapper;
                             DataType::Extension(
                                 "rerun.testing.datatypes.StringComponent".to_owned(),
-                                Box::new(DataType::Utf8),
+                                Box::new(Self::to_arrow_datatype()),
                                 None,
                             )
                             .to_logical_type()

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -54,7 +54,7 @@ pub fn quote_arrow_deserializer(
     let data_src = format_ident!("data");
 
     let datatype = &arrow_registry.get(&obj.fqname);
-    let quoted_datatype = ArrowDataTypeTokenizer(datatype, false);
+    let quoted_datatype = quote! { Self::to_arrow_datatype() };
 
     let obj_fqname = obj.fqname.as_str();
     let is_arrow_transparent = obj.datatype.is_none();

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -335,6 +335,7 @@ enum InnerRepr {
     NativeIterable,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn quote_arrow_field_serializer(
     objects: &Objects,
     extension_wrapper: Option<&str>,

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -6,7 +6,7 @@ use quote::{format_ident, quote};
 use crate::{ArrowRegistry, Object, Objects};
 
 use super::{
-    arrow::{is_backed_by_arrow_buffer, quote_fqname_as_type_path, ArrowDataTypeTokenizer},
+    arrow::{is_backed_by_arrow_buffer, quote_fqname_as_type_path},
     util::is_tuple_struct_from_obj,
 };
 
@@ -77,10 +77,14 @@ pub fn quote_arrow_serializer(
             quote!(Self { #quoted_data_dst })
         };
 
+        let datatype = &arrow_registry.get(&obj_field.fqname);
+        let quoted_datatype = quote! { Self::to_arrow_datatype() };
+
         let quoted_serializer = quote_arrow_field_serializer(
             objects,
             Some(obj.fqname.as_str()),
-            &arrow_registry.get(&obj_field.fqname),
+            datatype,
+            &quoted_datatype,
             obj_field.is_nullable,
             &bitmap_dst,
             &quoted_data_dst,
@@ -123,10 +127,14 @@ pub fn quote_arrow_serializer(
                     let data_dst = format_ident!("{}", obj_field.name);
                     let bitmap_dst = format_ident!("{data_dst}_bitmap");
 
+                    let datatype = &arrow_registry.get(&obj_field.fqname);
+                    let quoted_datatype = quote! { Self::to_arrow_datatype() };
+
                     let quoted_serializer = quote_arrow_field_serializer(
                         objects,
                         None,
-                        &arrow_registry.get(&obj_field.fqname),
+                        datatype,
+                        &quoted_datatype,
                         obj_field.is_nullable,
                         &bitmap_dst,
                         &data_dst,
@@ -186,10 +194,14 @@ pub fn quote_arrow_serializer(
                     let data_dst = format_ident!("{}", obj_field.name.to_case(Case::Snake));
                     let bitmap_dst = format_ident!("{data_dst}_bitmap");
 
+                    let datatype = &arrow_registry.get(&obj_field.fqname);
+                    let quoted_datatype = quote! { Self::to_arrow_datatype() };
+
                     let quoted_serializer = quote_arrow_field_serializer(
                         objects,
                         None,
-                        &arrow_registry.get(&obj_field.fqname),
+                        datatype,
+                        &quoted_datatype,
                         obj_field.is_nullable,
                         &bitmap_dst,
                         &data_dst,
@@ -327,12 +339,12 @@ fn quote_arrow_field_serializer(
     objects: &Objects,
     extension_wrapper: Option<&str>,
     datatype: &DataType,
+    quoted_datatype: &dyn quote::ToTokens,
     is_nullable: bool,
     bitmap_src: &proc_macro2::Ident,
     data_src: &proc_macro2::Ident,
     inner_repr: InnerRepr,
 ) -> TokenStream {
-    let quoted_datatype = ArrowDataTypeTokenizer(datatype, false);
     let quoted_datatype = if let Some(ext) = extension_wrapper {
         quote!(DataType::Extension(#ext.to_owned(), Box::new(#quoted_datatype), None))
     } else {
@@ -500,6 +512,7 @@ fn quote_arrow_field_serializer(
 
         DataType::List(inner) | DataType::FixedSizeList(inner, _) => {
             let inner_datatype = inner.data_type();
+            let quoted_inner_datatype = super::arrow::ArrowDataTypeTokenizer(inner_datatype, false);
 
             // Note: We only use the ArrowBuffer optimization for `Lists` but not `FixedSizeList`.
             // This is because the `ArrowBuffer` has a dynamic length, which would add more overhead
@@ -522,6 +535,7 @@ fn quote_arrow_field_serializer(
                 objects,
                 extension_wrapper,
                 inner_datatype,
+                &quoted_inner_datatype,
                 inner.is_nullable,
                 &quoted_inner_bitmap,
                 &quoted_inner_data,

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -127,14 +127,15 @@ pub fn quote_arrow_serializer(
                     let data_dst = format_ident!("{}", obj_field.name);
                     let bitmap_dst = format_ident!("{data_dst}_bitmap");
 
-                    let datatype = &arrow_registry.get(&obj_field.fqname);
-                    let quoted_datatype = quote! { Self::to_arrow_datatype() };
+                    let inner_datatype = &arrow_registry.get(&obj_field.fqname);
+                    let quoted_inner_datatype =
+                        super::arrow::ArrowDataTypeTokenizer(inner_datatype, false);
 
                     let quoted_serializer = quote_arrow_field_serializer(
                         objects,
                         None,
-                        datatype,
-                        &quoted_datatype,
+                        inner_datatype,
+                        &quoted_inner_datatype,
                         obj_field.is_nullable,
                         &bitmap_dst,
                         &data_dst,
@@ -194,14 +195,14 @@ pub fn quote_arrow_serializer(
                     let data_dst = format_ident!("{}", obj_field.name.to_case(Case::Snake));
                     let bitmap_dst = format_ident!("{data_dst}_bitmap");
 
-                    let datatype = &arrow_registry.get(&obj_field.fqname);
-                    let quoted_datatype = quote! { Self::to_arrow_datatype() };
+                    let inner_datatype = &arrow_registry.get(&obj_field.fqname);
+                    let quoted_inner_datatype = super::arrow::ArrowDataTypeTokenizer(inner_datatype, false);
 
                     let quoted_serializer = quote_arrow_field_serializer(
                         objects,
                         None,
-                        datatype,
-                        &quoted_datatype,
+                        inner_datatype,
+                        &quoted_inner_datatype,
                         obj_field.is_nullable,
                         &bitmap_dst,
                         &data_dst,


### PR DESCRIPTION
What the title says. Even though the code is generated, it is not free. Most importantly: more code means larger `.wasm`.

* Sparked by https://github.com/rerun-io/rerun/pull/3032

Maybe there is something similar we can do for C++?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3034) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3034)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fidl-reuse-dataype/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fidl-reuse-dataype/examples)