### PR TITLE
Round-trip test for tensors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,6 +5134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roundtrip_tensor"
+version = "0.9.0-alpha.3"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ndarray",
+ "rerun",
+]
+
+[[package]]
 name = "roundtrip_transform3d"
 version = "0.9.0-alpha.3"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5098,6 +5098,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "roundtrip_image"
+version = "0.9.0-alpha.3"
+dependencies = [
+ "anyhow",
+ "clap",
+ "image",
+ "ndarray",
+ "rerun",
+]
+
+[[package]]
 name = "roundtrip_line_strips2d"
 version = "0.9.0-alpha.3"
 dependencies = [

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-72817e73fe21dfe2dfb18e69f00fce7b04d519d15cfdcf963d14b6803b003383
+74c049984f6f4c63664abd3e9d63aa3855e399254c376ef68c22705ce24c6e04

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-74c049984f6f4c63664abd3e9d63aa3855e399254c376ef68c22705ce24c6e04
+f6259141991af01c7c3585b703b8149d0e9cd1e2449ae88ff5b0cb3a5d225058

--- a/crates/re_types/src/archetypes/image_ext.rs
+++ b/crates/re_types/src/archetypes/image_ext.rs
@@ -30,7 +30,7 @@ impl Image {
                 3 | 4 => {
                     data.shape[non_empty_dim_inds[0]].name = Some("height".into());
                     data.shape[non_empty_dim_inds[1]].name = Some("width".into());
-                    data.shape[non_empty_dim_inds[2]].name = Some("color".into());
+                    data.shape[non_empty_dim_inds[2]].name = Some("depth".into());
                 }
                 _ => return Err(ImageConstructionError::BadImageShape(data.shape)),
             },

--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -603,3 +603,24 @@ impl TensorData {
         dyn_img_result.ok_or(TensorImageSaveError::BadData)
     }
 }
+
+#[cfg(feature = "image")]
+impl TryFrom<image::DynamicImage> for TensorData {
+    type Error = TensorImageLoadError;
+
+    fn try_from(value: image::DynamicImage) -> Result<Self, Self::Error> {
+        Self::from_image(value)
+    }
+}
+
+#[cfg(feature = "image")]
+impl<P: image::Pixel, S> TryFrom<image::ImageBuffer<P, S>> for TensorData
+where
+    image::DynamicImage: std::convert::From<image::ImageBuffer<P, S>>,
+{
+    type Error = TensorImageLoadError;
+
+    fn try_from(value: image::ImageBuffer<P, S>) -> Result<Self, Self::Error> {
+        Self::from_image(value)
+    }
+}

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/_overrides/image.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/_overrides/image.py
@@ -1,40 +1,122 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import pyarrow as pa
 
 from rerun.log.error_utils import _send_warning
 
-from ...datatypes import TensorDataArray
-
 if TYPE_CHECKING:
+    from ...components import TensorDataArray
     from ...datatypes import TensorDataArrayLike
 
 
 def image_data_converter(data: TensorDataArrayLike) -> TensorDataArray:
+    from ...components import TensorDataArray
+    from ...datatypes import TensorDataType, TensorDimensionType
+
     tensor_data = TensorDataArray.from_similar(data)
 
     # TODO(jleibs): Doing this on raw arrow data is not great. Clean this up
     # once we coerce to a canonical non-arrow type.
