### PR TITLE
GC the blueprints before saving while preserving the current state

### DIFF
--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -5,8 +5,8 @@ use arrow2::array::UnionArray;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use re_arrow_store::{
-    DataStore, DataStoreConfig, GarbageCollectionTarget, LatestAtQuery, RangeQuery, TimeInt,
-    TimeRange,
+    DataStore, DataStoreConfig, GarbageCollectionOptions, GarbageCollectionTarget, LatestAtQuery,
+    RangeQuery, TimeInt, TimeRange,
 };
 use re_components::{
     datagen::{build_frame_nr, build_some_instances, build_some_rects},
@@ -276,7 +276,11 @@ fn gc(c: &mut Criterion) {
         let store = insert_table(Default::default(), InstanceKey::name(), &table);
         b.iter(|| {
             let mut store = store.clone();
-            let (_, stats_diff) = store.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0));
+            let (_, stats_diff) = store.gc(GarbageCollectionOptions {
+                target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
+                gc_timeless: false,
+                protect_latest: 0,
+            });
             stats_diff
         });
     });
@@ -294,8 +298,11 @@ fn gc(c: &mut Criterion) {
             );
             b.iter(|| {
                 let mut store = store.clone();
-                let (_, stats_diff) =
-                    store.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0));
+                let (_, stats_diff) = store.gc(GarbageCollectionOptions {
+                    target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
+                    gc_timeless: false,
+                    protect_latest: 0,
+                });
                 stats_diff
             });
         });

--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -37,7 +37,7 @@ pub mod test_util;
 
 pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
-pub use self::store_gc::GarbageCollectionTarget;
+pub use self::store_gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats, EntityStats};
 pub use self::store_write::{WriteError, WriteResult};

