### PR TITLE
Fix crash on reaching line number limit

### DIFF
--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -14,12 +14,15 @@
 
 mod channel_logger;
 mod multi_logger;
+mod result_extensions;
 mod setup;
 
 #[cfg(target_arch = "wasm32")]
 mod web_logger;
 
 pub use log::{Level, LevelFilter};
+
+pub use result_extensions::ResultExt;
 
 // The tracing macros support more syntax features than the log, that's why we use them:
 pub use tracing::{debug, error, info, trace, warn};

--- a/crates/re_log/src/result_extensions.rs
+++ b/crates/re_log/src/result_extensions.rs
@@ -1,0 +1,37 @@
+pub trait ResultExt<T, E> {
+    /// Logs an error if the result is an error and returns the result.
+    fn ok_or_log_error(self) -> Option<T>
+    where
+        E: std::fmt::Display;
+
+    /// Unwraps in debug builds otherwise logs an error if the result is an error and returns the result.
+    fn unwrap_debug_or_log_error(self) -> Option<T>
+    where
+        E: std::fmt::Display + std::fmt::Debug;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn ok_or_log_error(self) -> Option<T>
+    where
+        E: std::fmt::Display,
+    {
+        match self {
+            Ok(t) => Some(t),
+            Err(err) => {
+                log::error!("{err}");
+                None
+            }
+        }
+    }
+
+    fn unwrap_debug_or_log_error(self) -> Option<T>
+    where
+        E: std::fmt::Display + std::fmt::Debug,
+    {
+        if cfg!(debug_assertions) {
+            Some(self.unwrap())
+        } else {
+            self.ok_or_log_error()
+        }
+    }
+}

