### PR TITLE
Fix log spam during data store tests

### DIFF
--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -380,20 +380,24 @@ impl IndexedTable {
                 }
             }
 
-            let bucket_time_range = bucket.inner.read().time_range;
+            if 0 < config.indexed_bucket_num_rows {
+                let bucket_time_range = bucket.inner.read().time_range;
 
-            re_log::debug_once!(
-                "Failed to split bucket on timeline {}",
-                bucket.timeline.format_time_range(&bucket_time_range)
-            );
-
-            if bucket_time_range.min == bucket_time_range.max {
-                re_log::warn_once!(
-                    "Found over {} rows with the same timepoint {:?}={} - perhaps you forgot to update or remove the timeline?",
-                    config.indexed_bucket_num_rows,
-                    bucket.timeline.name(),
-                    bucket.timeline.typ().format(bucket_time_range.min)
+                re_log::debug_once!(
+                    "Failed to split bucket on timeline {}",
+                    bucket.timeline.format_time_range(&bucket_time_range)
                 );
+
+                if 1 < config.indexed_bucket_num_rows
+                    && bucket_time_range.min == bucket_time_range.max
+                {
+                    re_log::warn_once!(
+                        "Found over {} rows with the same timepoint {:?}={} - perhaps you forgot to update or remove the timeline?",
+                        config.indexed_bucket_num_rows,
+                        bucket.timeline.name(),
+                        bucket.timeline.typ().format(bucket_time_range.min)
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
The default value of `indexed_bucket_num_rows` is 512, but in some tests we set it to 0 or 1. That produces a lot of spurious warnings.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3149) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3149)
- [Docs preview](https://rerun.io/preview/11ba205b2c1cd8ba6d48b7512912f56490adf86c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/11ba205b2c1cd8ba6d48b7512912f56490adf86c/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)