### PR TITLE
Handle serde-field that fails to deserialize

### DIFF
--- a/crates/re_log_types/src/serde_field.rs
+++ b/crates/re_log_types/src/serde_field.rs
@@ -63,14 +63,17 @@ where
 
 impl<T> ArrowDeserialize for SerdeField<T>
 where
-    T: serde::ser::Serialize + serde::de::DeserializeOwned,
+    T: serde::ser::Serialize + serde::de::DeserializeOwned + Default,
 {
     type ArrayType = BinaryArray<i32>;
 
     #[inline]
     fn arrow_deserialize(v: <&Self::ArrayType as IntoIterator>::Item) -> Option<T> {
         re_tracing::profile_function!();
-        v.and_then(|v| rmp_serde::from_slice::<T>(v).ok())
+        Some(
+            v.and_then(|v| rmp_serde::from_slice::<T>(v).ok())
+                .unwrap_or_default(),
+        )
     }
 }
 
@@ -79,7 +82,7 @@ mod tests {
     use super::SerdeField;
     use arrow2_convert::{ArrowDeserialize, ArrowField, ArrowSerialize};
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, Default, serde::Deserialize, serde::Serialize)]
     struct SomeStruct {
         foo: String,
         bar: u32,

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -34,6 +34,7 @@ pub use command_sender::{
 };
 pub use component_ui_registry::{ComponentUiRegistry, UiVerbosity};
 pub use item::{resolve_mono_instance_path, resolve_mono_instance_path_item, Item, ItemCollection};
+use re_log_types::EntityPath;
 pub use selection_history::SelectionHistory;
 pub use selection_state::{
     HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
@@ -76,6 +77,12 @@ impl SpaceViewId {
 
     pub fn random() -> Self {
         Self(uuid::Uuid::new_v4())
+    }
+
+    pub fn from_entity_path(path: &EntityPath) -> Self {
+        path.last()
+            .and_then(|last| uuid::Uuid::parse_str(last.to_string().as_str()).ok())
+            .map_or(Self::invalid(), Self)
     }
 
     pub fn hashed_from_str(s: &str) -> Self {

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -70,6 +70,10 @@ pub mod external {
 pub struct SpaceViewId(uuid::Uuid);
 
 impl SpaceViewId {
+    pub fn invalid() -> Self {
+        Self(uuid::Uuid::nil())
+    }
+
     pub fn random() -> Self {
         Self(uuid::Uuid::new_v4())
     }

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -34,6 +34,20 @@ pub struct SpaceViewBlueprint {
     pub entities_determined_by_user: bool,
 }
 
+// Default needed for deserialization when adding/changing fields.
+impl Default for SpaceViewBlueprint {
+    fn default() -> Self {
+        Self {
+            id: SpaceViewId::invalid(),
+            display_name: "invalid".to_owned(),
+            class_name: SpaceViewClassName::new("invalid"),
+            space_origin: EntityPath::root(),
+            contents: Default::default(),
+            entities_determined_by_user: Default::default(),
+        }
+    }
+}
+
 /// Determine whether this `SpaceViewBlueprint` has user-edits relative to another `SpaceViewBlueprint`
 impl SpaceViewBlueprint {
     pub fn has_edits(&self, other: &Self) -> bool {

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -42,7 +42,7 @@ impl Default for SpaceViewBlueprint {
             display_name: "invalid".to_owned(),
             class_name: SpaceViewClassName::new("invalid"),
             space_origin: EntityPath::root(),
-            contents: Default::default(),
+            data_blueprint: Default::default(),
             entities_determined_by_user: Default::default(),
         }
     }


### PR DESCRIPTION
### What
arrow2-convert forces us into needing to provide data even if serde fail to deserialize the field. Fall back to default in this case, but specify invalid.

Resolves: https://github.com/rerun-io/rerun/issues/3127

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3129) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3129)
- [Docs preview](https://rerun.io/preview/f7ddbe7c2734e63199f57eb8cacfd847b40b4181/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f7ddbe7c2734e63199f57eb8cacfd847b40b4181/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)