--- a/crates/re_log/src/result_extensions.rs
+++ b/crates/re_log/src/result_extensions.rs
@@ -11,6 +11,7 @@ pub trait ResultExt<T, E> {
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E> {
+    #[track_caller]
     fn ok_or_log_error(self) -> Option<T>
     where
         E: std::fmt::Display,
@@ -18,12 +19,14 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         match self {
             Ok(t) => Some(t),
             Err(err) => {
-                log::error!("{err}");
+                let loc = std::panic::Location::caller();
+                log::error!("{}:{} {err}", loc.file(), loc.line());
                 None
             }
         }
     }
 
+    #[track_caller]
     fn unwrap_debug_or_log_error(self) -> Option<T>
     where
         E: std::fmt::Display + std::fmt::Debug,

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -233,7 +233,7 @@ impl framework::Example for Render2D {
         }
 
         let line_strip_draw_data = line_strip_builder.into_draw_data(re_ctx).unwrap();
-        let point_draw_data = point_cloud_builder.into_draw_data(re_ctx);
+        let point_draw_data = point_cloud_builder.into_draw_data(re_ctx).unwrap();
 
         let image_scale = 4.0;
         let rectangle_draw_data = RectangleDrawData::new(

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -106,7 +106,7 @@ impl RenderDepthClouds {
                 std::iter::empty::<re_renderer::PickingLayerInstanceId>(),
             );
 
-            builder.into_draw_data(re_ctx)
+            builder.into_draw_data(re_ctx).unwrap()
         };
 
         let mut view_builder = ViewBuilder::new(

--- a/crates/re_renderer/examples/multiview.rs
+++ b/crates/re_renderer/examples/multiview.rs
@@ -334,7 +334,7 @@ impl Example for Multiview {
                 std::iter::empty::<re_renderer::PickingLayerInstanceId>(),
             );
 
-        let point_cloud = builder.into_draw_data(re_ctx);
+        let point_cloud = builder.into_draw_data(re_ctx).unwrap();
         let meshes = build_mesh_instances(
             re_ctx,
             &self.model_mesh_instances,

--- a/crates/re_renderer/examples/picking.rs
+++ b/crates/re_renderer/examples/picking.rs
@@ -167,7 +167,7 @@ impl framework::Example for Picking {
                     point_set.picking_ids.iter().cloned(),
                 );
         }
-        view_builder.queue_draw(point_builder.into_draw_data(re_ctx));
+        view_builder.queue_draw(point_builder.into_draw_data(re_ctx).unwrap());
 
         let instances = self
             .model_mesh_instances

--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -5,6 +5,25 @@ use crate::{
     wgpu_resources::{BufferDesc, GpuBuffer, GpuBufferPool},
 };
 
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum CpuWriteGpuReadError {
+    #[error("Buffer is full, can't append more data!")]
+    BufferFull,
+
+    #[error("Target buffer has a size of {target_buffer_size}, can't write {copy_size} bytes with an offset of {destination_offset}!")]
+    TargetBufferTooSmall {
+        target_buffer_size: u64,
+        copy_size: u64,
+        destination_offset: u64,
+    },
+
+    #[error("Target texture doesn't fit the size of the written data to this buffer! Texture size: {target_texture_size} bytes, written data size: {written_data_size} bytes")]
+    TargetTextureBufferSizeMismatch {
+        target_texture_size: u64,
+        written_data_size: usize,
+    },
+}
+
 /// A sub-allocated staging buffer that can be written to.
 ///
 /// Behaves a bit like a fixed sized `Vec` in that far it keeps track of how many elements were written to it.
@@ -57,49 +76,102 @@ where
 
     /// Pushes a slice of elements into the buffer.
     ///
-    /// Panics if the data no longer fits into the buffer.
+    /// If the buffer is not big enough, only the first `self.remaining_capacity()` elements are pushed before returning an error.
     #[inline]
-    pub fn extend_from_slice(&mut self, elements: &[T]) {
+    pub fn extend_from_slice(&mut self, elements: &[T]) -> Result<(), CpuWriteGpuReadError> {
+        let (result, elements) = if elements.len() > self.remaining_capacity() {
+            (
+                Err(CpuWriteGpuReadError::BufferFull),
+                &elements[..self.remaining_capacity()],
+            )
+        } else {
+            (Ok(()), elements)
+        };
+
         let bytes = bytemuck::cast_slice(elements);
         self.as_mut_byte_slice()[..bytes.len()].copy_from_slice(bytes);
         self.unwritten_element_range.start += elements.len();
+
+        result
     }
 
     /// Pushes several elements into the buffer.
     ///
-    /// Panics if there are more elements than there is space in the buffer.
-    ///
-    /// Returns number of elements pushed.
+    /// If the buffer is not big enough, only the first `self.remaining_capacity()` elements are pushed before returning an error.
+    /// Otherwise, returns the number of elements pushed for convenience.
     #[inline]
-    pub fn extend(&mut self, elements: impl Iterator<Item = T>) -> usize {
+    pub fn extend(
+        &mut self,
+        elements: impl Iterator<Item = T>,
+    ) -> Result<usize, CpuWriteGpuReadError> {
         let num_written_before = self.num_written();
+
         for element in elements {
-            self.push(element);
+            if self.unwritten_element_range.start >= self.unwritten_element_range.end {
+                return Err(CpuWriteGpuReadError::BufferFull);
+            }
+
+            self.as_mut_byte_slice()[..std::mem::size_of::<T>()]
+                .copy_from_slice(bytemuck::bytes_of(&element));
+            self.unwritten_element_range.start += 1;
         }
-        self.num_written() - num_written_before
+
+        Ok(self.num_written() - num_written_before)
+    }
+
+    /// Fills the buffer with n instances of an element.
+    ///
+    /// If the buffer is not big enough, only the first `self.remaining_capacity()` elements are pushed before returning an error.
+    pub fn fill_n(&mut self, element: T, num_elements: usize) -> Result<(), CpuWriteGpuReadError> {
+        let (result, num_elements) = if num_elements > self.remaining_capacity() {
+            (
+                Err(CpuWriteGpuReadError::BufferFull),
+                self.remaining_capacity(),
+            )
+        } else {
+            (Ok(()), num_elements)
+        };
+
+        let mut offset = 0;
+        let buffer_bytes = self.as_mut_byte_slice();
+        let element_bytes = bytemuck::bytes_of(&element);
+
+        for _ in 0..num_elements {
+            let end = offset + std::mem::size_of::<T>();
+            buffer_bytes[offset..end].copy_from_slice(element_bytes);
+            offset = end;
+        }
+        self.unwritten_element_range.start += num_elements;
+
+        result
     }
 
     /// Pushes a single element into the buffer and advances the write pointer.
     ///
     /// Panics if the data no longer fits into the buffer.
     #[inline]
-    pub fn push(&mut self, element: T) {
-        assert!(
-            self.unwritten_element_range.start < self.unwritten_element_range.end,
-            "CpuWriteGpuReadBuffer<{}> is full ({} elements written)",
-            std::any::type_name::<T>(),
-            self.unwritten_element_range.start,
-        );
+    pub fn push(&mut self, element: T) -> Result<(), CpuWriteGpuReadError> {
+        if self.remaining_capacity() == 0 {
+            return Err(CpuWriteGpuReadError::BufferFull);
+        }
 
         self.as_mut_byte_slice()[..std::mem::size_of::<T>()]
             .copy_from_slice(bytemuck::bytes_of(&element));
         self.unwritten_element_range.start += 1;
+
+        Ok(())
     }
 
     /// The number of elements pushed into the buffer so far.
     #[inline]
     pub fn num_written(&self) -> usize {
         self.unwritten_element_range.start
+    }
+
+    /// The number of elements that can still be pushed into the buffer.
+    #[inline]
+    pub fn remaining_capacity(&self) -> usize {
+        self.unwritten_element_range.end - self.unwritten_element_range.start
     }
 
     /// Copies all so far written data to a rectangle on a single 2d texture layer.
@@ -114,16 +186,19 @@ where
         encoder: &mut wgpu::CommandEncoder,
         destination: wgpu::ImageCopyTexture<'_>,
         copy_extent: glam::UVec2,
-    ) {
+    ) -> Result<(), CpuWriteGpuReadError> {
         let buffer_info = Texture2DBufferInfo::new(destination.texture.format(), copy_extent);
 
         // Validate that we stay within the written part of the slice (wgpu can't fully know our intention here, so we have to check).
         // We go one step further and require the size to be exactly equal - it's too unlikely that you wrote more than is needed!
         // (and if you did you probably have regrets anyways!)
-        debug_assert_eq!(
-            buffer_info.buffer_size_padded as usize,
-            self.num_written() * std::mem::size_of::<T>()
-        );
+        if buffer_info.buffer_size_padded as usize != self.num_written() * std::mem::size_of::<T>()
+        {
+            return Err(CpuWriteGpuReadError::TargetTextureBufferSizeMismatch {
+                target_texture_size: buffer_info.buffer_size_padded,
+                written_data_size: self.num_written() * std::mem::size_of::<T>(),
+            });
+        }
 
         encoder.copy_buffer_to_texture(
             wgpu::ImageCopyBuffer {
@@ -141,6 +216,8 @@ where
                 depth_or_array_layers: 1,
             },
         );
+
+        Ok(())
     }
 
     /// Copies the entire buffer to another buffer and drops it.
@@ -149,13 +226,17 @@ where
         encoder: &mut wgpu::CommandEncoder,
         destination: &GpuBuffer,
         destination_offset: wgpu::BufferAddress,
-    ) {
+    ) -> Result<(), CpuWriteGpuReadError> {
         let copy_size = (std::mem::size_of::<T>() * self.unwritten_element_range.start) as u64;
 
-        // Wgpu does validation as well, but in debug mode we want to panic if the buffer doesn't fit.
-        debug_assert!(copy_size <= destination_offset + destination.size(),
-            "Target buffer has a size of {}, can't write {copy_size} bytes with an offset of {destination_offset}!",
-            destination.size());
+        // Wgpu does validation as well, but we want to be able to track this error right away.
+        if copy_size > destination_offset + destination.size() {
+            return Err(CpuWriteGpuReadError::TargetBufferTooSmall {
+                target_buffer_size: destination.size(),
+                copy_size,
+                destination_offset,
+            });
+        }
 
         encoder.copy_buffer_to_buffer(
             &self.chunk_buffer,
@@ -164,6 +245,8 @@ where
             destination_offset,
             copy_size,
         );
+
+        Ok(())
     }
 }
 

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -7,7 +7,9 @@ mod cpu_write_gpu_read_belt;
 mod gpu_readback_belt;
 mod uniform_buffer_fill;
 
-pub use cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};
+pub use cpu_write_gpu_read_belt::{
+    CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer, CpuWriteGpuReadError,
+};
 pub use gpu_readback_belt::{
     GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackError, GpuReadbackIdentifier,
     GpuReadbackUserDataStorage,

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -1,3 +1,5 @@
+use re_log::ResultExt;
+
 pub use super::cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};
 
 use crate::{wgpu_resources::BindGroupEntry, DebugLabel, RenderContext};
@@ -75,14 +77,14 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod>(
         &ctx.gpu_resources.buffers,
         num_buffers as _,
     );
-    staging_buffer.extend(content).ok(); // We just allocated the buffer for this exact size.
+    staging_buffer.extend(content).unwrap_debug_or_log_error();
     staging_buffer
         .copy_to_buffer(
             ctx.active_frame.before_view_builder_encoder.lock().get(),
             &buffer,
             0,
         )
-        .ok(); // We just allocated the target buffer for this exact size.
+        .unwrap_debug_or_log_error();
 
     (0..num_buffers)
         .map(|i| BindGroupEntry::Buffer {

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -75,12 +75,14 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod>(
         &ctx.gpu_resources.buffers,
         num_buffers as _,
     );
-    staging_buffer.extend(content);
-    staging_buffer.copy_to_buffer(
-        ctx.active_frame.before_view_builder_encoder.lock().get(),
-        &buffer,
-        0,
-    );
+    staging_buffer.extend(content).ok(); // We just allocated the buffer for this exact size.
+    staging_buffer
+        .copy_to_buffer(
+            ctx.active_frame.before_view_builder_encoder.lock().get(),
+            &buffer,
+            0,
+        )
+        .ok(); // We just allocated the target buffer for this exact size.
 
     (0..num_buffers)
         .map(|i| BindGroupEntry::Buffer {

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use re_log::ResultExt;
+
 use crate::{
     allocator::CpuWriteGpuReadBuffer,
     renderer::{
@@ -190,8 +192,8 @@ impl<'a> LineBatchBuilder<'a> {
     pub fn add_strip(&mut self, points: impl Iterator<Item = glam::Vec3>) -> LineStripBuilder<'_> {
         if self.0.strips.len() >= LineDrawData::MAX_NUM_STRIPS {
             re_log::error_once!(
-                "Reached maximum number of supported line strips of {}.
-     See also https://github.com/rerun-io/rerun/issues/957",
+                "Reached maximum number of supported line strips of {}. \
+                 See also https://github.com/rerun-io/rerun/issues/957",
                 LineDrawData::MAX_NUM_STRIPS
             );
             return LineStripBuilder::placeholder(self.0);
@@ -521,6 +523,6 @@ impl<'a> Drop for LineStripBuilder<'a> {
         self.builder
             .picking_instance_ids_buffer
             .fill_n(self.picking_instance_id, self.strip_range.len())
-            .ok(); // May run out of space, but we should have already handled that earlier.
+            .unwrap_debug_or_log_error(); // May run out of space, but we should have already handled that earlier.
     }
 }

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -231,8 +231,8 @@ impl<'a> LineBatchBuilder<'a> {
     ) -> LineStripBuilder<'_> {
         if self.0.strips.len() >= LineDrawData::MAX_NUM_STRIPS {
             re_log::error_once!(
-                "Reached maximum number of supported line strips of {}.
-     See also https://github.com/rerun-io/rerun/issues/957",
+                "Reached maximum number of supported line strips of {}. \
+                 See also https://github.com/rerun-io/rerun/issues/957",
                 LineDrawData::MAX_NUM_STRIPS
             );
             return LineStripBuilder::placeholder(self.0);

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -188,6 +188,15 @@ impl<'a> LineBatchBuilder<'a> {
 
     /// Adds a 3D series of line connected points.
     pub fn add_strip(&mut self, points: impl Iterator<Item = glam::Vec3>) -> LineStripBuilder<'_> {
+        if self.0.strips.len() >= LineDrawData::MAX_NUM_STRIPS {
+            re_log::error_once!(
+                "Reached maximum number of supported line strips of {}.
+     See also https://github.com/rerun-io/rerun/issues/957",
+                LineDrawData::MAX_NUM_STRIPS
+            );
+            return LineStripBuilder::placeholder(self.0);
+        }
+
         let old_strip_count = self.0.strips.len();
         let old_vertex_count = self.0.vertices.len();
         let strip_index = old_strip_count as _;
@@ -218,6 +227,15 @@ impl<'a> LineBatchBuilder<'a> {
         &mut self,
         segments: impl Iterator<Item = (glam::Vec3, glam::Vec3)>,
     ) -> LineStripBuilder<'_> {
+        if self.0.strips.len() >= LineDrawData::MAX_NUM_STRIPS {
+            re_log::error_once!(
+                "Reached maximum number of supported line strips of {}.
+     See also https://github.com/rerun-io/rerun/issues/957",
+                LineDrawData::MAX_NUM_STRIPS
+            );
+            return LineStripBuilder::placeholder(self.0);
+        }
+
         debug_assert_eq!(
             self.0.strips.len(),
             self.0.picking_instance_ids_buffer.num_written()
@@ -438,6 +456,16 @@ pub struct LineStripBuilder<'a> {
 }
 
 impl<'a> LineStripBuilder<'a> {
+    fn placeholder(series_builder: &'a mut LineStripSeriesBuilder) -> Self {
+        Self {
+            builder: series_builder,
+            outline_mask_ids: OutlineMaskPreference::NONE,
+            picking_instance_id: PickingLayerInstanceId::default(),
+            vertex_range: 0..0,
+            strip_range: 0..0,
+        }
+    }
+
     #[inline]
     pub fn radius(self, radius: Size) -> Self {
         for strip in self.builder.strips[self.strip_range.clone()].iter_mut() {

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -492,6 +492,7 @@ impl<'a> Drop for LineStripBuilder<'a> {
         }
         self.builder
             .picking_instance_ids_buffer
-            .extend(std::iter::repeat(self.picking_instance_id).take(self.strip_range.len()));
+            .fill_n(self.picking_instance_id, self.strip_range.len())
+            .ok(); // May run out of space, but we should have already handled that earlier.
     }
 }

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -230,15 +230,15 @@ impl GpuMesh {
                 &ctx.gpu_resources.buffers,
                 vb_combined_size as _,
             );
-            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_positions));
-            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_colors));
-            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_normals));
-            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_texcoords));
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_positions))?;
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_colors))?;
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_normals))?;
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_texcoords))?;
             staging_buffer.copy_to_buffer(
                 ctx.active_frame.before_view_builder_encoder.lock().get(),
                 &vertex_buffer_combined,
                 0,
-            );
+            )?;
             vertex_buffer_combined
         };
 
