### PR TITLE
Restore `analytics.json` when running `rerun reset`

### DIFF
--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -672,12 +672,23 @@ fn reset_viewer() -> anyhow::Result<()> {
 
     // Note: `remove_dir_all` fails if the directory doesn't exist.
     if data_dir.exists() {
+        // Keep analytics, because it is used to uniquely idenitfy users over time.
+        let analytics_file_path = data_dir.join("analytics.json");
+        let analytics = std::fs::read(&analytics_file_path);
+
         if let Err(err) = std::fs::remove_dir_all(&data_dir) {
             anyhow::bail!("Failed to remove {data_dir:?}: {err}");
         } else {
-            eprintln!("Removed {data_dir:?}.");
-            Ok(())
+            eprintln!("Cleared {data_dir:?}.");
         }
+
+        if let Ok(analytics) = analytics {
+            // Restore analytics.json:
+            std::fs::create_dir(&data_dir).ok();
+            std::fs::write(&analytics_file_path, analytics).ok();
+        }
+
+        Ok(())
     } else {
         eprintln!("Rerun state was already cleared.");
         Ok(())


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