--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -469,7 +469,7 @@ impl PersistentIndexedTable {
 
             // each data column
             for column in columns.values_mut() {
-                dropped_num_bytes += column.0.swap_remove(row_index).total_size_bytes();
+                dropped_num_bytes += column.0.remove(row_index).total_size_bytes();
             }
         }
 

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 
 use re_arrow_store::{
     test_row, test_util::sanity_unwrap, DataStore, DataStoreConfig, DataStoreStats,
-    GarbageCollectionTarget, LatestAtQuery, WriteError,
+    GarbageCollectionOptions, LatestAtQuery, WriteError,
 };
 use re_components::datagen::{
     build_frame_nr, build_log_time, build_some_colors, build_some_instances, build_some_point2d,
@@ -298,7 +298,7 @@ fn gc_correct() {
 
     let stats = DataStoreStats::from_store(&store);
 
-    let (row_ids, stats_diff) = store.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
+    let (row_ids, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
     let stats_diff = stats_diff + stats_empty; // account for fixed overhead
 
     assert_eq!(row_ids.len() as u64, stats.total.num_rows);
@@ -318,7 +318,7 @@ fn gc_correct() {
         assert!(store.get_msg_metadata(row_id).is_none());
     }
 
-    let (row_ids, stats_diff) = store.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
+    let (row_ids, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
     assert!(row_ids.is_empty());
     assert_eq!(DataStoreStats::default(), stats_diff);
 

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -889,6 +889,100 @@ fn gc_impl(store: &mut DataStore) {
     }
 }
 
+#[test]
+fn protected_gc() {
+    init_logs();
+
+    for config in re_arrow_store::test_util::all_configs() {
+        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        protected_gc_impl(&mut store);
+    }
+}
+
+fn protected_gc_impl(store: &mut DataStore) {
+    init_logs();
+
+    let ent_path = EntityPath::from("this/that");
+
+    let frame0: TimeInt = 0.into();
+    let frame1: TimeInt = 1.into();
+    let frame2: TimeInt = 2.into();
+    let frame3: TimeInt = 3.into();
+    let frame4: TimeInt = 4.into();
+
+    let (instances1, colors1) = (build_some_instances(3), build_some_colors(3));
+    let row1 = test_row!(ent_path @ [build_frame_nr(frame1)] => 3; [instances1.clone(), colors1]);
+
+    let points2 = build_some_point2d(3);
+    let row2 = test_row!(ent_path @ [build_frame_nr(frame2)] => 3; [instances1, points2]);
+
+    let points3 = build_some_point2d(10);
+    let row3 = test_row!(ent_path @ [build_frame_nr(frame3)] => 10; [points3]);
+
+    let colors4 = build_some_colors(5);
+    let row4 = test_row!(ent_path @ [build_frame_nr(frame4)] => 5; [colors4]);
+
+    store
+        .insert_table(&DataTable::from_rows(
+            TableId::random(),
+            [row1.clone(), row2.clone(), row3.clone(), row4.clone()],
+        ))
+        .unwrap();
+
+    // Re-insert row1 and row2 as timeless data as well
+    let mut table_timeless = DataTable::from_rows(TableId::random(), [row1.clone(), row2.clone()]);
+    table_timeless.col_timelines = Default::default();
+    store.insert_table(&table_timeless).unwrap();
+
+    store.gc(GarbageCollectionOptions {
+        target: GarbageCollectionTarget::DropAtLeastFraction(1.0),
+        gc_timeless: true,
+        protect_latest: 1,
+    });
+
+    let mut assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
+        let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+        let components_all = &[Color::name(), Point2D::name()];
+
+        let df = polars_util::latest_components(
+            store,
+            &LatestAtQuery::new(timeline_frame_nr, frame_nr),
+            &ent_path,
+            components_all,
+            &JoinType::Outer,
+        )
+        .unwrap();
+
+        let df_expected = joint_df(store.cluster_key(), rows);
+
+        store.sort_indices_if_needed();
+        assert_eq!(df_expected, df, "{store}");
+    };
+
+    // The timeless data was preserved
+    assert_latest_components(
+        frame0,
+        &[(Color::name(), &row1), (Point2D::name(), &row2)], // timeless
+    );
+
+    //
+    assert_latest_components(
+        frame3,
+        &[
+            (Color::name(), &row1),   // timeless
+            (Point2D::name(), &row3), // protected
+        ],
+    );
+
+    assert_latest_components(
+        frame4,
+        &[
+            (Color::name(), &row4),   //protected
+            (Point2D::name(), &row3), // protected
+        ],
+    );
+}
+
 // ---
 
 pub fn init_logs() {

--- a/crates/re_arrow_store/tests/dump.rs
+++ b/crates/re_arrow_store/tests/dump.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use itertools::Itertools;
 use re_arrow_store::{
-    test_row, test_util::sanity_unwrap, DataStore, DataStoreStats, GarbageCollectionTarget,
+    test_row, test_util::sanity_unwrap, DataStore, DataStoreStats, GarbageCollectionOptions,
     TimeInt, TimeRange, Timeline,
 };
 use re_components::datagen::{
@@ -31,11 +31,11 @@ fn data_store_dump() {
 
         // stress-test GC impl
         store1.wipe_timeless_data();
-        store1.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
+        store1.gc(GarbageCollectionOptions::gc_everything());
         store2.wipe_timeless_data();
-        store2.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
+        store2.gc(GarbageCollectionOptions::gc_everything());
         store3.wipe_timeless_data();
-        store3.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
+        store3.gc(GarbageCollectionOptions::gc_everything());
 
         data_store_dump_impl(&mut store1, &mut store2, &mut store3);
     }
@@ -125,8 +125,8 @@ fn data_store_dump_filtered() {
         data_store_dump_filtered_impl(&mut store1, &mut store2);
 
         // stress-test GC impl
-        store1.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
-        store2.gc(GarbageCollectionTarget::DropAtLeastFraction(1.0));
+        store1.gc(GarbageCollectionOptions::gc_everything());
+        store2.gc(GarbageCollectionOptions::gc_everything());
 
         data_store_dump_filtered_impl(&mut store1, &mut store2);
     }

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -230,7 +230,7 @@ impl StoreHub {
             if let Some(blueprint) = self.store_dbs.blueprint_mut(blueprint_id) {
                 if self.blueprint_last_save.get(blueprint_id) != Some(&blueprint.generation()) {
                     let gc_rows = blueprint.store_mut().gc(GarbageCollectionOptions {
-                        target: re_arrow_store::GarbageCollectionTarget::DropAtLeastFraction(1.0),
+                        target: re_arrow_store::GarbageCollectionTarget::Everything,
                         gc_timeless: true,
                         protect_latest: 1,
                     });

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -218,6 +218,7 @@ impl StoreHub {
     // TODO(#2579): implement persistence for web
     #[cfg(not(target_arch = "wasm32"))]
     pub fn persist_app_blueprints(&mut self) -> anyhow::Result<()> {
+        re_tracing::profile_function!();
         // Because we save blueprints based on their `ApplicationId`, we only
         // save the blueprints referenced by `blueprint_by_app_id`, even though
         // there may be other Blueprints in the Hub.

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -230,12 +230,12 @@ impl StoreHub {
 
             if let Some(blueprint) = self.store_dbs.blueprint_mut(blueprint_id) {
                 if self.blueprint_last_save.get(blueprint_id) != Some(&blueprint.generation()) {
-                    let gc_rows = blueprint.store_mut().gc(GarbageCollectionOptions {
+                    // GC everything but the latest row.
+                    blueprint.store_mut().gc(GarbageCollectionOptions {
                         target: re_arrow_store::GarbageCollectionTarget::Everything,
                         gc_timeless: true,
-                        protect_latest: 1,
+                        protect_latest: 1, // TODO(jleibs): Bump this after we have an undo buffer
                     });
-                    re_log::debug!("Cleaned up blueprint: {:?}", gc_rows);
                     // TODO(jleibs): Should we push this into a background thread? Blueprints should generally
                     // be small & fast to save, but maybe not once we start adding big pieces of user data?
                     let file_saver = save_database_to_file(blueprint, blueprint_path, None)?;


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3098

Because blueprints used timeless data and timeless data wasn't GC'd, we previously had no great way to clean up blueprints.

This PR does a few things:
 - 

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
