### PR TITLE
Show picking position when hovering something in the spatial view

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -654,6 +654,7 @@ pub fn picking(
         } else {
             // Hover ui for everything else
             response.on_hover_ui_at_pointer(|ui| {
+                hit_ui(ui, hit);
                 item_ui::instance_path_button(ctx, ui, Some(query.space_view_id), &instance_path);
                 instance_path.data_ui(ctx, ui, UiVerbosity::Reduced, &ctx.current_query());
             })
@@ -692,4 +693,11 @@ pub fn picking(
     ctx.selection_state_mut().set_hovered_space(hovered_space);
 
     Ok(response)
+}
+
+fn hit_ui(ui: &mut egui::Ui, hit: &crate::picking::PickingRayHit) {
+    if hit.hit_type == PickingHitType::GpuPickingResult {
+        let glam::Vec3 { x, y, z } = hit.space_position;
+        ui.label(format!("Picking position: [{x:.5}, {y:.5}, {z:.5})"));
+    }
 }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -698,6 +698,6 @@ pub fn picking(
 fn hit_ui(ui: &mut egui::Ui, hit: &crate::picking::PickingRayHit) {
     if hit.hit_type == PickingHitType::GpuPickingResult {
         let glam::Vec3 { x, y, z } = hit.space_position;
-        ui.label(format!("Picking position: [{x:.5}, {y:.5}, {z:.5}]"));
+        ui.label(format!("Hover position: [{x:.5}, {y:.5}, {z:.5}]"));
     }
 }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -698,6 +698,6 @@ pub fn picking(
 fn hit_ui(ui: &mut egui::Ui, hit: &crate::picking::PickingRayHit) {
     if hit.hit_type == PickingHitType::GpuPickingResult {
         let glam::Vec3 { x, y, z } = hit.space_position;
-        ui.label(format!("Picking position: [{x:.5}, {y:.5}, {z:.5})"));
+        ui.label(format!("Picking position: [{x:.5}, {y:.5}, {z:.5}]"));
     }
 }


### PR DESCRIPTION
### What
* closes https://github.com/rerun-io/rerun/issues/3226

When hovering a line:
![image](https://github.com/rerun-io/rerun/assets/1148717/6cd66057-1900-4615-a9fc-d7ec4ea8f84b)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3227) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3227)
- [Docs preview](https://rerun.io/preview/d798b5a0cf4433abaa3231c2ad21db0672fe0f33/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d798b5a0cf4433abaa3231c2ad21db0672fe0f33/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)