### PR TITLE
Inject marker components

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-1a348f3a826d5becab8ebcb82634dde7a2d932b84708e7c4818e38e0425c2485
+d7e5474555409f9824d33aa51d5d92664c8c32306cb8957a76388d918b9adc1b

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-bc2fcc2777af1eb153071a27ed5885192b6eb90f9dbbca67519059ef54a3ea1d
+1a348f3a826d5becab8ebcb82634dde7a2d932b84708e7c4818e38e0425c2485

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -116,8 +116,8 @@ impl crate::Archetype for AnnotationContext {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.AnnotationContextMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.AnnotationContextIndicator".into()
     }
 
     #[inline]
@@ -154,9 +154,9 @@ impl crate::Archetype for AnnotationContext {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.AnnotationContextMarker".to_owned(),
+                    "rerun.components.AnnotationContextIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.AnnotationContextMarker".to_owned()),
+                    Some("rerun.components.AnnotationContextIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -165,7 +165,7 @@ impl crate::Archetype for AnnotationContext {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.AnnotationContextMarker",
+                        "rerun.components.AnnotationContextIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -116,31 +116,63 @@ impl crate::Archetype for AnnotationContext {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.AnnotationContextMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        1
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([{
-            Some({
-                let array =
-                    <crate::components::AnnotationContext>::try_to_arrow([&self.context], None);
-                array.map(|array| {
-                    let datatype = ::arrow2::datatypes::DataType::Extension(
-                        "rerun.components.AnnotationContext".into(),
-                        Box::new(array.data_type().clone()),
-                        Some("rerun.annotation_context".into()),
-                    );
-                    (
-                        ::arrow2::datatypes::Field::new("context", datatype, false),
-                        array,
-                    )
+        Ok([
+            {
+                Some({
+                    let array =
+                        <crate::components::AnnotationContext>::try_to_arrow([&self.context], None);
+                    array.map(|array| {
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.components.AnnotationContext".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.annotation_context".into()),
+                        );
+                        (
+                            ::arrow2::datatypes::Field::new("context", datatype, false),
+                            array,
+                        )
+                    })
                 })
-            })
-            .transpose()
-            .with_context("rerun.archetypes.AnnotationContext#context")?
-        }]
+                .transpose()
+                .with_context("rerun.archetypes.AnnotationContext#context")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.AnnotationContextMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.AnnotationContextMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.AnnotationContextMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
+            },
+        ]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -139,8 +139,8 @@ impl crate::Archetype for Arrows3D {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.Arrows3DMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.Arrows3DIndicator".into()
     }
 
     #[inline]
@@ -298,9 +298,9 @@ impl crate::Archetype for Arrows3D {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Arrows3DMarker".to_owned(),
+                    "rerun.components.Arrows3DIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Arrows3DMarker".to_owned()),
+                    Some("rerun.components.Arrows3DIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -309,7 +309,7 @@ impl crate::Archetype for Arrows3D {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.Arrows3DMarker",
+                        "rerun.components.Arrows3DIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -139,6 +139,16 @@ impl crate::Archetype for Arrows3D {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.Arrows3DMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        self.vectors.len()
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
@@ -285,6 +295,26 @@ impl crate::Archetype for Arrows3D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Arrows3D#instance_keys")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.Arrows3DMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.Arrows3DMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.Arrows3DMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -97,33 +97,65 @@ impl crate::Archetype for DisconnectedSpace {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.DisconnectedSpaceMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        1
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([{
-            Some({
-                let array = <crate::components::DisconnectedSpace>::try_to_arrow(
-                    [&self.disconnected_space],
-                    None,
-                );
-                array.map(|array| {
-                    let datatype = ::arrow2::datatypes::DataType::Extension(
-                        "rerun.components.DisconnectedSpace".into(),
-                        Box::new(array.data_type().clone()),
-                        Some("rerun.disconnected_space".into()),
+        Ok([
+            {
+                Some({
+                    let array = <crate::components::DisconnectedSpace>::try_to_arrow(
+                        [&self.disconnected_space],
+                        None,
                     );
-                    (
-                        ::arrow2::datatypes::Field::new("disconnected_space", datatype, false),
-                        array,
-                    )
+                    array.map(|array| {
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.components.DisconnectedSpace".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.disconnected_space".into()),
+                        );
+                        (
+                            ::arrow2::datatypes::Field::new("disconnected_space", datatype, false),
+                            array,
+                        )
+                    })
                 })
-            })
-            .transpose()
-            .with_context("rerun.archetypes.DisconnectedSpace#disconnected_space")?
-        }]
+                .transpose()
+                .with_context("rerun.archetypes.DisconnectedSpace#disconnected_space")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.DisconnectedSpaceMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.DisconnectedSpaceMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.DisconnectedSpaceMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
+            },
+        ]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -97,8 +97,8 @@ impl crate::Archetype for DisconnectedSpace {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.DisconnectedSpaceMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.DisconnectedSpaceIndicator".into()
     }
 
     #[inline]
@@ -137,9 +137,9 @@ impl crate::Archetype for DisconnectedSpace {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.DisconnectedSpaceMarker".to_owned(),
+                    "rerun.components.DisconnectedSpaceIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.DisconnectedSpaceMarker".to_owned()),
+                    Some("rerun.components.DisconnectedSpaceIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -148,7 +148,7 @@ impl crate::Archetype for DisconnectedSpace {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.DisconnectedSpaceMarker",
+                        "rerun.components.DisconnectedSpaceIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -164,8 +164,8 @@ impl crate::Archetype for LineStrips2D {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.LineStrips2DMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.LineStrips2DIndicator".into()
     }
 
     #[inline]
@@ -323,9 +323,9 @@ impl crate::Archetype for LineStrips2D {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.LineStrips2DMarker".to_owned(),
+                    "rerun.components.LineStrips2DIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.LineStrips2DMarker".to_owned()),
+                    Some("rerun.components.LineStrips2DIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -334,7 +334,7 @@ impl crate::Archetype for LineStrips2D {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.LineStrips2DMarker",
+                        "rerun.components.LineStrips2DIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -164,6 +164,16 @@ impl crate::Archetype for LineStrips2D {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.LineStrips2DMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        self.strips.len()
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
@@ -310,6 +320,26 @@ impl crate::Archetype for LineStrips2D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.LineStrips2D#instance_keys")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.LineStrips2DMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.LineStrips2DMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.LineStrips2DMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -157,8 +157,8 @@ impl crate::Archetype for LineStrips3D {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.LineStrips3DMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.LineStrips3DIndicator".into()
     }
 
     #[inline]
@@ -296,9 +296,9 @@ impl crate::Archetype for LineStrips3D {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.LineStrips3DMarker".to_owned(),
+                    "rerun.components.LineStrips3DIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.LineStrips3DMarker".to_owned()),
+                    Some("rerun.components.LineStrips3DIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -307,7 +307,7 @@ impl crate::Archetype for LineStrips3D {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.LineStrips3DMarker",
+                        "rerun.components.LineStrips3DIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -157,6 +157,16 @@ impl crate::Archetype for LineStrips3D {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.LineStrips3DMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        self.strips.len()
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
@@ -283,6 +293,26 @@ impl crate::Archetype for LineStrips3D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.LineStrips3D#instance_keys")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.LineStrips3DMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.LineStrips3DMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.LineStrips3DMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -140,6 +140,16 @@ impl crate::Archetype for Points2D {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.Points2DMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        self.points.len()
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
@@ -307,6 +317,26 @@ impl crate::Archetype for Points2D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Points2D#instance_keys")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.Points2DMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.Points2DMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.Points2DMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -140,8 +140,8 @@ impl crate::Archetype for Points2D {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.Points2DMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.Points2DIndicator".into()
     }
 
     #[inline]
@@ -320,9 +320,9 @@ impl crate::Archetype for Points2D {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Points2DMarker".to_owned(),
+                    "rerun.components.Points2DIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Points2DMarker".to_owned()),
+                    Some("rerun.components.Points2DIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -331,7 +331,7 @@ impl crate::Archetype for Points2D {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.Points2DMarker",
+                        "rerun.components.Points2DIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -123,6 +123,16 @@ impl crate::Archetype for Points3D {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.Points3DMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        self.points.len()
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
@@ -270,6 +280,26 @@ impl crate::Archetype for Points3D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Points3D#instance_keys")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.Points3DMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.Points3DMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.Points3DMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -123,8 +123,8 @@ impl crate::Archetype for Points3D {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.Points3DMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.Points3DIndicator".into()
     }
 
     #[inline]
@@ -283,9 +283,9 @@ impl crate::Archetype for Points3D {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Points3DMarker".to_owned(),
+                    "rerun.components.Points3DIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Points3DMarker".to_owned()),
+                    Some("rerun.components.Points3DIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -294,7 +294,7 @@ impl crate::Archetype for Points3D {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.Points3DMarker",
+                        "rerun.components.Points3DIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -115,30 +115,63 @@ impl crate::Archetype for Transform3D {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.components.Transform3DMarker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        1
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([{
-            Some({
-                let array = <crate::components::Transform3D>::try_to_arrow([&self.transform], None);
-                array.map(|array| {
-                    let datatype = ::arrow2::datatypes::DataType::Extension(
-                        "rerun.components.Transform3D".into(),
-                        Box::new(array.data_type().clone()),
-                        Some("rerun.transform3d".into()),
-                    );
-                    (
-                        ::arrow2::datatypes::Field::new("transform", datatype, false),
-                        array,
-                    )
+        Ok([
+            {
+                Some({
+                    let array =
+                        <crate::components::Transform3D>::try_to_arrow([&self.transform], None);
+                    array.map(|array| {
+                        let datatype = ::arrow2::datatypes::DataType::Extension(
+                            "rerun.components.Transform3D".into(),
+                            Box::new(array.data_type().clone()),
+                            Some("rerun.transform3d".into()),
+                        );
+                        (
+                            ::arrow2::datatypes::Field::new("transform", datatype, false),
+                            array,
+                        )
+                    })
                 })
-            })
-            .transpose()
-            .with_context("rerun.archetypes.Transform3D#transform")?
-        }]
+                .transpose()
+                .with_context("rerun.archetypes.Transform3D#transform")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.components.Transform3DMarker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.components.Transform3DMarker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.components.Transform3DMarker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
+            },
+        ]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -115,8 +115,8 @@ impl crate::Archetype for Transform3D {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.components.Transform3DMarker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.components.Transform3DIndicator".into()
     }
 
     #[inline]
@@ -153,9 +153,9 @@ impl crate::Archetype for Transform3D {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Transform3DMarker".to_owned(),
+                    "rerun.components.Transform3DIndicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Transform3DMarker".to_owned()),
+                    Some("rerun.components.Transform3DIndicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -164,7 +164,7 @@ impl crate::Archetype for Transform3D {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.components.Transform3DMarker",
+                        "rerun.components.Transform3DIndicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -288,6 +288,25 @@ pub trait Archetype {
     /// All components including required, recommended, and optional.
     fn all_components() -> &'static [ComponentName];
 
+    /// Returns the name of the associated marker component, whose presence indicates that the
+    /// high-level archetype-based APIs where used to log the data.
+    ///
+    /// Marker components open new opportunities in terms of API design, better heuristics and
+    /// performance improvements on the query side.
+    ///
+    /// Marker components are non-splatted null arrays.
+    /// Their names follow the pattern `rerun.components.{ArchetypeName}Marker`, e.g.
+    /// `rerun.components.Points3DMarker`.
+    ///
+    /// The reason for not using splats is so that marker components don't require dedicated rows.
+    /// This is not an issue because of the way null arrays are stored: storing 1 null value or 1M null
+    /// values takes the same size.
+    fn marker_component() -> ComponentName;
+
+    /// Returns the number of instances of the archetype, i.e. the number of instances currently
+    /// present in its required component(s).
+    fn num_instances(&self) -> usize;
+
     // ---
 
     /// Serializes all non-null [`Component`]s of this [`Archetype`] into Arrow arrays.

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -288,20 +288,20 @@ pub trait Archetype {
     /// All components including required, recommended, and optional.
     fn all_components() -> &'static [ComponentName];
 
-    /// Returns the name of the associated marker component, whose presence indicates that the
+    /// Returns the name of the associated indicator component, whose presence indicates that the
     /// high-level archetype-based APIs where used to log the data.
     ///
-    /// Marker components open new opportunities in terms of API design, better heuristics and
+    /// Indicator components open new opportunities in terms of API design, better heuristics and
     /// performance improvements on the query side.
     ///
-    /// Marker components are non-splatted null arrays.
-    /// Their names follow the pattern `rerun.components.{ArchetypeName}Marker`, e.g.
-    /// `rerun.components.Points3DMarker`.
+    /// Indicator components are non-splatted null arrays.
+    /// Their names follow the pattern `rerun.components.{ArchetypeName}Indicator`, e.g.
+    /// `rerun.components.Points3DIndicator`.
     ///
-    /// The reason for not using splats is so that marker components don't require dedicated rows.
+    /// The reason for not using splats is so that indicator components don't require dedicated rows.
     /// This is not an issue because of the way null arrays are stored: storing 1 null value or 1M null
     /// values takes the same size.
-    fn marker_component() -> ComponentName;
+    fn indicator_component() -> ComponentName;
 
     /// Returns the number of instances of the archetype, i.e. the number of instances currently
     /// present in its required component(s).

--- a/crates/re_types/src/testing/archetypes/fuzzy.rs
+++ b/crates/re_types/src/testing/archetypes/fuzzy.rs
@@ -290,8 +290,8 @@ impl crate::Archetype for AffixFuzzer1 {
     }
 
     #[inline]
-    fn marker_component() -> crate::ComponentName {
-        "rerun.testing.archetypes.AffixFuzzer1Marker".into()
+    fn indicator_component() -> crate::ComponentName {
+        "rerun.testing.archetypes.AffixFuzzer1Indicator".into()
     }
 
     #[inline]
@@ -1935,9 +1935,9 @@ impl crate::Archetype for AffixFuzzer1 {
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.testing.archetypes.AffixFuzzer1Marker".to_owned(),
+                    "rerun.testing.archetypes.AffixFuzzer1Indicator".to_owned(),
                     Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.testing.archetypes.AffixFuzzer1Marker".to_owned()),
+                    Some("rerun.testing.archetypes.AffixFuzzer1Indicator".to_owned()),
                 );
                 let array = ::arrow2::array::NullArray::new(
                     datatype.to_logical_type().clone(),
@@ -1946,7 +1946,7 @@ impl crate::Archetype for AffixFuzzer1 {
                 .boxed();
                 Some((
                     ::arrow2::datatypes::Field::new(
-                        "rerun.testing.archetypes.AffixFuzzer1Marker",
+                        "rerun.testing.archetypes.AffixFuzzer1Indicator",
                         datatype,
                         false,
                     ),

--- a/crates/re_types/src/testing/archetypes/fuzzy.rs
+++ b/crates/re_types/src/testing/archetypes/fuzzy.rs
@@ -290,6 +290,16 @@ impl crate::Archetype for AffixFuzzer1 {
     }
 
     #[inline]
+    fn marker_component() -> crate::ComponentName {
+        "rerun.testing.archetypes.AffixFuzzer1Marker".into()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        1
+    }
+
+    #[inline]
     fn try_to_arrow(
         &self,
     ) -> crate::SerializationResult<
@@ -1922,6 +1932,26 @@ impl crate::Archetype for AffixFuzzer1 {
                     })
                     .transpose()
                     .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz2118")?
+            },
+            {
+                let datatype = ::arrow2::datatypes::DataType::Extension(
+                    "rerun.testing.archetypes.AffixFuzzer1Marker".to_owned(),
+                    Box::new(::arrow2::datatypes::DataType::Null),
+                    Some("rerun.testing.archetypes.AffixFuzzer1Marker".to_owned()),
+                );
+                let array = ::arrow2::array::NullArray::new(
+                    datatype.to_logical_type().clone(),
+                    self.num_instances(),
+                )
+                .boxed();
+                Some((
+                    ::arrow2::datatypes::Field::new(
+                        "rerun.testing.archetypes.AffixFuzzer1Marker",
+                        datatype,
+                        false,
+                    ),
+                    array,
+                ))
             },
         ]
         .into_iter()

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1279,7 +1279,7 @@ fn archetype_to_data_cells(
         }
     });
 
-    let marker_fqname = format!("rerun.components.{}Marker", obj.name);
+    let indicator_fqname = format!("rerun.components.{}Indicator", obj.name);
     Method {
         docs: "Creates a list of Rerun DataCell from this archetype.".into(),
         declaration: MethodDeclaration {
@@ -1295,7 +1295,7 @@ fn archetype_to_data_cells(
             #(#push_cells)*
             {
                 const auto result =
-                    create_marker_component(#marker_fqname, num_instances());
+                    create_indicator_component(#indicator_fqname, num_instances());
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1228,6 +1228,7 @@ fn archetype_to_data_cells(
 ) -> Method {
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("result.hpp");
+    hpp_includes.insert_rerun("arrow.hpp");
     hpp_includes.insert_system("vector"); // std::vector
 
     // TODO(andreas): Splats need to be handled separately.
@@ -1278,6 +1279,7 @@ fn archetype_to_data_cells(
         }
     });
 
+    let marker_fqname = format!("rerun.components.{}Marker", obj.name);
     Method {
         docs: "Creates a list of Rerun DataCell from this archetype.".into(),
         declaration: MethodDeclaration {
@@ -1291,6 +1293,14 @@ fn archetype_to_data_cells(
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             #(#push_cells)*
+            {
+                const auto result =
+                    create_marker_component(#marker_fqname, num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             return cells;

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -1047,8 +1047,8 @@ fn quote_trait_impls_from_obj(
                 })
             };
 
-            let marker_fqname =
-                format!("{}Marker", obj.fqname).replace("rerun.archetypes", "rerun.components");
+            let indicator_fqname =
+                format!("{}Indicator", obj.fqname).replace("rerun.archetypes", "rerun.components");
 
             quote! {
                 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; #num_required]> =
@@ -1094,8 +1094,8 @@ fn quote_trait_impls_from_obj(
                     }
 
                     #[inline]
-                    fn marker_component() -> crate::ComponentName  {
-                        #marker_fqname.into()
+                    fn indicator_component() -> crate::ComponentName  {
+                        #indicator_fqname.into()
                     }
 
                     #[inline]
@@ -1110,19 +1110,19 @@ fn quote_trait_impls_from_obj(
                         use crate::{Loggable as _, ResultExt as _};
                         Ok([
                             #({ #all_serializers }),*,
-                            // Inject the marker component.
+                            // Inject the indicator component.
                             {
                                 let datatype = ::arrow2::datatypes::DataType::Extension(
-                                    #marker_fqname.to_owned(),
+                                    #indicator_fqname.to_owned(),
                                     Box::new(::arrow2::datatypes::DataType::Null),
                                     // NOTE: Mandatory during migration to codegen.
-                                    Some(#marker_fqname.to_owned()),
+                                    Some(#indicator_fqname.to_owned()),
                                 );
                                 let array = ::arrow2::array::NullArray::new(
                                     datatype.to_logical_type().clone(), self.num_instances(),
                                 ).boxed();
                                 Some((
-                                    ::arrow2::datatypes::Field::new(#marker_fqname, datatype, false),
+                                    ::arrow2::datatypes::Field::new(#indicator_fqname, datatype, false),
                                     array,
                                 ))
                             },

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -886,6 +886,24 @@ fn quote_trait_impls_from_obj(
                 (num_components, quoted_components)
             }
 
+            let first_required_comp = obj
+                .fields
+                .iter()
+                .find(|field| {
+                    field
+                        .try_get_attr::<String>(ATTR_RERUN_COMPONENT_REQUIRED)
+                        .is_some()
+                })
+                // NOTE: must have at least one required component.
+                .unwrap();
+
+            let num_instances = if first_required_comp.typ.is_plural() {
+                let name = format_ident!("{}", first_required_comp.name);
+                quote!(self.#name.len())
+            } else {
+                quote!(1)
+            };
+
             let (num_required, required) =
                 compute_components(obj, ATTR_RERUN_COMPONENT_REQUIRED, objects);
             let (num_recommended, recommended) =
@@ -1029,6 +1047,9 @@ fn quote_trait_impls_from_obj(
                 })
             };
 
+            let marker_fqname =
+                format!("{}Marker", obj.fqname).replace("rerun.archetypes", "rerun.components");
+
             quote! {
                 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; #num_required]> =
                     once_cell::sync::Lazy::new(|| {[#required]});
@@ -1073,11 +1094,39 @@ fn quote_trait_impls_from_obj(
                     }
 
                     #[inline]
+                    fn marker_component() -> crate::ComponentName  {
+                        #marker_fqname.into()
+                    }
+
+                    #[inline]
+                    fn num_instances(&self) -> usize {
+                        #num_instances
+                    }
+
+                    #[inline]
                     fn try_to_arrow(
                         &self,
                     ) -> crate::SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>> {
                         use crate::{Loggable as _, ResultExt as _};
-                        Ok([ #({ #all_serializers },)* ].into_iter().flatten().collect())
+                        Ok([
+                            #({ #all_serializers }),*,
+                            // Inject the marker component.
+                            {
+                                let datatype = ::arrow2::datatypes::DataType::Extension(
+                                    #marker_fqname.to_owned(),
+                                    Box::new(::arrow2::datatypes::DataType::Null),
+                                    // NOTE: Mandatory during migration to codegen.
+                                    Some(#marker_fqname.to_owned()),
+                                );
+                                let array = ::arrow2::array::NullArray::new(
+                                    datatype.to_logical_type().clone(), self.num_instances(),
+                                ).boxed();
+                                Some((
+                                    ::arrow2::datatypes::Field::new(#marker_fqname, datatype, false),
+                                    array,
+                                ))
+                            },
+                        ].into_iter().flatten().collect())
                     }
 
                     #[inline]

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -48,6 +48,14 @@ impl re_types::Archetype for ColorArchetype {
         Self::required_components()
     }
 
+    fn marker_component() -> re_types::ComponentName {
+        unimplemented!()
+    }
+
+    fn num_instances(&self) -> usize {
+        unimplemented!()
+    }
+
     fn try_to_arrow(
         &self,
     ) -> re_types::SerializationResult<

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -48,7 +48,7 @@ impl re_types::Archetype for ColorArchetype {
         Self::required_components()
     }
 
-    fn marker_component() -> re_types::ComponentName {
+    fn indicator_component() -> re_types::ComponentName {
         unimplemented!()
     }
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -18,6 +18,16 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result = create_marker_component(
+                    "rerun.components.AnnotationContextMarker",
+                    num_instances()
+                );
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -19,8 +19,8 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result = create_marker_component(
-                    "rerun.components.AnnotationContextMarker",
+                const auto result = create_indicator_component(
+                    "rerun.components.AnnotationContextIndicator",
                     num_instances()
                 );
                 if (result.is_err()) {

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/annotation_context.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -80,8 +80,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.Arrows3DMarker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.Arrows3DIndicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -79,6 +79,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.Arrows3DMarker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -19,6 +19,16 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result = create_marker_component(
+                    "rerun.components.DisconnectedSpaceMarker",
+                    num_instances()
+                );
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -20,8 +20,8 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result = create_marker_component(
-                    "rerun.components.DisconnectedSpaceMarker",
+                const auto result = create_indicator_component(
+                    "rerun.components.DisconnectedSpaceIndicator",
                     num_instances()
                 );
                 if (result.is_err()) {

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/disconnected_space.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -79,8 +79,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.LineStrips2DMarker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.LineStrips2DIndicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -78,6 +78,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.LineStrips2DMarker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -69,6 +69,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.LineStrips3DMarker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -70,8 +70,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.LineStrips3DMarker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.LineStrips3DIndicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -89,8 +89,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.Points2DMarker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.Points2DIndicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -88,6 +88,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.Points2DMarker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -79,6 +79,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.Points3DMarker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -80,8 +80,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.Points3DMarker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.Points3DIndicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -19,8 +19,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.Transform3DMarker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.Transform3DIndicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -18,6 +18,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.Transform3DMarker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../arrow.hpp"
 #include "../components/transform3d.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"

--- a/rerun_cpp/src/rerun/arrow.cpp
+++ b/rerun_cpp/src/rerun/arrow.cpp
@@ -3,6 +3,7 @@
 #include <arrow/api.h>
 #include <arrow/io/api.h>
 #include <arrow/ipc/api.h>
+#include <string>
 
 namespace rerun {
     Result<std::shared_ptr<arrow::Buffer>> ipc_from_table(const arrow::Table& table) {
@@ -17,5 +18,25 @@ namespace rerun {
         } else {
             return result.status();
         }
+    }
+
+    Result<rerun::DataCell> create_marker_component(
+        const char* marker_fqname, size_t num_instances
+    ) {
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto builder = std::make_shared<arrow::NullBuilder>(pool);
+        ARROW_RETURN_NOT_OK(builder->AppendNulls(static_cast<uint64_t>(num_instances)));
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        auto schema = arrow::schema({arrow::field(marker_fqname, arrow::null(), false)});
+
+        rerun::DataCell cell;
+        cell.component_name = marker_fqname;
+        const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+        RR_RETURN_NOT_OK(ipc_result.error);
+        cell.buffer = std::move(ipc_result.value);
+
+        return cell;
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/arrow.cpp
+++ b/rerun_cpp/src/rerun/arrow.cpp
@@ -20,8 +20,8 @@ namespace rerun {
         }
     }
 
-    Result<rerun::DataCell> create_marker_component(
-        const char* marker_fqname, size_t num_instances
+    Result<rerun::DataCell> create_indicator_component(
+        const char* indicator_fqname, size_t num_instances
     ) {
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto builder = std::make_shared<arrow::NullBuilder>(pool);
@@ -29,10 +29,10 @@ namespace rerun {
         std::shared_ptr<arrow::Array> array;
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-        auto schema = arrow::schema({arrow::field(marker_fqname, arrow::null(), false)});
+        auto schema = arrow::schema({arrow::field(indicator_fqname, arrow::null(), false)});
 
         rerun::DataCell cell;
-        cell.component_name = marker_fqname;
+        cell.component_name = indicator_fqname;
         const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
         RR_RETURN_NOT_OK(ipc_result.error);
         cell.buffer = std::move(ipc_result.value);

--- a/rerun_cpp/src/rerun/arrow.hpp
+++ b/rerun_cpp/src/rerun/arrow.hpp
@@ -17,5 +17,5 @@ namespace rerun {
     /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
     Result<std::shared_ptr<arrow::Buffer>> ipc_from_table(const arrow::Table& table);
 
-    Result<rerun::DataCell> create_marker_component(const char* arch_name, size_t num_instances);
+    Result<rerun::DataCell> create_indicator_component(const char* arch_name, size_t num_instances);
 } // namespace rerun

--- a/rerun_cpp/src/rerun/arrow.hpp
+++ b/rerun_cpp/src/rerun/arrow.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <memory>
+#include "data_cell.hpp"
 #include "result.hpp"
 
 namespace arrow {
@@ -15,4 +16,6 @@ namespace rerun {
     /// * <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>
     /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
     Result<std::shared_ptr<arrow::Buffer>> ipc_from_table(const arrow::Table& table);
+
+    Result<rerun::DataCell> create_marker_component(const char* arch_name, size_t num_instances);
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -639,8 +639,10 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                const auto result =
-                    create_marker_component("rerun.components.AffixFuzzer1Marker", num_instances());
+                const auto result = create_indicator_component(
+                    "rerun.components.AffixFuzzer1Indicator",
+                    num_instances()
+                );
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -638,6 +638,14 @@ namespace rerun {
                 }
                 cells.emplace_back(std::move(result.value));
             }
+            {
+                const auto result =
+                    create_marker_component("rerun.components.AffixFuzzer1Marker", num_instances());
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
 
             return cells;
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <rerun/arrow.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>

--- a/rerun_py/rerun_sdk/rerun/_rerun2/log.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/log.py
@@ -65,21 +65,21 @@ def _add_extension_components(
             instanced[name] = pa_value  # noqa
 
 
-def _add_marker_component(
+def _add_indicator_component(
     arch_name: str,
     num_instances: int,
     instanced: dict[str, pa.ExtensionArray],
 ) -> None:
-    marker_name = f"rerun.components.{arch_name}Marker"
+    indicator_name = f"rerun.components.{arch_name}Indicator"
 
-    class MarkerComponentType(pa.ExtensionType):  # type: ignore[misc]
+    class IndicatorComponentType(pa.ExtensionType):  # type: ignore[misc]
         def __init__(self) -> None:
-            pa.ExtensionType.__init__(self, pa.null(), marker_name)
+            pa.ExtensionType.__init__(self, pa.null(), indicator_name)
 
         def __arrow_ext_serialize__(self) -> bytes:
             return b""
 
-    instanced[marker_name] = pa.nulls(num_instances, type=MarkerComponentType()).storage
+    instanced[indicator_name] = pa.nulls(num_instances, type=IndicatorComponentType()).storage
 
 
 def _extract_components(entity: Archetype) -> Iterable[tuple[NamedExtensionArray, bool]]:
@@ -174,7 +174,7 @@ def log(
     if ext:
         _add_extension_components(instanced, splats, ext, None)
 
-    _add_marker_component(type(entity).__name__, num_instances, instanced)
+    _add_indicator_component(type(entity).__name__, num_instances, instanced)
 
     if splats:
         splats["rerun.instance_key"] = _splat()


### PR DESCRIPTION
A very light implementation of marker components, i.e. no code is generated for the actual markers, they are simply injected just-in-time in each SDK's log methods and/or archetype builders.

Marker components are empty components that indicate that a row was logged using our high-level archetype-based APIs.
They open new opportunities in terms of API design, better heuristics and performance improvements on the query side.

Marker components are non-splatted null arrays.
Their names follow the pattern `rerun.components.{ArchetypeName}Marker`, e.g. `rerun.components.Points3DMarker`.
The reason for not using splats is so that marker components don't require dedicated rows. This is not an issue because of the way null arrays are stored: storing 1 null value or 1M null values takes the same size.

Roundtrip tests are used to check for regressions.
Here's an example dump for a 3D point cloud:
```
┌──────────┬───────────────────────────────┬──────────────────────────────────┬───────────────────────────────────┬─────────────────────┬─────────────────────────────────┬────────────────────┬─────────────────┬──────────────────────────┬──────────────┐
│ log_tick ┆ log_time                      ┆ rerun.row_id                     ┆ rerun.entity_path                 ┆ rerun.num_instances ┆ rerun.components.Points3DMarker ┆ rerun.instance_key ┆ rerun.label     ┆ rerun.point3d            ┆ rerun.radius │
│ ---      ┆ ---                           ┆ ---                              ┆ ---                               ┆ ---                 ┆ ---                             ┆ ---                ┆ ---             ┆ ---                      ┆ ---          │
│ i64      ┆ timestamp(ns)                 ┆ extension<rerun.tuid>[struct[2]] ┆ extension<rerun.entity_path>[str] ┆ u32                 ┆ list[null]                      ┆ list[u64]          ┆ list[str]       ┆ list[fixed-list[f32; 3]] ┆ list[f32]    │
╞══════════╪═══════════════════════════════╪══════════════════════════════════╪═══════════════════════════════════╪═════════════════════╪═════════════════════════════════╪════════════════════╪═════════════════╪══════════════════════════╪══════════════╡
│ 0        ┆ 2023-08-28 09:22:44.104730281 ┆ 177F81ACCDFAE2C7325F77DD605543A0 ┆ points3d                          ┆ 2                   ┆ [-, -]                          ┆ [66, 666]          ┆ [hello, friend] ┆ [[1, 2, 3], [4, 5, 6]]   ┆ [0.42, 0.43] │
└──────────┴───────────────────────────────┴──────────────────────────────────┴───────────────────────────────────┴─────────────────────┴─────────────────────────────────┴────────────────────┴─────────────────┴──────────────────────────┴──────────────┘
```

Required for #3032

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3121) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3121)
- [Docs preview](https://rerun.io/preview/c5fba3abe05fb3b20da92dee91f2d955b02bcc9d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c5fba3abe05fb3b20da92dee91f2d955b02bcc9d/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)