### PR TITLE
Fix bug in `ReceiveSet`: drop disconnected receivers

### DIFF
--- a/crates/re_smart_channel/src/lib.rs
+++ b/crates/re_smart_channel/src/lib.rs
@@ -1,9 +1,6 @@
 //! A channel that keeps track of latency and queue length.
 
-use std::sync::{
-    atomic::{AtomicBool, AtomicU64},
-    Arc,
-};
+use std::sync::{atomic::AtomicU64, Arc};
 
 use web_time::Instant;
 
@@ -152,17 +149,8 @@ pub(crate) fn smart_channel_with_stats<T: Send>(
 ) -> (Sender<T>, Receiver<T>) {
     let (tx, rx) = crossbeam::channel::unbounded();
     let sender_source = Arc::new(sender_source);
-    let sender = Sender {
-        tx,
-        source: sender_source,
-        stats: stats.clone(),
-    };
-    let receiver = Receiver {
-        rx,
-        stats,
-        source,
-        connected: AtomicBool::new(true),
-    };
+    let sender = Sender::new(tx, sender_source, stats.clone());
+    let receiver = Receiver::new(rx, stats, source);
     (sender, receiver)
 }
 

--- a/crates/re_smart_channel/src/receiver.rs
+++ b/crates/re_smart_channel/src/receiver.rs
@@ -9,12 +9,25 @@ use crate::{
 
 pub struct Receiver<T: Send> {
     pub(crate) rx: crossbeam::channel::Receiver<SmartMessage<T>>,
-    pub(crate) stats: Arc<SharedStats>,
+    stats: Arc<SharedStats>,
     pub(crate) source: Arc<SmartChannelSource>,
-    pub(crate) connected: AtomicBool,
+    connected: AtomicBool,
 }
 
 impl<T: Send> Receiver<T> {
+    pub(crate) fn new(
+        rx: crossbeam::channel::Receiver<SmartMessage<T>>,
+        stats: Arc<SharedStats>,
+        source: Arc<SmartChannelSource>,
+    ) -> Self {
+        Self {
+            rx,
+            stats,
+            source,
+            connected: AtomicBool::new(true),
+        }
+    }
+
     /// Are we still connected?
     ///
     /// Once false, we will never be connected again: the source has run dry.

--- a/crates/re_smart_channel/src/sender.rs
+++ b/crates/re_smart_channel/src/sender.rs
@@ -6,12 +6,20 @@ use crate::{SendError, SharedStats, SmartMessage, SmartMessagePayload, SmartMess
 
 #[derive(Clone)]
 pub struct Sender<T: Send> {
-    pub(crate) tx: crossbeam::channel::Sender<SmartMessage<T>>,
-    pub(crate) source: Arc<SmartMessageSource>,
-    pub(crate) stats: Arc<SharedStats>,
+    tx: crossbeam::channel::Sender<SmartMessage<T>>,
+    source: Arc<SmartMessageSource>,
+    stats: Arc<SharedStats>,
 }
 
 impl<T: Send> Sender<T> {
+    pub(crate) fn new(
+        tx: crossbeam::channel::Sender<SmartMessage<T>>,
+        source: Arc<SmartMessageSource>,
+        stats: Arc<SharedStats>,
+    ) -> Self {
+        Self { tx, source, stats }
+    }
+
     /// Clones the sender with an updated source.
     pub fn clone_as(&self, source: SmartMessageSource) -> Self {
         Self {

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -213,7 +213,14 @@ impl AppState {
             // We move the time at the very end of the frame,
             // so we have one frame to see the first data before we move the time.
             let dt = ui.ctx().input(|i| i.stable_dt);
-            let more_data_is_coming = rx.is_connected();
+
+            // Are we still connected to the data source for the current store?
+            let more_data_is_coming = if let Some(store_source) = &store_db.data_source {
+                rx.sources().iter().any(|s| s.as_ref() == store_source)
+            } else {
+                false
+            };
+
             let needs_repaint = ctx.rec_cfg.time_ctrl.update(
                 store_db.times_per_timeline(),
                 dt,


### PR DESCRIPTION
### What
`ReceiveSet` had a bug where receivers were never dropped once disconnected.

I added a unit-test and a fix.

We should have a UI panel where one can see all connected receivers…

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3137) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3137)
- [Docs preview](https://rerun.io/preview/448ec54a7d193deaa0443d5b8a523787702b6351/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/448ec54a7d193deaa0443d5b8a523787702b6351/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)