### PR TITLE
A nice speed up of 3D points clouds by ~69%

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,9 @@
 # `cargo rerun` is short a convenient shorthand, skipping the web viewer.
 rerun = "run --package rerun-cli --no-default-features --features native_viewer --"
 
+# like `rerun`, but with --release
+rerun-release = "run --package rerun-cli --no-default-features --features native_viewer --release --"
+
 # `cargo rerun-web` is short a convenient shorthand for building & starting the web viewer.
 rerun-web = "run --package rerun-cli --no-default-features --features web_viewer -- --web-viewer"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,6 +4391,7 @@ dependencies = [
  "macaw",
  "nohash-hasher",
  "parking_lot 0.12.1",
+ "rayon",
  "re_arrow_store",
  "re_components",
  "re_data_store",

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -314,7 +314,8 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_optional_component<'a, C: Component + Clone + 'a>(
         &'a self,
     ) -> DeserializationResult<impl Iterator<Item = Option<C>> + '_> {
-        re_tracing::profile_function!();
+        re_tracing::profile_function!(C::name());
+
         let component = self.components.get(&C::name());
 
         if let Some(component) = component {
@@ -322,8 +323,10 @@ impl<A: Archetype> ArchetypeView<A> {
 
             let mut component_instance_key_iter = component.iter_instance_keys();
 
-            let component_value_iter =
-                C::try_from_arrow_opt(component.values.as_arrow_ref())?.into_iter();
+            let component_value_iter = {
+                re_tracing::profile_scope!("try_from_arrow_opt", C::name());
+                C::try_from_arrow_opt(component.values.as_arrow_ref())?.into_iter()
+            };
 
             let next_component_instance_key = component_instance_key_iter.next();
 

--- a/crates/re_space_view_spatial/Cargo.toml
+++ b/crates/re_space_view_spatial/Cargo.toml
@@ -42,6 +42,7 @@ itertools.workspace = true
 macaw = { workspace = true, features = ["with_serde"] }
 nohash-hasher.workspace = true
 parking_lot.workspace = true
+rayon.workspace = true
 serde = "1"
 smallvec = { workspace = true, features = ["serde"] }
 vec1.workspace = true

--- a/crates/re_space_view_spatial/src/contexts/annotation_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/annotation_context.rs
@@ -14,6 +14,7 @@ impl ViewContextSystem for AnnotationSceneContext {
         ctx: &mut re_viewer_context::ViewerContext<'_>,
         query: &re_viewer_context::ViewQuery<'_>,
     ) {
+        re_tracing::profile_function!();
         self.0.load(
             ctx,
             &query.latest_at_query(),

--- a/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use nohash_hasher::IntMap;
+
 use re_log_types::EntityPathHash;
 use re_types::{components::DrawOrder, Loggable as _};
 use re_viewer_context::{ArchetypeDefinition, ViewContextSystem};

--- a/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
+++ b/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
@@ -66,6 +66,7 @@ impl ViewContextSystem for SharedRenderBuilders {
         ctx: &mut re_viewer_context::ViewerContext<'_>,
         _query: &re_viewer_context::ViewQuery<'_>,
     ) {
+        re_tracing::profile_function!();
         self.lines = Mutex::new(Some(
             LineStripSeriesBuilder::new(ctx.render_ctx)
                 .radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES),

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -280,6 +280,8 @@ fn transform_at(
     pinhole_image_plane_distance: impl Fn(&EntityPath) -> f32,
     encountered_pinhole: &mut Option<EntityPath>,
 ) -> Result<Option<glam::Affine3A>, UnreachableTransformReason> {
+    re_tracing::profile_function!();
+
     let pinhole = store.query_latest_component::<Pinhole>(entity_path, query);
     if pinhole.is_some() {
         if encountered_pinhole.is_some() {

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -7,7 +7,7 @@ use re_types::{
     Archetype as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, ResolvedAnnotationInfo, SpaceViewSystemExecutionError,
+    ArchetypeDefinition, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
@@ -41,7 +41,7 @@ impl Arrows3DPart {
         arch_view: &'a ArchetypeView<Arrows3D>,
         instance_path_hashes: &'a [InstancePathHash],
         colors: &'a [egui::Color32],
-        annotation_infos: &'a [ResolvedAnnotationInfo],
+        annotation_infos: &'a ResolvedAnnotationInfos,
         world_from_obj: glam::Affine3A,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -6,7 +6,7 @@ use re_types::{
     Archetype as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, ResolvedAnnotationInfo, SpaceViewSystemExecutionError,
+    ArchetypeDefinition, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
@@ -41,7 +41,7 @@ impl Lines2DPart {
         arch_view: &'a ArchetypeView<LineStrips2D>,
         instance_path_hashes: &'a [InstancePathHash],
         colors: &'a [egui::Color32],
-        annotation_infos: &'a [ResolvedAnnotationInfo],
+        annotation_infos: &'a ResolvedAnnotationInfos,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
             annotation_infos.iter(),

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -6,7 +6,7 @@ use re_types::{
     Archetype as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, ResolvedAnnotationInfo, SpaceViewSystemExecutionError,
+    ArchetypeDefinition, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
@@ -41,7 +41,7 @@ impl Lines3DPart {
         arch_view: &'a ArchetypeView<LineStrips3D>,
         instance_path_hashes: &'a [InstancePathHash],
         colors: &'a [egui::Color32],
-        annotation_infos: &'a [ResolvedAnnotationInfo],
+        annotation_infos: &'a ResolvedAnnotationInfos,
         world_from_obj: glam::Affine3A,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         re_tracing::profile_function!();

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -29,7 +29,7 @@ use re_types::datatypes::{KeypointId, KeypointPair};
 use re_types::Archetype;
 use re_viewer_context::SpaceViewClassRegistryError;
 use re_viewer_context::{
-    auto_color, Annotations, DefaultColor, ResolvedAnnotationInfo, SpaceViewSystemRegistry,
+    auto_color, Annotations, DefaultColor, ResolvedAnnotationInfos, SpaceViewSystemRegistry,
     ViewPartCollection, ViewQuery,
 };
 
@@ -105,7 +105,7 @@ pub fn picking_id_from_instance_key(
 pub fn process_colors<'a, A: Archetype>(
     arch_view: &'a re_query::ArchetypeView<A>,
     ent_path: &'a EntityPath,
-    annotation_infos: &'a [ResolvedAnnotationInfo],
+    annotation_infos: &'a ResolvedAnnotationInfos,
 ) -> Result<impl Iterator<Item = egui::Color32> + 'a, re_query::QueryError> {
     re_tracing::profile_function!();
     let default_color = DefaultColor::EntityPath(ent_path);
@@ -153,7 +153,7 @@ fn process_annotations_and_keypoints<Primary, A: Archetype>(
     arch_view: &re_query::ArchetypeView<A>,
     annotations: &Arc<Annotations>,
     mut primary_into_position: impl FnMut(&Primary) -> glam::Vec3,
-) -> Result<(Vec<ResolvedAnnotationInfo>, Keypoints), re_query::QueryError>
+) -> Result<(ResolvedAnnotationInfos, Keypoints), re_query::QueryError>
 where
     Primary: re_types::Component + Clone + Default,
 {
@@ -169,9 +169,8 @@ where
             .resolved_class_description(None)
             .annotation_info();
 
-        re_tracing::profile_scope!("vec!");
         return Ok((
-            vec![resolved_annotation; arch_view.num_instances()],
+            ResolvedAnnotationInfos::Same(arch_view.num_instances(), resolved_annotation),
             keypoints,
         ));
     }
@@ -196,7 +195,7 @@ where
     })
     .collect();
 
-    Ok((annotation_info, keypoints))
+    Ok((ResolvedAnnotationInfos::Many(annotation_info), keypoints))
 }
 
 #[derive(Clone)]

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -168,6 +168,8 @@ where
         let resolved_annotation = annotations
             .resolved_class_description(None)
             .annotation_info();
+
+        re_tracing::profile_scope!("vec!");
         return Ok((
             vec![resolved_annotation; arch_view.num_instances()],
             keypoints,

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -224,11 +224,13 @@ pub struct UiLabel {
 pub fn load_keypoint_connections(
     ent_context: &SpatialSceneEntityContext<'_>,
     ent_path: &re_data_store::EntityPath,
-    keypoints: Keypoints,
+    keypoints: &Keypoints,
 ) {
     if keypoints.is_empty() {
         return;
     }
+
+    re_tracing::profile_function!();
 
     // Generate keypoint connections if any.
     let mut line_builder = ent_context.shared_render_builders.lines();
@@ -240,7 +242,7 @@ pub fn load_keypoint_connections(
     for ((class_id, _time), keypoints_in_class) in keypoints {
         let resolved_class_description = ent_context
             .annotations
-            .resolved_class_description(Some(class_id));
+            .resolved_class_description(Some(*class_id));
 
         let Some(class_description) = resolved_class_description.class_description else {
             continue;

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -167,7 +167,7 @@ impl Points2DPart {
             }
         };
 
-        load_keypoint_connections(ent_context, ent_path, keypoints);
+        load_keypoint_connections(ent_context, ent_path, &keypoints);
 
         self.data.extend_bounding_box_with_points(
             arch_view

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -6,7 +6,7 @@ use re_types::{
     Archetype,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, ResolvedAnnotationInfo, SpaceViewSystemExecutionError,
+    ArchetypeDefinition, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
@@ -41,7 +41,7 @@ impl Points2DPart {
         arch_view: &'a ArchetypeView<Points2D>,
         instance_path_hashes: &'a [InstancePathHash],
         colors: &'a [egui::Color32],
-        annotation_infos: &'a [ResolvedAnnotationInfo],
+        annotation_infos: &'a ResolvedAnnotationInfos,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         let labels = itertools::izip!(
             annotation_infos.iter(),

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -6,7 +6,7 @@ use re_types::{
     Archetype as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, ResolvedAnnotationInfo, SpaceViewSystemExecutionError,
+    ArchetypeDefinition, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
@@ -43,7 +43,7 @@ impl Points3DPart {
         arch_view: &'a ArchetypeView<Points3D>,
         instance_path_hashes: &'a [InstancePathHash],
         colors: &'a [egui::Color32],
-        annotation_infos: &'a [ResolvedAnnotationInfo],
+        annotation_infos: &'a ResolvedAnnotationInfos,
         world_from_obj: glam::Affine3A,
     ) -> Result<impl Iterator<Item = UiLabel> + 'a, QueryError> {
         re_tracing::profile_function!();
@@ -178,15 +178,6 @@ impl Points3DPart {
         }
 
         load_keypoint_connections(ent_context, ent_path, &keypoints);
-
-        #[cfg(not(target_arch = "wasm32"))]
-        if annotation_infos.len() > 1000 {
-            // Dropping this is surprisingly expensive, so do it in a background thread:
-            rayon::spawn(move || {
-                re_tracing::profile_scope!("drop(annotation_infos)");
-                std::mem::drop(annotation_infos);
-            });
-        }
 
         Ok(())
     }

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -174,6 +174,12 @@ impl Points3DPart {
 
         load_keypoint_connections(ent_context, ent_path, &keypoints);
 
+        {
+            // Suprisingly expensive 😬
+            re_tracing::profile_scope!("drop(annotation_infos)");
+            std::mem::drop(annotation_infos);
+        }
+
         self.data.extend_bounding_box_with_points(
             arch_view
                 .iter_required_component::<Point3D>()?

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -172,7 +172,7 @@ impl Points3DPart {
             }
         }
 
-        load_keypoint_connections(ent_context, ent_path, keypoints);
+        load_keypoint_connections(ent_context, ent_path, &keypoints);
 
         self.data.extend_bounding_box_with_points(
             arch_view

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -170,6 +170,11 @@ impl Points3DPart {
                     }
                 }
             }
+
+            self.data.extend_bounding_box_with_points(
+                positions.iter().copied(),
+                ent_context.world_from_obj,
+            );
         }
 
         load_keypoint_connections(ent_context, ent_path, &keypoints);
@@ -179,13 +184,6 @@ impl Points3DPart {
             re_tracing::profile_scope!("drop(annotation_infos)");
             std::mem::drop(annotation_infos);
         }
-
-        self.data.extend_bounding_box_with_points(
-            arch_view
-                .iter_required_component::<Point3D>()?
-                .map(glam::Vec3::from),
-            ent_context.world_from_obj,
-        );
 
         Ok(())
     }

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -129,6 +129,8 @@ impl SpaceViewClass for SpatialSpaceView3D {
         query: &ViewQuery<'_>,
         draw_data: Vec<re_renderer::QueueableDrawData>,
     ) -> Result<(), SpaceViewSystemExecutionError> {
+        re_tracing::profile_function!();
+
         state.scene_bbox = calculate_bounding_box(parts, &mut state.scene_bbox_accum);
         state.scene_num_primitives = view_ctx
             .get::<PrimitiveCounter>()?

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -41,6 +41,8 @@ testing = []
 [dependencies]
 # Rerun
 re_error.workspace = true
+re_string_interner.workspace = true
+re_tracing.workspace = true
 
 # External
 anyhow.workspace = true
@@ -66,9 +68,6 @@ glam = { workspace = true, optional = true }
 macaw = { workspace = true, optional = true }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
-# Rerun
-re_string_interner.workspace = true
-re_tracing.workspace = true
 
 [dev-dependencies]
 

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -537,6 +537,7 @@ impl<T> ResultExt<T> for SerializationResult<T> {
         })
     }
 
+    #[track_caller]
     fn detailed_unwrap(self) -> T {
         match self {
             Ok(v) => v,
@@ -566,6 +567,7 @@ impl<T> ResultExt<T> for DeserializationResult<T> {
         })
     }
 
+    #[track_caller]
     fn detailed_unwrap(self) -> T {
         match self {
             Ok(v) => v,

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -81,7 +81,7 @@ impl From<ClassDescription> for CachedClassDescription {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ResolvedClassDescription<'a> {
     pub class_id: Option<ClassId>,
     pub class_description: Option<&'a ClassDescription>,

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -47,6 +47,8 @@ impl Annotations {
         &self,
         class_id: Option<re_types::components::ClassId>,
     ) -> ResolvedClassDescription<'_> {
+        re_tracing::profile_function!();
+
         let found = class_id.and_then(|class_id| self.class_map.get(&class_id.0));
         ResolvedClassDescription {
             class_id: class_id.map(|id| id.0),

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -131,6 +131,8 @@ impl<'a> ResolvedClassDescription<'a> {
     }
 }
 
+// ----------------------------------------------------------------------------
+
 #[derive(Clone, Default)]
 pub struct ResolvedAnnotationInfo {
     pub class_id: Option<ClassId>,
@@ -173,6 +175,30 @@ impl ResolvedAnnotationInfo {
         }
     }
 }
+
+// ----------------------------------------------------------------------------
+
+/// Many [`ResolvedAnnotationInfo`], with optimization
+/// for a common case where they are all the same.
+pub enum ResolvedAnnotationInfos {
+    /// All the same
+    Same(usize, ResolvedAnnotationInfo),
+
+    /// All different
+    Many(Vec<ResolvedAnnotationInfo>),
+}
+
+impl ResolvedAnnotationInfos {
+    pub fn iter(&self) -> impl Iterator<Item = &ResolvedAnnotationInfo> {
+        use itertools::Either;
+        match self {
+            Self::Same(n, info) => Either::Left(std::iter::repeat(info).take(*n)),
+            Self::Many(infos) => Either::Right(infos.iter()),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 #[derive(Default, Clone, Debug)]
 pub struct AnnotationMap(pub BTreeMap<EntityPath, Arc<Annotations>>);

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -22,7 +22,10 @@ pub mod gpu_bridge;
 
 use std::hash::BuildHasher;
 
-pub use annotations::{AnnotationMap, Annotations, ResolvedAnnotationInfo, MISSING_ANNOTATIONS};
+pub use annotations::{
+    AnnotationMap, Annotations, ResolvedAnnotationInfo, ResolvedAnnotationInfos,
+    MISSING_ANNOTATIONS,
+};
 pub use app_options::AppOptions;
 pub use caches::{Cache, Caches};
 pub use command_sender::{

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -222,7 +222,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
                 match part.execute(ctx, query, &view_ctx) {
                     Ok(part_draw_data) => draw_data.extend(part_draw_data),
                     Err(err) => {
-                        re_log::error_once!("Error executing view part system: {}", err);
+                        re_log::error_once!("Error executing view part system: {err}");
                     }
                 }
             }
@@ -231,7 +231,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
         typed_state_wrapper_mut(state, |state| {
             if let Err(err) = self.ui(ctx, ui, state, &view_ctx, &parts, query, draw_data) {
                 // TODO(andreas): Draw an error message on top of the space view ui instead of logging.
-                re_log::error_once!("Error drawing ui for space view: {}", err);
+                re_log::error_once!("Error drawing ui for space view: {err}");
             }
         });
     }

--- a/crates/re_ws_comms/src/client.rs
+++ b/crates/re_ws_comms/src/client.rs
@@ -27,11 +27,11 @@ impl Connection {
                 WsEvent::Message(message) => match message {
                     WsMessage::Binary(binary) => on_binary_msg(binary),
                     WsMessage::Text(text) => {
-                        re_log::warn!("Unexpected text message: {:?}", text);
+                        re_log::warn!("Unexpected text message: {text:?}");
                         ControlFlow::Continue(())
                     }
                     WsMessage::Unknown(text) => {
-                        re_log::warn!("Unknown message: {:?}", text);
+                        re_log::warn!("Unknown message: {text:?}");
                         ControlFlow::Continue(())
                     }
                     WsMessage::Ping(_data) => {
@@ -44,7 +44,7 @@ impl Connection {
                     }
                 },
                 WsEvent::Error(error) => {
-                    re_log::error!("Connection error: {}", error);
+                    re_log::error!("Connection error: {error}");
                     ControlFlow::Break(())
                 }
                 WsEvent::Closed => {


### PR DESCRIPTION
### What
On native, use `rayon` to parallelize the gathering of positions, radii, colors, and picking ids. Of course, this only works on native. I also noticed that we spent a lot of time generating identical annotation infos for all the points, so I happy-pathed that.

Test: `cargo rerun-release ../opf.rrd --profile`, looking at just the 3D view, averaged over ~30 frames:

Full frame 37.0ms -> 26.6ms ≈ 39% faster

`Points3DPart`: 25.7ms -> 15.2ms ≈ 69% faster

Before:
![Screenshot 2023-08-27 at 17 39 52](https://github.com/rerun-io/rerun/assets/1148717/95b2de1b-ab21-489b-8e05-039e8de50692)

After:
![image](https://github.com/rerun-io/rerun/assets/1148717/2e0f7dc7-ccce-4cd8-9157-162bb642c795)



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3114/examples/structure_from_motion/) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3114)
- [Docs preview](https://rerun.io/preview/d70a51a580149f974aec0c089fb8f899e132c518/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d70a51a580149f974aec0c089fb8f899e132c518/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)