### PR TITLE
Fix the 3d space view's tooltip help text

### DIFF
--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -289,12 +289,12 @@ pub fn help_text(re_ui: &re_ui::ReUi) -> egui::WidgetText {
     layout.add_button_text("WASD");
     layout.add(" and ");
     layout.add_button_text("QE");
-    layout.add("\n");
+    layout.add(".\n");
 
     layout.add(SPEED_UP_3D_MODIFIER);
-    layout.add(" slows down, ");
+    layout.add(" speeds up, ");
     layout.add(SLOW_DOWN_3D_MODIFIER);
-    layout.add(" speeds up\n\n");
+    layout.add(" slows down.\n\n");
 
     layout.add_button_text("double-click");
     layout.add(" an object to focus the view on it.\n");


### PR DESCRIPTION
### What

As the title says. Speed up/slow down were inverted.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3132) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3132)
- [Docs preview](https://rerun.io/preview/075fb6879c831fbfaf96757b07f867eea0a43589/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/075fb6879c831fbfaf96757b07f867eea0a43589/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)