### PR TITLE
Update resolved analytics URL

### DIFF
--- a/crates/re_analytics/src/sink_native.rs
+++ b/crates/re_analytics/src/sink_native.rs
@@ -110,7 +110,7 @@ impl PostHogSink {
                 }
             };
 
-            // 2023-02-26 the resolved URL was https://eu.posthog.com/capture (in Europe)
+            // 2023-08-25 the resolved URL was https://tel.rerun.io/
 
             Ok(resolved_url)
         })


### PR DESCRIPTION
It's now `tel.rerun.io` all the way.

```
curl -Lv http://tel.rerun.io 2>&1 | rg Location:
< Location: https://tel.rerun.io:443/
```

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
