### PR TITLE
Add `DrawOrder` component to `Image` archetype

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -24,6 +24,17 @@ table Image (
   "attr.rust.derive": "PartialEq",
   order: 100
 ) {
+  // --- Required ---
+
   /// The image data. Should always be a rank-2 or rank-3 tensor.
-  data: rerun.components.TensorData ("attr.rerun.component_required", required, order: 2000);
+  data: rerun.components.TensorData ("attr.rerun.component_required", required, order: 1000);
+
+  // --- Optional ---
+
+
+  /// An optional floating point value that specifies the 2D drawing order.
+  /// Objects with higher values are drawn on top of those with lower values.
+  ///
+  /// The default for 2D points is -10.0.
+  draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
 }

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-99c0316197e324854f99d4d6e86ca11670198420f9864d69921eb0596f981847
+02e355095c59bc89dac399a4bb4364ff9aa1a906b0162dcc5f4c663266c4220a

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -49,6 +49,12 @@
 pub struct Image {
     /// The image data. Should always be a rank-2 or rank-3 tensor.
     pub data: crate::components::TensorData,
+
+    /// An optional floating point value that specifies the 2D drawing order.
+    /// Objects with higher values are drawn on top of those with lower values.
+    ///
+    /// The default for 2D points is -10.0.
+    pub draw_order: Option<crate::components::DrawOrder>,
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
@@ -57,14 +63,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.draw_order".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.components.TensorData".into(),
+            "rerun.draw_order".into(),
+        ]
+    });
 
 impl Image {
-    pub const NUM_COMPONENTS: usize = 1usize;
+    pub const NUM_COMPONENTS: usize = 2usize;
 }
 
 impl crate::Archetype for Image {
@@ -104,10 +115,15 @@ impl crate::Archetype for Image {
     }
 
     fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
-        [Some(&self.data as &dyn crate::ComponentList)]
-            .into_iter()
-            .flatten()
-            .collect()
+        [
+            Some(&self.data as &dyn crate::ComponentList),
+            self.draw_order
+                .as_ref()
+                .map(|comp| comp as &dyn crate::ComponentList),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     #[inline]
@@ -135,6 +151,26 @@ impl crate::Archetype for Image {
                 })
                 .transpose()
                 .with_context("rerun.archetypes.Image#data")?
+            },
+            {
+                self.draw_order
+                    .as_ref()
+                    .map(|single| {
+                        let array = <crate::components::DrawOrder>::try_to_arrow([single]);
+                        array.map(|array| {
+                            let datatype = ::arrow2::datatypes::DataType::Extension(
+                                "rerun.components.DrawOrder".into(),
+                                Box::new(array.data_type().clone()),
+                                Some("rerun.draw_order".into()),
+                            );
+                            (
+                                ::arrow2::datatypes::Field::new("draw_order", datatype, false),
+                                array,
+                            )
+                        })
+                    })
+                    .transpose()
+                    .with_context("rerun.archetypes.Image#draw_order")?
             },
             {
                 let datatype = ::arrow2::datatypes::DataType::Extension(
@@ -186,12 +222,33 @@ impl crate::Archetype for Image {
                 .ok_or_else(crate::DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Image#data")?
         };
-        Ok(Self { data })
+        let draw_order = if let Some(array) = arrays_by_name.get("draw_order") {
+            Some({
+                <crate::components::DrawOrder>::try_from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.Image#draw_order")?
+                    .into_iter()
+                    .next()
+                    .flatten()
+                    .ok_or_else(crate::DeserializationError::missing_data)
+                    .with_context("rerun.archetypes.Image#draw_order")?
+            })
+        } else {
+            None
+        };
+        Ok(Self { data, draw_order })
     }
 }
 
 impl Image {
     pub fn new(data: impl Into<crate::components::TensorData>) -> Self {
-        Self { data: data.into() }
+        Self {
+            data: data.into(),
+            draw_order: None,
+        }
+    }
+
+    pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
+        self.draw_order = Some(draw_order.into());
+        self
     }
 }

--- a/crates/re_types/src/archetypes/image_ext.rs
+++ b/crates/re_types/src/archetypes/image_ext.rs
@@ -37,7 +37,10 @@ impl Image {
             _ => return Err(ImageConstructionError::BadImageShape(data.shape)),
         };
 
-        Ok(Self { data: data.into() })
+        Ok(Self {
+            data: data.into(),
+            draw_order: None,
+        })
     }
 
     pub fn with_id(self, id: crate::datatypes::TensorId) -> Self {
@@ -48,6 +51,7 @@ impl Image {
                 buffer: self.data.0.buffer,
             }
             .into(),
+            draw_order: None,
         }
     }
 }

--- a/crates/re_types/tests/image.rs
+++ b/crates/re_types/tests/image.rs
@@ -31,6 +31,7 @@ fn image_roundtrip() {
             buffer: TensorBuffer::U8(vec![1, 2, 3, 4, 5, 6].into()),
         }
         .into(),
+        draw_order: None,
     }];
 
     let all_arch_serialized = [Image::try_from(ndarray::array![[1u8, 2, 3], [4, 5, 6]])

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -3,16 +3,25 @@
 
 #include "image.hpp"
 
+#include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 
 namespace rerun {
     namespace archetypes {
         Result<std::vector<rerun::DataCell>> Image::to_data_cells() const {
             std::vector<rerun::DataCell> cells;
-            cells.reserve(1);
+            cells.reserve(2);
 
             {
                 const auto result = rerun::components::TensorData::to_data_cell(&data, 1);
+                if (result.is_err()) {
+                    return result.error;
+                }
+                cells.emplace_back(std::move(result.value));
+            }
+            if (draw_order.has_value()) {
+                const auto& value = draw_order.value();
+                const auto result = rerun::components::DrawOrder::to_data_cell(&value, 1);
                 if (result.is_err()) {
                     return result.error;
                 }

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -4,11 +4,13 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -26,10 +28,25 @@ namespace rerun {
             /// The image data. Should always be a rank-2 or rank-3 tensor.
             rerun::components::TensorData data;
 
+            /// An optional floating point value that specifies the 2D drawing order.
+            /// Objects with higher values are drawn on top of those with lower values.
+            ///
+            /// The default for 2D points is -10.0.
+            std::optional<rerun::components::DrawOrder> draw_order;
+
           public:
             Image() = default;
 
             Image(rerun::components::TensorData _data) : data(std::move(_data)) {}
+
+            /// An optional floating point value that specifies the 2D drawing order.
+            /// Objects with higher values are drawn on top of those with lower values.
+            ///
+            /// The default for 2D points is -10.0.
+            Image& with_draw_order(rerun::components::DrawOrder _draw_order) {
+                draw_order = std::move(_draw_order);
+                return *this;
+            }
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/image.py
@@ -33,5 +33,17 @@ class Image(Archetype):
     The image data. Should always be a rank-2 or rank-3 tensor.
     """
 
+    draw_order: components.DrawOrderArray | None = field(
+        metadata={"component": "secondary"},
+        default=None,
+        converter=components.DrawOrderArray.from_similar,  # type: ignore[misc]
+    )
+    """
+    An optional floating point value that specifies the 2D drawing order.
+    Objects with higher values are drawn on top of those with lower values.
+
+    The default for 2D points is -10.0.
+    """
+
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__


### PR DESCRIPTION
:point_up: 

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3182) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3182)
- [Docs preview](https://rerun.io/preview/ef03c495715b21e03526cee6d0b9e824e40cf4b9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ef03c495715b21e03526cee6d0b9e824e40cf4b9/examples) <!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW--><!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)