### PR TITLE
[c++] Fix incorrect sign on cast for AppendNull

### DIFF
--- a/rerun_cpp/src/rerun/arrow.cpp
+++ b/rerun_cpp/src/rerun/arrow.cpp
@@ -25,7 +25,7 @@ namespace rerun {
     ) {
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto builder = std::make_shared<arrow::NullBuilder>(pool);
-        ARROW_RETURN_NOT_OK(builder->AppendNulls(static_cast<uint64_t>(num_instances)));
+        ARROW_RETURN_NOT_OK(builder->AppendNulls(static_cast<int64_t>(num_instances)));
         std::shared_ptr<arrow::Array> array;
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 


### PR DESCRIPTION
### What

Noticed since on my Mac this makes roundtrip test compilation fail (via warning & werror):
```
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/src/rerun/arrow.cpp:28:50: error: implicit conversion changes signedness: 'uint64_t' (aka 'unsigned long long') to 'int64_t' (aka 'long long') [-Werror,-Wsign-conversion]
        ARROW_RETURN_NOT_OK(builder->AppendNulls(static_cast<uint64_t>(num_instances)));
                                     ~~~~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/include/arrow/status.h:57:62: note: expanded from macro 'ARROW_RETURN_NOT_OK'
    ::arrow::Status __s = ::arrow::internal::GenericToStatus(status);    
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3248) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3248)
- [Docs preview](https://rerun.io/preview/ae8a88d174d15a21f714eeb029b143d4efbb0d8b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ae8a88d174d15a21f714eeb029b143d4efbb0d8b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)