### PR TITLE
Fix bbox for line-strip-3d

### DIFF
--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -155,7 +155,7 @@ impl Lines3DPart {
             }
 
             for p in strip.0 {
-                bounding_box.extend(glam::vec3(p.x(), p.y(), 0.0));
+                bounding_box.extend(p.into());
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/rerun-io/rerun/issues/3179

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3218) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3218)
- [Docs preview](https://rerun.io/preview/1baaadd6714ba6374fc0d844c5c9906e3e70ddac/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1baaadd6714ba6374fc0d844c5c9906e3e70ddac/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)