### PR TITLE
Track file sizes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 - [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
 - [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
 - [Recent benchmark results](https://ref.rerun.io/dev/bench/)
-- [WASM size tracking](https://ref.rerun.io/dev/sizes/)
+- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,5 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 - [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
 - [Docs preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/docs)
 - [Examples preview](https://rerun.io/preview/{{ "pr:%s"|format(pr.branch)|encode_uri_component }}/examples)
+- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
+- [WASM size tracking](https://ref.rerun.io/dev/sizes/)

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -54,6 +54,15 @@ jobs:
       SOURCE_LINK_COMMIT_OVERRIDE: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
+  track-sizes:
+    name: "Track Sizes"
+    needs: [build-web-demo]
+    uses: ./.github/workflows/reusable_track_size.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    secrets: inherit
+
   upload-web-demo:
     name: "Upload Web Demo"
     needs: [build-web-demo]

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -68,6 +68,14 @@ jobs:
       MARK_PRERELEASE_FOR_MAINLINE: true
     secrets: inherit
 
+  track-sizes:
+    name: "Track Sizes"
+    needs: [build-web-demo]
+    uses: ./.github/workflows/reusable_track_size.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
+    secrets: inherit
+
   build-linux:
     needs: [checks]
     name: "Linux: Build/Test Wheels"

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -1,0 +1,139 @@
+name: "Track Size"
+
+on:
+  workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+      ADHOC_NAME:
+        required: false
+        type: string
+        default: ""
+      PR_NUMBER:
+        required: false
+        type: number
+
+permissions:
+  contents: write
+  id-token: write
+  deployments: write
+  pull-requests: write
+
+jobs:
+  wasm:
+    name: "WASM"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get context
+        id: context
+        run: |
+          echo "full_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(echo ${{github.sha}} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          echo "main_branch_full_sha=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
+          echo "main_branch_short_sha=$(git rev-parse origin/main | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: ">= 363.0.0"
+
+      - name: Download web_viewer
+        uses: actions/download-artifact@v3
+        with:
+          name: web_viewer
+          path: web_viewer
+
+      - name: Download web_demo
+        uses: actions/download-artifact@v3
+        with:
+          name: web_demo
+          path: web_demo
+
+      - name: Download main branch results
+        run: |
+          file_path="gs://rerun-builds/sizes/commit/${{ steps.context.outputs.main_branch_short_sha }}/data.json"
+          gsutil -q stat $file_path
+          status_code=$?
+
+          if [[ $status_code == 0 ]]; then
+            gsutil cp $file_path "/tmp/prev.json"
+          else
+            echo "[]" > "/tmp/prev.json"
+          fi
+
+      - name: Measure sizes
+        id: measure
+        shell: bash
+        run: |
+          entries=()
+
+          entries+="WASM (release):web_viewer/re_viewer_bg.wasm:MB"
+          entries+="JS (release):web_viewer/re_viewer.js:KB"
+
+          entries+="WASM (debug):web_viewer/re_viewer_debug_bg.wasm:MB"
+          entries+="JS (debug):web_viewer/re_viewer_debug.js:KB"
+
+          for file in web_demo/examples/**/*.rrd; do
+            name=$(basename $(dirname "$file"))
+            entries+="$dir.rrd:$file:KB"
+          done
+
+          data=$(python3 scripts/ci/sizes.py measure "${entries[@]}")
+          echo $data
+          echo "$data" > "/tmp/data.json"
+
+          comparison=$(python3 scripts/ci/sizes.py compare --threshold=10 "/tmp/prev.json" "/tmp/data.json")
+          echo $comparison
+          echo "comparison=$comparison" >> "$GITHUB_OUTPUT"
+
+      - name: Upload data to GCS (commit)
+        if: inputs.ADHOC_NAME == ''
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: /tmp/data.json
+          destination: "rerun-builds/sizes/commit/${{ steps.context.outputs.short_sha }}"
+
+      - name: Upload data to GCS (adhoc)
+        if: inputs.ADHOC_NAME != ''
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: /tmp/data.json
+          destination: "rerun-builds/sizes/adhoc/${{ inputs.ADHOC_NAME }}"
+
+      - name: Store benchmark result
+        # Only run on `main`
+        if: github.ref == 'refs/heads/main'
+        # https://github.com/benchmark-action/github-action-benchmark
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Sizes
+          tool: customSmallerIsBetter
+          output-file-path: /tmp/benchmark
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Show alert with commit on detecting possible size regression
+          comment-on-alert: true
+          alert-threshold: "110%"
+          fail-on-alert: false
+          comment-always: false
+
+          save-data-file: true
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/sizes
+          max-items-in-chart: 30
+
+      - name: Create PR comment
+        if: inputs.PR_NUMBER != '' && steps.measure.outputs.comparison != ''
+        # https://github.com/mshick/add-pr-comment
+        uses: mshick/add-pr-comment@v2.8.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            # Size changes
+
+            ${{ steps.measure.outputs.comparison }}
+

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -30,10 +30,20 @@ jobs:
       - name: Get context
         id: context
         run: |
-          echo "full_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$(echo ${{github.sha}} | cut -c1-7)" >> "$GITHUB_OUTPUT"
-          echo "main_branch_full_sha=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
-          echo "main_branch_short_sha=$(git rev-parse origin/main | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          echo "head_short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+          if [ -n ${{ inputs.PR_NUMBER }} ]; then
+            base_short_sha=$(echo ${{ github.event.pull_request.base.sha }} | cut -c1-7)
+          else
+            base_short_sha=$short_sha
+          fi
+          echo "base_short_sha=$base_short_sha" >> "$GITHUB_OUTPUT"
+
+      - id: "auth"
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
@@ -52,9 +62,9 @@ jobs:
           name: web_demo
           path: web_demo
 
-      - name: Download main branch results
+      - name: Download base branch results
         run: |
-          file_path="gs://rerun-builds/sizes/commit/${{ steps.context.outputs.main_branch_short_sha }}/data.json"
+          file_path="gs://rerun-builds/sizes/commit/${{ steps.context.outputs.base_short_sha }}/data.json"
           gsutil -q stat $file_path
           status_code=$?
 
@@ -94,7 +104,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: /tmp/data.json
-          destination: "rerun-builds/sizes/commit/${{ steps.context.outputs.short_sha }}"
+          destination: "rerun-builds/sizes/commit/${{ steps.context.outputs.head_short_sha }}"
 
       - name: Upload data to GCS (adhoc)
         if: inputs.ADHOC_NAME != ''

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -65,10 +65,8 @@ jobs:
       - name: Download base branch results
         run: |
           file_path="gs://rerun-builds/sizes/commit/${{ steps.context.outputs.base_short_sha }}/data.json"
-          gsutil -q stat $file_path
-          status_code=$?
 
-          if [[ $status_code == 0 ]]; then
+          if [ "$(gsutil -q stat $file_path ; echo $?)" = 0 ]; then
             gsutil cp $file_path "/tmp/prev.json"
           else
             echo "[]" > "/tmp/prev.json"

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   wasm:
-    name: "WASM"
+    name: "Wasm"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -70,10 +70,10 @@ jobs:
         run: |
           entries=()
 
-          entries+="WASM (release):web_viewer/re_viewer_bg.wasm:MB"
+          entries+="Wasm (release):web_viewer/re_viewer_bg.wasm:MB"
           entries+="JS (release):web_viewer/re_viewer.js:KB"
 
-          entries+="WASM (debug):web_viewer/re_viewer_debug_bg.wasm:MB"
+          entries+="Wasm (debug):web_viewer/re_viewer_debug_bg.wasm:MB"
           entries+="JS (debug):web_viewer/re_viewer_debug.js:KB"
 
           for file in web_demo/examples/**/*.rrd; do

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -83,16 +83,28 @@ jobs:
 
           for file in web_demo/examples/**/*.rrd; do
             name=$(basename $(dirname "$file"))
-            entries+=("$dir.rrd:$file:KB")
+            entries+=("$name.rrd:$file:KB")
           done
 
           data=$(python3 scripts/ci/sizes.py measure "${entries[@]}")
           echo "$data"
+
           echo "$data" > "/tmp/data.json"
 
           comparison=$(python3 scripts/ci/sizes.py compare --threshold=10 "/tmp/prev.json" "/tmp/data.json")
           echo "$comparison"
-          echo "comparison=$comparison" >> "$GITHUB_OUTPUT"
+
+          {
+            echo 'comparison<<EOF'
+            echo "$comparison"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$comparison" ]; then
+            echo "is_comparison_set=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_comparison_set=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload data to GCS (commit)
         if: inputs.ADHOC_NAME == ''
@@ -132,7 +144,7 @@ jobs:
           max-items-in-chart: 30
 
       - name: Create PR comment
-        if: inputs.PR_NUMBER != '' && steps.measure.outputs.comparison != ''
+        if: inputs.PR_NUMBER != '' && steps.measure.outputs.is_comparison_set == 'true'
         # https://github.com/mshick/add-pr-comment
         uses: mshick/add-pr-comment@v2.8.1
         with:

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -78,23 +78,23 @@ jobs:
         run: |
           entries=()
 
-          entries+="Wasm (release):web_viewer/re_viewer_bg.wasm:MB"
-          entries+="JS (release):web_viewer/re_viewer.js:KB"
+          entries+=("Wasm (release):web_viewer/re_viewer_bg.wasm:MB")
+          entries+=("JS (release):web_viewer/re_viewer.js:KB")
 
-          entries+="Wasm (debug):web_viewer/re_viewer_debug_bg.wasm:MB"
-          entries+="JS (debug):web_viewer/re_viewer_debug.js:KB"
+          entries+=("Wasm (debug):web_viewer/re_viewer_debug_bg.wasm:MB")
+          entries+=("JS (debug):web_viewer/re_viewer_debug.js:KB")
 
           for file in web_demo/examples/**/*.rrd; do
             name=$(basename $(dirname "$file"))
-            entries+="$dir.rrd:$file:KB"
+            entries+=("$dir.rrd:$file:KB")
           done
 
           data=$(python3 scripts/ci/sizes.py measure "${entries[@]}")
-          echo $data
+          echo "$data"
           echo "$data" > "/tmp/data.json"
 
           comparison=$(python3 scripts/ci/sizes.py compare --threshold=10 "/tmp/prev.json" "/tmp/data.json")
-          echo $comparison
+          echo "$comparison"
           echo "comparison=$comparison" >> "$GITHUB_OUTPUT"
 
       - name: Upload data to GCS (commit)

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -21,8 +21,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  wasm:
-    name: "Wasm"
+  track-sizes:
+    name: "Track Sizes"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -78,11 +78,8 @@ jobs:
         run: |
           entries=()
 
-          entries+=("Wasm (release):web_viewer/re_viewer_bg.wasm:MB")
-          entries+=("JS (release):web_viewer/re_viewer.js:KB")
-
-          entries+=("Wasm (debug):web_viewer/re_viewer_debug_bg.wasm:MB")
-          entries+=("JS (debug):web_viewer/re_viewer_debug.js:KB")
+          entries+=("Wasm:web_viewer/re_viewer_bg.wasm:MB")
+          entries+=("JS:web_viewer/re_viewer.js:KB")
 
           for file in web_demo/examples/**/*.rrd; do
             name=$(basename $(dirname "$file"))

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -91,7 +91,7 @@ jobs:
 
           echo "$data" > "/tmp/data.json"
 
-          comparison=$(python3 scripts/ci/sizes.py compare --threshold=10 "/tmp/prev.json" "/tmp/data.json")
+          comparison=$(python3 scripts/ci/sizes.py compare --threshold=5 "/tmp/prev.json" "/tmp/data.json")
           echo "$comparison"
 
           {

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -167,7 +167,7 @@ def measure(files: list[str], format: Format) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a PR summary page")
 
-    cmds_parser = parser.add_subparsers(title="cmds", dest="cmd")
+    cmds_parser = parser.add_subparsers(title="cmds", dest="cmd", help="Command")
 
     compare_parser = cmds_parser.add_parser("compare", help="Compare results")
     compare_parser.add_argument("before", type=str, help="Previous result .json file")
@@ -177,7 +177,7 @@ def main() -> None:
         type=float,
         required=False,
         default=20,
-        help="Only print row if value is `N%` larger or smaller",
+        help="Only print row if value is N%% larger or smaller",
     )
 
     measure_parser = cmds_parser.add_parser("measure", help="Measure sizes")
@@ -188,7 +188,7 @@ def main() -> None:
         default=Format.JSON,
         help="Format to render",
     )
-    measure_parser.add_argument("files", nargs="*", help="Entries to measure. Format: `name:path[:unit]`")
+    measure_parser.add_argument("files", nargs="*", help="Entries to measure. Format: name:path[:unit]")
 
     args = parser.parse_args()
 

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -137,12 +137,12 @@ def compare(previous_path: str, current_path: str, threshold: float) -> None:
             value = entry["current"]["value"]
             unit = entry["current"]["unit"]
 
-            rows.append((name, "<none>", f"{value} {unit}", "+100%"))
+            rows.append((name, "(none)", f"{value} {unit}", "+100%"))
         elif "previous" in entry:
             value = entry["previous"]["value"]
             unit = entry["previous"]["unit"]
 
-            rows.append((name, f"{value} {unit}", "<deleted>", "-100%"))
+            rows.append((name, f"{value} {unit}", "(deleted)", "-100%"))
 
     if len(rows) > 0:
         sys.stdout.write(render_table_rows(rows, headers))

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -9,12 +9,12 @@ Use the script:
     python3 scripts/ci/sizes.py --help
 
     python3 scripts/ci/sizes.py measure \
-        "WASM (release)":web_viewer/re_viewer_bg.wasm \
-        "WASM (debug)":web_viewer/re_viewer_debug_bg.wasm
+        "Wasm (release)":web_viewer/re_viewer_bg.wasm \
+        "Wasm (debug)":web_viewer/re_viewer_debug_bg.wasm
 
     python3 scripts/ci/sizes.py measure --format=table \
-        "WASM (release)":web_viewer/re_viewer_bg.wasm \
-        "WASM (debug)":web_viewer/re_viewer_debug_bg.wasm
+        "Wasm (release)":web_viewer/re_viewer_bg.wasm \
+        "Wasm (debug)":web_viewer/re_viewer_debug_bg.wasm
 
     python3 scripts/ci/sizes.py compare --threshold=20 previous.json current.json
 """

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -125,17 +125,24 @@ def compare(previous_path: str, current_path: str, threshold: float) -> None:
             sign = "+" if change > 0 else ""
 
             if abs(current - previous) >= min_change:
-                rows.append((name, cell(previous, div), cell(current, div), sign + str(change) + "%"))
+                rows.append(
+                    (
+                        name,
+                        f"{cell(previous, div)} {unit}",
+                        f"{cell(current, div)} {unit}",
+                        sign + str(change) + "%",
+                    )
+                )
         elif "current" in entry:
             value = entry["current"]["value"]
             unit = entry["current"]["unit"]
 
-            rows.append((name, "<none>", value, "+100%"))
+            rows.append((name, "<none>", f"{value} {unit}", "+100%"))
         elif "previous" in entry:
             value = entry["previous"]["value"]
             unit = entry["previous"]["unit"]
 
-            rows.append((name, value, "<deleted>", "-100%"))
+            rows.append((name, f"{value} {unit}", "<deleted>", "-100%"))
 
     if len(rows) > 0:
         sys.stdout.write(render_table_rows(rows, headers))

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+"""
+Measure or compare sizes of a list of files.
+
+This produces the format for use in https://github.com/benchmark-action/github-action-benchmark.
+
+Use the script:
+    python3 scripts/ci/sizes.py --help
+
+    python3 scripts/ci/sizes.py measure \
+        "WASM (release)":web_viewer/re_viewer_bg.wasm \
+        "WASM (debug)":web_viewer/re_viewer_debug_bg.wasm
+
+    python3 scripts/ci/sizes.py measure --format=table \
+        "WASM (release)":web_viewer/re_viewer_bg.wasm \
+        "WASM (debug)":web_viewer/re_viewer_debug_bg.wasm
+
+    python3 scripts/ci/sizes.py compare --threshold=20 previous.json current.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os.path
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+def get_unit(size: int | float) -> str:
+    UNITS = ["B", "KB", "MB", "GB", "TB"]
+
+    unit_index = 0
+    while size > 1024:
+        size /= 1024
+        unit_index += 1
+
+    return UNITS[unit_index]
+
+
+DIVISORS = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024 * 1024,
+    "GB": 1024 * 1024 * 1024,
+    "TB": 1024 * 1024 * 1024 * 1024,
+}
+
+
+def get_divisor(unit: str) -> int:
+    return DIVISORS[unit.upper()] or 1
+
+
+def cell(value: float, div: float) -> str:
+    return str(round(value / div, 3))
+
+
+def render_table_dict(data: list[dict[str, str]]) -> str:
+    keys = data[0].keys()
+    column_widths = [max(len(key), max(len(str(row[key])) for row in data)) for key in keys]
+    separator = "|" + "|".join("-" * (width + 2) for width in column_widths)
+    header_row = "|".join(f" {key.center(width)} " for key, width in zip(keys, column_widths))
+
+    table = f"|{header_row}|\n{separator}|\n"
+    for row in data:
+        row_str = "|".join(f" {str(row.get(key, '')).ljust(width)} " for key, width in zip(keys, column_widths))
+        table += f"|{row_str}|\n"
+
+    return table
+
+
+def render_table_rows(rows: list[Any], headers: list[str]) -> str:
+    column_widths = [max(len(str(item)) for item in col) for col in zip(*([tuple(headers)] + rows))]
+    separator = "|" + "|".join("-" * (width + 2) for width in column_widths)
+    header_row = "|".join(f" {header.center(width)} " for header, width in zip(headers, column_widths))
+
+    table = f"|{header_row}|\n{separator}|\n"
+    for row in rows:
+        row_str = "|".join(f" {str(item).ljust(width)} " for item, width in zip(row, column_widths))
+        table += f"|{row_str}|\n"
+
+    return table
+
+
+class Format(Enum):
+    JSON = "json"
+    GITHUB = "github"
+
+    def render(self, data: list[dict[str, str]]) -> str:
+        if self is Format.JSON:
+            return json.dumps(data)
+        if self is Format.GITHUB:
+            return render_table_dict(data)
+
+
+def compare(previous_path: str, current_path: str, threshold: float) -> None:
+    previous = json.loads(Path(previous_path).read_text())
+    current = json.loads(Path(current_path).read_text())
+
+    entries = {}
+    for entry in current:
+        name = entry["name"]
+        entries[name] = {"current": entry}
+    for entry in previous:
+        name = entry["name"]
+        if name not in entries:
+            entries[name] = {}
+        entries[name]["previous"] = entry
+
+    headers = ["Name", "Previous", "Current", "Change"]
+    rows: list[tuple[str, str, str, str]] = []
+    for name, entry in entries.items():
+        if "previous" in entry and "current" in entry:
+            previous = float(entry["previous"]["value"]) * DIVISORS[entry["previous"]["unit"]]
+            current = float(entry["current"]["value"]) * DIVISORS[entry["current"]["unit"]]
+
+            min_change = previous * (threshold / 100)
+
+            unit = get_unit(min(previous, current))
+            div = get_divisor(unit)
+
+            change = ((previous / current) * 100) - 100
+            sign = "+" if change > 0 else ""
+
+            if abs(current - previous) >= min_change:
+                rows.append((name, cell(previous, div), cell(current, div), sign + str(change) + "%"))
+        elif "current" in entry:
+            value = entry["current"]["value"]
+            unit = entry["current"]["unit"]
+
+            rows.append((name, "<none>", value, "+100%"))
+        elif "previous" in entry:
+            value = entry["previous"]["value"]
+            unit = entry["previous"]["unit"]
+
+            rows.append((name, value, "<deleted>", "-100%"))
+
+    if len(rows) > 0:
+        sys.stdout.write(render_table_rows(rows, headers))
+        sys.stdout.flush()
+
+
+def measure(files: list[str], format: Format) -> None:
+    output: list[dict[str, str]] = []
+    for arg in files:
+        parts = arg.split(":")
+        name = parts[0]
+        file = parts[1]
+        size = os.path.getsize(file)
+        unit = parts[2] if len(parts) > 2 else get_unit(size)
+        div = get_divisor(unit)
+
+        output.append(
+            {
+                "name": name,
+                "value": str(round(size / div, 3)),
+                "unit": unit,
+            }
+        )
+
+    sys.stdout.write(format.render(output))
+    sys.stdout.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a PR summary page")
+
+    cmds_parser = parser.add_subparsers(title="cmds", dest="cmd")
+
+    compare_parser = cmds_parser.add_parser("compare", help="Compare results")
+    compare_parser.add_argument("before", type=str, help="Previous result .json file")
+    compare_parser.add_argument("after", type=str, help="Current result .json file")
+    compare_parser.add_argument(
+        "--threshold",
+        type=float,
+        required=False,
+        default=20,
+        help="Only print row if value is `N%` larger or smaller",
+    )
+
+    measure_parser = cmds_parser.add_parser("measure", help="Measure sizes")
+    measure_parser.add_argument(
+        "--format",
+        type=Format,
+        choices=list(Format),
+        default=Format.JSON,
+        help="Format to render",
+    )
+    measure_parser.add_argument("files", nargs="*", help="Entries to measure. Format: `name:path[:unit]`")
+
+    args = parser.parse_args()
+
+    if args.cmd == "compare":
+        compare(args.before, args.after, args.threshold)
+    elif args.cmd == "measure":
+        measure(args.files, args.format)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Fixes https://github.com/rerun-io/rerun/issues/2511

- Adds `scripts/ci/sizes.py` for measuring and comparing file sizes
  - This works for any files, not just WASM files
- Use the new script in a new `reusable_track_size.yml` workflow
  - Measures sizes of various files (`.wasm`, `.js`, demo `.rrd`), and uploads the results to GCS
  - Compares the results to `main` and posts a PR comment if the size changed significantly (+10% or -10%)
  - Builds file size graphs and pushes them to `gh-pages` on every commit to `main`
- Also updated the PR description template to include links to benchmark graphs and the new size graphs.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3037) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3037)
- [Docs preview](https://rerun.io/preview/pr%3Ajan%2Ftrack-wasm-size/docs)
- [Examples preview](https://rerun.io/preview/pr%3Ajan%2Ftrack-wasm-size/examples)