### PR TITLE
Use deterministic flushing when building web demo `.rrd` files

### DIFF
--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -83,7 +83,7 @@ jobs:
 
           for file in web_demo/examples/**/*.rrd; do
             name=$(basename $(dirname "$file"))
-            entries+=("$name.rrd:$file:kiB")
+            entries+=("$name.rrd:$file:MiB")
           done
 
           data=$(python3 scripts/ci/sizes.py measure "${entries[@]}")

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -78,12 +78,12 @@ jobs:
         run: |
           entries=()
 
-          entries+=("Wasm:web_viewer/re_viewer_bg.wasm:MB")
-          entries+=("JS:web_viewer/re_viewer.js:KB")
+          entries+=("Wasm:web_viewer/re_viewer_bg.wasm:MiB")
+          entries+=("JS:web_viewer/re_viewer.js:KiB")
 
           for file in web_demo/examples/**/*.rrd; do
             name=$(basename $(dirname "$file"))
-            entries+=("$name.rrd:$file:KB")
+            entries+=("$name.rrd:$file:KiB")
           done
 
           data=$(python3 scripts/ci/sizes.py measure "${entries[@]}")

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -79,11 +79,11 @@ jobs:
           entries=()
 
           entries+=("Wasm:web_viewer/re_viewer_bg.wasm:MiB")
-          entries+=("JS:web_viewer/re_viewer.js:KiB")
+          entries+=("JS:web_viewer/re_viewer.js:kiB")
 
           for file in web_demo/examples/**/*.rrd; do
             name=$(basename $(dirname "$file"))
-            entries+=("$name.rrd:$file:KiB")
+            entries+=("$name.rrd:$file:kiB")
           done
 
           data=$(python3 scripts/ci/sizes.py measure "${entries[@]}")

--- a/scripts/ci/build_demo_app.py
+++ b/scripts/ci/build_demo_app.py
@@ -58,7 +58,7 @@ class Example:
             check=True,
         )
 
-        print(f"{rrd_path}: {os.path.getsize(rrd_path) / 1e6:.1f} MB")
+        print(f"{rrd_path}: {os.path.getsize(rrd_path) / (1024 * 1024):.1f} MiB")
 
     def supports_save(self) -> bool:
         with open(self.path) as f:

--- a/scripts/ci/build_demo_app.py
+++ b/scripts/ci/build_demo_app.py
@@ -47,8 +47,14 @@ class Example:
             f"--save={rrd_path}",
         ]
 
+        # Configure flushing so that:
+        # * the resulting file size is deterministic
+        # * the file is chunked into small batches for better streaming
+        env = {**os.environ, "RERUN_FLUSH_TICK_SECS": "1000000000", "RERUN_FLUSH_NUM_BYTES": str(128 * 1024)}
+
         subprocess.run(
             args + self.build_args,
+            env=env,
             check=True,
         )
 

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -142,7 +142,7 @@ def compare(previous_path: str, current_path: str, threshold: float) -> None:
             value = entry["previous"]["value"]
             unit = entry["previous"]["unit"]
 
-            rows.append((name, f"{value:.2f} {unit}", "(deleted)", "-100%"))
+            rows.append((name, f"{value} {unit}", "(deleted)", "-100%"))
 
     if len(rows) > 0:
         sys.stdout.write(render_table_rows(rows, headers))

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -12,7 +12,7 @@ Use the script:
         "Wasm (release)":web_viewer/re_viewer_bg.wasm \
         "Wasm (debug)":web_viewer/re_viewer_debug_bg.wasm
 
-    python3 scripts/ci/sizes.py measure --format=table \
+    python3 scripts/ci/sizes.py measure --format=github \
         "Wasm (release)":web_viewer/re_viewer_bg.wasm \
         "Wasm (debug)":web_viewer/re_viewer_debug_bg.wasm
 
@@ -30,7 +30,7 @@ from typing import Any
 
 
 def get_unit(size: int | float) -> str:
-    UNITS = ["B", "KB", "MB", "GB", "TB"]
+    UNITS = ["B", "kiB", "MiB", "GiB", "TiB"]
 
     unit_index = 0
     while size > 1024:
@@ -42,19 +42,19 @@ def get_unit(size: int | float) -> str:
 
 DIVISORS = {
     "B": 1,
-    "KB": 1024,
-    "MB": 1024 * 1024,
-    "GB": 1024 * 1024 * 1024,
-    "TB": 1024 * 1024 * 1024 * 1024,
+    "kiB": 1024,
+    "MiB": 1024 * 1024,
+    "GiB": 1024 * 1024 * 1024,
+    "TiB": 1024 * 1024 * 1024 * 1024,
 }
 
 
 def get_divisor(unit: str) -> int:
-    return DIVISORS[unit.upper()] or 1
+    return DIVISORS[unit]
 
 
 def cell(value: float, div: float) -> str:
-    return str(round(value / div, 3))
+    return f"{value / div:.2f}"
 
 
 def render_table_dict(data: list[dict[str, str]]) -> str:
@@ -130,19 +130,19 @@ def compare(previous_path: str, current_path: str, threshold: float) -> None:
                         name,
                         f"{cell(previous, div)} {unit}",
                         f"{cell(current, div)} {unit}",
-                        sign + str(change) + "%",
+                        f"{sign}{change:.2f}%",
                     )
                 )
         elif "current" in entry:
             value = entry["current"]["value"]
             unit = entry["current"]["unit"]
 
-            rows.append((name, "(none)", f"{value} {unit}", "+100%"))
+            rows.append((name, "(none)", f"{value:.2f} {unit}", "+100%"))
         elif "previous" in entry:
             value = entry["previous"]["value"]
             unit = entry["previous"]["unit"]
 
-            rows.append((name, f"{value} {unit}", "(deleted)", "-100%"))
+            rows.append((name, f"{value:.2f} {unit}", "(deleted)", "-100%"))
 
     if len(rows) > 0:
         sys.stdout.write(render_table_rows(rows, headers))
@@ -162,7 +162,7 @@ def measure(files: list[str], format: Format) -> None:
         output.append(
             {
                 "name": name,
-                "value": str(round(size / div, 3)),
+                "value": str(round(size / div, 2)),
                 "unit": unit,
             }
         )

--- a/scripts/ci/sizes.py
+++ b/scripts/ci/sizes.py
@@ -137,7 +137,7 @@ def compare(previous_path: str, current_path: str, threshold: float) -> None:
             value = entry["current"]["value"]
             unit = entry["current"]["unit"]
 
-            rows.append((name, "(none)", f"{value:.2f} {unit}", "+100%"))
+            rows.append((name, "(none)", f"{value} {unit}", "+100%"))
         elif "previous" in entry:
             value = entry["previous"]["value"]
             unit = entry["previous"]["unit"]


### PR DESCRIPTION
### What

I saw this in https://github.com/rerun-io/rerun/pull/3063
<img width="482" alt="Screenshot 2023-08-22 at 13 40 24" src="https://github.com/rerun-io/rerun/assets/1148717/dd741d41-641d-41a2-89d1-77311b719879">

and spotted several problems:

A) there was nothing in that PR changing the .rrd files
B) the comparison format uses way too many decimals
C) the comparison uses "KB" which isn't a unit

The first problem should be fixed by turning off time-based batch flushing (first commit).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3064) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3064)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Fdeterministic-web-demo/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Fdeterministic-web-demo/examples)
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)