### PR TITLE
C++ no longer leak arrow headers into our own headers, include minimal set

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-7f3229bd4b4272102f9f5bced8f57400c5284b743ab084272f9e791325d8ef58
+c5b064c9b91770cd0c201ec7bf11a7ad2b9dbcd5b6bb08e45f3f4f008fb635ff

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-2555b93a9b13437eef87e1bd05e0c5257cd2d29d7652d4e4062c163f0d747900
+7a44c2b5c62146d49813d959839de99a6df50847e0d1bd0fdba4431bdecdef04

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-c5b064c9b91770cd0c201ec7bf11a7ad2b9dbcd5b6bb08e45f3f4f008fb635ff
+2555b93a9b13437eef87e1bd05e0c5257cd2d29d7652d4e4062c163f0d747900

--- a/crates/re_types_builder/src/codegen/cpp/array_builder.rs
+++ b/crates/re_types_builder/src/codegen/cpp/array_builder.rs
@@ -1,0 +1,206 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+
+use crate::{Object, ObjectSpecifics, Objects, Type};
+
+use super::{
+    forward_decl::{ForwardDecl, ForwardDecls},
+    includes::Includes,
+    quote_fqname_as_type_path, quote_integer,
+};
+
+pub fn arrow_array_builder_type(typ: &Type, objects: &Objects) -> Ident {
+    arrow_array_builder_type_and_declaration(typ, objects, &mut ForwardDecls::default())
+}
+
+fn arrow_array_builder_type_and_declaration(
+    typ: &Type,
+    objects: &Objects,
+    declarations: &mut ForwardDecls,
+) -> Ident {
+    match typ {
+        Type::Int8
+        | Type::Int16
+        | Type::Int32
+        | Type::Int64
+        | Type::UInt8
+        | Type::UInt16
+        | Type::UInt32
+        | Type::UInt64
+        | Type::Float16
+        | Type::Float32
+        | Type::Float64 => {
+            let klass = match typ {
+                Type::Int8 => "Int8",
+                Type::Int16 => "Int16",
+                Type::Int32 => "Int32",
+                Type::Int64 => "Int64",
+                Type::UInt8 => "UInt8",
+                Type::UInt16 => "UInt16",
+                Type::UInt32 => "UInt32",
+                Type::UInt64 => "UInt64",
+                Type::Float16 => "Float16",
+                Type::Float32 => "Float",
+                Type::Float64 => "Float64",
+                _ => {
+                    unreachable!();
+                }
+            };
+            let klass_type = format_ident!("{klass}Type");
+
+            declarations.insert(
+                "arrow",
+                ForwardDecl::TemplateClass(format_ident!("NumericBuilder")),
+            );
+            declarations.insert("arrow", ForwardDecl::Class(klass_type.clone()));
+
+            let ident = format_ident!("{klass}Builder");
+            declarations.insert(
+                "arrow",
+                ForwardDecl::Alias {
+                    from: ident.clone(),
+                    to: quote!(NumericBuilder<#klass_type>),
+                },
+            );
+            ident
+        }
+        Type::String => {
+            let ident = format_ident!("StringBuilder");
+            declarations.insert("arrow", ForwardDecl::Class(ident.clone()));
+            ident
+        }
+        Type::Bool => {
+            let ident = format_ident!("BooleanBuilder");
+            declarations.insert("arrow", ForwardDecl::Class(ident.clone()));
+            ident
+        }
+        Type::Array { .. } => {
+            let ident = format_ident!("FixedSizeListBuilder");
+            declarations.insert("arrow", ForwardDecl::Class(ident.clone()));
+            ident
+        }
+        Type::Vector { .. } => {
+            let ident = format_ident!("ListBuilder");
+            declarations.insert("arrow", ForwardDecl::Class(ident.clone()));
+            ident
+        }
+        Type::Object(fqname) => {
+            arrow_array_builder_type_object(&objects[fqname], objects, declarations)
+        }
+    }
+}
+
+pub fn arrow_array_builder_type_object(
+    obj: &Object,
+    objects: &Objects,
+    declarations: &mut ForwardDecls,
+) -> Ident {
+    if obj.is_arrow_transparent() {
+        arrow_array_builder_type_and_declaration(&obj.fields[0].typ, objects, declarations)
+    } else {
+        let class_ident = match obj.specifics {
+            ObjectSpecifics::Struct => format_ident!("StructBuilder"),
+            ObjectSpecifics::Union { .. } => format_ident!("DenseUnionBuilder"),
+        };
+
+        declarations.insert("arrow", ForwardDecl::Class(class_ident.clone()));
+        class_ident
+    }
+}
+
+pub fn quote_arrow_array_builder_type_instantiation(
+    typ: &Type,
+    objects: &Objects,
+    cpp_includes: &mut Includes,
+    is_top_level_type: bool,
+) -> TokenStream {
+    let builder_type = arrow_array_builder_type(typ, objects);
+
+    match typ {
+        Type::UInt8
+        | Type::UInt16
+        | Type::UInt32
+        | Type::UInt64
+        | Type::Int8
+        | Type::Int16
+        | Type::Int32
+        | Type::Int64
+        | Type::Bool
+        | Type::Float16
+        | Type::Float32
+        | Type::Float64
+        | Type::String => {
+            quote!(std::make_shared<arrow::#builder_type>(memory_pool))
+        }
+        Type::Vector { elem_type } => {
+            let element_builder = quote_arrow_array_builder_type_instantiation(
+                &elem_type.clone().into(),
+                objects,
+                cpp_includes,
+                false,
+            );
+            quote!(std::make_shared<arrow::#builder_type>(memory_pool, #element_builder))
+        }
+        Type::Array { elem_type, length } => {
+            let quoted_length = quote_integer(length);
+            let element_builder = quote_arrow_array_builder_type_instantiation(
+                &elem_type.clone().into(),
+                objects,
+                cpp_includes,
+                false,
+            );
+            quote!(std::make_shared<arrow::#builder_type>(memory_pool, #element_builder, #quoted_length))
+        }
+        Type::Object(fqname) => {
+            let object = &objects[fqname];
+
+            if !is_top_level_type {
+                // Propagating error here is hard since we're in a nested context.
+                // But also not that important since we *know* that this only fails for null pools and we already checked that now.
+                // For the unlikely broken case, Rerun result will give us a nullptr which will then
+                // fail the subsequent actions inside arrow, so the error will still propagate.
+                let quoted_fqname = quote_fqname_as_type_path(cpp_includes, fqname);
+                quote!(#quoted_fqname::new_arrow_array_builder(memory_pool).value)
+            } else if object.is_arrow_transparent() {
+                quote_arrow_array_builder_type_instantiation(
+                    &object.fields[0].typ,
+                    objects,
+                    cpp_includes,
+                    false,
+                )
+            } else {
+                let field_builders = object.fields.iter().map(|field| {
+                    quote_arrow_array_builder_type_instantiation(
+                        &field.typ,
+                        objects,
+                        cpp_includes,
+                        false,
+                    )
+                });
+
+                match object.specifics {
+                    ObjectSpecifics::Struct => {
+                        quote! {
+                            std::make_shared<arrow::#builder_type>(
+                                to_arrow_datatype(),
+                                memory_pool,
+                                std::vector<std::shared_ptr<arrow::ArrayBuilder>>({ #(#field_builders,)* })
+                            )
+                        }
+                    }
+                    ObjectSpecifics::Union { .. } => {
+                        quote! {
+                             std::make_shared<arrow::#builder_type>(
+                                 memory_pool,
+                                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
+                                     std::make_shared<arrow::NullBuilder>(memory_pool), #(#field_builders,)*
+                                 }),
+                                 to_arrow_datatype()
+                             )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/re_types_builder/src/codegen/cpp/includes.rs
+++ b/crates/re_types_builder/src/codegen/cpp/includes.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeSet;
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::objects::is_testing_fqname;
-
-use super::{NEWLINE_TOKEN, SYS_INCLUDE_PATH_PREFIX_TOKEN, SYS_INCLUDE_PATH_SUFFIX_TOKEN};
+use super::{ANGLE_BRACKET_LEFT_TOKEN, ANGLE_BRACKET_RIGHT_TOKEN, NEWLINE_TOKEN};
 
 /// Keeps track of necessary includes for a file.
 pub struct Includes {
@@ -92,7 +90,7 @@ impl quote::ToTokens for Includes {
         let hash = quote! { # };
         let system = system.iter().map(|name| {
             // Need to mark system includes with tokens since they are usually not idents (can contain slashes and dots)
-            quote! { #hash include #SYS_INCLUDE_PATH_PREFIX_TOKEN #name #SYS_INCLUDE_PATH_SUFFIX_TOKEN #NEWLINE_TOKEN }
+            quote! { #hash include #ANGLE_BRACKET_LEFT_TOKEN #name #ANGLE_BRACKET_RIGHT_TOKEN #NEWLINE_TOKEN }
         });
         let local = local.iter().map(|name| {
             quote! { #hash include #name #NEWLINE_TOKEN }

--- a/crates/re_types_builder/src/codegen/cpp/includes.rs
+++ b/crates/re_types_builder/src/codegen/cpp/includes.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeSet;
 use proc_macro2::TokenStream;
 use quote::quote;
 
+use crate::objects::is_testing_fqname;
+
 use super::{ANGLE_BRACKET_LEFT_TOKEN, ANGLE_BRACKET_RIGHT_TOKEN, NEWLINE_TOKEN};
 
 /// Keeps track of necessary includes for a file.

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -376,12 +376,14 @@ impl QuotedObject {
                 methods.push(arrow_data_type_method(
                     obj,
                     objects,
+                    &mut hpp_includes,
                     &mut cpp_includes,
                     &mut hpp_declarations,
                 ));
                 methods.push(new_arrow_array_builder_method(
                     obj,
                     objects,
+                    &mut hpp_includes,
                     &mut cpp_includes,
                     &mut hpp_declarations,
                 ));
@@ -712,12 +714,14 @@ impl QuotedObject {
         methods.push(arrow_data_type_method(
             obj,
             objects,
+            &mut hpp_includes,
             &mut cpp_includes,
             &mut hpp_declarations,
         ));
         methods.push(new_arrow_array_builder_method(
             obj,
             objects,
+            &mut hpp_includes,
             &mut cpp_includes,
             &mut hpp_declarations,
         ));
@@ -1044,9 +1048,11 @@ fn single_field_constructor_methods(
 fn arrow_data_type_method(
     obj: &Object,
     objects: &Objects,
+    hpp_includes: &mut Includes,
     cpp_includes: &mut Includes,
     hpp_declarations: &mut ForwardDecls,
 ) -> Method {
+    hpp_includes.insert_system("memory"); // std::shared_ptr
     cpp_includes.insert_system("arrow/type_fwd.h");
     hpp_declarations.insert("arrow", ForwardDecl::Class(format_ident!("DataType")));
 
@@ -1075,9 +1081,11 @@ fn arrow_data_type_method(
 fn new_arrow_array_builder_method(
     obj: &Object,
     objects: &Objects,
+    hpp_includes: &mut Includes,
     cpp_includes: &mut Includes,
     hpp_declarations: &mut ForwardDecls,
 ) -> Method {
+    hpp_includes.insert_system("memory"); // std::shared_ptr
     cpp_includes.insert_system("arrow/builder.h");
     hpp_declarations.insert("arrow", ForwardDecl::Class(format_ident!("MemoryPool")));
 
@@ -1156,6 +1164,7 @@ fn component_to_data_cell_method(
     hpp_includes: &mut Includes,
     cpp_includes: &mut Includes,
 ) -> Method {
+    hpp_includes.insert_system("memory"); // std::shared_ptr
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("result.hpp");
     cpp_includes.insert_rerun("arrow.hpp"); // ipc_from_table

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -495,6 +495,7 @@ impl QuotedObject {
 
                     // Provide a non-array version if it's a vector.
                     if let Type::Vector { elem_type } = &obj_field.typ {
+                        hpp_includes.insert_system("vector"); // std::vector
                         let elem_type = quote_element_type(&mut hpp_includes, elem_type);
                         methods.push(Method {
                             docs: obj_field.docs.clone().into(),
@@ -1218,6 +1219,7 @@ fn archetype_to_data_cells(
 ) -> Method {
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("result.hpp");
+    hpp_includes.insert_system("vector"); // std::vector
 
     // TODO(andreas): Splats need to be handled separately.
 

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1048,8 +1048,14 @@ fn single_field_constructor_methods(
     methods
 }
 
-fn arrow_data_type_method(obj: &Object, objects: &Objects, cpp_includes: &mut Includes) -> Method {
-    cpp_includes.system.insert("arrow/api.h".to_owned());
+fn arrow_data_type_method(
+    obj: &Object,
+    objects: &Objects,
+    cpp_includes: &mut Includes,
+    hpp_declarations: &mut ForwardDecls,
+) -> Method {
+    cpp_includes.insert_system("arrow/type_fwd.h");
+    hpp_declarations.insert("arrow", ForwardDecl::Class(format_ident!("DataType")));
 
     let quoted_datatype = quote_arrow_data_type(
         &Type::Object(obj.fqname.clone()),
@@ -1079,7 +1085,8 @@ fn new_arrow_array_builder_method(
     cpp_includes: &mut Includes,
     hpp_declarations: &mut ForwardDecls,
 ) -> Method {
-    cpp_includes.system.insert("arrow/api.h".to_owned());
+    cpp_includes.insert_system("arrow/builder.h");
+    hpp_declarations.insert("arrow", ForwardDecl::Class(format_ident!("MemoryPool")));
 
     let builder_instantiation = quote_arrow_array_builder_type_instantiation(
         &Type::Object(obj.fqname.clone()),
@@ -1115,7 +1122,7 @@ fn fill_arrow_array_builder_method(
     hpp_declarations: &mut ForwardDecls,
     objects: &Objects,
 ) -> Method {
-    cpp_includes.system.insert("arrow/api.h".to_owned());
+    cpp_includes.insert_system("arrow/builder.h".to_owned());
 
     let builder = format_ident!("builder");
     let arrow_builder_type = arrow_array_builder_type_object(obj, objects, hpp_declarations);
@@ -1159,7 +1166,7 @@ fn component_to_data_cell_method(
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("result.hpp");
     cpp_includes.insert_rerun("arrow.hpp"); // ipc_from_table
-    cpp_includes.insert_system("arrow/api.h");
+    cpp_includes.insert_system("arrow/table.h"); // Table::Make
 
     let todo_pool = quote_comment("TODO(andreas): Allow configuring the memory pool.");
 
@@ -1219,7 +1226,6 @@ fn archetype_to_data_cells(
 ) -> Method {
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("result.hpp");
-    cpp_includes.insert_system("arrow/api.h");
 
     // TODO(andreas): Splats need to be handled separately.
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -5,8 +5,6 @@
 
 #include "../components/annotation_context.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> AnnotationContext::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -7,7 +7,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <vector>
 
 namespace rerun {
     namespace archetypes {

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -11,8 +11,6 @@
 #include "../components/radius.hpp"
 #include "../components/vector3d.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> Arrows3D::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -13,7 +13,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -5,8 +5,6 @@
 
 #include "../components/disconnected_space.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> DisconnectedSpace::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -7,7 +7,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
 

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <vector>
 
 namespace rerun {
     namespace archetypes {

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -11,8 +11,6 @@
 #include "../components/line_strip2d.hpp"
 #include "../components/radius.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> LineStrips2D::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -13,7 +13,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -10,8 +10,6 @@
 #include "../components/line_strip3d.hpp"
 #include "../components/radius.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> LineStrips3D::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -12,7 +12,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -12,8 +12,6 @@
 #include "../components/point2d.hpp"
 #include "../components/radius.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> Points2D::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -14,7 +14,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -11,8 +11,6 @@
 #include "../components/point3d.hpp"
 #include "../components/radius.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> Points3D::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -13,7 +13,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -5,8 +5,6 @@
 
 #include "../components/transform3d.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> Transform3D::to_data_cells() const {

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -7,7 +7,6 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
 

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <vector>
 
 namespace rerun {
     namespace archetypes {

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/class_description_map_elem.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -21,27 +23,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>>
-            AnnotationContext::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::ListBuilder>> AnnotationContext::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
                 rerun::datatypes::ClassDescriptionMapElem::new_arrow_array_builder(memory_pool)
-                    .ValueOrDie()
+                    .value
             ));
         }
 
-        arrow::Status AnnotationContext::fill_arrow_array_builder(
+        Error AnnotationContext::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AnnotationContext *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::StructBuilder *>(builder->value_builder());
@@ -52,7 +58,7 @@ namespace rerun {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.class_map.data()) {
-                    ARROW_RETURN_NOT_OK(
+                    RR_RETURN_NOT_OK(
                         rerun::datatypes::ClassDescriptionMapElem::fill_arrow_array_builder(
                             value_builder,
                             element.class_map.data(),
@@ -62,7 +68,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AnnotationContext::to_data_cell(
@@ -71,9 +77,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AnnotationContext::new_arrow_array_builder(pool));
+            auto builder_result = AnnotationContext::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(AnnotationContext::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(AnnotationContext::fill_arrow_array_builder(
                     builder.get(),
                     instances,
                     num_instances
@@ -90,11 +98,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AnnotationContext::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -7,10 +7,15 @@
 #include "../datatypes/class_description_map_elem.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -56,12 +61,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AnnotationContext* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/class_id.cpp
+++ b/rerun_cpp/src/rerun/components/class_id.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/class_id.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,36 +19,37 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt16Builder>> ClassId::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt16Builder>> ClassId::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::ClassId::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::ClassId::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status ClassId::fill_arrow_array_builder(
+        Error ClassId::fill_arrow_array_builder(
             arrow::UInt16Builder *builder, const ClassId *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::ClassId) == sizeof(ClassId));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::ClassId *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> ClassId::to_data_cell(
@@ -55,9 +58,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, ClassId::new_arrow_array_builder(pool));
+            auto builder_result = ClassId::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     ClassId::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -69,11 +74,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = ClassId::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -7,9 +7,18 @@
 #include "../datatypes/class_id.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt16Type;
+    using UInt16Builder = NumericBuilder<UInt16Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -36,12 +45,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/color.cpp
+++ b/rerun_cpp/src/rerun/components/color.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/color.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,45 +19,48 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt32Builder>> Color::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt32Builder>> Color::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Color::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::Color::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status Color::fill_arrow_array_builder(
+        Error Color::fill_arrow_array_builder(
             arrow::UInt32Builder *builder, const Color *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Color) == sizeof(Color));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Color::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Color::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Color *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Color::to_data_cell(const Color *instances, size_t num_instances) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Color::new_arrow_array_builder(pool));
+            auto builder_result = Color::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Color::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -67,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Color::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -7,9 +7,18 @@
 #include "../datatypes/color.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt32Type;
+    using UInt32Builder = NumericBuilder<UInt32Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -59,12 +68,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.cpp
@@ -5,7 +5,9 @@
 
 #include "../arrow.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -16,23 +18,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::BooleanBuilder>>
-            DisconnectedSpace::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::BooleanBuilder>> DisconnectedSpace::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::BooleanBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::BooleanBuilder>(memory_pool));
         }
 
-        arrow::Status DisconnectedSpace::fill_arrow_array_builder(
+        Error DisconnectedSpace::fill_arrow_array_builder(
             arrow::BooleanBuilder *builder, const DisconnectedSpace *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->is_disconnected));
@@ -41,7 +47,7 @@ namespace rerun {
                 static_cast<int64_t>(num_elements)
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> DisconnectedSpace::to_data_cell(
@@ -50,9 +56,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, DisconnectedSpace::new_arrow_array_builder(pool));
+            auto builder_result = DisconnectedSpace::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(DisconnectedSpace::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(DisconnectedSpace::fill_arrow_array_builder(
                     builder.get(),
                     instances,
                     num_instances
@@ -69,11 +77,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = DisconnectedSpace::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -7,6 +7,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -6,9 +6,14 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class BooleanBuilder;
+    class DataType;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -38,12 +43,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::BooleanBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::BooleanBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::BooleanBuilder* builder, const DisconnectedSpace* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/draw_order.cpp
+++ b/rerun_cpp/src/rerun/components/draw_order.cpp
@@ -5,7 +5,9 @@
 
 #include "../arrow.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -16,24 +18,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FloatBuilder>> DrawOrder::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FloatBuilder>> DrawOrder::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        arrow::Status DrawOrder::fill_arrow_array_builder(
+        Error DrawOrder::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
@@ -41,7 +46,7 @@ namespace rerun {
                 builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> DrawOrder::to_data_cell(
@@ -50,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, DrawOrder::new_arrow_array_builder(pool));
+            auto builder_result = DrawOrder::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     DrawOrder::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -65,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = DrawOrder::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -6,9 +6,18 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class FloatType;
+    class MemoryPool;
+    using FloatBuilder = NumericBuilder<FloatType>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -39,12 +48,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -7,6 +7,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/instance_key.cpp
+++ b/rerun_cpp/src/rerun/components/instance_key.cpp
@@ -5,7 +5,9 @@
 
 #include "../arrow.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -16,24 +18,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt64Builder>> InstanceKey::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt64Builder>> InstanceKey::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::UInt64Builder>(memory_pool));
+            return Result(std::make_shared<arrow::UInt64Builder>(memory_pool));
         }
 
-        arrow::Status InstanceKey::fill_arrow_array_builder(
+        Error InstanceKey::fill_arrow_array_builder(
             arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
@@ -41,7 +46,7 @@ namespace rerun {
                 builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> InstanceKey::to_data_cell(
@@ -50,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, InstanceKey::new_arrow_array_builder(pool));
+            auto builder_result = InstanceKey::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     InstanceKey::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -65,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = InstanceKey::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -7,6 +7,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -6,9 +6,18 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt64Type;
+    using UInt64Builder = NumericBuilder<UInt64Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -33,12 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt64Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt64Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/keypoint_id.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,36 +19,37 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt16Builder>> KeypointId::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt16Builder>> KeypointId::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status KeypointId::fill_arrow_array_builder(
+        Error KeypointId::fill_arrow_array_builder(
             arrow::UInt16Builder *builder, const KeypointId *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::KeypointId) == sizeof(KeypointId));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::KeypointId *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> KeypointId::to_data_cell(
@@ -55,9 +58,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, KeypointId::new_arrow_array_builder(pool));
+            auto builder_result = KeypointId::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     KeypointId::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -70,11 +75,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = KeypointId::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -7,9 +7,18 @@
 #include "../datatypes/keypoint_id.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt16Type;
+    using UInt16Builder = NumericBuilder<UInt16Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -36,12 +45,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/label.cpp
+++ b/rerun_cpp/src/rerun/components/label.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/label.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,45 +19,48 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StringBuilder>> Label::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StringBuilder>> Label::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Label::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::Label::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status Label::fill_arrow_array_builder(
+        Error Label::fill_arrow_array_builder(
             arrow::StringBuilder *builder, const Label *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Label) == sizeof(Label));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Label::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Label::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Label *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Label::to_data_cell(const Label *instances, size_t num_instances) {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Label::new_arrow_array_builder(pool));
+            auto builder_result = Label::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Label::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -67,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Label::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/label.hpp
+++ b/rerun_cpp/src/rerun/components/label.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 

--- a/rerun_cpp/src/rerun/components/label.hpp
+++ b/rerun_cpp/src/rerun/components/label.hpp
@@ -7,10 +7,15 @@
 #include "../datatypes/label.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <string>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StringBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -47,12 +52,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const Label* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/vec2d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -19,27 +21,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> LineStrip2D::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> LineStrip2D::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
-                rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).ValueOrDie()
+                rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).value
             ));
         }
 
-        arrow::Status LineStrip2D::fill_arrow_array_builder(
+        Error LineStrip2D::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const LineStrip2D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder =
@@ -51,7 +56,7 @@ namespace rerun {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.points.data()) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
                         value_builder,
                         element.points.data(),
                         element.points.size()
@@ -59,7 +64,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> LineStrip2D::to_data_cell(
@@ -68,9 +73,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, LineStrip2D::new_arrow_array_builder(pool));
+            auto builder_result = LineStrip2D::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     LineStrip2D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -83,11 +90,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = LineStrip2D::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -7,10 +7,15 @@
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -47,12 +52,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const LineStrip2D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -7,10 +7,15 @@
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -47,12 +52,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const LineStrip3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/origin3d.cpp
+++ b/rerun_cpp/src/rerun/components/origin3d.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,35 +19,37 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-            Origin3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Origin3D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status Origin3D::fill_arrow_array_builder(
+        Error Origin3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Origin3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(Origin3D));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Vec3D *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Origin3D::to_data_cell(
@@ -54,9 +58,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Origin3D::new_arrow_array_builder(pool));
+            auto builder_result = Origin3D::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Origin3D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -68,11 +74,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Origin3D::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/origin3d.hpp
+++ b/rerun_cpp/src/rerun/components/origin3d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/origin3d.hpp
+++ b/rerun_cpp/src/rerun/components/origin3d.hpp
@@ -7,9 +7,14 @@
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -54,11 +59,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Origin3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/point2d.cpp
+++ b/rerun_cpp/src/rerun/components/point2d.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/vec2d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,35 +19,37 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-            Point2D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Point2D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status Point2D::fill_arrow_array_builder(
+        Error Point2D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Point2D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(Point2D));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Vec2D *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Point2D::to_data_cell(
@@ -54,9 +58,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Point2D::new_arrow_array_builder(pool));
+            auto builder_result = Point2D::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Point2D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -68,11 +74,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Point2D::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/point2d.hpp
+++ b/rerun_cpp/src/rerun/components/point2d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/point2d.hpp
+++ b/rerun_cpp/src/rerun/components/point2d.hpp
@@ -7,9 +7,14 @@
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -50,11 +55,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Point2D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/point3d.cpp
+++ b/rerun_cpp/src/rerun/components/point3d.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,35 +19,37 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-            Point3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Point3D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status Point3D::fill_arrow_array_builder(
+        Error Point3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Point3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(Point3D));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Vec3D *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Point3D::to_data_cell(
@@ -54,9 +58,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Point3D::new_arrow_array_builder(pool));
+            auto builder_result = Point3D::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Point3D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -68,11 +74,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Point3D::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/point3d.hpp
+++ b/rerun_cpp/src/rerun/components/point3d.hpp
@@ -7,9 +7,14 @@
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -54,11 +59,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Point3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/point3d.hpp
+++ b/rerun_cpp/src/rerun/components/point3d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/radius.cpp
+++ b/rerun_cpp/src/rerun/components/radius.cpp
@@ -5,7 +5,9 @@
 
 #include "../arrow.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -16,24 +18,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FloatBuilder>> Radius::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FloatBuilder>> Radius::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        arrow::Status Radius::fill_arrow_array_builder(
+        Error Radius::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
@@ -41,7 +46,7 @@ namespace rerun {
                 builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Radius::to_data_cell(
@@ -50,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Radius::new_arrow_array_builder(pool));
+            auto builder_result = Radius::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Radius::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -64,11 +71,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Radius::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -7,6 +7,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -6,9 +6,18 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class FloatType;
+    class MemoryPool;
+    using FloatBuilder = NumericBuilder<FloatType>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -33,12 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/transform3d.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/transform3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,35 +19,38 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            Transform3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> Transform3D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Transform3D::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::Transform3D::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status Transform3D::fill_arrow_array_builder(
+        Error Transform3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const Transform3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Transform3D) == sizeof(Transform3D));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Transform3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Transform3D::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Transform3D *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Transform3D::to_data_cell(
@@ -54,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Transform3D::new_arrow_array_builder(pool));
+            auto builder_result = Transform3D::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Transform3D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -69,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Transform3D::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -7,9 +7,14 @@
 #include "../datatypes/transform3d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -35,12 +40,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/components/vector3d.cpp
+++ b/rerun_cpp/src/rerun/components/vector3d.cpp
@@ -6,7 +6,9 @@
 #include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace components {
@@ -17,35 +19,37 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-            Vector3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vector3D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie()
-            );
+            return Result(rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        arrow::Status Vector3D::fill_arrow_array_builder(
+        Error Vector3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Vector3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(Vector3D));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::Vec3D *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> Vector3D::to_data_cell(
@@ -54,9 +58,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, Vector3D::new_arrow_array_builder(pool));
+            auto builder_result = Vector3D::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     Vector3D::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -68,11 +74,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = Vector3D::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -7,9 +7,14 @@
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -54,11 +59,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vector3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -8,6 +8,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.cpp
@@ -3,7 +3,8 @@
 
 #include "angle.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -16,14 +17,14 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> Angle::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> Angle::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::DenseUnionBuilder>(
+            return Result(std::make_shared<arrow::DenseUnionBuilder>(
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::NullBuilder>(memory_pool),
@@ -34,14 +35,17 @@ namespace rerun {
             ));
         }
 
-        arrow::Status Angle::fill_arrow_array_builder(
+        Error Angle::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const Angle *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -72,7 +76,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -3,10 +3,17 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
 #include <cstring>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -92,12 +99,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder *builder, const Angle *elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
@@ -6,7 +6,8 @@
 #include "color.hpp"
 #include "label.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -19,31 +20,35 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            AnnotationInfo::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::StructBuilder>> AnnotationInfo::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::UInt16Builder>(memory_pool),
-                    rerun::datatypes::Label::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::Color::new_arrow_array_builder(memory_pool).ValueOrDie(),
+                    rerun::datatypes::Label::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::Color::new_arrow_array_builder(memory_pool).value,
                 })
             ));
         }
 
-        arrow::Status AnnotationInfo::fill_arrow_array_builder(
+        Error AnnotationInfo::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AnnotationInfo *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -59,7 +64,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.label.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Label::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Label::fill_arrow_array_builder(
                             field_builder,
                             &element.label.value(),
                             1
@@ -75,7 +80,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.color.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Color::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Color::fill_arrow_array_builder(
                             field_builder,
                             &element.color.value(),
                             1
@@ -87,7 +92,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -8,6 +8,7 @@
 #include "label.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
 

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -3,13 +3,19 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "color.hpp"
 #include "label.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -46,12 +52,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AnnotationInfo* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/class_description.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.cpp
@@ -6,7 +6,8 @@
 #include "annotation_info.hpp"
 #include "keypoint_pair.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -35,47 +36,48 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            ClassDescription::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::StructBuilder>> ClassDescription::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::AnnotationInfo::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                    rerun::datatypes::AnnotationInfo::new_arrow_array_builder(memory_pool).value,
                     std::make_shared<arrow::ListBuilder>(
                         memory_pool,
-                        rerun::datatypes::AnnotationInfo::new_arrow_array_builder(memory_pool)
-                            .ValueOrDie()
+                        rerun::datatypes::AnnotationInfo::new_arrow_array_builder(memory_pool).value
                     ),
                     std::make_shared<arrow::ListBuilder>(
                         memory_pool,
-                        rerun::datatypes::KeypointPair::new_arrow_array_builder(memory_pool)
-                            .ValueOrDie()
+                        rerun::datatypes::KeypointPair::new_arrow_array_builder(memory_pool).value
                     ),
                 })
             ));
         }
 
-        arrow::Status ClassDescription::fill_arrow_array_builder(
+        Error ClassDescription::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const ClassDescription *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
                 auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(0));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].info,
                         1
@@ -93,13 +95,11 @@ namespace rerun {
                     const auto &element = elements[elem_idx];
                     ARROW_RETURN_NOT_OK(field_builder->Append());
                     if (element.keypoint_annotations.data()) {
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
-                                value_builder,
-                                element.keypoint_annotations.data(),
-                                element.keypoint_annotations.size()
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
+                            value_builder,
+                            element.keypoint_annotations.data(),
+                            element.keypoint_annotations.size()
+                        ));
                     }
                 }
             }
@@ -114,19 +114,17 @@ namespace rerun {
                     const auto &element = elements[elem_idx];
                     ARROW_RETURN_NOT_OK(field_builder->Append());
                     if (element.keypoint_connections.data()) {
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::KeypointPair::fill_arrow_array_builder(
-                                value_builder,
-                                element.keypoint_connections.data(),
-                                element.keypoint_connections.size()
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::KeypointPair::fill_arrow_array_builder(
+                            value_builder,
+                            element.keypoint_connections.data(),
+                            element.keypoint_connections.size()
+                        ));
                     }
                 }
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -8,6 +8,7 @@
 #include "keypoint_pair.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -3,12 +3,18 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "annotation_info.hpp"
 #include "keypoint_pair.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -56,12 +62,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const ClassDescription* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
@@ -6,7 +6,8 @@
 #include "class_description.hpp"
 #include "class_id.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -22,39 +23,41 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
+        Result<std::shared_ptr<arrow::StructBuilder>>
             ClassDescriptionMapElem::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::ClassId::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::ClassDescription::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                    rerun::datatypes::ClassId::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::ClassDescription::new_arrow_array_builder(memory_pool).value,
                 })
             ));
         }
 
-        arrow::Status ClassDescriptionMapElem::fill_arrow_array_builder(
+        Error ClassDescriptionMapElem::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const ClassDescriptionMapElem *elements,
             size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].class_id,
                         1
@@ -65,18 +68,16 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(1));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(
-                        rerun::datatypes::ClassDescription::fill_arrow_array_builder(
-                            field_builder,
-                            &elements[elem_idx].class_description,
-                            1
-                        )
-                    );
+                    RR_RETURN_NOT_OK(rerun::datatypes::ClassDescription::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].class_description,
+                        1
+                    ));
                 }
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -8,6 +8,7 @@
 #include "class_id.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -3,12 +3,18 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "class_description.hpp"
 #include "class_id.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -34,12 +40,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const ClassDescriptionMapElem* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/class_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.cpp
@@ -3,7 +3,8 @@
 
 #include "class_id.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,24 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt16Builder>> ClassId::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt16Builder>> ClassId::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::UInt16Builder>(memory_pool));
+            return Result(std::make_shared<arrow::UInt16Builder>(memory_pool));
         }
 
-        arrow::Status ClassId::fill_arrow_array_builder(
+        Error ClassId::fill_arrow_array_builder(
             arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->id));
@@ -37,7 +41,7 @@ namespace rerun {
                 builder->AppendValues(&elements->id, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/class_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.hpp
@@ -3,9 +3,20 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt16Type;
+    using UInt16Builder = NumericBuilder<UInt16Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -27,12 +38,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/color.cpp
+++ b/rerun_cpp/src/rerun/datatypes/color.cpp
@@ -3,7 +3,8 @@
 
 #include "color.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,24 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt32Builder>> Color::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt32Builder>> Color::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
+            return Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
         }
 
-        arrow::Status Color::fill_arrow_array_builder(
+        Error Color::fill_arrow_array_builder(
             arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->rgba));
@@ -37,7 +41,7 @@ namespace rerun {
                 builder->AppendValues(&elements->rgba, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/color.hpp
+++ b/rerun_cpp/src/rerun/datatypes/color.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/color.hpp
+++ b/rerun_cpp/src/rerun/datatypes/color.hpp
@@ -3,9 +3,20 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt32Type;
+    using UInt32Builder = NumericBuilder<UInt32Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -57,12 +68,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
@@ -3,7 +3,8 @@
 
 #include "keypoint_id.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,24 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt16Builder>> KeypointId::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::UInt16Builder>> KeypointId::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::UInt16Builder>(memory_pool));
+            return Result(std::make_shared<arrow::UInt16Builder>(memory_pool));
         }
 
-        arrow::Status KeypointId::fill_arrow_array_builder(
+        Error KeypointId::fill_arrow_array_builder(
             arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->id));
@@ -37,7 +41,7 @@ namespace rerun {
                 builder->AppendValues(&elements->id, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
@@ -3,9 +3,20 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt16Type;
+    using UInt16Builder = NumericBuilder<UInt16Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -27,12 +38,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt16Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
@@ -5,7 +5,8 @@
 
 #include "keypoint_id.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -17,38 +18,41 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> KeypointPair::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> KeypointPair::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).ValueOrDie(),
+                    rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).value,
                 })
             ));
         }
 
-        arrow::Status KeypointPair::fill_arrow_array_builder(
+        Error KeypointPair::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const KeypointPair *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(0));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].keypoint0,
                         1
@@ -59,7 +63,7 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::UInt16Builder *>(builder->field_builder(1));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].keypoint1,
                         1
@@ -68,7 +72,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -7,6 +7,7 @@
 #include "keypoint_id.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -3,11 +3,17 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "keypoint_id.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -33,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const KeypointPair* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/label.cpp
+++ b/rerun_cpp/src/rerun/datatypes/label.cpp
@@ -3,7 +3,8 @@
 
 #include "label.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,24 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StringBuilder>> Label::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StringBuilder>> Label::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StringBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        arrow::Status Label::fill_arrow_array_builder(
+        Error Label::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const Label* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -37,7 +41,7 @@ namespace rerun {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].value));
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/label.hpp
+++ b/rerun_cpp/src/rerun/datatypes/label.hpp
@@ -3,10 +3,17 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
 #include <string>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StringBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -38,12 +45,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const Label* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/label.hpp
+++ b/rerun_cpp/src/rerun/datatypes/label.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -3,7 +3,8 @@
 
 #include "mat3x3.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -13,28 +14,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Mat3x3::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Mat3x3::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FixedSizeListBuilder>(
+            return Result(std::make_shared<arrow::FixedSizeListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool),
                 9
             ));
         }
 
-        arrow::Status Mat3x3::fill_arrow_array_builder(
+        Error Mat3x3::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Mat3x3 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -47,7 +51,7 @@ namespace rerun {
                 nullptr
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -7,6 +7,7 @@
 #include "vec3d.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -3,10 +3,16 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -52,11 +58,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Mat3x3* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -3,7 +3,8 @@
 
 #include "mat4x4.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -13,28 +14,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Mat4x4::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Mat4x4::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FixedSizeListBuilder>(
+            return Result(std::make_shared<arrow::FixedSizeListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool),
                 16
             ));
         }
 
-        arrow::Status Mat4x4::fill_arrow_array_builder(
+        Error Mat4x4::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Mat4x4 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -47,7 +51,7 @@ namespace rerun {
                 nullptr
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -3,10 +3,16 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "vec4d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -66,11 +72,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Mat4x4* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -7,6 +7,7 @@
 #include "vec4d.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.cpp
@@ -3,7 +3,8 @@
 
 #include "quaternion.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -13,27 +14,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-            Quaternion::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Quaternion::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FixedSizeListBuilder>(
+            return Result(std::make_shared<arrow::FixedSizeListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool),
                 4
             ));
         }
 
-        arrow::Status Quaternion::fill_arrow_array_builder(
+        Error Quaternion::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Quaternion *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -46,7 +51,7 @@ namespace rerun {
                 nullptr
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -3,8 +3,15 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -43,11 +50,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Quaternion* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
@@ -6,7 +6,8 @@
 #include "quaternion.hpp"
 #include "rotation_axis_angle.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -27,32 +28,35 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            Rotation3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> Rotation3D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::DenseUnionBuilder>(
+            return Result(std::make_shared<arrow::DenseUnionBuilder>(
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::NullBuilder>(memory_pool),
-                    rerun::datatypes::Quaternion::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::RotationAxisAngle::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                    rerun::datatypes::Quaternion::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::RotationAxisAngle::new_arrow_array_builder(memory_pool).value,
                 }),
                 to_arrow_datatype()
             ));
         }
 
-        arrow::Status Rotation3D::fill_arrow_array_builder(
+        Error Rotation3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const Rotation3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -71,7 +75,7 @@ namespace rerun {
                     case detail::Rotation3DTag::Quaternion: {
                         auto variant_builder =
                             static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Quaternion::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Quaternion::fill_arrow_array_builder(
                             variant_builder,
                             &union_instance._data.quaternion,
                             1
@@ -81,7 +85,7 @@ namespace rerun {
                     case detail::Rotation3DTag::AxisAngle: {
                         auto variant_builder =
                             static_cast<arrow::StructBuilder *>(variant_builder_untyped);
-                        ARROW_RETURN_NOT_OK(
+                        RR_RETURN_NOT_OK(
                             rerun::datatypes::RotationAxisAngle::fill_arrow_array_builder(
                                 variant_builder,
                                 &union_instance._data.axis_angle,
@@ -93,7 +97,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -3,13 +3,19 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "quaternion.hpp"
 #include "rotation_axis_angle.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <cstring>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -109,12 +115,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder *builder, const Rotation3D *elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
@@ -6,7 +6,8 @@
 #include "angle.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -18,30 +19,34 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            RotationAxisAngle::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::StructBuilder>> RotationAxisAngle::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::Angle::new_arrow_array_builder(memory_pool).ValueOrDie(),
+                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::Angle::new_arrow_array_builder(memory_pool).value,
                 })
             ));
         }
 
-        arrow::Status RotationAxisAngle::fill_arrow_array_builder(
+        Error RotationAxisAngle::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const RotationAxisAngle *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -49,7 +54,7 @@ namespace rerun {
                     static_cast<arrow::FixedSizeListBuilder *>(builder->field_builder(0));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].axis,
                         1
@@ -61,7 +66,7 @@ namespace rerun {
                     static_cast<arrow::DenseUnionBuilder *>(builder->field_builder(1));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::Angle::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::Angle::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].angle,
                         1
@@ -70,7 +75,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -8,6 +8,7 @@
 #include "vec3d.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -3,11 +3,17 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "angle.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -36,12 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const RotationAxisAngle* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.cpp
@@ -5,7 +5,8 @@
 
 #include "vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -18,32 +19,35 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> Scale3D::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> Scale3D::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::DenseUnionBuilder>(
+            return Result(std::make_shared<arrow::DenseUnionBuilder>(
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::NullBuilder>(memory_pool),
-                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie(),
+                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value,
                     std::make_shared<arrow::FloatBuilder>(memory_pool),
                 }),
                 to_arrow_datatype()
             ));
         }
 
-        arrow::Status Scale3D::fill_arrow_array_builder(
+        Error Scale3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const Scale3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -62,7 +66,7 @@ namespace rerun {
                     case detail::Scale3DTag::ThreeD: {
                         auto variant_builder =
                             static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                             variant_builder,
                             &union_instance._data.three_d,
                             1
@@ -78,7 +82,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -3,12 +3,18 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <cstring>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -108,12 +114,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder *builder, const Scale3D *elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.cpp
@@ -6,7 +6,8 @@
 #include "translation_and_mat3x3.hpp"
 #include "translation_rotation_scale3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -27,35 +28,39 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            Transform3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> Transform3D::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::DenseUnionBuilder>(
+            return Result(std::make_shared<arrow::DenseUnionBuilder>(
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::NullBuilder>(memory_pool),
                     rerun::datatypes::TranslationAndMat3x3::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                        .value,
                     rerun::datatypes::TranslationRotationScale3D::new_arrow_array_builder(
                         memory_pool
                     )
-                        .ValueOrDie(),
+                        .value,
                 }),
                 to_arrow_datatype()
             ));
         }
 
-        arrow::Status Transform3D::fill_arrow_array_builder(
+        Error Transform3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const Transform3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -74,7 +79,7 @@ namespace rerun {
                     case detail::Transform3DTag::TranslationAndMat3x3: {
                         auto variant_builder =
                             static_cast<arrow::StructBuilder *>(variant_builder_untyped);
-                        ARROW_RETURN_NOT_OK(
+                        RR_RETURN_NOT_OK(
                             rerun::datatypes::TranslationAndMat3x3::fill_arrow_array_builder(
                                 variant_builder,
                                 &union_instance._data.translation_and_mat3x3,
@@ -86,7 +91,7 @@ namespace rerun {
                     case detail::Transform3DTag::TranslationRotationScale: {
                         auto variant_builder =
                             static_cast<arrow::StructBuilder *>(variant_builder_untyped);
-                        ARROW_RETURN_NOT_OK(
+                        RR_RETURN_NOT_OK(
                             rerun::datatypes::TranslationRotationScale3D::fill_arrow_array_builder(
                                 variant_builder,
                                 &union_instance._data.translation_rotation_scale,
@@ -98,7 +103,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -3,13 +3,19 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "translation_and_mat3x3.hpp"
 #include "translation_rotation_scale3d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <cstring>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -108,12 +114,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder *builder, const Transform3D *elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
@@ -6,7 +6,8 @@
 #include "mat3x3.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -19,31 +20,35 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            TranslationAndMat3x3::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::StructBuilder>> TranslationAndMat3x3::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::Mat3x3::new_arrow_array_builder(memory_pool).ValueOrDie(),
+                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::Mat3x3::new_arrow_array_builder(memory_pool).value,
                     std::make_shared<arrow::BooleanBuilder>(memory_pool),
                 })
             ));
         }
 
-        arrow::Status TranslationAndMat3x3::fill_arrow_array_builder(
+        Error TranslationAndMat3x3::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const TranslationAndMat3x3 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -53,7 +58,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.translation.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                             field_builder,
                             &element.translation.value(),
                             1
@@ -70,7 +75,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.matrix.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Mat3x3::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Mat3x3::fill_arrow_array_builder(
                             field_builder,
                             &element.matrix.value(),
                             1
@@ -90,7 +95,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -8,6 +8,7 @@
 #include "vec3d.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -3,12 +3,18 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "mat3x3.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -65,12 +71,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TranslationAndMat3x3* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
@@ -7,7 +7,8 @@
 #include "scale3d.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -21,33 +22,36 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
+        Result<std::shared_ptr<arrow::StructBuilder>>
             TranslationRotationScale3D::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::Rotation3D::new_arrow_array_builder(memory_pool).ValueOrDie(),
-                    rerun::datatypes::Scale3D::new_arrow_array_builder(memory_pool).ValueOrDie(),
+                    rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::Rotation3D::new_arrow_array_builder(memory_pool).value,
+                    rerun::datatypes::Scale3D::new_arrow_array_builder(memory_pool).value,
                     std::make_shared<arrow::BooleanBuilder>(memory_pool),
                 })
             ));
         }
 
-        arrow::Status TranslationRotationScale3D::fill_arrow_array_builder(
+        Error TranslationRotationScale3D::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const TranslationRotationScale3D *elements,
             size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -57,7 +61,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.translation.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
                             field_builder,
                             &element.translation.value(),
                             1
@@ -74,7 +78,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.rotation.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Rotation3D::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Rotation3D::fill_arrow_array_builder(
                             field_builder,
                             &element.rotation.value(),
                             1
@@ -91,7 +95,7 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.scale.has_value()) {
-                        ARROW_RETURN_NOT_OK(rerun::datatypes::Scale3D::fill_arrow_array_builder(
+                        RR_RETURN_NOT_OK(rerun::datatypes::Scale3D::fill_arrow_array_builder(
                             field_builder,
                             &element.scale.value(),
                             1
@@ -111,7 +115,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -3,13 +3,19 @@
 
 #pragma once
 
+#include "../result.hpp"
 #include "rotation3d.hpp"
 #include "scale3d.hpp"
 #include "vec3d.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -176,12 +182,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TranslationRotationScale3D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -9,6 +9,7 @@
 #include "vec3d.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 namespace arrow {

--- a/rerun_cpp/src/rerun/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.cpp
@@ -3,7 +3,8 @@
 
 #include "vec2d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -13,28 +14,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec2D::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec2D::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FixedSizeListBuilder>(
+            return Result(std::make_shared<arrow::FixedSizeListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool),
                 2
             ));
         }
 
-        arrow::Status Vec2D::fill_arrow_array_builder(
+        Error Vec2D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Vec2D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -47,7 +51,7 @@ namespace rerun {
                 nullptr
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -3,8 +3,15 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -35,11 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vec2D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.cpp
@@ -3,7 +3,8 @@
 
 #include "vec3d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -13,28 +14,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec3D::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec3D::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FixedSizeListBuilder>(
+            return Result(std::make_shared<arrow::FixedSizeListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool),
                 3
             ));
         }
 
-        arrow::Status Vec3D::fill_arrow_array_builder(
+        Error Vec3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Vec3D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -47,7 +51,7 @@ namespace rerun {
                 nullptr
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -3,8 +3,15 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -39,11 +46,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vec3D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.cpp
@@ -3,7 +3,8 @@
 
 #include "vec4d.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -13,28 +14,31 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec4D::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FixedSizeListBuilder>> Vec4D::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FixedSizeListBuilder>(
+            return Result(std::make_shared<arrow::FixedSizeListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool),
                 4
             ));
         }
 
-        arrow::Status Vec4D::fill_arrow_array_builder(
+        Error Vec4D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder *builder, const Vec4D *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -47,7 +51,7 @@ namespace rerun {
                 nullptr
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -3,8 +3,15 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
+#include "../result.hpp"
+
 #include <cstdint>
+
+namespace arrow {
+    class DataType;
+    class FixedSizeListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -43,11 +50,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
-                new_arrow_array_builder(arrow::MemoryPool* memory_pool);
+            static Result<std::shared_ptr<arrow::FixedSizeListBuilder>> new_arrow_array_builder(
+                arrow::MemoryPool* memory_pool
+            );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vec4D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -6,6 +6,7 @@
 #include "../result.hpp"
 
 #include <cstdint>
+#include <memory>
 
 namespace arrow {
     class DataType;

--- a/rerun_cpp/src/rerun/error.hpp
+++ b/rerun_cpp/src/rerun/error.hpp
@@ -13,13 +13,23 @@ namespace arrow {
 
 struct rr_error;
 
+/// Return error if a given rerun::Error producing expression is not rerun::ErrorCode::Ok.
+#define RR_RETURN_NOT_OK(status_expr)      \
+    do {                                   \
+        const auto _status_ = status_expr; \
+        if (_status_.is_err()) {           \
+            return _status_;               \
+        }                                  \
+    } while (false)
+
 namespace rerun {
     /// Status codes returned by the SDK as part of `Status`.
     ///
     /// Category codes are used to group errors together, but are never returned directly.
     enum class ErrorCode : uint32_t {
-        Ok = 0,
-        OutOfMemory = 1,
+        Ok = 0x0000'0000,
+        OutOfMemory = 0x0000'0001,
+        NotImplemented = 0x0000'0002,
 
         // Invalid argument errors.
         _CategoryArgument = 0x0000'0010,
@@ -85,6 +95,11 @@ namespace rerun {
 
         /// Construct from an arrow status.
         Error(const arrow::Status& status);
+
+        /// Creates a new error set to ok.
+        static Error ok() {
+            return Error();
+        }
 
         /// Compare two errors for equality. Requires the description to match.
         bool operator==(const Error& other) const {

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -24,8 +24,6 @@
 #include "../components/affix_fuzzer8.hpp"
 #include "../components/affix_fuzzer9.hpp"
 
-#include <arrow/api.h>
-
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> AffixFuzzer1::to_data_cells() const {

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -24,7 +24,6 @@
 #include "../components/affix_fuzzer8.hpp"
 #include "../components/affix_fuzzer9.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,36 +19,38 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer1::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer1::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer1::fill_arrow_array_builder(
+        Error AffixFuzzer1::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer1 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(AffixFuzzer1));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::AffixFuzzer1 *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer1::to_data_cell(
@@ -55,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer1::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer1::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer1::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -70,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer1::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -5,11 +5,16 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
@@ -3,7 +3,9 @@
 
 #include "affix_fuzzer10.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -15,24 +17,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StringBuilder>> AffixFuzzer10::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StringBuilder>> AffixFuzzer10::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StringBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        arrow::Status AffixFuzzer10::fill_arrow_array_builder(
+        Error AffixFuzzer10::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -45,7 +50,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer10::to_data_cell(
@@ -54,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer10::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer10::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer10::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -69,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer10::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
@@ -3,13 +3,18 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StringBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
@@ -3,7 +3,9 @@
 
 #include "affix_fuzzer11.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -15,27 +17,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer11::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer11::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::FloatBuilder>(memory_pool)
             ));
         }
 
-        arrow::Status AffixFuzzer11::fill_arrow_array_builder(
+        Error AffixFuzzer11::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer11 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
@@ -56,7 +61,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer11::to_data_cell(
@@ -65,9 +70,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer11::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer11::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer11::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -80,11 +87,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer11::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
@@ -3,13 +3,18 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer11* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
@@ -3,7 +3,9 @@
 
 #include "affix_fuzzer12.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -15,27 +17,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer12::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer12::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::StringBuilder>(memory_pool)
             ));
         }
 
-        arrow::Status AffixFuzzer12::fill_arrow_array_builder(
+        Error AffixFuzzer12::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer12 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::StringBuilder *>(builder->value_builder());
@@ -53,7 +58,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer12::to_data_cell(
@@ -62,9 +67,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer12::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer12::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer12::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -77,11 +84,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer12::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
@@ -3,13 +3,18 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer12* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
@@ -3,7 +3,9 @@
 
 #include "affix_fuzzer13.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -15,27 +17,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer13::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer13::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
                 std::make_shared<arrow::StringBuilder>(memory_pool)
             ));
         }
 
-        arrow::Status AffixFuzzer13::fill_arrow_array_builder(
+        Error AffixFuzzer13::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer13 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::StringBuilder *>(builder->value_builder());
@@ -58,7 +63,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer13::to_data_cell(
@@ -67,9 +72,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer13::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer13::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer13::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -82,11 +89,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer13::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
@@ -11,6 +10,12 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -36,12 +41,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer13* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,35 +19,38 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            AffixFuzzer14::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> AffixFuzzer14::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer14::fill_arrow_array_builder(
+        Error AffixFuzzer14::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const AffixFuzzer14 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::AffixFuzzer3) == sizeof(AffixFuzzer14));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::AffixFuzzer3 *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer14::to_data_cell(
@@ -54,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer14::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer14::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer14::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -69,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer14::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -5,11 +5,16 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer14* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,31 +19,34 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            AffixFuzzer15::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> AffixFuzzer15::new_arrow_array_builder(
+            arrow::MemoryPool* memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer15::fill_arrow_array_builder(
+        Error AffixFuzzer15::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             (void)num_elements;
-            return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
+            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer15::to_data_cell(
@@ -50,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer15::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer15::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer15::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -65,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer15::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
@@ -5,12 +5,17 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -37,12 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -19,27 +21,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer16::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer16::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
-                rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).ValueOrDie()
+                rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
             ));
         }
 
-        arrow::Status AffixFuzzer16::fill_arrow_array_builder(
+        Error AffixFuzzer16::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer16 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
@@ -50,7 +55,7 @@ namespace rerun {
                 const auto &element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.many_required_unions.data()) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
                         value_builder,
                         element.many_required_unions.data(),
                         element.many_required_unions.size()
@@ -58,7 +63,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer16::to_data_cell(
@@ -67,9 +72,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer16::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer16::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer16::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -82,11 +89,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer16::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
@@ -5,12 +5,17 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -37,12 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -19,27 +21,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer17::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer17::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
-                rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).ValueOrDie()
+                rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
             ));
         }
 
-        arrow::Status AffixFuzzer17::fill_arrow_array_builder(
+        Error AffixFuzzer17::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer17 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
@@ -51,20 +56,18 @@ namespace rerun {
                 if (element.many_optional_unions.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());
                     if (element.many_optional_unions.value().data()) {
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
-                                value_builder,
-                                element.many_optional_unions.value().data(),
-                                element.many_optional_unions.value().size()
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                            value_builder,
+                            element.many_optional_unions.value().data(),
+                            element.many_optional_unions.value().size()
+                        ));
                     }
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer17::to_data_cell(
@@ -73,9 +76,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer17::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer17::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer17::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -88,11 +93,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer17::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
@@ -5,13 +5,18 @@
 
 #include "../datatypes/affix_fuzzer3.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -40,12 +45,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer4.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -19,27 +21,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer18::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer18::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
-                rerun::datatypes::AffixFuzzer4::new_arrow_array_builder(memory_pool).ValueOrDie()
+                rerun::datatypes::AffixFuzzer4::new_arrow_array_builder(memory_pool).value
             ));
         }
 
-        arrow::Status AffixFuzzer18::fill_arrow_array_builder(
+        Error AffixFuzzer18::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer18 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::DenseUnionBuilder *>(builder->value_builder());
@@ -51,20 +56,18 @@ namespace rerun {
                 if (element.many_optional_unions.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());
                     if (element.many_optional_unions.value().data()) {
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
-                                value_builder,
-                                element.many_optional_unions.value().data(),
-                                element.many_optional_unions.value().size()
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
+                            value_builder,
+                            element.many_optional_unions.value().data(),
+                            element.many_optional_unions.value().size()
+                        ));
                     }
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer18::to_data_cell(
@@ -73,9 +76,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer18::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer18::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer18::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -88,11 +93,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer18::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
@@ -5,13 +5,18 @@
 
 #include "../datatypes/affix_fuzzer4.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -40,12 +45,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer4.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer5.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,36 +19,38 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer19::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer19::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer5::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer5::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer19::fill_arrow_array_builder(
+        Error AffixFuzzer19::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer19 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::AffixFuzzer5) == sizeof(AffixFuzzer19));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer5::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer5::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::AffixFuzzer5 *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer19::to_data_cell(
@@ -55,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer19::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer19::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer19::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -70,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer19::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -7,6 +7,7 @@
 #include "../datatypes/affix_fuzzer5.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -6,12 +6,17 @@
 #include "../datatypes/affix_fuzzer4.hpp"
 #include "../datatypes/affix_fuzzer5.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -39,12 +44,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer19* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,36 +19,38 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer2::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer2::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer2::fill_arrow_array_builder(
+        Error AffixFuzzer2::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer2 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(AffixFuzzer2));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::AffixFuzzer1 *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer2::to_data_cell(
@@ -55,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer2::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer2::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer2::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -70,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer2::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -5,11 +5,16 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer20.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,36 +19,39 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer20::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer20::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer20::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(
+                rerun::datatypes::AffixFuzzer20::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer20::fill_arrow_array_builder(
+        Error AffixFuzzer20::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer20 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::AffixFuzzer20) == sizeof(AffixFuzzer20));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer20::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer20::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::AffixFuzzer20 *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer20::to_data_cell(
@@ -55,9 +60,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer20::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer20::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer20::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -70,11 +77,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer20::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -5,11 +5,16 @@
 
 #include "../datatypes/affix_fuzzer20.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer20.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,36 +19,38 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer3::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer3::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer3::fill_arrow_array_builder(
+        Error AffixFuzzer3::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer3 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(AffixFuzzer3));
-            ARROW_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
                 builder,
                 reinterpret_cast<const rerun::datatypes::AffixFuzzer1 *>(elements),
                 num_elements
             ));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer3::to_data_cell(
@@ -55,9 +59,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer3::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer3::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer3::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -70,11 +76,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer3::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -5,11 +5,16 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -34,12 +39,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,32 +19,34 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer4::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer4::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer4::fill_arrow_array_builder(
+        Error AffixFuzzer4::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             (void)num_elements;
-            return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
+            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer4::to_data_cell(
@@ -51,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer4::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer4::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer4::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -66,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer4::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
@@ -5,12 +5,17 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -36,12 +41,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,32 +19,34 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer5::fill_arrow_array_builder(
+        Error AffixFuzzer5::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             (void)num_elements;
-            return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
+            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer5::to_data_cell(
@@ -51,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer5::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer5::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer5::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -66,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer5::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
@@ -5,12 +5,17 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -36,12 +41,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -17,32 +19,34 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer6::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer6::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+            return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        arrow::Status AffixFuzzer6::fill_arrow_array_builder(
+        Error AffixFuzzer6::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             (void)num_elements;
-            return arrow::Status::NotImplemented(("TODO(andreas) Handle nullable extensions"));
+            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer6::to_data_cell(
@@ -51,9 +55,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer6::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer6::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer6::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -66,11 +72,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer6::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
@@ -5,12 +5,17 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -36,12 +41,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
@@ -5,7 +5,9 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -19,27 +21,30 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer7::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::ListBuilder>> AffixFuzzer7::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::ListBuilder>(
+            return Result(std::make_shared<arrow::ListBuilder>(
                 memory_pool,
-                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).ValueOrDie()
+                rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             ));
         }
 
-        arrow::Status AffixFuzzer7::fill_arrow_array_builder(
+        Error AffixFuzzer7::fill_arrow_array_builder(
             arrow::ListBuilder *builder, const AffixFuzzer7 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             auto value_builder = static_cast<arrow::StructBuilder *>(builder->value_builder());
@@ -51,20 +56,18 @@ namespace rerun {
                 if (element.many_optional.has_value()) {
                     ARROW_RETURN_NOT_OK(builder->Append());
                     if (element.many_optional.value().data()) {
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
-                                value_builder,
-                                element.many_optional.value().data(),
-                                element.many_optional.value().size()
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+                            value_builder,
+                            element.many_optional.value().data(),
+                            element.many_optional.value().size()
+                        ));
                     }
                 } else {
                     ARROW_RETURN_NOT_OK(builder->AppendNull());
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer7::to_data_cell(
@@ -73,9 +76,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool *pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer7::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer7::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer7::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -88,11 +93,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer7::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
@@ -5,13 +5,18 @@
 
 #include "../datatypes/affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class ListBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -38,12 +43,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
@@ -6,6 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
@@ -3,12 +3,21 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class FloatType;
+    class MemoryPool;
+    using FloatBuilder = NumericBuilder<FloatType>;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -33,12 +42,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const AffixFuzzer8* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
@@ -3,7 +3,9 @@
 
 #include "affix_fuzzer9.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
 #include <rerun/arrow.hpp>
 
 namespace rerun {
@@ -15,24 +17,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StringBuilder>> AffixFuzzer9::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StringBuilder>> AffixFuzzer9::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StringBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        arrow::Status AffixFuzzer9::fill_arrow_array_builder(
+        Error AffixFuzzer9::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -40,7 +45,7 @@ namespace rerun {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].single_string_required));
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
 
         Result<rerun::DataCell> AffixFuzzer9::to_data_cell(
@@ -49,9 +54,11 @@ namespace rerun {
             // TODO(andreas): Allow configuring the memory pool.
             arrow::MemoryPool* pool = arrow::default_memory_pool();
 
-            ARROW_ASSIGN_OR_RAISE(auto builder, AffixFuzzer9::new_arrow_array_builder(pool));
+            auto builder_result = AffixFuzzer9::new_arrow_array_builder(pool);
+            RR_RETURN_NOT_OK(builder_result.error);
+            auto builder = std::move(builder_result.value);
             if (instances && num_instances > 0) {
-                ARROW_RETURN_NOT_OK(
+                RR_RETURN_NOT_OK(
                     AffixFuzzer9::fill_arrow_array_builder(builder.get(), instances, num_instances)
                 );
             }
@@ -64,11 +71,9 @@ namespace rerun {
 
             rerun::DataCell cell;
             cell.component_name = AffixFuzzer9::NAME;
-            const auto result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            if (result.is_err()) {
-                return result.error;
-            }
-            cell.buffer = std::move(result.value);
+            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+            RR_RETURN_NOT_OK(ipc_result.error);
+            cell.buffer = std::move(ipc_result.value);
 
             return cell;
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
@@ -3,12 +3,17 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StringBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace components {
@@ -33,12 +38,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.cpp
@@ -5,7 +5,8 @@
 
 #include "flattened_scalar.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -40,14 +41,14 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer1::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer1::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
@@ -67,21 +68,23 @@ namespace rerun {
                         std::make_shared<arrow::StringBuilder>(memory_pool)
                     ),
                     std::make_shared<arrow::FloatBuilder>(memory_pool),
-                    rerun::datatypes::FlattenedScalar::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                    rerun::datatypes::FlattenedScalar::new_arrow_array_builder(memory_pool).value,
                     std::make_shared<arrow::BooleanBuilder>(memory_pool),
                 })
             ));
         }
 
-        arrow::Status AffixFuzzer1::fill_arrow_array_builder(
+        Error AffixFuzzer1::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer1 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -194,7 +197,7 @@ namespace rerun {
                 auto field_builder = static_cast<arrow::StructBuilder *>(builder->field_builder(7));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::FlattenedScalar::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::FlattenedScalar::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].almost_flattened_scalar,
                         1
@@ -216,7 +219,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
@@ -6,6 +6,7 @@
 #include "flattened_scalar.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/result.hpp>
 #include <string>

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
@@ -5,11 +5,17 @@
 
 #include "flattened_scalar.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <rerun/result.hpp>
 #include <string>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -39,12 +45,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.cpp
@@ -3,7 +3,8 @@
 
 #include "affix_fuzzer2.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,24 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::FloatBuilder>> AffixFuzzer2::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::FloatBuilder>> AffixFuzzer2::new_arrow_array_builder(
             arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        arrow::Status AffixFuzzer2::fill_arrow_array_builder(
+        Error AffixFuzzer2::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -42,7 +46,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
@@ -3,10 +3,20 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class FloatType;
+    class MemoryPool;
+    using FloatBuilder = NumericBuilder<FloatType>;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -28,12 +38,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::FloatBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.cpp
@@ -6,7 +6,8 @@
 #include "primitive_component.hpp"
 #include "string_component.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -18,53 +19,53 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer20::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer20::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     rerun::datatypes::PrimitiveComponent::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
-                    rerun::datatypes::StringComponent::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                        .value,
+                    rerun::datatypes::StringComponent::new_arrow_array_builder(memory_pool).value,
                 })
             ));
         }
 
-        arrow::Status AffixFuzzer20::fill_arrow_array_builder(
+        Error AffixFuzzer20::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer20 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
                 auto field_builder = static_cast<arrow::UInt32Builder *>(builder->field_builder(0));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(
-                        rerun::datatypes::PrimitiveComponent::fill_arrow_array_builder(
-                            field_builder,
-                            &elements[elem_idx].p,
-                            1
-                        )
-                    );
+                    RR_RETURN_NOT_OK(rerun::datatypes::PrimitiveComponent::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].p,
+                        1
+                    ));
                 }
             }
             {
                 auto field_builder = static_cast<arrow::StringBuilder *>(builder->field_builder(1));
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    ARROW_RETURN_NOT_OK(rerun::datatypes::StringComponent::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(rerun::datatypes::StringComponent::fill_arrow_array_builder(
                         field_builder,
                         &elements[elem_idx].s,
                         1
@@ -73,7 +74,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
@@ -7,6 +7,7 @@
 #include "string_component.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <rerun/result.hpp>
 
 namespace arrow {

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
@@ -6,8 +6,14 @@
 #include "primitive_component.hpp"
 #include "string_component.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+#include <rerun/result.hpp>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -23,12 +29,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -5,7 +5,8 @@
 
 #include "affix_fuzzer1.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -32,13 +33,14 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            AffixFuzzer3::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> AffixFuzzer3::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::DenseUnionBuilder>(
+            return Result(std::make_shared<arrow::DenseUnionBuilder>(
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::NullBuilder>(memory_pool),
@@ -46,8 +48,7 @@ namespace rerun {
                     std::make_shared<arrow::FloatBuilder>(memory_pool),
                     std::make_shared<arrow::ListBuilder>(
                         memory_pool,
-                        rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool)
-                            .ValueOrDie()
+                        rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
                     ),
                     std::make_shared<arrow::FixedSizeListBuilder>(
                         memory_pool,
@@ -59,14 +60,17 @@ namespace rerun {
             ));
         }
 
-        arrow::Status AffixFuzzer3::fill_arrow_array_builder(
+        Error AffixFuzzer3::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const AffixFuzzer3 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -103,7 +107,8 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder *>(variant_builder_untyped);
                         (void)variant_builder;
-                        return arrow::Status::NotImplemented(
+                        return Error(
+                            ErrorCode::NotImplemented,
                             "TODO(andreas): list types in unions are not yet supported"
                         );
                         break;
@@ -112,7 +117,8 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::FixedSizeListBuilder *>(variant_builder_untyped);
                         (void)variant_builder;
-                        return arrow::Status::NotImplemented(
+                        return Error(
+                            ErrorCode::NotImplemented,
                             "TODO(andreas): list types in unions are not yet supported"
                         );
                         break;
@@ -120,7 +126,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -5,13 +5,19 @@
 
 #include "affix_fuzzer1.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <cstring>
 #include <new>
 #include <optional>
+#include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -152,12 +158,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder *builder, const AffixFuzzer3 *elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <new>
 #include <optional>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -5,7 +5,8 @@
 
 #include "affix_fuzzer3.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -39,41 +40,42 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>>
-            AffixFuzzer4::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::DenseUnionBuilder>> AffixFuzzer4::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::DenseUnionBuilder>(
+            return Result(std::make_shared<arrow::DenseUnionBuilder>(
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
                     std::make_shared<arrow::NullBuilder>(memory_pool),
-                    rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                    rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value,
                     std::make_shared<arrow::ListBuilder>(
                         memory_pool,
-                        rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool)
-                            .ValueOrDie()
+                        rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
                     ),
                     std::make_shared<arrow::ListBuilder>(
                         memory_pool,
-                        rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool)
-                            .ValueOrDie()
+                        rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
                     ),
                 }),
                 to_arrow_datatype()
             ));
         }
 
-        arrow::Status AffixFuzzer4::fill_arrow_array_builder(
+        Error AffixFuzzer4::fill_arrow_array_builder(
             arrow::DenseUnionBuilder *builder, const AffixFuzzer4 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -92,20 +94,19 @@ namespace rerun {
                     case detail::AffixFuzzer4Tag::single_required: {
                         auto variant_builder =
                             static_cast<arrow::DenseUnionBuilder *>(variant_builder_untyped);
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
-                                variant_builder,
-                                &union_instance._data.single_required,
-                                1
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                            variant_builder,
+                            &union_instance._data.single_required,
+                            1
+                        ));
                         break;
                     }
                     case detail::AffixFuzzer4Tag::many_required: {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder *>(variant_builder_untyped);
                         (void)variant_builder;
-                        return arrow::Status::NotImplemented(
+                        return Error(
+                            ErrorCode::NotImplemented,
                             "TODO(andreas): list types in unions are not yet supported"
                         );
                         break;
@@ -114,7 +115,8 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder *>(variant_builder_untyped);
                         (void)variant_builder;
-                        return arrow::Status::NotImplemented(
+                        return Error(
+                            ErrorCode::NotImplemented,
                             "TODO(andreas): list types in unions are not yet supported"
                         );
                         break;
@@ -122,7 +124,7 @@ namespace rerun {
                 }
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <new>
 #include <optional>
 #include <rerun/result.hpp>

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -5,13 +5,19 @@
 
 #include "affix_fuzzer3.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <cstring>
 #include <new>
 #include <optional>
+#include <rerun/result.hpp>
 #include <utility>
 #include <vector>
+
+namespace arrow {
+    class DataType;
+    class DenseUnionBuilder;
+    class MemoryPool;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -153,12 +159,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType> &to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::DenseUnionBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool *memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder *builder, const AffixFuzzer4 *elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.cpp
@@ -5,7 +5,8 @@
 
 #include "affix_fuzzer4.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -20,31 +21,33 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(
+        Result<std::shared_ptr<arrow::StructBuilder>> AffixFuzzer5::new_arrow_array_builder(
             arrow::MemoryPool *memory_pool
         ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
-                    rerun::datatypes::AffixFuzzer4::new_arrow_array_builder(memory_pool)
-                        .ValueOrDie(),
+                    rerun::datatypes::AffixFuzzer4::new_arrow_array_builder(memory_pool).value,
                 })
             ));
         }
 
-        arrow::Status AffixFuzzer5::fill_arrow_array_builder(
+        Error AffixFuzzer5::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const AffixFuzzer5 *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -54,13 +57,11 @@ namespace rerun {
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                     const auto &element = elements[elem_idx];
                     if (element.single_optional_union.has_value()) {
-                        ARROW_RETURN_NOT_OK(
-                            rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
-                                field_builder,
-                                &element.single_optional_union.value(),
-                                1
-                            )
-                        );
+                        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
+                            field_builder,
+                            &element.single_optional_union.value(),
+                            1
+                        ));
                     } else {
                         ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                     }
@@ -68,7 +69,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
@@ -6,6 +6,7 @@
 #include "affix_fuzzer4.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
@@ -5,10 +5,16 @@
 
 #include "affix_fuzzer4.hpp"
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
 #include <optional>
+#include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -32,12 +38,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.cpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.cpp
@@ -3,7 +3,8 @@
 
 #include "flattened_scalar.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -14,13 +15,14 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StructBuilder>>
-            FlattenedScalar::new_arrow_array_builder(arrow::MemoryPool *memory_pool) {
+        Result<std::shared_ptr<arrow::StructBuilder>> FlattenedScalar::new_arrow_array_builder(
+            arrow::MemoryPool *memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StructBuilder>(
+            return Result(std::make_shared<arrow::StructBuilder>(
                 to_arrow_datatype(),
                 memory_pool,
                 std::vector<std::shared_ptr<arrow::ArrayBuilder>>({
@@ -29,14 +31,17 @@ namespace rerun {
             ));
         }
 
-        arrow::Status FlattenedScalar::fill_arrow_array_builder(
+        Error FlattenedScalar::fill_arrow_array_builder(
             arrow::StructBuilder *builder, const FlattenedScalar *elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             {
@@ -48,7 +53,7 @@ namespace rerun {
             }
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
@@ -3,9 +3,15 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+#include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StructBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -26,12 +32,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StructBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const FlattenedScalar* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <rerun/result.hpp>
 #include <utility>
 

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.cpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.cpp
@@ -3,7 +3,8 @@
 
 #include "primitive_component.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,23 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::UInt32Builder>>
-            PrimitiveComponent::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+        Result<std::shared_ptr<arrow::UInt32Builder>> PrimitiveComponent::new_arrow_array_builder(
+            arrow::MemoryPool* memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
+            return Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
         }
 
-        arrow::Status PrimitiveComponent::fill_arrow_array_builder(
+        Error PrimitiveComponent::fill_arrow_array_builder(
             arrow::UInt32Builder* builder, const PrimitiveComponent* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             static_assert(sizeof(*elements) == sizeof(elements->value));
@@ -36,7 +41,7 @@ namespace rerun {
                 builder->AppendValues(&elements->value, static_cast<int64_t>(num_elements))
             );
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
@@ -3,9 +3,19 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+#include <rerun/result.hpp>
 #include <utility>
+
+namespace arrow {
+    template <typename T>
+    class NumericBuilder;
+
+    class DataType;
+    class MemoryPool;
+    class UInt32Type;
+    using UInt32Builder = NumericBuilder<UInt32Type>;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -26,12 +36,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::UInt32Builder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const PrimitiveComponent* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <rerun/result.hpp>
 #include <utility>
 

--- a/rerun_cpp/tests/generated/datatypes/string_component.cpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.cpp
@@ -3,7 +3,8 @@
 
 #include "string_component.hpp"
 
-#include <arrow/api.h>
+#include <arrow/builder.h>
+#include <arrow/type_fwd.h>
 
 namespace rerun {
     namespace datatypes {
@@ -12,23 +13,27 @@ namespace rerun {
             return datatype;
         }
 
-        arrow::Result<std::shared_ptr<arrow::StringBuilder>>
-            StringComponent::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
+        Result<std::shared_ptr<arrow::StringBuilder>> StringComponent::new_arrow_array_builder(
+            arrow::MemoryPool* memory_pool
+        ) {
             if (!memory_pool) {
-                return arrow::Status::Invalid("Memory pool is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
-            return arrow::Result(std::make_shared<arrow::StringBuilder>(memory_pool));
+            return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        arrow::Status StringComponent::fill_arrow_array_builder(
+        Error StringComponent::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const StringComponent* elements, size_t num_elements
         ) {
             if (!builder) {
-                return arrow::Status::Invalid("Passed array builder is null.");
+                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (!elements) {
-                return arrow::Status::Invalid("Cannot serialize null pointer to arrow array.");
+                return Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Cannot serialize null pointer to arrow array."
+                );
             }
 
             ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
@@ -36,7 +41,7 @@ namespace rerun {
                 ARROW_RETURN_NOT_OK(builder->Append(elements[elem_idx].value));
             }
 
-            return arrow::Status::OK();
+            return Error::ok();
         }
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/string_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>

--- a/rerun_cpp/tests/generated/datatypes/string_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.hpp
@@ -3,10 +3,16 @@
 
 #pragma once
 
-#include <arrow/type_fwd.h>
 #include <cstdint>
+#include <rerun/result.hpp>
 #include <string>
 #include <utility>
+
+namespace arrow {
+    class DataType;
+    class MemoryPool;
+    class StringBuilder;
+} // namespace arrow
 
 namespace rerun {
     namespace datatypes {
@@ -27,12 +33,12 @@ namespace rerun {
             static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();
 
             /// Creates a new array builder with an array of this type.
-            static arrow::Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
+            static Result<std::shared_ptr<arrow::StringBuilder>> new_arrow_array_builder(
                 arrow::MemoryPool* memory_pool
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static arrow::Status fill_arrow_array_builder(
+            static Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const StringComponent* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/header_checks.cpp
+++ b/rerun_cpp/tests/header_checks.cpp
@@ -1,0 +1,13 @@
+#include <rerun.hpp>
+
+// ARROW_EXPORT is included by <arrow/util/visibility.h>
+// ARROW_EXPAND is included by <arrow/util/macros.h>
+// Both are included by almost all arrow headers.
+#if defined(ARROW_EXPORT) || defined(ARROW_EXPAND)
+static_assert(
+    false,
+    "ARROW_EXPORT or ARROW_EXPAND should not be defined. This indicates that we're leaking arrow "
+    "headers through "
+    "rerun.hpp!"
+);
+#endif


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/2919
* Fixes https://github.com/rerun-io/rerun/issues/2873

### What

We now use our own status type everywhere, allowing us to predeclare everything arrow.
On top of that I made sure that we include a much more minimal set of arrow headers for the serialization code itself.

There's a static assertion in the unit test that ensures that we don't start leaking arrow headers into the future

Haven't measured, but it feels like this also improved compile times of the sdk which were already pretty good.

-----------

The one thing that's noted in #2873 but is not happening here yet (?) is splitting out the utility methods. The idea  would be this (actual generated code I already have on a test branch!) :
```cpp
        struct LineStrip2D {
// .........
            /// Creates a Rerun DataCell from an array of LineStrip2D components.
            static Result<rerun::DataCell> to_data_cell(
                const LineStrip2D* instances, size_t num_instances
            );
        };

        /// Serialization utilities for arrays of LineStrip2D
        namespace LineStrip2DSerializationUtils {
            /// Returns the arrow data type this type corresponds to.
            static const std::shared_ptr<arrow::DataType>& to_arrow_datatype();

            /// Creates a new array builder with an array of this type.
            static Result<std::shared_ptr<arrow::ListBuilder>> new_arrow_array_builder(
                arrow::MemoryPool* memory_pool
            );

            /// Fills an arrow array builder with an array of this type.
            static Error fill_arrow_array_builder(
                arrow::ListBuilder* builder, const LineStrip2D* elements, size_t num_elements
            );
        } // namespace LineStrip2DSerializationUtils
```

The problem is that this makes calling these helpers unnecessary complicated sicne I need to append `SerializationUtils` to the typename of some previously static method calls which is suprisingly cumbersome 🤔 
EDIT: Briefly chatted with Emil about it. Let's do it, it's actually not that hard

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3041) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3041)
- [Docs preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fdont-leak-arrow-headers/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aandreas%2Fcpp%2Fdont-leak-arrow-headers/examples)
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)