### PR TITLE
Clamp time panel height to avoid visual glitches

### DIFF
--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -76,7 +76,7 @@ impl TimePanel {
             panel_frame.inner_margin.right = 0.0;
         }
 
-        let screen_height = ui.ctx().screen_rect().width();
+        let window_height = ui.ctx().screen_rect().height();
 
         let collapsed = egui::TopBottomPanel::bottom("time_panel_collapsed")
             .resizable(false)
@@ -85,12 +85,14 @@ impl TimePanel {
             .default_height(44.0);
 
         let min_height = 150.0;
+        let min_top_space = 180.0;
         let expanded = egui::TopBottomPanel::bottom("time_panel_expanded")
             .resizable(true)
             .show_separator_line(false)
             .frame(panel_frame)
             .min_height(min_height)
-            .default_height((0.25 * screen_height).clamp(min_height, 250.0).round());
+            .max_height((window_height - min_top_space).at_least(min_height).round())
+            .default_height((0.25 * window_height).clamp(min_height, 250.0).round());
 
         egui::TopBottomPanel::show_animated_between_inside(
             ui,

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -64,6 +64,10 @@ impl TimePanel {
         ui: &mut egui::Ui,
         time_panel_expanded: bool,
     ) {
+        // this is the size of everything above the central panel (window title bar, top bar on web,
+        // etc.)
+        let screen_header_height = ui.cursor().top();
+
         let top_bar_height = 28.0;
         let margin = ctx.re_ui.bottom_panel_margin();
         let mut panel_frame = ctx.re_ui.bottom_panel_frame();
@@ -85,7 +89,7 @@ impl TimePanel {
             .default_height(44.0);
 
         let min_height = 150.0;
-        let min_top_space = 180.0;
+        let min_top_space = 150.0 + screen_header_height;
         let expanded = egui::TopBottomPanel::bottom("time_panel_expanded")
             .resizable(true)
             .show_separator_line(false)


### PR DESCRIPTION
### What

Fixes #3152

*Note to reviewer*: I had to resort to some semi-hack to measure the height of "everything above the viewport", i.e. windows title bar vs. heading banner on web (which are significantly different). That's the `screen_header_height` variable. Open to suggestion to make that cleaner.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3169) (if applicable)~~ PR demo somehow failed, here is the [demo for commit 8fb79bf](https://demo.rerun.io/commit/8fb79bf/examples/structure_from_motion/)

- [PR Build Summary](https://build.rerun.io/pr/3169)
- [Docs preview](https://rerun.io/preview/d110bc598c8fd1644d1ad658b45ece7d9c752df0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d110bc598c8fd1644d1ad658b45ece7d9c752df0/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)