@@ -259,12 +259,12 @@ impl GpuMesh {
                 &ctx.gpu_resources.buffers,
                 data.indices.len(),
             );
-            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.indices));
+            staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.indices))?;
             staging_buffer.copy_to_buffer(
                 ctx.active_frame.before_view_builder_encoder.lock().get(),
                 &index_buffer,
                 0,
-            );
+            )?;
             index_buffer
         };
 

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -1,7 +1,10 @@
 use crate::{
     allocator::CpuWriteGpuReadBuffer,
     draw_phases::PickingLayerObjectId,
-    renderer::{PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudVertex},
+    renderer::{
+        PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudDrawDataError,
+        PointCloudVertex,
+    },
     Color32, DebugLabel, DepthOffset, OutlineMaskPreference, PickingLayerInstanceId, RenderContext,
     Size,
 };
@@ -97,7 +100,10 @@ impl PointCloudBuilder {
     }
 
     /// Finalizes the builder and returns a point cloud draw data with all the points added so far.
-    pub fn into_draw_data(self, ctx: &mut crate::context::RenderContext) -> PointCloudDrawData {
+    pub fn into_draw_data(
+        self,
+        ctx: &mut crate::context::RenderContext,
+    ) -> Result<PointCloudDrawData, PointCloudDrawDataError> {
         PointCloudDrawData::new(ctx, self)
     }
 }
