### PR TITLE
Limit the size of component tooltips with `UiVerbosity::Reduced`

### DIFF
--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -77,7 +77,7 @@ impl DataUi for EntityComponentWithInstances {
             egui_extras::TableBuilder::new(ui)
                 .resizable(false)
                 .vscroll(true)
-                .auto_shrink([false, true])
+                .auto_shrink([true, true])
                 .max_scroll_height(100.0)
                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                 .columns(egui_extras::Column::auto(), 2)

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -98,7 +98,7 @@ impl DataUi for EntityComponentWithInstances {
                             // last row, suggest that there is more.
                             row.col(|ui| {
                                 ui.label(format!(
-                                    "{} more…",
+                                    "… and {} more.",
                                     re_format::format_large_number(
                                         (num_instances - max_row + 1) as _
                                     )

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -72,8 +72,8 @@ impl DataUi for EntityComponentWithInstances {
         let displayed_row = if num_instances <= max_row {
             num_instances
         } else {
-            // this accounts for the "…x more" using a row
-            max_row - 1
+            // this accounts for the "…x more" using a row and handles `num_instances == 0`
+            max_row.saturating_sub(1)
         };
 
         if num_instances == 0 {

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -48,8 +48,15 @@ impl DataUi for EntityComponentWithInstances {
         // in some cases, we don't want to display all instances
         let max_row = match verbosity {
             UiVerbosity::Small => 0,
-            UiVerbosity::Reduced => num_instances.at_most(4),
+            UiVerbosity::Reduced => num_instances.at_most(4), // includes "... x more" if any
             UiVerbosity::All => num_instances,
+        };
+
+        let displayed_row = if num_instances <= max_row {
+            num_instances
+        } else {
+            // this accounts for the "... x more" using a row
+            max_row - 1
         };
 
         if num_instances == 0 {
@@ -93,20 +100,8 @@ impl DataUi for EntityComponentWithInstances {
                 .body(|mut body| {
                     re_ui::ReUi::setup_table_body(&mut body);
                     let row_height = re_ui::ReUi::table_line_height();
-                    body.rows(row_height, max_row, |index, mut row| {
-                        if index == max_row - 1 && num_instances > max_row {
-                            // last row, suggest that there is more.
-                            row.col(|ui| {
-                                ui.label(format!(
-                                    "… and {} more.",
-                                    re_format::format_large_number(
-                                        (num_instances - max_row + 1) as _
-                                    )
-                                ));
-                            });
-
-                            row.col(|_| {});
-                        } else if let Some(instance_key) = instance_keys.get(index) {
+                    body.rows(row_height, displayed_row, |index, mut row| {
+                        if let Some(instance_key) = instance_keys.get(index) {
                             row.col(|ui| {
                                 let instance_path =
                                     InstancePath::instance(self.entity_path.clone(), *instance_key);
@@ -132,6 +127,12 @@ impl DataUi for EntityComponentWithInstances {
                         }
                     });
                 });
+            if num_instances > displayed_row {
+                ui.label(format!(
+                    "…and {} more.",
+                    re_format::format_large_number((num_instances - displayed_row) as _)
+                ));
+            }
         }
     }
 }

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -48,14 +48,14 @@ impl DataUi for EntityComponentWithInstances {
         // in some cases, we don't want to display all instances
         let max_row = match verbosity {
             UiVerbosity::Small => 0,
-            UiVerbosity::Reduced => num_instances.at_most(4), // includes "... x more" if any
+            UiVerbosity::Reduced => num_instances.at_most(4), // includes "…x more" if any
             UiVerbosity::All => num_instances,
         };
 
         let displayed_row = if num_instances <= max_row {
             num_instances
         } else {
-            // this accounts for the "... x more" using a row
+            // this accounts for the "…x more" using a row
             max_row - 1
         };
 

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -52,6 +52,23 @@ impl DataUi for EntityComponentWithInstances {
             UiVerbosity::All => num_instances,
         };
 
+        // Here we enforce that exactly `max_row` rows are displayed, which means that:
+        // - For `num_instances == max_row`, then `max_row` rows are displayed.
+        // - For `num_instances == max_row + 1`, then `max_row-1` rows are displayed and "…2 more"
+        //   is appended.
+        //
+        // ┏━━━┳━━━┳━━━┳━━━┓
+        // ┃ 3 ┃ 4 ┃ 5 ┃ 6 ┃ <- num_instances
+        // ┗━━━┻━━━┻━━━┻━━━┛
+        // ┌───┬───┬───┬───┐ ┐
+        // │ x │ x │ x │ x │ │
+        // ├───┼───┼───┼───┤ │
+        // │ x │ x │ x │ x │ │
+        // ├───┼───┼───┼───┤ ├─ max_row == 4
+        // │ x │ x │ x │ x │ │
+        // ├───┼───┼───┼───┤ │
+        // │   │ x │…+2│…+3│ │
+        // └───┴───┴───┴───┘ ┘
         let displayed_row = if num_instances <= max_row {
             num_instances
         } else {


### PR DESCRIPTION
### What

Limit the size of component tooltips with `UiVerbosity::Reduced`

Fixes #3154

<img width="227" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/b0bde6b0-52ba-4d9b-9f4f-e709638de983">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3171) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3171)
- [Docs preview](https://rerun.io/preview/35244cb0963af9643740613271415a8b7d4f4475/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/35244cb0963af9643740613271415a8b7d4f4475/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)