### PR TITLE
C++ CMake: let users chose dynamic or static linking for Arrow

### DIFF
--- a/rerun_cpp/tests/CMakeLists.txt
+++ b/rerun_cpp/tests/CMakeLists.txt
@@ -17,6 +17,25 @@ add_executable(rerun_sdk_tests ${rerun_sdk_tests_SRC})
 
 set_default_warning_settings(rerun_sdk_tests)
 
+
+# -----------------------------------------------------------------------------
+# Arrow:
+option(ARROW_LINK_SHARED "Link to the Arrow shared library" ON)
+
+find_package(Arrow REQUIRED)
+
+# Arrow requires a C++17 compliant compiler
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+message(STATUS "Arrow version: ${ARROW_VERSION}")
+message(STATUS "Arrow SO version: ${ARROW_FULL_SO_VERSION}")
+
+if(ARROW_LINK_SHARED)
+    target_link_libraries(rerun_sdk_tests PRIVATE Arrow::arrow_shared)
+else()
+    target_link_libraries(rerun_sdk_tests PRIVATE Arrow::arrow_static)
+endif()
+
 # Include arrow explicitly again, otherwise the arrow headers won't be declared as system headers.
 # and instead become regular headers, causing warnings to be emitted.
-target_link_libraries(rerun_sdk_tests PRIVATE loguru::loguru Catch2::Catch2 Arrow::arrow_static rerun_sdk)
+target_link_libraries(rerun_sdk_tests PRIVATE loguru::loguru Catch2::Catch2 rerun_sdk)


### PR DESCRIPTION
```
CMake Error at rerun_cpp/tests/CMakeLists.txt:22 (target_link_libraries):
  Target "rerun_sdk_tests" links to:

    Arrow::arrow_static

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3059) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3059)
- [Docs preview](https://rerun.io/preview/pr%3Acmc%2Ffix_cpp_test_build/docs)
- [Examples preview](https://rerun.io/preview/pr%3Acmc%2Ffix_cpp_test_build/examples)
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)