### PR TITLE
Normalize quaternions

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/quaternion.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/quaternion.fbs
@@ -7,6 +7,9 @@ namespace rerun.datatypes;
 // ---
 
 /// A Quaternion represented by 4 real numbers.
+///
+/// Note: although the x,y,z,w components of the quaternion will be passed through to the
+/// datastore as provided, when used in the viewer Quaternions will always be normalized.
 //
 // Expectations:
 struct Quaternion (

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-249523fa197d35daa753a52ee6d52745fdb9c68d944ec7ea6a34217f561d6e91
+a6cd9c542af65eaa30d0a55d409f937ef4a51b2d51bd5576b6997f01319ef113

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -13,6 +13,9 @@
 #![allow(clippy::unnecessary_cast)]
 
 /// A Quaternion represented by 4 real numbers.
+///
+/// Note: although the x,y,z,w components of the quaternion will be passed through to the
+/// datastore as provided, when used in the viewer Quaternions will always be normalized.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Quaternion(pub [f32; 4usize]);
 

--- a/crates/re_types/src/datatypes/quaternion_ext.rs
+++ b/crates/re_types/src/datatypes/quaternion_ext.rs
@@ -28,7 +28,7 @@ impl From<Quaternion> for glam::Quat {
     #[inline]
     fn from(q: Quaternion) -> Self {
         let [x, y, z, w] = q.0;
-        Self::from_xyzw(x, y, z, w)
+        Self::from_xyzw(x, y, z, w).normalize()
     }
 }
 

--- a/crates/re_types/src/datatypes/transform3d_ext.rs
+++ b/crates/re_types/src/datatypes/transform3d_ext.rs
@@ -81,7 +81,7 @@ impl From<Transform3D> for glam::Affine3A {
                 from_parent: _,
             }) => glam::Affine3A::from_scale_rotation_translation(
                 scale.map_or(glam::Vec3::ONE, |s| s.into()),
-                rotation.map_or(glam::Quat::IDENTITY, |q| q.into()),
+                rotation.map_or(glam::Quat::IDENTITY, |q| glam::Quat::from(q).normalize()),
                 translation.map_or(glam::Vec3::ZERO, |v| v.into()),
             ),
         }

--- a/crates/re_types/src/datatypes/transform3d_ext.rs
+++ b/crates/re_types/src/datatypes/transform3d_ext.rs
@@ -81,7 +81,7 @@ impl From<Transform3D> for glam::Affine3A {
                 from_parent: _,
             }) => glam::Affine3A::from_scale_rotation_translation(
                 scale.map_or(glam::Vec3::ONE, |s| s.into()),
-                rotation.map_or(glam::Quat::IDENTITY, |q| glam::Quat::from(q).normalize()),
+                rotation.map_or(glam::Quat::IDENTITY, |q| q.into()),
                 translation.map_or(glam::Vec3::ZERO, |v| v.into()),
             ),
         }

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -17,6 +17,9 @@ namespace arrow {
 namespace rerun {
     namespace datatypes {
         /// A Quaternion represented by 4 real numbers.
+        ///
+        /// Note: although the x,y,z,w components of the quaternion will be passed through to the
+        /// datastore as provided, when used in the viewer Quaternions will always be normalized.
         struct Quaternion {
             float xyzw[4];
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion.py
@@ -23,7 +23,12 @@ __all__ = ["Quaternion", "QuaternionArray", "QuaternionArrayLike", "QuaternionLi
 
 @define(init=False)
 class Quaternion:
-    """A Quaternion represented by 4 real numbers."""
+    """
+    A Quaternion represented by 4 real numbers.
+
+    Note: although the x,y,z,w components of the quaternion will be passed through to the
+    datastore as provided, when used in the viewer Quaternions will always be normalized.
+    """
 
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         quaternion_init(self, *args, **kwargs)


### PR DESCRIPTION
### What
Without normalizing quaternions, the cameras.rs scene part could end up determining that a quaternion is not iso, resulting in unexpextedly failing to show the view frustum.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3094) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3094)
- [Docs preview](https://rerun.io/preview/596b11c21a3d8470ddba00d4c24aef965b45869a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/596b11c21a3d8470ddba00d4c24aef965b45869a/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)