### PR TITLE
Make `custom_space_view` example more verbose

### DIFF
--- a/examples/rust/custom_space_view/src/main.rs
+++ b/examples/rust/custom_space_view/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_env = re_viewer::AppEnvironment::Custom("My extended Rerun Viewer".to_owned());
 
     println!(
-        "This example starts a custom Rerun Viewer that is ready to accept data... you have to give it some!"
+        "This example starts a custom Rerun Viewer that is ready to accept data… you have to give it some!"
     );
     println!("Try for example to run: `cargo run -p minimal_options -- --connect` in another terminal instance.");
 

--- a/examples/rust/custom_space_view/src/main.rs
+++ b/examples/rust/custom_space_view/src/main.rs
@@ -41,6 +41,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This is used for analytics, if the `analytics` feature is on in `Cargo.toml`
     let app_env = re_viewer::AppEnvironment::Custom("My extended Rerun Viewer".to_owned());
 
+    println!(
+        "This example starts a custom Rerun Viewer that is ready to accept data... you have to give it some!"
+    );
+    println!("Try for example to run: `cargo run -p minimal_options -- --connect` in another terminal instance.");
+
     re_viewer::run_native_app(Box::new(move |cc, re_ui| {
         let rx = re_viewer::wake_up_ui_thread_on_each_msg(rx, cc.egui_ctx.clone());
 


### PR DESCRIPTION
Turns out it's _not_ broken, it's just waiting to be fed data. Updated to tell the user to do so.

Fixes #3122 

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3123) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3123)
- [Docs preview](https://rerun.io/preview/6a76bb6b443d698c81a4e9b02c3d0bc6bd1237fe/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6a76bb6b443d698c81a4e9b02c3d0bc6bd1237fe/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)