-    shape = tensor_data[0].value["shape"].values.field(0).to_numpy()
-    non_empty_dims = [d for d in shape if d != 1]
+    shape_dims = tensor_data[0].value["shape"].values.field(0).to_numpy()
+    shape_names = tensor_data[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
+
+    non_empty_dims = find_non_empty_dim_indices(shape_dims)
+
     num_non_empty_dims = len(non_empty_dims)
 
     # TODO(jleibs): What `recording` should we be passing here? How should we be getting it?
     if num_non_empty_dims < 2 or 3 < num_non_empty_dims:
-        _send_warning(f"Expected image, got array of shape {shape}", 1, recording=None)
+        _send_warning(f"Expected image, got array of shape {shape_dims}", 1, recording=None)
 
     if num_non_empty_dims == 3:
-        depth = shape[-1]
-        if depth not in (1, 3, 4):
+        depth = shape_dims[non_empty_dims[-1]]
+        if depth not in (3, 4):
             _send_warning(
-                f"Expected image depth of 1 (gray), 3 (RGB) or 4 (RGBA). Instead got array of shape {shape}",
+                f"Expected image 3 (RGB) or 4 (RGBA). Instead got array of shape {shape_dims}",
                 1,
                 recording=None,
             )
 
-    # TODO(jleibs): The rust code labels the tensor dimensions as well. Would be nice to do something
-    # similar here if they are unnamed.
+    # IF no labels are set, add them
+    # TODO(jleibs): Again, needing to do this at the arrow level is awful
+    if all(label is None for label in shape_names):
+        for ind, label in zip(non_empty_dims, ["height", "width", "depth"]):
+            shape_names[ind] = label
+
+        tensor_data_type = TensorDataType().storage_type
+        shape_data_type = TensorDimensionType().storage_type
+
+        shape_names = pa.array(
+            shape_names, mask=np.array([n is None for n in shape_names]), type=shape_data_type.field("name").type
+        )
+
+        new_shape = pa.ListArray.from_arrays(
+            offsets=[0, len(shape_dims)],
+            values=pa.StructArray.from_arrays(
+                [
+                    tensor_data[0].value["shape"].values.field(0),
+                    shape_names,
+                ],
+                fields=[shape_data_type.field("size"), shape_data_type.field("name")],
+            ),
+        ).cast(tensor_data_type.field("shape").type)
+
+        return cast(
+            TensorDataArray,
+            TensorDataArray._EXTENSION_TYPE().wrap_array(
+                pa.StructArray.from_arrays(
+                    [
+                        tensor_data.storage.field(0),
+                        new_shape,
+                        tensor_data.storage.field(2),
+                    ],
+                    fields=[
+                        tensor_data_type.field("id"),
+                        tensor_data_type.field("shape"),
+                        tensor_data_type.field("buffer"),
+                    ],
+                ).cast(tensor_data.storage.type)
+            ),
+        )
 
     # TODO(jleibs): Should we enforce specific names on images? Specifically, what if the existing names are wrong.
 
     return tensor_data
+
+
+# This code follows closely from `image_ext.rs`
+def find_non_empty_dim_indices(shape: list[int]) -> list[int]:
+    """Returns the indices of an appropriate set of non-empty dimensions."""
+    if len(shape) < 2:
+        return list(range(len(shape)))
+
+    indices = list(d[0] for d in filter(lambda d: d[1] != 1, enumerate(shape)))
+
+    # 0 must be valid since shape isn't empty or we would have returned an Err above
+    first_non_empty = next(iter(indices), 0)
+    last_non_empty = next(reversed(indices), first_non_empty)
+
+    # Note, these are inclusive ranges
+
+    # First, empty inner dimensions are more likely to be intentional than empty outer dimensions.
+    # Grow to a min-size of 2.
+    # (1x1x3x1) -> 3x1 mono rather than 1x1x3 RGB
+    while (last_non_empty - first_non_empty) < 1 and last_non_empty < (len(shape) - 1):
+        print(f"{last_non_empty} {first_non_empty} {len(shape)}")
+        last_non_empty += 1
+
+    target = 1
+    if shape[last_non_empty] in (3, 4):
+        target = 2
+
+    # Next, consider empty outer dimensions if we still need them.
+    # Grow up to 3 if the inner dimension is already 3 or 4 (Color Images)
+    # Otherwise, only grow up to 2.
+    # (1x1x3) -> 1x1x3 rgb rather than 1x3 mono
+    while (last_non_empty - first_non_empty) < target and first_non_empty > 0:
+        first_non_empty -= 1
+
+    return list(range(first_non_empty, last_non_empty + 1))

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/tensor_data.py
@@ -102,12 +102,12 @@ def tensordata_init(
     from ..tensor_data import _tensordata_buffer_converter, _tensordata_id_converter
 
     # Assign an id if one wasn't provided
-    if id:
+    if id is not None:
         self.id = _tensordata_id_converter(id)
     else:
         self.id = _tensordata_id_converter(uuid.uuid4())
 
-    if shape:
+    if shape is not None:
         resolved_shape = list(shape)
     else:
         resolved_shape = None

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -17,9 +17,9 @@ IMAGE_INPUTS: list[rrd.TensorDataArrayLike] = [
     rrd.TensorData(
         id=rrd.TensorId(uuid=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
         shape=[
-            rrd.TensorDimension(10),
-            rrd.TensorDimension(20),
-            rrd.TensorDimension(3),
+            rrd.TensorDimension(10, "height"),
+            rrd.TensorDimension(20, "width"),
+            rrd.TensorDimension(3, "depth"),
         ],
         buffer=rrd.TensorBuffer(RANDOM_IMAGE_SOURCE),
     ),

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -44,6 +44,7 @@ def main() -> None:
     )
     parser.add_argument("--target", type=str, default=None, help="Target used for cargo invocations")
     parser.add_argument("--target-dir", type=str, default=None, help="Target directory used for cargo invocations")
+    parser.add_argument("archetype", nargs="*", type=str, default=None, help="Run only the specified archetypes")
 
     args = parser.parse_args()
 
@@ -87,7 +88,13 @@ def main() -> None:
         print("")
 
     files = [f for f in listdir(ARCHETYPES_PATH) if isfile(join(ARCHETYPES_PATH, f))]
-    archetypes = [filename for filename, extension in [os.path.splitext(file) for file in files] if extension == ".fbs"]
+
+    if args.archetype is not None:
+        archetypes = args.archetype
+    else:
+        archetypes = [
+            filename for filename, extension in [os.path.splitext(file) for file in files] if extension == ".fbs"
+        ]
 
     for arch in archetypes:
         arch_opt_out = opt_out.get(arch, [])

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -23,7 +23,7 @@ ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 opt_out = {
     "line_strips2d": ["cpp"],  # TODO(#2786): Needs rect
     "points2d": ["cpp"],  # TODO(#2786): Needs rect
-    "image": ["cpp", "py", "rust"],
+    "image": ["cpp"],
     "tensor": ["cpp"],
 }
 

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -24,6 +24,7 @@ opt_out = {
     "line_strips2d": ["cpp"],  # TODO(#2786): Needs rect
     "points2d": ["cpp"],  # TODO(#2786): Needs rect
     "image": ["cpp", "py", "rust"],
+    "tensor": ["cpp"],
 }
 
 

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -24,7 +24,7 @@ opt_out = {
     "line_strips2d": ["cpp"],  # TODO(#2786): Needs rect
     "points2d": ["cpp"],  # TODO(#2786): Needs rect
     "image": ["cpp", "py", "rust"],
-    "tensor": ["cpp", "py", "rust"],
+    "tensor": ["cpp"],
 }
 
 

--- a/scripts/ci/run_e2e_roundtrip_tests.py
+++ b/scripts/ci/run_e2e_roundtrip_tests.py
@@ -24,7 +24,6 @@ opt_out = {
     "line_strips2d": ["cpp"],  # TODO(#2786): Needs rect
     "points2d": ["cpp"],  # TODO(#2786): Needs rect
     "image": ["cpp", "py", "rust"],
-    "tensor": ["cpp"],
 }
 
 
@@ -89,7 +88,7 @@ def main() -> None:
 
     files = [f for f in listdir(ARCHETYPES_PATH) if isfile(join(ARCHETYPES_PATH, f))]
 
-    if args.archetype is not None:
+    if len(args.archetype) > 0:
         archetypes = args.archetype
     else:
         archetypes = [

--- a/tests/cpp/roundtrips/tensor/main.cpp
+++ b/tests/cpp/roundtrips/tensor/main.cpp
@@ -6,7 +6,7 @@
 namespace rr = rerun;
 
 int main(int argc, char** argv) {
-    auto rec_stream = rr::RecordingStream("rerun_example_roundtrip_tensor");
+    auto rec_stream = rr::RecordingStream("rerun_example_roundtrip_points3d");
     rec_stream.save(argv[1]).throw_on_failure();
 
     uint8_t id[16] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
@@ -23,6 +23,8 @@ int main(int argc, char** argv) {
         data.push_back(i);
     }
 
+    // TODO(jleibs) Tensor data can't actually be logged yet because C++ Unions
+    // don't supported nested list-types.
     rec_stream.log(
         "tensor",
         rr::archetypes::Tensor(rr::datatypes::TensorData{

--- a/tests/cpp/roundtrips/tensor/main.cpp
+++ b/tests/cpp/roundtrips/tensor/main.cpp
@@ -1,0 +1,34 @@
+#include <optional>
+#include <rerun/archetypes/tensor.hpp>
+#include <rerun/datatypes/tensor_data.hpp>
+#include <rerun/recording_stream.hpp>
+
+namespace rr = rerun;
+
+int main(int argc, char** argv) {
+    auto rec_stream = rr::RecordingStream("rerun_example_roundtrip_tensor");
+    rec_stream.save(argv[1]).throw_on_failure();
+
+    uint8_t id[16] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
+
+    std::vector<rr::datatypes::TensorDimension> dimensions{
+        rr::datatypes::TensorDimension{3, std::nullopt},
+        rr::datatypes::TensorDimension{4, std::nullopt},
+        rr::datatypes::TensorDimension{5, std::nullopt},
+        rr::datatypes::TensorDimension{6, std::nullopt}
+    };
+
+    std::vector<int32_t> data;
+    for (auto i = 0; i < 360; ++i) {
+        data.push_back(i);
+    }
+
+    rec_stream.log(
+        "tensor",
+        rr::archetypes::Tensor(rr::datatypes::TensorData{
+            rr::datatypes::TensorId(id),
+            dimensions,
+            rr::datatypes::TensorBuffer::i32(data)
+        })
+    );
+}

--- a/tests/cpp/roundtrips/tensor/main.cpp
+++ b/tests/cpp/roundtrips/tensor/main.cpp
@@ -6,8 +6,8 @@
 namespace rr = rerun;
 
 int main(int argc, char** argv) {
-    auto rec_stream = rr::RecordingStream("rerun_example_roundtrip_points3d");
-    rec_stream.save(argv[1]).throw_on_failure();
+    auto rec = rr::RecordingStream("rerun_example_roundtrip_tensor");
+    rec.save(argv[1]).throw_on_failure();
 
     uint8_t id[16] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
 
@@ -15,8 +15,7 @@ int main(int argc, char** argv) {
         rr::datatypes::TensorDimension{3, std::nullopt},
         rr::datatypes::TensorDimension{4, std::nullopt},
         rr::datatypes::TensorDimension{5, std::nullopt},
-        rr::datatypes::TensorDimension{6, std::nullopt}
-    };
+        rr::datatypes::TensorDimension{6, std::nullopt}};
 
     std::vector<int32_t> data;
     for (auto i = 0; i < 360; ++i) {
@@ -25,12 +24,11 @@ int main(int argc, char** argv) {
 
     // TODO(jleibs) Tensor data can't actually be logged yet because C++ Unions
     // don't supported nested list-types.
-    rec_stream.log(
+    rec.log(
         "tensor",
         rr::archetypes::Tensor(rr::datatypes::TensorData{
             rr::datatypes::TensorId(id),
             dimensions,
-            rr::datatypes::TensorBuffer::i32(data)
-        })
+            rr::datatypes::TensorBuffer::i32(data)})
     );
 }

--- a/tests/python/roundtrips/image/main.py
+++ b/tests/python/roundtrips/image/main.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+"""Logs a `Image` archetype for roundtrip checks."""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import rerun as rr
+import rerun.experimental as rr2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+
+    rr.script_setup(args, "rerun_example_roundtrip_image")
+
+    # 2x3x3 image. Red channel = x. Green channel = y. Blue channel = 128.
+    image = np.zeros((2, 3, 3), dtype=np.uint8)
+    for i in range(3):
+        image[:, i, 0] = i
+    for i in range(2):
+        image[i, :, 1] = i
+    image[:, :, 2] = 128
+
+    image = rr2.dt.TensorData(array=image, id=np.arange(10, 26))
+
+    rr2.log("image", rr2.Image(image))
+
+    rr.script_teardown(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/roundtrips/tensor/main.py
+++ b/tests/python/roundtrips/tensor/main.py
@@ -18,7 +18,7 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_roundtrip_tensor")
 
-    tensor = np.array(np.arange(0, 360)).reshape((3, 4, 5, 6))
+    tensor = np.array(np.arange(0, 360), dtype=np.int32).reshape((3, 4, 5, 6))
     tensor = rr2.dt.TensorData(array=tensor, id=np.arange(10, 26))
 
     rr2.log("tensor", rr2.Tensor(tensor))

--- a/tests/python/roundtrips/tensor/main.py
+++ b/tests/python/roundtrips/tensor/main.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+"""Logs a `Tensor` archetype for roundtrip checks."""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import rerun as rr
+import rerun.experimental as rr2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+
+    rr.script_setup(args, "rerun_example_roundtrip_tensor")
+
+    tensor = np.array(np.arange(0, 360)).reshape((3, 4, 5, 6))
+    tensor = rr2.dt.TensorData(array=tensor, id=np.arange(10, 26))
+
+    rr2.log("tensor", rr2.Tensor(tensor))
+
+    rr.script_teardown(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rust/roundtrips/image/Cargo.toml
+++ b/tests/rust/roundtrips/image/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "roundtrip_image"
+edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+
+anyhow = "1.0"
+clap = { version = "4.0", features = ["derive"] }
+image.workspace = true
+ndarray.workspace = true

--- a/tests/rust/roundtrips/image/src/main.rs
+++ b/tests/rust/roundtrips/image/src/main.rs
@@ -1,0 +1,47 @@
+//! Logs an `Image` archetype for roundtrip checks.
+
+use image::{Rgb, RgbImage};
+use rerun::{archetypes::Image, datatypes::TensorId, external::re_log, MsgSender, RecordingStream};
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[command(flatten)]
+    rerun: rerun::clap::RerunArgs,
+}
+
+fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
+    // Need a deterministic id for round-trip tests. Used (10..26)
+    let id = TensorId {
+        uuid: core::array::from_fn(|i| (i + 10) as u8),
+    };
+
+    let mut img = RgbImage::new(3, 2);
+
+    // 2x3x3 image. Red channel = x. Green channel = y. Blue channel = 128.
+    for x in 0..3 {
+        for y in 0..2 {
+            img.put_pixel(x, y, Rgb([x as u8, y as u8, 128]));
+        }
+    }
+
+    MsgSender::from_archetype("image", &Image::try_from(img)?.with_id(id))?.send(rec_stream)?;
+
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    re_log::setup_native_logging();
+
+    use clap::Parser as _;
+    let args = Args::parse();
+
+    let default_enabled = true;
+    args.rerun.clone().run(
+        "rerun_example_roundtrip_image",
+        default_enabled,
+        move |rec_stream| {
+            run(&rec_stream, &args).unwrap();
+        },
+    )
+}

--- a/tests/rust/roundtrips/image/src/main.rs
+++ b/tests/rust/roundtrips/image/src/main.rs
@@ -1,7 +1,7 @@
 //! Logs an `Image` archetype for roundtrip checks.
 
 use image::{Rgb, RgbImage};
-use rerun::{archetypes::Image, datatypes::TensorId, external::re_log, MsgSender, RecordingStream};
+use rerun::{archetypes::Image, datatypes::TensorId, external::re_log, RecordingStream};
 
 #[derive(Debug, clap::Parser)]
 #[clap(author, version, about)]
@@ -10,7 +10,7 @@ struct Args {
     rerun: rerun::clap::RerunArgs,
 }
 
-fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
+fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
     // Need a deterministic id for round-trip tests. Used (10..26)
     let id = TensorId {
         uuid: core::array::from_fn(|i| (i + 10) as u8),
@@ -25,7 +25,7 @@ fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
         }
     }
 
-    MsgSender::from_archetype("image", &Image::try_from(img)?.with_id(id))?.send(rec_stream)?;
+    rec.log("image", &Image::try_from(img)?.with_id(id))?;
 
     Ok(())
 }
@@ -40,8 +40,8 @@ fn main() -> anyhow::Result<()> {
     args.rerun.clone().run(
         "rerun_example_roundtrip_image",
         default_enabled,
-        move |rec_stream| {
-            run(&rec_stream, &args).unwrap();
+        move |rec| {
+            run(&rec, &args).unwrap();
         },
     )
 }

--- a/tests/rust/roundtrips/tensor/Cargo.toml
+++ b/tests/rust/roundtrips/tensor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "roundtrip_tensor"
+edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+
+anyhow = "1.0"
+clap = { version = "4.0", features = ["derive"] }
+ndarray.workspace = true

--- a/tests/rust/roundtrips/tensor/src/main.rs
+++ b/tests/rust/roundtrips/tensor/src/main.rs
@@ -1,0 +1,42 @@
+//! Logs a `Tensor` archetype for roundtrip checks.
+
+use rerun::{
+    archetypes::Tensor, datatypes::TensorId, external::re_log, MsgSender, RecordingStream,
+};
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[command(flatten)]
+    rerun: rerun::clap::RerunArgs,
+}
+
+fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
+    let tensor = ndarray::Array::from_shape_vec((3, 4, 5, 6), (0..360).collect())?;
+
+    // Need a deterministic id for round-trip tests. Used (10..26)
+    let id = TensorId {
+        uuid: core::array::from_fn(|i| (i + 10) as u8),
+    };
+
+    MsgSender::from_archetype("tensor", &Tensor::try_from(tensor)?.with_id(id))?
+        .send(rec_stream)?;
+
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    re_log::setup_native_logging();
+
+    use clap::Parser as _;
+    let args = Args::parse();
+
+    let default_enabled = true;
+    args.rerun.clone().run(
+        "rerun_example_roundtrip_tensor",
+        default_enabled,
+        move |rec_stream| {
+            run(&rec_stream, &args).unwrap();
+        },
+    )
+}

--- a/tests/rust/roundtrips/tensor/src/main.rs
+++ b/tests/rust/roundtrips/tensor/src/main.rs
@@ -12,7 +12,7 @@ struct Args {
 }
 
 fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
-    let tensor = ndarray::Array::from_shape_vec((3, 4, 5, 6), (0..360).collect())?;
+    let tensor = ndarray::Array::from_shape_vec((3, 4, 5, 6), (0..360).collect::<Vec<i32>>())?;
 
     // Need a deterministic id for round-trip tests. Used (10..26)
     let id = TensorId {

--- a/tests/rust/roundtrips/tensor/src/main.rs
+++ b/tests/rust/roundtrips/tensor/src/main.rs
@@ -1,8 +1,6 @@
 //! Logs a `Tensor` archetype for roundtrip checks.
 
-use rerun::{
-    archetypes::Tensor, datatypes::TensorId, external::re_log, MsgSender, RecordingStream,
-};
+use rerun::{archetypes::Tensor, datatypes::TensorId, external::re_log, RecordingStream};
 
 #[derive(Debug, clap::Parser)]
 #[clap(author, version, about)]
@@ -11,7 +9,7 @@ struct Args {
     rerun: rerun::clap::RerunArgs,
 }
 
-fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
+fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
     let tensor = ndarray::Array::from_shape_vec((3, 4, 5, 6), (0..360).collect::<Vec<i32>>())?;
 
     // Need a deterministic id for round-trip tests. Used (10..26)
@@ -19,8 +17,7 @@ fn run(rec_stream: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
         uuid: core::array::from_fn(|i| (i + 10) as u8),
     };
 
-    MsgSender::from_archetype("tensor", &Tensor::try_from(tensor)?.with_id(id))?
-        .send(rec_stream)?;
+    rec.log("tensor", &Tensor::try_from(tensor)?.with_id(id))?;
 
     Ok(())
 }
@@ -35,8 +32,8 @@ fn main() -> anyhow::Result<()> {
     args.rerun.clone().run(
         "rerun_example_roundtrip_tensor",
         default_enabled,
-        move |rec_stream| {
-            run(&rec_stream, &args).unwrap();
+        move |rec| {
+            run(&rec, &args).unwrap();
         },
     )
 }


### PR DESCRIPTION
### What
Implement Image and Tensor roundtrip tests.

Added helpers to convert from DynamicImage / ImageBuffer on the rust side.
Expanded the functionality of the python image converter to do the same index-checking and labeling as we do in rust to get full matching on the round-trip.

Renamed the "color" label to "depth" to match the historical labeling..

cpp tests are not implemented yet because we don't have support for union lists in cpp.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3203) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3203)
- [Docs preview](https://rerun.io/preview/66e81abd70e74fc59f6fc26eb2695aca04e15de5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/66e81abd70e74fc59f6fc26eb2695aca04e15de5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)