### PR TITLE
Activate recording when openening via file dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix crash when trying to render too many line segments [#3093](https://github.com/rerun-io/rerun/pull/3093)
 - Handle serde-field that fails to deserialize [#3130](https://github.com/rerun-io/rerun/pull/3130)
 - GC the blueprints before saving while preserving the current state [#3148](https://github.com/rerun-io/rerun/pull/3148)
+- Activate new recording when opening via file dialog [#3199](https://github.com/rerun-io/rerun/pull/3199)
 
 #### 🧑‍🏫 Examples
 - Make `custom_space_view` example more verbose [#3123](https://github.com/rerun-io/rerun/pull/3123)

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -290,7 +290,15 @@ impl App {
             SystemCommand::LoadRrd(path) => {
                 let with_notification = true;
                 if let Some(rrd) = crate::loading::load_file_path(&path, with_notification) {
+                    let new_recording_id = rrd
+                        .recordings()
+                        .next()
+                        .map(|store| store.store_id())
+                        .cloned();
                     store_hub.add_bundle(rrd);
+                    if let Some(id) = new_recording_id {
+                        store_hub.set_recording_id(id);
+                    }
                 }
             }
             SystemCommand::ResetViewer => self.reset(store_hub, egui_ctx),


### PR DESCRIPTION
### What
After opening a recording, we need to set the recording_id on the store_hub.

This fix only applies to release-0.8 since this has been changed already in the new welcome screen logic on main.

Resolves: https://github.com/rerun-io/rerun/issues/3080 on `release-0.8` branch.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3199) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3199)
- [Docs preview](https://rerun.io/preview/3199/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3199/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)