### PR TITLE
[bugfix] Allow user to edit colormap for depth images

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -425,7 +425,7 @@ fn colormap_props_ui(ui: &mut egui::Ui, entity_props: &mut EntityProperties) {
                     .selectable_label(current == proposed, proposed.to_string())
                     .clicked()
                 {
-                    entity_props.color_mapper = EditableAutoValue::Auto(proposed);
+                    entity_props.color_mapper = EditableAutoValue::UserEdited(proposed);
                 }
             };
 


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3240

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3241) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3241)
- [Docs preview](https://rerun.io/preview/168d18e5a2e461d4a6a4cce14775382cb80f44ca/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/168d18e5a2e461d4a6a4cce14775382cb80f44ca/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)