### PR TITLE
Make use of `EditableAutoValue` implementing `Deref`

### DIFF
--- a/crates/re_data_store/src/editable_auto_value.rs
+++ b/crates/re_data_store/src/editable_auto_value.rs
@@ -75,6 +75,8 @@ where
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.get()
+        match self {
+            EditableAutoValue::Auto(v) | EditableAutoValue::UserEdited(v) => v,
+        }
     }
 }

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -186,7 +186,7 @@ impl TransformContext {
                 &child_tree.path,
                 data_store,
                 query,
-                |p| *entity_properties.get(p).pinhole_image_plane_distance.get(),
+                |p| *entity_properties.get(p).pinhole_image_plane_distance,
                 &mut encountered_pinhole,
             ) {
                 Err(unreachable_reason) => {

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -223,9 +223,8 @@ fn update_transform3d_lines_heuristics(
         if let Some(pinhole_path) = is_pinhole_extrinsics_of(ctx.store_db.store(), ent_path, ctx) {
             // If there's a pinhole, we orient ourselves on its image plane distance
             let pinhole_path_props = entity_properties.get(pinhole_path);
-            properties.transform_3d_size = EditableAutoValue::Auto(
-                pinhole_path_props.pinhole_image_plane_distance.get() * 0.25,
-            );
+            properties.transform_3d_size =
+                EditableAutoValue::Auto(*pinhole_path_props.pinhole_image_plane_distance * 0.25);
         } else {
             // Size should be proportional to the scene extent, here covered by its diagonal
             let diagonal_length = (scene_bbox_accum.max - scene_bbox_accum.min).length();

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -61,7 +61,7 @@ impl CamerasPart {
                 return;
             };
 
-        let frustum_length = *props.pinhole_image_plane_distance.get();
+        let frustum_length = *props.pinhole_image_plane_distance;
 
         // If the camera is our reference, there is nothing for us to display.
         if transforms.reference_path() == ent_path {

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -225,7 +225,7 @@ impl ImagesPart {
                 }
             };
 
-            if *ent_props.backproject_depth.get() && tensor.meaning == TensorDataMeaning::Depth {
+            if *ent_props.backproject_depth && tensor.meaning == TensorDataMeaning::Depth {
                 if let Some(parent_pinhole_path) = transforms.parent_pinhole(ent_path) {
                     // NOTE: we don't pass in `world_from_obj` because this corresponds to the
                     // transform of the projection plane, which is of no use to us here.
@@ -342,11 +342,11 @@ impl ImagesPart {
             &tensor_stats,
         )?;
 
-        let depth_from_world_scale = *properties.depth_from_world_scale.get();
+        let depth_from_world_scale = *properties.depth_from_world_scale;
 
         let world_depth_from_texture_depth = 1.0 / depth_from_world_scale;
 
-        let colormap = match *properties.color_mapper.get() {
+        let colormap = match *properties.color_mapper {
             re_data_store::ColorMapper::Colormap(colormap) => match colormap {
                 re_data_store::Colormap::Grayscale => Colormap::Grayscale,
                 re_data_store::Colormap::Turbo => Colormap::Turbo,
@@ -362,7 +362,7 @@ impl ImagesPart {
         // at that distance.
         let fov_y = intrinsics.fov_y().unwrap_or(1.0);
         let pixel_width_from_depth = (0.5 * fov_y).tan() / (0.5 * height as f32);
-        let radius_scale = *properties.backproject_radius_scale.get();
+        let radius_scale = *properties.backproject_radius_scale;
         let point_radius_from_world_depth = radius_scale * pixel_width_from_depth;
 
         Ok(DepthCloud {

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -51,7 +51,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
                 continue;
             }
 
-            if !props.transform_3d_visible.get() {
+            if !*props.transform_3d_visible {
                 continue;
             }
 
@@ -72,7 +72,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
                 &mut line_builder,
                 world_from_obj,
                 Some(ent_path),
-                *props.transform_3d_size.get(),
+                *props.transform_3d_size,
                 query
                     .highlights
                     .entity_outline_mask(ent_path.hash())

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -439,7 +439,7 @@ fn pinhole_props_ui(
         .is_some()
     {
         ui.label("Image plane distance");
-        let mut distance = *entity_props.pinhole_image_plane_distance.get();
+        let mut distance = *entity_props.pinhole_image_plane_distance;
         let speed = (distance * 0.05).at_least(0.01);
         if ui
             .add(
@@ -477,7 +477,7 @@ fn depth_props_ui(
         .query_latest_component_at_closest_ancestor::<Pinhole>(entity_path, &query)?
         .0;
 
-    let mut backproject_depth = *entity_props.backproject_depth.get();
+    let mut backproject_depth = *entity_props.backproject_depth;
 
     if ctx
         .re_ui

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -241,8 +241,8 @@ impl TimeControl {
                 self.following = false;
 
                 // Start from beginning if we are at the end:
-                if let Some(time_points) = times_per_timeline.get(self.timeline.get()) {
-                    if let Some(state) = self.states.get_mut(self.timeline.get()) {
+                if let Some(time_points) = times_per_timeline.get(&self.timeline) {
+                    if let Some(state) = self.states.get_mut(&self.timeline) {
                         if max(time_points) <= state.time {
                             state.time = min(time_points).into();
                         }
@@ -256,7 +256,7 @@ impl TimeControl {
                 self.playing = true;
                 self.following = true;
 
-                if let Some(time_points) = times_per_timeline.get(self.timeline.get()) {
+                if let Some(time_points) = times_per_timeline.get(&self.timeline) {
                     // Set the time to the max:
                     match self.states.entry(*self.timeline) {
                         std::collections::btree_map::Entry::Vacant(entry) => {
@@ -308,8 +308,8 @@ impl TimeControl {
     }
 
     pub fn restart(&mut self, times_per_timeline: &TimesPerTimeline) {
-        if let Some(time_points) = times_per_timeline.get(self.timeline.get()) {
-            if let Some(state) = self.states.get_mut(self.timeline.get()) {
+        if let Some(time_points) = times_per_timeline.get(&self.timeline) {
+            if let Some(state) = self.states.get_mut(&self.timeline) {
                 state.time = min(time_points).into();
                 self.following = false;
             }
@@ -344,8 +344,8 @@ impl TimeControl {
             // the beginning in play mode.
 
             // Start from beginning if we are at the end:
-            if let Some(time_points) = times_per_timeline.get(self.timeline.get()) {
-                if let Some(state) = self.states.get_mut(self.timeline.get()) {
+            if let Some(time_points) = times_per_timeline.get(&self.timeline) {
+                if let Some(state) = self.states.get_mut(&self.timeline) {
                     if max(time_points) <= state.time {
                         state.time = min(time_points).into();
                         self.playing = true;
@@ -380,7 +380,7 @@ impl TimeControl {
 
     /// playback fps
     pub fn set_fps(&mut self, fps: f32) {
-        if let Some(state) = self.states.get_mut(self.timeline.get()) {
+        if let Some(state) = self.states.get_mut(&self.timeline) {
             state.fps = fps;
         }
     }
@@ -407,7 +407,7 @@ impl TimeControl {
     /// The currently selected timeline
     #[inline]
     pub fn timeline(&self) -> &Timeline {
-        self.timeline.get()
+        &self.timeline
     }
 
     /// The time type of the currently selected timeline
@@ -473,7 +473,7 @@ impl TimeControl {
 
     /// Remove the current loop selection.
     pub fn remove_loop_selection(&mut self) {
-        if let Some(state) = self.states.get_mut(self.timeline.get()) {
+        if let Some(state) = self.states.get_mut(&self.timeline) {
             state.loop_selection = None;
         }
         if self.looping() == Looping::Selection {
@@ -525,7 +525,7 @@ impl TimeControl {
 
     /// The range of time we are currently zoomed in on.
     pub fn reset_time_view(&mut self) {
-        if let Some(state) = self.states.get_mut(self.timeline.get()) {
+        if let Some(state) = self.states.get_mut(&self.timeline) {
             state.view = None;
         }
     }


### PR DESCRIPTION
Treat `EditableAutoValue` like a smart pointer.

Remove a lot of ugly `.get()`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3067) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3067)
- [Docs preview](https://rerun.io/preview/pr%3Aemilk%2Feditable-auto-deref/docs)
- [Examples preview](https://rerun.io/preview/pr%3Aemilk%2Feditable-auto-deref/examples)
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)