### PR TITLE
Fix hot repaint: run pending commands _last_, skip request_repaint()

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1058,7 +1058,7 @@ impl eframe::App for App {
 
         self.handle_dropping_files(egui_ctx);
 
-        // Run pending commands last:
+        // Run pending commands last (so we don't have to wait for a repaint before they are run):
         self.run_pending_ui_commands(frame, egui_ctx, &app_blueprint, store_context.as_ref());
         self.run_pending_system_commands(&mut store_hub, egui_ctx);
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -855,8 +855,6 @@ impl App {
                     .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(path)));
             }
         }
-
-        egui_ctx.request_repaint();
     }
 
     /// This function will create an empty blueprint whenever the welcome screen should be
@@ -1058,11 +1056,11 @@ impl eframe::App for App {
             self.command_sender.send_ui(cmd);
         }
 
-        self.run_pending_ui_commands(frame, egui_ctx, &app_blueprint, store_context.as_ref());
-
-        self.run_pending_system_commands(&mut store_hub, egui_ctx);
-
         self.handle_dropping_files(egui_ctx);
+
+        // Run pending commands last:
+        self.run_pending_ui_commands(frame, egui_ctx, &app_blueprint, store_context.as_ref());
+        self.run_pending_system_commands(&mut store_hub, egui_ctx);
 
         // Return the `StoreHub` to the Viewer so we have it on the next frame
         self.store_hub = Some(store_hub);


### PR DESCRIPTION
### What
* closes https://github.com/rerun-io/rerun/issues/2888

I accidentally called `request_repaint` every frame 😬 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3136) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3136)
- [Docs preview](https://rerun.io/preview/051afd31caa8b0e19bffff35c76054ca8bdad5e9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/051afd31caa8b0e19bffff35c76054ca8bdad5e9/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)