### PR TITLE
A better Rust interface for `Color` datatype and component

### DIFF
--- a/crates/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/re_space_view_spatial/src/mesh_loader.rs
@@ -116,7 +116,9 @@ impl LoadedMesh {
             vertex_colors
                 .iter()
                 .map(|c| {
-                    Rgba32Unmul::from_rgba_unmul_array(re_types::datatypes::Color(*c).to_array())
+                    Rgba32Unmul::from_rgba_unmul_array(
+                        re_types::datatypes::Color::from_u32(*c).to_array(),
+                    )
                 })
                 .collect()
         } else {

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -1,7 +1,4 @@
-use egui::{
-    plot::{Legend, Line, Plot, Points},
-    Color32,
-};
+use egui::plot::{Legend, Line, Plot, Points};
 
 use re_arrow_store::TimeType;
 use re_format::next_grid_tick_magnitude_ns;
@@ -175,8 +172,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
                     .map(|p| [(p.0 - time_offset) as _, p.1])
                     .collect::<Vec<_>>();
 
-                let c = line.color;
-                let color = Color32::from_rgba_premultiplied(c[0], c[1], c[2], c[3]);
+                let color = line.color;
 
                 match line.kind {
                     PlotSeriesKind::Continuous => plot_ui.line(

--- a/crates/re_types/src/components/color_ext.rs
+++ b/crates/re_types/src/components/color_ext.rs
@@ -46,6 +46,6 @@ impl Color {
 impl From<Color> for ecolor::Color32 {
     fn from(color: Color) -> Self {
         let [r, g, b, a] = color.to_array();
-        Self::from_rgba_premultiplied(r, g, b, a)
+        Self::from_rgba_unmultiplied(r, g, b, a)
     }
 }

--- a/crates/re_types/src/components/color_ext.rs
+++ b/crates/re_types/src/components/color_ext.rs
@@ -8,9 +8,16 @@ impl Color {
 
     #[inline]
     pub fn from_unmultiplied_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
-        Self::from([r, g, b, a])
+        Self::from(crate::datatypes::Color::from_unmultiplied_rgba(r, g, b, a))
     }
 
+    /// Most significant byte is `r`, least significant byte is `a`.
+    #[inline]
+    pub fn from_u32(rgba: u32) -> Self {
+        Self(rgba.into())
+    }
+
+    /// `[r, g, b, a]`
     #[inline]
     pub fn to_array(self) -> [u8; 4] {
         [
@@ -19,6 +26,12 @@ impl Color {
             (self.0 .0 >> 8) as u8,
             self.0 .0 as u8,
         ]
+    }
+
+    /// Most significant byte is `r`, least significant byte is `a`.
+    #[inline]
+    pub fn to_u32(self) -> u32 {
+        self.0 .0
     }
 }
 

--- a/crates/re_types/src/datatypes/color_ext.rs
+++ b/crates/re_types/src/datatypes/color_ext.rs
@@ -8,9 +8,17 @@ impl Color {
 
     #[inline]
     pub fn from_unmultiplied_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
-        Self::from([r, g, b, a])
+        let [r, g, b, a] = [r as u32, g as u32, b as u32, a as u32];
+        Self(r << 24 | g << 16 | b << 8 | a)
     }
 
+    /// Most significant byte is `r`, least significant byte is `a`.
+    #[inline]
+    pub fn from_u32(rgba: u32) -> Self {
+        Self(rgba)
+    }
+
+    /// `[r, g, b, a]`
     #[inline]
     pub fn to_array(self) -> [u8; 4] {
         [
@@ -20,24 +28,25 @@ impl Color {
             self.0 as u8,
         ]
     }
+
+    /// Most significant byte is `r`, least significant byte is `a`.
+    #[inline]
+    pub fn to_u32(self) -> u32 {
+        self.0
+    }
 }
 
 impl From<u32> for Color {
     #[inline]
-    fn from(c: u32) -> Self {
-        Self(c)
+    fn from(rgba: u32) -> Self {
+        Self::from_u32(rgba)
     }
 }
 
 impl From<[u8; 4]> for Color {
     #[inline]
-    fn from(bytes: [u8; 4]) -> Self {
-        Self(
-            (bytes[0] as u32) << 24
-                | (bytes[1] as u32) << 16
-                | (bytes[2] as u32) << 8
-                | (bytes[3] as u32),
-        )
+    fn from([r, g, b, a]: [u8; 4]) -> Self {
+        Self::from_unmultiplied_rgba(r, g, b, a)
     }
 }
 

--- a/crates/re_types/src/datatypes/color_ext.rs
+++ b/crates/re_types/src/datatypes/color_ext.rs
@@ -54,6 +54,6 @@ impl From<[u8; 4]> for Color {
 impl From<Color> for ecolor::Color32 {
     fn from(color: Color) -> Self {
         let [r, g, b, a] = color.to_array();
-        Self::from_rgba_premultiplied(r, g, b, a)
+        Self::from_rgba_unmultiplied(r, g, b, a)
     }
 }

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -136,13 +136,14 @@ pub struct ResolvedAnnotationInfo {
 }
 
 impl ResolvedAnnotationInfo {
+    /// `rgba` should be unmultiplied
     pub fn color(
         &self,
-        color: Option<&[u8; 4]>,
+        rgba: Option<&[u8; 4]>,
         default_color: DefaultColor<'_>,
     ) -> re_renderer::Color32 {
-        if let Some([r, g, b, a]) = color {
-            re_renderer::Color32::from_rgba_premultiplied(*r, *g, *b, *a)
+        if let Some([r, g, b, a]) = rgba {
+            re_renderer::Color32::from_rgba_unmultiplied(*r, *g, *b, *a)
         } else if let Some(color) = self.annotation_info.as_ref().and_then(|info| {
             info.color
                 .map(|c| c.into())

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -43,7 +43,8 @@ impl From<GltfPrimitive> for Mesh3D {
             indices: indices.map(|i| i.into()),
             vertex_positions: vertex_positions.into_iter().flatten().collect(),
             vertex_normals: vertex_normals.map(|normals| normals.into_iter().flatten().collect()),
-            vertex_colors: vertex_colors.map(|colors| colors.into_iter().map(|c| c.0 .0).collect()),
+            vertex_colors: vertex_colors
+                .map(|colors| colors.into_iter().map(|c| c.to_u32()).collect()),
         };
 
         raw.sanity_check().unwrap();

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -863,13 +863,13 @@ fn log_meshes(
                 [_, 3] => Some(
                     slice_from_np_array(&vertex_colors)
                         .chunks_exact(3)
-                        .map(|c| Color::from_rgb(c[0], c[1], c[2]).0 .0)
+                        .map(|c| Color::from_rgb(c[0], c[1], c[2]).to_u32())
                         .collect(),
                 ),
                 [_, 4] => Some(
                     slice_from_np_array(&vertex_colors)
                         .chunks_exact(4)
-                        .map(|c| Color::from_unmultiplied_rgba(c[0], c[1], c[2], c[3]).0 .0)
+                        .map(|c| Color::from_unmultiplied_rgba(c[0], c[1], c[2], c[3]).to_u32())
                         .collect(),
                 ),
                 shape => {


### PR DESCRIPTION
### What
I was quickly looking into turning `Color` from a `u32` into a `[u8; 4]` and in the process I realized we were leaking its internals all over the place.

This PR doesn't stop the leakage, but at least adds helper functions to let users choose their representation.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3115) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3115)
- [Docs preview](https://rerun.io/preview/c59d625bb7c5e9ff472de1f3508524486b068ed3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c59d625bb7c5e9ff472de1f3508524486b068ed3/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)