### PR TITLE
Fix GitHub labels used in our weekly releases

### DIFF
--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -40,9 +40,7 @@ jobs:
           branch: "weekly-release-${{ env.CRATE_VERSION }}"
           commit-message: "[weekly-release] ${{ env.CRATE_VERSION }}"
           title: "Release ${{ env.CRATE_VERSION }}"
-          labels: |
-            "⛴ release"
-            "exclude from changelog"
+          labels: "⛴ release, exclude from changelog"
           committer: "Rerun Bot <bot@rerun.io>"
           author: "Rerun Bot <bot@rerun.io>"
           body: |

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -40,7 +40,9 @@ jobs:
           branch: "weekly-release-${{ env.CRATE_VERSION }}"
           commit-message: "[weekly-release] ${{ env.CRATE_VERSION }}"
           title: "Release ${{ env.CRATE_VERSION }}"
-          labels: "⛴ release, exclude from changelog"
+          labels: |
+            ⛴ release
+            exclude from changelog
           committer: "Rerun Bot <bot@rerun.io>"
           author: "Rerun Bot <bot@rerun.io>"
           body: |


### PR DESCRIPTION
See https://github.com/rerun-io/rerun/pull/3057:

<img width="617" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/140bebd8-fbd7-4354-ba7b-af574f9e4608">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3061) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3061)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-weekly-release-labels/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Ffix-weekly-release-labels/examples)
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)