### PR TITLE
Support loading images and meshes on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,7 @@ dependencies = [
  "itertools 0.11.0",
  "rayon",
  "re_build_tools",
+ "re_components",
  "re_log",
  "re_log_encoding",
  "re_log_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,7 +4049,6 @@ dependencies = [
  "re_log",
  "re_log_encoding",
  "re_log_types",
- "re_sdk",
  "re_smart_channel",
  "re_tracing",
  "re_ws_comms",

--- a/crates/re_components/src/lib.rs
+++ b/crates/re_components/src/lib.rs
@@ -33,7 +33,6 @@ mod text_box;
 mod text_entry;
 mod vec;
 
-#[cfg(not(target_arch = "wasm32"))]
 mod load_file;
 
 #[cfg(feature = "arrow_datagen")]
@@ -66,7 +65,9 @@ pub use self::{
 pub use self::tensor::{TensorImageLoadError, TensorImageSaveError};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use self::load_file::{data_cell_from_file_path, data_cell_from_mesh_file_path, FromFileError};
+pub use self::load_file::{data_cell_from_file_path, data_cell_from_mesh_file_path};
+
+pub use self::load_file::{data_cell_from_file_contents, FromFileError};
 
 // This is very convenient to re-export
 pub use re_log_types::LegacyComponent;

--- a/crates/re_data_source/Cargo.toml
+++ b/crates/re_data_source/Cargo.toml
@@ -23,6 +23,7 @@ sdk = ["dep:re_sdk"]
 
 
 [dependencies]
+re_components.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_log.workspace = true

--- a/crates/re_data_source/Cargo.toml
+++ b/crates/re_data_source/Cargo.toml
@@ -19,8 +19,6 @@ all-features = true
 [features]
 default = []
 
-sdk = ["dep:re_sdk"]
-
 
 [dependencies]
 re_components.workspace = true
@@ -34,9 +32,6 @@ re_ws_comms = { workspace = true, features = ["client"] }
 anyhow.workspace = true
 itertools.workspace = true
 rayon.workspace = true
-
-# Optional:
-re_sdk = { workspace = true, optional = true }
 
 
 [build-dependencies]

--- a/crates/re_data_source/src/data_source.rs
+++ b/crates/re_data_source/src/data_source.rs
@@ -117,6 +117,9 @@ impl DataSource {
                 let store_id = re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
                 crate::load_file_path::load_file_path(store_id, path.clone(), tx)
                     .with_context(|| format!("{path:?}"))?;
+                if let Some(on_msg) = on_msg {
+                    on_msg();
+                }
                 Ok(rx)
             }
 
@@ -129,6 +132,9 @@ impl DataSource {
                 let store_id = re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
                 crate::load_file_contents::load_file_contents(store_id, file_contents, tx)
                     .with_context(|| format!("{name:?}"))?;
+                if let Some(on_msg) = on_msg {
+                    on_msg();
+                }
                 Ok(rx)
             }
 

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -103,9 +103,12 @@ impl EntityPath {
     /// The returned path will only have one part.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_file_path_as_single_string(file_path: &std::path::Path) -> Self {
-        Self::new(vec![EntityPathPart::Index(crate::Index::String(
-            file_path.to_string_lossy().to_string(),
-        ))])
+        Self::from_single_string(file_path.to_string_lossy().to_string())
+    }
+
+    /// Treat the string as one opaque string, NOT splitting on any slashes.
+    pub fn from_single_string(string: String) -> Self {
+        Self::new(vec![EntityPathPart::Index(crate::Index::String(string))])
     }
 
     #[inline]

--- a/crates/re_sdk/src/msg_sender.rs
+++ b/crates/re_sdk/src/msg_sender.rs
@@ -181,6 +181,30 @@ impl MsgSender {
         })
     }
 
+    /// Log the given mesh or image file.
+    ///
+    /// Supported file formats are:
+    ///  * `glb`, `gltf`, `obj`: encoded meshes, leaving it to the viewer to decode
+    ///  * `jpg`, `jpeg`: encoded JPEG, leaving it to the viewer to decode. Requires the `image` feature.
+    ///  * `png` and other image formats: decoded here. Requires the `image` feature.
+    ///
+    /// All other formats will return an error.
+    pub fn from_file_contents(
+        file_name: &str,
+        bytes: Vec<u8>,
+    ) -> Result<Self, re_components::FromFileError> {
+        let ent_path = re_log_types::EntityPath::from_file_path_as_single_string(
+            std::path::Path::new(file_name),
+        );
+        let cell = re_components::data_cell_from_file_contents(file_name, bytes)?;
+
+        Ok(Self {
+            num_instances: Some(cell.num_instances()),
+            instanced: vec![cell],
+            ..Self::new(ent_path)
+        })
+    }
+
     // --- Time ---
 
     /// Appends a given `timepoint` to the current message.

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -329,7 +329,7 @@ impl App {
                         self.add_receiver(rx);
                     }
                     Err(err) => {
-                        re_log::error!("Failed to open data source: {err}");
+                        re_log::error!("Failed to open data source: {}", re_error::format(err));
                     }
                 }
             }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -855,6 +855,8 @@ impl App {
                     .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(path)));
             }
         }
+
+        egui_ctx.request_repaint();
     }
 
     /// This function will create an empty blueprint whenever the welcome screen should be

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1208,6 +1208,8 @@ fn open_file_dialog_native() -> Vec<std::path::PathBuf> {
 async fn async_open_rrd_dialog() -> Vec<re_data_source::FileContents> {
     let files = rfd::AsyncFileDialog::new()
         .add_filter("Rerun data file", &["rrd"])
+        .add_filter("Meshes", re_data_source::SUPPORTED_MESH_EXTENSIONS)
+        .add_filter("Images", re_data_source::SUPPORTED_IMAGE_EXTENSIONS)
         .pick_files()
         .await
         .unwrap_or_default();

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -48,7 +48,7 @@ native_viewer = ["dep:re_viewer"]
 server = ["re_sdk_comms/server"]
 
 ## Embed the Rerun SDK and re-export all of its public symbols.
-sdk = ["dep:re_sdk", "re_data_source/sdk"]
+sdk = ["dep:re_sdk"]
 
 ## Support serving a web viewer over HTTP.
 ##


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/2229

### What
Drag-dropping images and meshes now works on web, as does File->Open.

I also managed to get rid of the use of `MsgSender` to create a `LogMsg`, simplifying the dependencies a bit (if not the code).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3131) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3131)
- [Docs preview](https://rerun.io/preview/551ba6c6df4dd6d2d13760f51942e83bff3fe4ce/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/551ba6c6df4dd6d2d13760f51942e83bff3fe4ce/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)