### PR TITLE
Fix instantiateStreaming usage on web

### DIFF
--- a/scripts/ci/demo_assets/static/index.js
+++ b/scripts/ci/demo_assets/static/index.js
@@ -104,14 +104,20 @@ function load_wasm() {
           }
           controller.close();
         },
-      })
+      }),
+      {
+        status: response.status,
+        statusText: response.statusText,
+      }
     );
-    const wasm = await res.blob();
 
-    // Don't fade in the progress bar if we haven't hit it already.
-    clearTimeout(timeoutId);
+    for (const [key, value] of response.headers.entries()) {
+      res.headers.set(key, value);
+    }
 
-    wasm_bindgen(URL.createObjectURL(wasm)).then(on_wasm_loaded).catch(on_wasm_error);
+    wasm_bindgen(res)
+      .then(() => (clearTimeout(timeoutId), on_wasm_loaded()))
+      .catch(on_wasm_error);
   }
 
   wasm_with_progress();

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -264,14 +264,17 @@
                         }
                         controller.close();
                     },
-                }));
-                const wasm = await res.blob();
+                }), {
+                    status: response.status,
+                    statusText: response.statusText,
+                });
 
-                // Don't fade in the progress bar if we haven't hit it already.
-                clearTimeout(timeoutId);
+                for (const [key, value] of response.headers.entries()) {
+                    res.headers.set(key, value);
+                }
 
-                wasm_bindgen(URL.createObjectURL(wasm))
-                    .then(on_wasm_loaded)
+                wasm_bindgen(res)
+                    .then(() => (clearTimeout(timeoutId), on_wasm_loaded()))
                     .catch(on_wasm_error);
             }
 

--- a/web_viewer/index_bundled.html
+++ b/web_viewer/index_bundled.html
@@ -262,14 +262,17 @@
                         }
                         controller.close();
                     },
-                }));
-                const wasm = await res.blob();
+                }), {
+                    status: response.status,
+                    statusText: response.statusText,
+                });
 
-                // Don't fade in the progress bar if we haven't hit it already.
-                clearTimeout(timeoutId);
+                for (const [key, value] of response.headers.entries()) {
+                    res.headers.set(key, value);
+                }
 
-                wasm_bindgen(URL.createObjectURL(wasm))
-                    .then(on_wasm_loaded)
+                wasm_bindgen(res)
+                    .then(() => (clearTimeout(timeoutId), on_wasm_loaded()))
                     .catch(on_wasm_error);
             }
 


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

This is a fix for:
![image](https://github.com/rerun-io/rerun/assets/1665677/370f9e51-aa82-4359-aa4b-dd72cf942a7a)

The WASM was being fetched in full before instantiation (the `await res.blob()`), so we weren't getting the benefit of `instantiateStreaming`. This PR should also improve loading times on slow connections.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3209) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3209)
- [Docs preview](https://rerun.io/preview/51c233aa61893ece69b0bb0695309b23fef469b5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/51c233aa61893ece69b0bb0695309b23fef469b5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)