### PR TITLE
Fix typos in Python SDK's readme

### DIFF
--- a/examples/python/notebook/README.md
+++ b/examples/python/notebook/README.md
@@ -1,7 +1,7 @@
 # Overview
 
-Rerun has limited support for running directly embedded within a [jupyter][https://jupyter.org/] notebook.
-Many additional environments beyond jupyter are supported such as [Google Colab][https://colab.research.google.com/]
+Rerun has limited support for direct embedding within a [Jupyter](https://jupyter.org/) notebook.
+Many additional environments beyond Jupyter are supported such as [Google Colab](https://colab.research.google.com/)
 or [VSCode](https://code.visualstudio.com/blogs/2021/08/05/notebooks).
 
 In order to show a rerun viewer inline within the notebook you need to use a special in-memory


### PR DESCRIPTION
### What

- Rephrased "running directly embedded" to "direct embedding."
- Updated URLs to adhere to casing.
  - Original: `[jupyter](https://jupyter.org/)` and `[Google Colab](https://colab.research.google.com/)`.
  - Updated: `[Jupyter](https://jupyter.org/)` and `[Google Colab](https://colab.research.google.com/)`.

### Checklist
* ✅ I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ N/A] I've included a screenshot or gif (if applicable)
* [N/A ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
