### PR TITLE
Bring back wayland support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ comfy-table = { version = "6.1", default-features = false }
 const_panic = { version = "0.2.8", features = ["rust_1_64"] }
 crossbeam = "0.8"
 ecolor = "0.22.0"
-eframe = { version = "0.22.0", default-features = false, features = ["x11"] }
+eframe = { version = "0.22.0", default-features = false, features = ["default_fonts", "wayland", "x11"] }
 egui = { version = "0.22.0", features = ["extra_debug_asserts", "log"] }
 egui_extras = { version = "0.22.0", features = ["log"] }
 egui_tiles = { version = "0.2" }


### PR DESCRIPTION
At some point, `eframe` made wayland support optional behind a feature flag, which broke Rerun's wayland support since we don't specify that feature flag.

### What

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
