### PR TITLE
Bug fix: `cargo rerun websocket-url`

### DIFF
--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use anyhow::Context as _;
 use clap::Subcommand;
 use itertools::Itertools;
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 use re_data_source::DataSource;
 use re_log_types::{LogMsg, PythonVersion};
@@ -472,7 +471,7 @@ async fn run_impl(
         }
 
         data_sources
-            .into_par_iter()
+            .into_iter()
             .map(|data_source| data_source.stream(None))
             .collect::<Result<Vec<_>, _>>()?
     };


### PR DESCRIPTION
Broke in https://github.com/rerun-io/rerun/pull/3116

Tried to use tokio from a rayon thread, which doesn't work out-of-the-box. But the rayon use is unnecessary - each call to `data_source.stream` is non-blocking anyways.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3160) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3160)
- [Docs preview](https://rerun.io/preview/11d5fea9d4982d50c808bc571299a9ded4d37177/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/11d5fea9d4982d50c808bc571299a9ded4d37177/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)