### PR TITLE
Make AutoSpaceView default consistently when resetting blueprint

### DIFF
--- a/crates/re_viewport/src/blueprint_components/viewport.rs
+++ b/crates/re_viewport/src/blueprint_components/viewport.rs
@@ -1,6 +1,6 @@
 use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
 
-use re_log_types::{serde_field::SerdeField, ComponentName, LegacyComponent};
+use re_log_types::{serde_field::SerdeField, ComponentName, LegacyComponent, StoreInfo};
 
 pub use re_viewer_context::SpaceViewId;
 
@@ -18,9 +18,15 @@ pub const VIEWPORT_PATH: &str = "viewport";
 ///     DataType::Boolean
 /// );
 /// ```
-#[derive(Clone, Default, ArrowField, ArrowSerialize, ArrowDeserialize)]
+#[derive(Clone, ArrowField, ArrowSerialize, ArrowDeserialize)]
 #[arrow_field(transparent)]
 pub struct AutoSpaceViews(pub bool);
+
+impl AutoSpaceViews {
+    pub fn default_for(store_info: Option<&StoreInfo>) -> Self {
+        Self(store_info.map_or(false, |ri| ri.is_app_default_blueprint()))
+    }
+}
 
 impl LegacyComponent for AutoSpaceViews {
     #[inline]

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -61,9 +61,9 @@ impl<'a> ViewportBlueprint<'a> {
 
         *space_views = Default::default();
         *tree = Default::default();
-        *maximized = Default::default();
-        *has_been_user_edited = Default::default();
-        *auto_space_views = Default::default();
+        *maximized = None;
+        *has_been_user_edited = false;
+        *auto_space_views = AutoSpaceViews::default_for(self.blueprint_db.store_info()).0;
 
         for space_view in default_created_space_views(ctx, spaces_info) {
             self.add_space_view(space_view);
@@ -303,11 +303,7 @@ pub fn load_viewport_blueprint(blueprint_db: &re_data_store::StoreDb) -> Viewpor
         .query_timeless_component::<AutoSpaceViews>(&VIEWPORT_PATH.into())
         .unwrap_or_else(|| {
             // Only enable auto-space-views if this is the app-default blueprint
-            AutoSpaceViews(
-                blueprint_db
-                    .store_info()
-                    .map_or(false, |ri| ri.is_app_default_blueprint()),
-            )
+            AutoSpaceViews::default_for(blueprint_db.store_info())
         });
 
     let space_view_maximized = blueprint_db


### PR DESCRIPTION
### What
We noticed that although the blueprint "reset" button resets the view and re-runs the heuristics (once), the state we end up in is slightly different from the "default" blueprint state, which is to rerun the heuristics on every frame.

This actually explains some inconsistent behavior we have seen recently as once a blueprint is cached you never actually get the full incremental auto-heuristic behavior again (for better of for worse).

WARNING: this actually introduces a performance regression into scenes with large number of entities because the auto heuristic is currently slow. A potential point of discussion is whether this is the right thing to do.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3077) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3077)
- [Docs preview](https://rerun.io/preview/0d753d044513cdda21f6eff4349f1bbbeda33f75/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0d753d044513cdda21f6eff4349f1bbbeda33f75/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)