@@ -206,22 +212,27 @@ impl<'a> PointCloudBatchBuilder<'a> {
         }
         {
             re_tracing::profile_scope!("colors");
-            let num_written = self.0.color_buffer.extend(colors.take(num_points));
-            // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
-            self.0
-                .color_buffer
-                .extend(std::iter::repeat(Color32::TRANSPARENT).take(num_points - num_written));
+            if let Ok(num_written) = self.0.color_buffer.extend(colors.take(num_points)) {
+                // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
+                self.0
+                    .color_buffer
+                    .fill_n(Color32::TRANSPARENT, num_points - num_written)
+                    .ok();
+            }
         }
         {
             re_tracing::profile_scope!("picking_instance_ids");
-            let num_written = self
+            if let Ok(num_written) = self
                 .0
                 .picking_instance_ids_buffer
-                .extend(picking_instance_ids.take(num_points));
-            // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
-            self.0.picking_instance_ids_buffer.extend(
-                std::iter::repeat(PickingLayerInstanceId::default()).take(num_points - num_written),
-            );
+                .extend(picking_instance_ids.take(num_points))
+            {
+                // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
+                self.0
+                    .picking_instance_ids_buffer
+                    .fill_n(PickingLayerInstanceId::default(), num_points - num_written)
+                    .ok();
+            }
         }
 
         self

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -1,3 +1,5 @@
+use re_log::ResultExt;
+
 use crate::{
     allocator::CpuWriteGpuReadBuffer,
     draw_phases::PickingLayerObjectId,
@@ -212,26 +214,32 @@ impl<'a> PointCloudBatchBuilder<'a> {
         }
         {
             re_tracing::profile_scope!("colors");
-            if let Ok(num_written) = self.0.color_buffer.extend(colors.take(num_points)) {
+            if let Some(num_written) = self
+                .0
+                .color_buffer
+                .extend(colors.take(num_points))
+                .unwrap_debug_or_log_error()
+            {
                 // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
                 self.0
                     .color_buffer
                     .fill_n(Color32::TRANSPARENT, num_points - num_written)
-                    .ok();
+                    .unwrap_debug_or_log_error();
             }
         }
         {
             re_tracing::profile_scope!("picking_instance_ids");
-            if let Ok(num_written) = self
+            if let Some(num_written) = self
                 .0
                 .picking_instance_ids_buffer
                 .extend(picking_instance_ids.take(num_points))
+                .unwrap_debug_or_log_error()
             {
                 // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
                 self.0
                     .picking_instance_ids_buffer
                     .fill_n(PickingLayerInstanceId::default(), num_points - num_written)
-                    .ok();
+                    .unwrap_debug_or_log_error();
             }
         }
 

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -343,6 +343,9 @@ pub enum LineDrawDataError {
 
     #[error("A resource failed to resolve.")]
     PoolError(#[from] PoolError),
+
+    #[error("Failed to transfer data to the GPU")]
+    FailedTransferringDataToGpu(#[from] crate::allocator::CpuWriteGpuReadError),
 }
 
 // Textures are 2D since 1D textures are very limited in size (8k typically).
@@ -579,8 +582,7 @@ impl LineDrawData {
                 strip_texture_extent,
             );
 
-            picking_instance_ids_buffer
-                .extend(std::iter::repeat(Default::default()).take(num_strips_padding));
+            picking_instance_ids_buffer.fill_n(Default::default(), num_strips_padding)?;
             picking_instance_ids_buffer.copy_to_texture2d(
                 ctx.active_frame.before_view_builder_encoder.lock().get(),
                 wgpu::ImageCopyTexture {
@@ -590,7 +592,7 @@ impl LineDrawData {
                     aspect: wgpu::TextureAspect::All,
                 },
                 glam::uvec2(strip_texture_extent.width, strip_texture_extent.height),
-            );
+            )?;
         }
 
         let draw_data_uniform_buffer_bindings = create_and_fill_uniform_buffer_batch(

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -422,15 +422,17 @@ impl LineDrawData {
         );
 
         let vertices = if vertices.len() >= Self::MAX_NUM_VERTICES {
-            re_log::error_once!("Reached maximum number of supported line vertices. Clamping down to {}, passed were {}.
- See also https://github.com/rerun-io/rerun/issues/957", Self::MAX_NUM_VERTICES, vertices.len() );
+            re_log::error_once!("Reached maximum number of supported line vertices. Clamping down to {}, passed were {}. \
+                                See also https://github.com/rerun-io/rerun/issues/957", Self::MAX_NUM_VERTICES, vertices.len() );
             &vertices[..Self::MAX_NUM_VERTICES]
         } else {
             &vertices[..]
         };
         let strips = if strips.len() > Self::MAX_NUM_STRIPS {
-            re_log::error_once!("Reached maximum number of supported line strips. Clamping down to {}, passed were {}. This may lead to rendering artifacts.
- See also https://github.com/rerun-io/rerun/issues/957", Self::MAX_NUM_STRIPS, strips.len());
+            re_log::error_once!("Reached maximum number of supported line strips. Clamping down to {}, passed were {}. \
+                                 This may lead to rendering artifacts. \
+                                 See also https://github.com/rerun-io/rerun/issues/957",
+                                 Self::MAX_NUM_STRIPS, strips.len());
             &strips[..Self::MAX_NUM_STRIPS]
         } else {
             // Can only check for strip index validity if we haven't clamped the strips!

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -248,7 +248,7 @@ impl MeshDrawData {
                             .0
                             .map_or([0, 0, 0, 0], |mask| [mask[0], mask[1], 0, 0]),
                         picking_layer_id: instance.picking_layer_id.into(),
-                    });
+                    })?;
                 }
                 num_processed_instances += count;
 
@@ -266,7 +266,7 @@ impl MeshDrawData {
                 ctx.active_frame.before_view_builder_encoder.lock().get(),
                 &instance_buffer,
                 0,
-            );
+            )?;
         }
 
         Ok(MeshDrawData {

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -238,8 +238,8 @@ impl PointCloudDrawData {
 
         let vertices = if vertices.len() > Self::MAX_NUM_POINTS {
             re_log::error_once!(
-                "Reached maximum number of supported points. Clamping down to {}, passed were {}.
- See also https://github.com/rerun-io/rerun/issues/957",
+                "Reached maximum number of supported points. Clamping down to {}, passed were {}. \
+                See also https://github.com/rerun-io/rerun/issues/957",
                 Self::MAX_NUM_POINTS,
                 vertices.len()
             );

--- a/crates/re_renderer/src/resource_managers/resource_manager.rs
+++ b/crates/re_renderer/src/resource_managers/resource_manager.rs
@@ -45,6 +45,9 @@ pub enum ResourceManagerError {
 
     #[error("Invalid mesh given as input")]
     InvalidMesh(#[from] crate::mesh::MeshError),
+
+    #[error("Failed to transfer data to the GPU")]
+    FailedTransferringDataToGpu(#[from] crate::allocator::CpuWriteGpuReadError),
 }
 
 #[derive(Clone, Copy)]

--- a/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
+++ b/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
@@ -44,7 +44,13 @@ impl SharedRenderBuilders {
             self.points
                 .lock()
                 .take()
-                .map(|l| l.into_draw_data(render_ctx).into()),
+                .and_then(|l| match l.into_draw_data(render_ctx) {
+                    Ok(d) => Some(d.into()),
+                    Err(err) => {
+                        re_log::error_once!("Failed to build point draw data: {err}");
+                        None
+                    }
+                }),
         );
         result
     }

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-6d8235375501eef76b6c7aa2ed3443684299c23260987911db6522c0dd2afbef
+7b01022a2dca1662785ed7cfa7605fed897f53c4c6dc0c5ec14b14fad72edaa3


### PR DESCRIPTION
### What

* Fixes: #3075
* Related to: #3076

The second commit is the actual fix. But to avoid this family of crashes, the cpuwritegpuread belt now always does error checks and returns errors instead of paniking

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3093) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3093)
- [Docs preview](https://rerun.io/preview/b6b737939d3219b0ca32e763d7276b5ca0d504ee/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b6b737939d3219b0ca32e763d7276b5ca0d504ee/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)