### PR TITLE
Add an aspect ratio check to `upload_image.py`

### DIFF
--- a/examples/python/detect_and_track_objects/README.md
+++ b/examples/python/detect_and_track_objects/README.md
@@ -2,15 +2,15 @@
 title: Detect and Track Objects
 python: https://github.com/rerun-io/rerun/tree/latest/examples/python/detect_and_track_objects/main.py
 tags: [2D, huggingface, object-detection, object-tracking, opencv]
-thumbnail: https://static.rerun.io/04a244d056f9cfb2ac496830392916d613902def_detect_and_track_objects_480w.png
+thumbnail: https://static.rerun.io/efb301d64eef6f25e8f6ae29294bd003c0cda3a7_detect_and_track_objects_480w.png
 ---
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/04a244d056f9cfb2ac496830392916d613902def_detect_and_track_objects_480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/d9b970d5388bcbaa631b20938a941a19e47f316d_detect_and_track_objects_768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/3c8f6c4a24ed89f8cad351c25b7b39affa9d48a4_detect_and_track_objects_1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/ddfe03d04002ad9ee1b545cdad9eb02eb1e35d9f_detect_and_track_objects_1200w.png">
-  <img src="https://static.rerun.io/27aa9cc1ff7ae05f45193ce6d38dd1ed60f70276_detect_and_track_objects_full.png" alt="Detect and Track Objects example screenshot">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/efb301d64eef6f25e8f6ae29294bd003c0cda3a7_detect_and_track_objects_480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/a3df0cb3670a9f60fe0faf47ecec8d07433e1c0f_detect_and_track_objects_768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/0f88a4c52aa3f3bafd42063208f10f070383380c_detect_and_track_objects_1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/b4b918d8247ba2bb43c51cd2141e1e21de990e51_detect_and_track_objects_1200w.png">
+  <img src="https://static.rerun.io/59f5b97a8724f9037353409ab3d0b7cb47d1544b_detect_and_track_objects_full.png" alt="">
 </picture>
 
 Another more elaborate example applying simple object detection and segmentation on a video using the Huggingface `transformers` library. Tracking across frames is performed using [CSRT](https://arxiv.org/pdf/1611.08461.pdf) from OpenCV.

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -109,9 +109,10 @@ class Uploader:
     def _check_aspect_ratio(self, image: Path | Image):
         if isinstance(image, Path):
             image = PIL.Image.open(image)
-        aspect_ratio = image.width / image.height
 
+        aspect_ratio = image.width / image.height
         aspect_ok = ASPECT_RATIO_RANGE[0] < aspect_ratio < ASPECT_RATIO_RANGE[1]
+
         if not aspect_ok and not self.auto_accept:
             logging.warning(
                 f"Aspect ratio is {aspect_ratio:.2f} but should be between {ASPECT_RATIO_RANGE[0]} and "

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -111,7 +111,8 @@ class Uploader:
             image = PIL.Image.open(image)
         aspect_ratio = image.width / image.height
 
-        if not (self.auto_accept or (ASPECT_RATIO_RANGE[0] < aspect_ratio < ASPECT_RATIO_RANGE[1])):
+        aspect_ok = ASPECT_RATIO_RANGE[0] < aspect_ratio < ASPECT_RATIO_RANGE[1]
+        if not aspect_ok and not self.auto_accept:
             logging.warning(
                 f"Aspect ratio is {aspect_ratio:.2f} but should be between {ASPECT_RATIO_RANGE[0]} and "
                 f"{ASPECT_RATIO_RANGE[1]}."


### PR DESCRIPTION
### What

The example page both on web and in-app benefits from homogenous aspect ratio for example thumbnails. Having a bit of leeway _is_ beneficial to fine-tune the look though. This PR updates `upload_image.py` with a  check on the aspect ratio and asks for confirmation if it is not within bounds. This confirmation can be auto-accepted with an argument.

This PR also updates the screenshot/thumbnail for `detect_and_track_objects`, which were way out of bound.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3195) (if applicable)~~

- [PR Build Summary](https://build.rerun.io/pr/3195)
- [Docs preview](https://rerun.io/preview/a1f86d77eb1b942ebeded8e8ee532dad710dd4bc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a1f86d77eb1b942ebeded8e8ee532dad710dd4bc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)