### PR TITLE
Change paper visualizations url

### DIFF
--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -127,7 +127,7 @@ root:
         - name: text-logging
           python: python/text_logging
 
-    - name: paper-walkthrough
+    - name: paper-visualizations
       title: Paper Visualizations
       prelude: |
         The following examples use Rerun to create visual walkthroughs of papers. They are typically forks


### PR DESCRIPTION
### What
Change URL for paper visualizations to .../paper-visualizations instead of .../paper-walkthrough


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3140) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3140)
- [Docs preview](https://rerun.io/preview/4bb2275ba67ed8e6e0c6480ad2a38c6ae963f7e7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4bb2275ba67ed8e6e0c6480ad2a38c6ae963f7e7/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)