### PR TITLE
First-class indicator components for Rust

### DIFF
--- a/crates/re_components/src/lib.rs
+++ b/crates/re_components/src/lib.rs
@@ -52,9 +52,9 @@ pub use self::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use self::load_file::{data_cell_from_file_path, data_cell_from_mesh_file_path};
+pub use self::load_file::{data_cells_from_file_path, data_cells_from_mesh_file_path};
 
-pub use self::load_file::{data_cell_from_file_contents, FromFileError};
+pub use self::load_file::{data_cells_from_file_contents, FromFileError};
 
 // This is very convenient to re-export
 pub use re_log_types::LegacyComponent;

--- a/crates/re_components/src/load_file.rs
+++ b/crates/re_components/src/load_file.rs
@@ -48,7 +48,7 @@ pub fn data_cells_from_file_path(
         #[cfg(feature = "image")]
         _ => {
             use re_types::Archetype;
-            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::new_list(1);
+            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
                 re_types::archetypes::Image::indicator_component(),
                 indicator.to_arrow(),
@@ -100,7 +100,7 @@ pub fn data_cells_from_file_contents(
             };
 
             use re_types::Archetype;
-            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::new_list(1);
+            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
                 re_types::archetypes::Image::indicator_component(),
                 indicator.to_arrow(),

--- a/crates/re_components/src/load_file.rs
+++ b/crates/re_components/src/load_file.rs
@@ -1,6 +1,6 @@
 use re_log_types::DataCell;
 
-/// Errors from [`data_cell_from_file_path`] and [`data_cell_from_mesh_file_path`].
+/// Errors from [`data_cells_from_file_path`] and [`data_cells_from_mesh_file_path`].
 #[derive(thiserror::Error, Debug)]
 pub enum FromFileError {
     #[cfg(not(target_arch = "wasm32"))]
@@ -30,7 +30,9 @@ pub enum FromFileError {
 ///
 /// All other extensions will return an error.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn data_cell_from_file_path(file_path: &std::path::Path) -> Result<DataCell, FromFileError> {
+pub fn data_cells_from_file_path(
+    file_path: &std::path::Path,
+) -> Result<Vec<DataCell>, FromFileError> {
     let extension = file_path
         .extension()
         .unwrap_or_default()
@@ -39,18 +41,27 @@ pub fn data_cell_from_file_path(file_path: &std::path::Path) -> Result<DataCell,
         .to_string();
 
     match extension.as_str() {
-        "glb" => data_cell_from_mesh_file_path(file_path, crate::MeshFormat::Glb),
-        "glft" => data_cell_from_mesh_file_path(file_path, crate::MeshFormat::Gltf),
-        "obj" => data_cell_from_mesh_file_path(file_path, crate::MeshFormat::Obj),
+        "glb" => data_cells_from_mesh_file_path(file_path, crate::MeshFormat::Glb),
+        "glft" => data_cells_from_mesh_file_path(file_path, crate::MeshFormat::Gltf),
+        "obj" => data_cells_from_mesh_file_path(file_path, crate::MeshFormat::Obj),
 
         #[cfg(feature = "image")]
         _ => {
+            use re_types::Archetype;
+            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::new_list(1);
+            let indicator_cell = DataCell::from_arrow(
+                re_types::archetypes::Image::indicator_component(),
+                indicator.to_arrow(),
+            );
+
             // Assume an image (there are so many image extensions):
-            // TODO(#3159): include the `ImageIndicator` component.
             let tensor = re_types::components::TensorData(
                 re_types::datatypes::TensorData::from_image_file(file_path)?,
             );
-            Ok(DataCell::try_from_native(std::iter::once(&tensor))?)
+            Ok(vec![
+                indicator_cell,
+                DataCell::try_from_native(std::iter::once(&tensor))?,
+            ])
         }
 
         #[cfg(not(feature = "image"))]
@@ -61,10 +72,10 @@ pub fn data_cell_from_file_path(file_path: &std::path::Path) -> Result<DataCell,
     }
 }
 
-pub fn data_cell_from_file_contents(
+pub fn data_cells_from_file_contents(
     file_name: &str,
     bytes: Vec<u8>,
-) -> Result<DataCell, FromFileError> {
+) -> Result<Vec<DataCell>, FromFileError> {
     re_tracing::profile_function!(file_name);
 
     let extension = std::path::Path::new(file_name)
@@ -75,9 +86,9 @@ pub fn data_cell_from_file_contents(
         .to_string();
 
     match extension.as_str() {
-        "glb" => data_cell_from_mesh_file_contents(bytes, crate::MeshFormat::Glb),
-        "glft" => data_cell_from_mesh_file_contents(bytes, crate::MeshFormat::Gltf),
-        "obj" => data_cell_from_mesh_file_contents(bytes, crate::MeshFormat::Obj),
+        "glb" => data_cells_from_mesh_file_contents(bytes, crate::MeshFormat::Glb),
+        "glft" => data_cells_from_mesh_file_contents(bytes, crate::MeshFormat::Gltf),
+        "obj" => data_cells_from_mesh_file_contents(bytes, crate::MeshFormat::Obj),
 
         #[cfg(feature = "image")]
         _ => {
@@ -88,12 +99,21 @@ pub fn data_cell_from_file_contents(
                     .map_err(re_types::tensor_data::TensorImageLoadError::from)?
             };
 
+            use re_types::Archetype;
+            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::new_list(1);
+            let indicator_cell = DataCell::from_arrow(
+                re_types::archetypes::Image::indicator_component(),
+                indicator.to_arrow(),
+            );
+
             // Assume an image (there are so many image extensions):
-            // TODO(#3159): include the `ImageIndicator` component.
             let tensor = re_types::components::TensorData(
                 re_types::datatypes::TensorData::from_image_bytes(bytes, format)?,
             );
-            Ok(DataCell::try_from_native(std::iter::once(&tensor))?)
+            Ok(vec![
+                indicator_cell,
+                DataCell::try_from_native(std::iter::once(&tensor))?,
+            ])
         }
 
         #[cfg(not(feature = "image"))]
@@ -111,18 +131,19 @@ pub fn data_cell_from_file_contents(
 ///
 /// All other extensions will return an error.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn data_cell_from_mesh_file_path(
+pub fn data_cells_from_mesh_file_path(
     file_path: &std::path::Path,
     format: crate::MeshFormat,
-) -> Result<DataCell, FromFileError> {
+) -> Result<Vec<DataCell>, FromFileError> {
     let bytes = std::fs::read(file_path)?;
-    data_cell_from_mesh_file_contents(bytes, format)
+    data_cells_from_mesh_file_contents(bytes, format)
 }
 
-pub fn data_cell_from_mesh_file_contents(
+pub fn data_cells_from_mesh_file_contents(
     bytes: Vec<u8>,
     format: crate::MeshFormat,
-) -> Result<DataCell, FromFileError> {
+) -> Result<Vec<DataCell>, FromFileError> {
+    // TODO(#2788): mesh indicator
     let mesh = crate::EncodedMesh3D {
         format,
         bytes: bytes.into(),
@@ -134,5 +155,5 @@ pub fn data_cell_from_mesh_file_contents(
         ],
     };
     let mesh = crate::Mesh3D::Encoded(mesh);
-    Ok(DataCell::try_from_native(std::iter::once(&mesh))?)
+    Ok(vec![DataCell::try_from_native(std::iter::once(&mesh))?])
 }

--- a/crates/re_data_source/src/load_file_contents.rs
+++ b/crates/re_data_source/src/load_file_contents.rs
@@ -82,9 +82,9 @@ fn log_msg_from_file_contents(
     let FileContents { name, bytes } = file_contents;
 
     let entity_path = re_log_types::EntityPath::from_single_string(name.clone());
-    let cell = re_components::data_cell_from_file_contents(&name, bytes.to_vec())?;
+    let cells = re_components::data_cells_from_file_contents(&name, bytes.to_vec())?;
 
-    let num_instances = cell.num_instances();
+    let num_instances = cells.first().map_or(0, |cell| cell.num_instances());
 
     let timepoint = re_log_types::TimePoint::default();
 
@@ -93,7 +93,7 @@ fn log_msg_from_file_contents(
         timepoint,
         entity_path,
         num_instances,
-        vec![cell],
+        cells,
     );
 
     let data_table =

--- a/crates/re_data_source/src/load_file_path.rs
+++ b/crates/re_data_source/src/load_file_path.rs
@@ -75,9 +75,9 @@ fn log_msg_from_file_path(
     file_path: &std::path::Path,
 ) -> anyhow::Result<LogMsg> {
     let entity_path = re_log_types::EntityPath::from_file_path_as_single_string(file_path);
-    let cell = re_components::data_cell_from_file_path(file_path)?;
+    let cells = re_components::data_cells_from_file_path(file_path)?;
 
-    let num_instances = cell.num_instances();
+    let num_instances = cells.first().map_or(0, |cell| cell.num_instances());
 
     let timepoint = re_log_types::TimePoint::default();
 
@@ -86,7 +86,7 @@ fn log_msg_from_file_path(
         timepoint,
         entity_path,
         num_instances,
-        vec![cell],
+        cells,
     );
 
     let data_table =

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -94,8 +94,8 @@ pub mod coordinates {
 }
 
 pub use re_types::{
-    archetypes, datatypes, Archetype, ArchetypeName, Component, ComponentList, ComponentName,
-    Datatype, DatatypeList, DatatypeName, Loggable,
+    archetypes, datatypes, AnyComponentList, Archetype, ArchetypeName, Component, ComponentList,
+    ComponentName, Datatype, DatatypeList, DatatypeName, GenericIndicatorComponent, Loggable,
 };
 
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -94,7 +94,7 @@ pub mod coordinates {
 }
 
 pub use re_types::{
-    archetypes, datatypes, AnyComponentBatch, Archetype, ArchetypeName, Component, ComponentBatch,
+    archetypes, datatypes, MaybeOwnedComponentBatch, Archetype, ArchetypeName, Component, ComponentBatch,
     ComponentName, Datatype, DatatypeBatch, DatatypeName, GenericIndicatorComponent, Loggable,
 };
 

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -94,8 +94,9 @@ pub mod coordinates {
 }
 
 pub use re_types::{
-    archetypes, datatypes, MaybeOwnedComponentBatch, Archetype, ArchetypeName, Component, ComponentBatch,
-    ComponentName, Datatype, DatatypeBatch, DatatypeName, GenericIndicatorComponent, Loggable,
+    archetypes, datatypes, Archetype, ArchetypeName, Component, ComponentBatch, ComponentName,
+    Datatype, DatatypeBatch, DatatypeName, GenericIndicatorComponent, Loggable,
+    MaybeOwnedComponentBatch,
 };
 
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -67,7 +67,7 @@ pub mod time {
 /// These are the different _components_ you can log.
 ///
 /// They all implement the [`Component`][`re_types::Component`] trait,
-/// and can be used in [`RecordingStream::log_component_lists`].
+/// and can be used in [`RecordingStream::log_component_batches`].
 pub mod components {
     pub use re_components::{
         Box3D, EncodedMesh3D, Mesh3D, MeshFormat, Pinhole, Quaternion, RawMesh3D, Rect2D, Scalar,
@@ -94,8 +94,8 @@ pub mod coordinates {
 }
 
 pub use re_types::{
-    archetypes, datatypes, AnyComponentList, Archetype, ArchetypeName, Component, ComponentList,
-    ComponentName, Datatype, DatatypeList, DatatypeName, GenericIndicatorComponent, Loggable,
+    archetypes, datatypes, AnyComponentBatch, Archetype, ArchetypeName, Component, ComponentBatch,
+    ComponentName, Datatype, DatatypeBatch, DatatypeName, GenericIndicatorComponent, Loggable,
 };
 
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -648,7 +648,7 @@ impl RecordingStream {
             arch.num_instances() as u32,
             arch.as_component_batches()
                 .iter()
-                .map(|any_comp_batch| any_comp_batch.as_batch()),
+                .map(|any_comp_batch| any_comp_batch.as_ref()),
         )
     }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -9,7 +9,7 @@ use re_log_types::{
     DataTableBatcherConfig, DataTableBatcherError, EntityPath, LogMsg, RowId, StoreId, StoreInfo,
     StoreKind, StoreSource, Time, TimeInt, TimePoint, TimeType, Timeline, TimelineName,
 };
-use re_types::{components::InstanceKey, Archetype, ComponentList, SerializationError};
+use re_types::{components::InstanceKey, Archetype, ComponentBatch, SerializationError};
 
 #[cfg(feature = "web_viewer")]
 use re_web_viewer_server::WebViewerServerPort;
@@ -642,17 +642,17 @@ impl RecordingStream {
         timeless: bool,
         arch: &impl Archetype,
     ) -> RecordingStreamResult<()> {
-        self.log_component_lists(
+        self.log_component_batches(
             ent_path,
             timeless,
             arch.num_instances() as u32,
-            arch.as_component_lists()
+            arch.as_component_batches()
                 .iter()
-                .map(|any_comp_list| any_comp_list.as_list()),
+                .map(|any_comp_batch| any_comp_batch.as_batch()),
         )
     }
 
-    /// Logs a set of [`ComponentList`]s into Rerun.
+    /// Logs a set of [`ComponentBatch`]es into Rerun.
     ///
     /// If `timeless` is set to `false`, all timestamp data associated with this message will be
     /// dropped right before sending it to Rerun.
@@ -674,12 +674,12 @@ impl RecordingStream {
     /// See [SDK Micro Batching] for more information.
     ///
     /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
-    pub fn log_component_lists<'a>(
+    pub fn log_component_batches<'a>(
         &self,
         ent_path: impl Into<EntityPath>,
         timeless: bool,
         num_instances: u32,
-        comp_lists: impl IntoIterator<Item = &'a dyn ComponentList>,
+        comp_batches: impl IntoIterator<Item = &'a dyn ComponentBatch>,
     ) -> RecordingStreamResult<()> {
         if !self.is_enabled() {
             return Ok(()); // silently drop the message
@@ -687,17 +687,17 @@ impl RecordingStream {
 
         let ent_path = ent_path.into();
 
-        let comp_lists: Result<Vec<_>, _> = comp_lists
+        let comp_batches: Result<Vec<_>, _> = comp_batches
             .into_iter()
-            .map(|comp_list| {
-                comp_list
+            .map(|comp_batch| {
+                comp_batch
                     .try_to_arrow()
-                    .map(|array| (comp_list.arrow_field(), array))
+                    .map(|array| (comp_batch.arrow_field(), array))
             })
             .collect();
-        let comp_lists = comp_lists?;
+        let comp_batches = comp_batches?;
 
-        let cells: Result<Vec<_>, _> = comp_lists
+        let cells: Result<Vec<_>, _> = comp_batches
             .into_iter()
             .map(|(field, array)| {
                 // NOTE: Unreachable, a top-level Field will always be a component, and thus an

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -1,6 +1,6 @@
 use re_arrow_store::LatestAtQuery;
 use re_query::query_archetype;
-use re_types::{Archetype as _, Loggable as _};
+use re_types::Archetype as _;
 use re_viewer_context::{
     ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
     ViewPartSystem, ViewQuery, ViewerContext,
@@ -27,12 +27,9 @@ impl NamedViewSystem for TextDocumentSystem {
 
 impl ViewPartSystem for TextDocumentSystem {
     fn archetype(&self) -> ArchetypeDefinition {
-        // TODO(#3159): use actual archetype definition
-        // TextDocument::all_components().try_into().unwrap()
-        vec1::vec1![
-            re_types::archetypes::TextDocument::indicator_component(),
-            re_types::components::Text::name(),
-        ]
+        re_types::archetypes::TextDocument::all_components()
+            .try_into()
+            .unwrap()
     }
 
     fn execute(

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-a1f2391f1aa04cd83af25fae3765de7838889e5290c8cc179a94c1c9c6f9c965
+7a3de53e9966019619269ea17da7fabf738eb04f830069418ece89c1a5595f65

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-eb8cf5a504ec73ac98e6b2d803d25ecb36bbef69d71cfe828cecbc94a0d0a0ef
+25b8b4d22313c4f32b640e05ff4d461e09347bad081d4f585324a0d05bafa457

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-7edc082106fba6b7898025ba26a949903d4cf0f01e7588ec5e3252fb0e562033
+eb8cf5a504ec73ac98e6b2d803d25ecb36bbef69d71cfe828cecbc94a0d0a0ef

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-25b8b4d22313c4f32b640e05ff4d461e09347bad081d4f585324a0d05bafa457
+26c3ac326a279be1a64c8ba27ce87064941b80f61d9c14b01b069e8a87038fbb

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-7a3de53e9966019619269ea17da7fabf738eb04f830069418ece89c1a5595f65
+7edc082106fba6b7898025ba26a949903d4cf0f01e7588ec5e3252fb0e562033

--- a/crates/re_types/src/archetype.rs
+++ b/crates/re_types/src/archetype.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnyComponentBatch, ComponentBatch, ComponentName, DeserializationResult, ResultExt as _,
+    MaybeOwnedComponentBatch, ComponentBatch, ComponentName, DeserializationResult, ResultExt as _,
     SerializationResult, _Backtrace,
 };
 
@@ -127,7 +127,7 @@ pub trait Archetype {
     // NOTE: Don't bother returning a CoW here: we need to dynamically discard optional components
     // depending on their presence (or lack thereof) at runtime anyway.
     #[inline]
-    fn as_component_batches(&self) -> Vec<AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
         vec![]
     }
 

--- a/crates/re_types/src/archetype.rs
+++ b/crates/re_types/src/archetype.rs
@@ -36,9 +36,6 @@ pub trait Archetype {
     /// The associated indicator component, whose presence indicates that the high-level
     /// archetype-based APIs were used to log the data.
     ///
-    /// Indicator components open new opportunities in terms of API design, better heuristics and
-    /// performance improvements on the query side.
-    ///
     /// ## Internal representation
     ///
     /// Indicator components are non-splatted null arrays.
@@ -116,7 +113,7 @@ pub trait Archetype {
     fn num_instances(&self) -> usize {
         self.as_component_batches()
             .first()
-            .map_or(0, |comp_batch| comp_batch.as_batch().num_instances())
+            .map_or(0, |comp_batch| comp_batch.as_ref().num_instances())
     }
 
     /// Exposes the archetype's contents as a set of [`ComponentBatch`]s.
@@ -152,10 +149,10 @@ pub trait Archetype {
             .into_iter()
             .map(|comp_batch| {
                 comp_batch
-                    .as_batch()
+                    .as_ref()
                     .try_to_arrow()
-                    .map(|array| (comp_batch.as_batch().arrow_field(), array))
-                    .with_context(comp_batch.as_batch().name())
+                    .map(|array| (comp_batch.as_ref().arrow_field(), array))
+                    .with_context(comp_batch.as_ref().name())
             })
             .collect()
     }

--- a/crates/re_types/src/archetype.rs
+++ b/crates/re_types/src/archetype.rs
@@ -1,5 +1,5 @@
 use crate::{
-    MaybeOwnedComponentBatch, ComponentBatch, ComponentName, DeserializationResult, ResultExt as _,
+    ComponentBatch, ComponentName, DeserializationResult, MaybeOwnedComponentBatch, ResultExt as _,
     SerializationResult, _Backtrace,
 };
 

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -82,20 +82,30 @@ pub struct AnnotationContext {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.annotation_context".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.AnnotationContextIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.annotation_context".into()]);
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.annotation_context".into(),
+            "rerun.components.AnnotationContextIndicator".into(),
+        ]
+    });
 
 impl AnnotationContext {
-    pub const NUM_COMPONENTS: usize = 1usize;
+    pub const NUM_COMPONENTS: usize = 2usize;
 }
 
+/// Indicator component for the [`AnnotationContext`] [`crate::Archetype`]
+pub type AnnotationContextIndicator = crate::GenericIndicatorComponent<AnnotationContext>;
+
 impl crate::Archetype for AnnotationContext {
+    type Indicator = AnnotationContextIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.AnnotationContext".into()
@@ -122,20 +132,18 @@ impl crate::Archetype for AnnotationContext {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.AnnotationContextIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
-        [Some(&self.context as &dyn crate::ComponentList)]
-            .into_iter()
-            .flatten()
-            .collect()
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+        [
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.context as &dyn crate::ComponentList).into()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     #[inline]
@@ -145,47 +153,24 @@ impl crate::Archetype for AnnotationContext {
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([
-            {
-                Some({
-                    let array =
-                        <crate::components::AnnotationContext>::try_to_arrow([&self.context]);
-                    array.map(|array| {
-                        let datatype = ::arrow2::datatypes::DataType::Extension(
-                            "rerun.components.AnnotationContext".into(),
-                            Box::new(array.data_type().clone()),
-                            Some("rerun.annotation_context".into()),
-                        );
-                        (
-                            ::arrow2::datatypes::Field::new("context", datatype, false),
-                            array,
-                        )
-                    })
+        Ok([{
+            Some({
+                let array = <crate::components::AnnotationContext>::try_to_arrow([&self.context]);
+                array.map(|array| {
+                    let datatype = ::arrow2::datatypes::DataType::Extension(
+                        "rerun.components.AnnotationContext".into(),
+                        Box::new(array.data_type().clone()),
+                        Some("rerun.annotation_context".into()),
+                    );
+                    (
+                        ::arrow2::datatypes::Field::new("context", datatype, false),
+                        array,
+                    )
                 })
-                .transpose()
-                .with_context("rerun.archetypes.AnnotationContext#context")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.AnnotationContextIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.AnnotationContextIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.AnnotationContextIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
-            },
-        ]
+            })
+            .transpose()
+            .with_context("rerun.archetypes.AnnotationContext#context")?
+        }]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -136,7 +136,7 @@ impl crate::Archetype for AnnotationContext {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.context as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -48,7 +48,7 @@
 ///
 ///    // Log a batch of 2 rectangles with different class IDs
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "detections",
 ///        false,
 ///        2,
@@ -63,7 +63,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -136,10 +136,10 @@ impl crate::Archetype for AnnotationContext {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.context as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.context as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -154,7 +154,7 @@ impl crate::Archetype for Arrows3D {
         self.vectors.len()
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.vectors as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -154,28 +154,28 @@ impl crate::Archetype for Arrows3D {
         self.vectors.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.vectors as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.vectors as &dyn crate::ComponentBatch).into()),
             self.origins
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -81,8 +81,13 @@ pub struct Arrows3D {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.Vector3D".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Origin3D".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.components.Origin3D".into(),
+            "rerun.components.Arrows3DIndicator".into(),
+        ]
+    });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -95,11 +100,12 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Vector3D".into(),
             "rerun.components.Origin3D".into(),
+            "rerun.components.Arrows3DIndicator".into(),
             "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.label".into(),
@@ -109,10 +115,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     });
 
 impl Arrows3D {
-    pub const NUM_COMPONENTS: usize = 7usize;
+    pub const NUM_COMPONENTS: usize = 8usize;
 }
 
+/// Indicator component for the [`Arrows3D`] [`crate::Archetype`]
+pub type Arrows3DIndicator = crate::GenericIndicatorComponent<Arrows3D>;
+
 impl crate::Archetype for Arrows3D {
+    type Indicator = Arrows3DIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.Arrows3D".into()
@@ -139,36 +150,32 @@ impl crate::Archetype for Arrows3D {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.Arrows3DIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         self.vectors.len()
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.vectors as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.vectors as &dyn crate::ComponentList).into()),
             self.origins
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -320,26 +327,6 @@ impl crate::Archetype for Arrows3D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Arrows3D#instance_keys")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Arrows3DIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Arrows3DIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.Arrows3DIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -121,16 +121,16 @@ impl crate::Archetype for DepthImage {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.meter
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -60,8 +60,8 @@ pub struct DepthImage {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.DepthImageIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -71,20 +71,26 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
+            "rerun.components.DepthImageIndicator".into(),
             "rerun.components.DepthMeter".into(),
             "rerun.draw_order".into(),
         ]
     });
 
 impl DepthImage {
-    pub const NUM_COMPONENTS: usize = 3usize;
+    pub const NUM_COMPONENTS: usize = 4usize;
 }
 
+/// Indicator component for the [`DepthImage`] [`crate::Archetype`]
+pub type DepthImageIndicator = crate::GenericIndicatorComponent<DepthImage>;
+
 impl crate::Archetype for DepthImage {
+    type Indicator = DepthImageIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.DepthImage".into()
@@ -111,24 +117,20 @@ impl crate::Archetype for DepthImage {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.DepthImageIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.data as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentList).into()),
             self.meter
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -200,26 +202,6 @@ impl crate::Archetype for DepthImage {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.DepthImage#draw_order")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.DepthImageIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.DepthImageIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.DepthImageIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -121,7 +121,7 @@ impl crate::Archetype for DepthImage {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -108,7 +108,7 @@ impl crate::Archetype for DisconnectedSpace {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.disconnected_space as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -108,10 +108,10 @@ impl crate::Archetype for DisconnectedSpace {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.disconnected_space as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.disconnected_space as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -54,20 +54,30 @@ pub struct DisconnectedSpace {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.disconnected_space".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.DisconnectedSpaceIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.disconnected_space".into()]);
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.disconnected_space".into(),
+            "rerun.components.DisconnectedSpaceIndicator".into(),
+        ]
+    });
 
 impl DisconnectedSpace {
-    pub const NUM_COMPONENTS: usize = 1usize;
+    pub const NUM_COMPONENTS: usize = 2usize;
 }
 
+/// Indicator component for the [`DisconnectedSpace`] [`crate::Archetype`]
+pub type DisconnectedSpaceIndicator = crate::GenericIndicatorComponent<DisconnectedSpace>;
+
 impl crate::Archetype for DisconnectedSpace {
+    type Indicator = DisconnectedSpaceIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.DisconnectedSpace".into()
@@ -94,20 +104,18 @@ impl crate::Archetype for DisconnectedSpace {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.DisconnectedSpaceIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
-        [Some(&self.disconnected_space as &dyn crate::ComponentList)]
-            .into_iter()
-            .flatten()
-            .collect()
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+        [
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.disconnected_space as &dyn crate::ComponentList).into()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     #[inline]
@@ -117,48 +125,27 @@ impl crate::Archetype for DisconnectedSpace {
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([
-            {
-                Some({
-                    let array = <crate::components::DisconnectedSpace>::try_to_arrow([
-                        &self.disconnected_space
-                    ]);
-                    array.map(|array| {
-                        let datatype = ::arrow2::datatypes::DataType::Extension(
-                            "rerun.components.DisconnectedSpace".into(),
-                            Box::new(array.data_type().clone()),
-                            Some("rerun.disconnected_space".into()),
-                        );
-                        (
-                            ::arrow2::datatypes::Field::new("disconnected_space", datatype, false),
-                            array,
-                        )
-                    })
+        Ok([{
+            Some({
+                let array =
+                    <crate::components::DisconnectedSpace>::try_to_arrow(
+                        [&self.disconnected_space],
+                    );
+                array.map(|array| {
+                    let datatype = ::arrow2::datatypes::DataType::Extension(
+                        "rerun.components.DisconnectedSpace".into(),
+                        Box::new(array.data_type().clone()),
+                        Some("rerun.disconnected_space".into()),
+                    );
+                    (
+                        ::arrow2::datatypes::Field::new("disconnected_space", datatype, false),
+                        array,
+                    )
                 })
-                .transpose()
-                .with_context("rerun.archetypes.DisconnectedSpace#disconnected_space")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.DisconnectedSpaceIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.DisconnectedSpaceIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.DisconnectedSpaceIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
-            },
-        ]
+            })
+            .transpose()
+            .with_context("rerun.archetypes.DisconnectedSpace#disconnected_space")?
+        }]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -58,25 +58,31 @@ pub struct Image {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.ImageIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.draw_order".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
+            "rerun.components.ImageIndicator".into(),
             "rerun.draw_order".into(),
         ]
     });
 
 impl Image {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
+/// Indicator component for the [`Image`] [`crate::Archetype`]
+pub type ImageIndicator = crate::GenericIndicatorComponent<Image>;
+
 impl crate::Archetype for Image {
+    type Indicator = ImageIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.Image".into()
@@ -103,21 +109,17 @@ impl crate::Archetype for Image {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.ImageIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.data as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentList).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -169,26 +171,6 @@ impl crate::Archetype for Image {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Image#draw_order")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.ImageIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.ImageIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.ImageIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -113,13 +113,13 @@ impl crate::Archetype for Image {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -113,7 +113,7 @@ impl crate::Archetype for Image {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -183,7 +183,7 @@ impl crate::Archetype for LineStrips2D {
         self.strips.len()
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.strips as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -41,7 +41,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -69,7 +69,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -183,28 +183,28 @@ impl crate::Archetype for LineStrips2D {
         self.strips.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.strips as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -110,8 +110,14 @@ pub struct LineStrips2D {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.linestrip2d".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.radius".into(),
+            "rerun.colorrgba".into(),
+            "rerun.components.LineStrips2DIndicator".into(),
+        ]
+    });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -123,12 +129,13 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.linestrip2d".into(),
             "rerun.radius".into(),
             "rerun.colorrgba".into(),
+            "rerun.components.LineStrips2DIndicator".into(),
             "rerun.label".into(),
             "rerun.draw_order".into(),
             "rerun.class_id".into(),
@@ -137,10 +144,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     });
 
 impl LineStrips2D {
-    pub const NUM_COMPONENTS: usize = 7usize;
+    pub const NUM_COMPONENTS: usize = 8usize;
 }
 
+/// Indicator component for the [`LineStrips2D`] [`crate::Archetype`]
+pub type LineStrips2DIndicator = crate::GenericIndicatorComponent<LineStrips2D>;
+
 impl crate::Archetype for LineStrips2D {
+    type Indicator = LineStrips2DIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.LineStrips2D".into()
@@ -167,36 +179,32 @@ impl crate::Archetype for LineStrips2D {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.LineStrips2DIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         self.strips.len()
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.strips as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.strips as &dyn crate::ComponentList).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -348,26 +356,6 @@ impl crate::Archetype for LineStrips2D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.LineStrips2D#instance_keys")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.LineStrips2DIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.LineStrips2DIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.LineStrips2DIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -172,25 +172,25 @@ impl crate::Archetype for LineStrips3D {
         self.strips.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.strips as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -172,7 +172,7 @@ impl crate::Archetype for LineStrips3D {
         self.strips.len()
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.strips as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -101,8 +101,14 @@ pub struct LineStrips3D {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.linestrip3d".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.radius".into(),
+            "rerun.colorrgba".into(),
+            "rerun.components.LineStrips3DIndicator".into(),
+        ]
+    });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -113,12 +119,13 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 6usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.linestrip3d".into(),
             "rerun.radius".into(),
             "rerun.colorrgba".into(),
+            "rerun.components.LineStrips3DIndicator".into(),
             "rerun.label".into(),
             "rerun.class_id".into(),
             "rerun.instance_key".into(),
@@ -126,10 +133,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 6usize]> =
     });
 
 impl LineStrips3D {
-    pub const NUM_COMPONENTS: usize = 6usize;
+    pub const NUM_COMPONENTS: usize = 7usize;
 }
 
+/// Indicator component for the [`LineStrips3D`] [`crate::Archetype`]
+pub type LineStrips3DIndicator = crate::GenericIndicatorComponent<LineStrips3D>;
+
 impl crate::Archetype for LineStrips3D {
+    type Indicator = LineStrips3DIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.LineStrips3D".into()
@@ -156,33 +168,29 @@ impl crate::Archetype for LineStrips3D {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.LineStrips3DIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         self.strips.len()
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.strips as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.strips as &dyn crate::ComponentList).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -314,26 +322,6 @@ impl crate::Archetype for LineStrips3D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.LineStrips3D#instance_keys")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.LineStrips3DIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.LineStrips3DIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.LineStrips3DIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -80,8 +80,14 @@ pub struct Points2D {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.point2d".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.radius".into(),
+            "rerun.colorrgba".into(),
+            "rerun.components.Points2DIndicator".into(),
+        ]
+    });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -94,12 +100,13 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.point2d".into(),
             "rerun.radius".into(),
             "rerun.colorrgba".into(),
+            "rerun.components.Points2DIndicator".into(),
             "rerun.label".into(),
             "rerun.draw_order".into(),
             "rerun.class_id".into(),
@@ -109,10 +116,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     });
 
 impl Points2D {
-    pub const NUM_COMPONENTS: usize = 8usize;
+    pub const NUM_COMPONENTS: usize = 9usize;
 }
 
+/// Indicator component for the [`Points2D`] [`crate::Archetype`]
+pub type Points2DIndicator = crate::GenericIndicatorComponent<Points2D>;
+
 impl crate::Archetype for Points2D {
+    type Indicator = Points2DIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.Points2D".into()
@@ -139,39 +151,35 @@ impl crate::Archetype for Points2D {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.Points2DIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         self.points.len()
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.points as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.points as &dyn crate::ComponentList).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.keypoint_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -343,26 +351,6 @@ impl crate::Archetype for Points2D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Points2D#instance_keys")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Points2DIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Points2DIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.Points2DIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -29,7 +29,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -155,31 +155,31 @@ impl crate::Archetype for Points2D {
         self.points.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.points as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.points as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.keypoint_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -155,7 +155,7 @@ impl crate::Archetype for Points2D {
         self.points.len()
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.points as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -67,8 +67,14 @@ pub struct Points3D {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.point3d".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.radius".into(), "rerun.colorrgba".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.radius".into(),
+            "rerun.colorrgba".into(),
+            "rerun.components.Points3DIndicator".into(),
+        ]
+    });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -80,12 +86,13 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.point3d".into(),
             "rerun.radius".into(),
             "rerun.colorrgba".into(),
+            "rerun.components.Points3DIndicator".into(),
             "rerun.label".into(),
             "rerun.class_id".into(),
             "rerun.keypoint_id".into(),
@@ -94,10 +101,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     });
 
 impl Points3D {
-    pub const NUM_COMPONENTS: usize = 7usize;
+    pub const NUM_COMPONENTS: usize = 8usize;
 }
 
+/// Indicator component for the [`Points3D`] [`crate::Archetype`]
+pub type Points3DIndicator = crate::GenericIndicatorComponent<Points3D>;
+
 impl crate::Archetype for Points3D {
+    type Indicator = Points3DIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.Points3D".into()
@@ -124,36 +136,32 @@ impl crate::Archetype for Points3D {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.Points3DIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         self.points.len()
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.points as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.points as &dyn crate::ComponentList).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.keypoint_ids
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -305,26 +313,6 @@ impl crate::Archetype for Points3D {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.Points3D#instance_keys")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Points3DIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Points3DIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.Points3DIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -140,28 +140,28 @@ impl crate::Archetype for Points3D {
         self.points.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.points as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.points as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.keypoint_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -140,7 +140,7 @@ impl crate::Archetype for Points3D {
         self.points.len()
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.points as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -125,7 +125,7 @@ impl crate::Archetype for SegmentationImage {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -70,25 +70,31 @@ pub struct SegmentationImage {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.SegmentationImageIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.draw_order".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
+            "rerun.components.SegmentationImageIndicator".into(),
             "rerun.draw_order".into(),
         ]
     });
 
 impl SegmentationImage {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
+/// Indicator component for the [`SegmentationImage`] [`crate::Archetype`]
+pub type SegmentationImageIndicator = crate::GenericIndicatorComponent<SegmentationImage>;
+
 impl crate::Archetype for SegmentationImage {
+    type Indicator = SegmentationImageIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.SegmentationImage".into()
@@ -115,21 +121,17 @@ impl crate::Archetype for SegmentationImage {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.SegmentationImageIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.data as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentList).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -181,26 +183,6 @@ impl crate::Archetype for SegmentationImage {
                     })
                     .transpose()
                     .with_context("rerun.archetypes.SegmentationImage#draw_order")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.SegmentationImageIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.SegmentationImageIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.SegmentationImageIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -125,13 +125,13 @@ impl crate::Archetype for SegmentationImage {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -99,10 +99,10 @@ impl crate::Archetype for Tensor {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -99,7 +99,7 @@ impl crate::Archetype for Tensor {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -45,20 +45,30 @@ pub struct Tensor {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.TensorIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.components.TensorData".into(),
+            "rerun.components.TensorIndicator".into(),
+        ]
+    });
 
 impl Tensor {
-    pub const NUM_COMPONENTS: usize = 1usize;
+    pub const NUM_COMPONENTS: usize = 2usize;
 }
 
+/// Indicator component for the [`Tensor`] [`crate::Archetype`]
+pub type TensorIndicator = crate::GenericIndicatorComponent<Tensor>;
+
 impl crate::Archetype for Tensor {
+    type Indicator = TensorIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.Tensor".into()
@@ -85,20 +95,18 @@ impl crate::Archetype for Tensor {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.TensorIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
-        [Some(&self.data as &dyn crate::ComponentList)]
-            .into_iter()
-            .flatten()
-            .collect()
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+        [
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentList).into()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     #[inline]
@@ -108,46 +116,24 @@ impl crate::Archetype for Tensor {
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([
-            {
-                Some({
-                    let array = <crate::components::TensorData>::try_to_arrow([&self.data]);
-                    array.map(|array| {
-                        let datatype = ::arrow2::datatypes::DataType::Extension(
-                            "rerun.components.TensorData".into(),
-                            Box::new(array.data_type().clone()),
-                            Some("rerun.components.TensorData".into()),
-                        );
-                        (
-                            ::arrow2::datatypes::Field::new("data", datatype, false),
-                            array,
-                        )
-                    })
+        Ok([{
+            Some({
+                let array = <crate::components::TensorData>::try_to_arrow([&self.data]);
+                array.map(|array| {
+                    let datatype = ::arrow2::datatypes::DataType::Extension(
+                        "rerun.components.TensorData".into(),
+                        Box::new(array.data_type().clone()),
+                        Some("rerun.components.TensorData".into()),
+                    );
+                    (
+                        ::arrow2::datatypes::Field::new("data", datatype, false),
+                        array,
+                    )
                 })
-                .transpose()
-                .with_context("rerun.archetypes.Tensor#data")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.TensorIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.TensorIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.TensorIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
-            },
-        ]
+            })
+            .transpose()
+            .with_context("rerun.archetypes.Tensor#data")?
+        }]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -76,7 +76,7 @@ impl crate::Archetype for TextDocument {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.body as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -22,20 +22,30 @@ pub struct TextDocument {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.label".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.TextDocumentIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.label".into()]);
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.label".into(),
+            "rerun.components.TextDocumentIndicator".into(),
+        ]
+    });
 
 impl TextDocument {
-    pub const NUM_COMPONENTS: usize = 1usize;
+    pub const NUM_COMPONENTS: usize = 2usize;
 }
 
+/// Indicator component for the [`TextDocument`] [`crate::Archetype`]
+pub type TextDocumentIndicator = crate::GenericIndicatorComponent<TextDocument>;
+
 impl crate::Archetype for TextDocument {
+    type Indicator = TextDocumentIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.TextDocument".into()
@@ -62,20 +72,18 @@ impl crate::Archetype for TextDocument {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.TextDocumentIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
-        [Some(&self.body as &dyn crate::ComponentList)]
-            .into_iter()
-            .flatten()
-            .collect()
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+        [
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.body as &dyn crate::ComponentList).into()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     #[inline]
@@ -85,46 +93,24 @@ impl crate::Archetype for TextDocument {
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([
-            {
-                Some({
-                    let array = <crate::components::Text>::try_to_arrow([&self.body]);
-                    array.map(|array| {
-                        let datatype = ::arrow2::datatypes::DataType::Extension(
-                            "rerun.components.Text".into(),
-                            Box::new(array.data_type().clone()),
-                            Some("rerun.label".into()),
-                        );
-                        (
-                            ::arrow2::datatypes::Field::new("body", datatype, false),
-                            array,
-                        )
-                    })
+        Ok([{
+            Some({
+                let array = <crate::components::Text>::try_to_arrow([&self.body]);
+                array.map(|array| {
+                    let datatype = ::arrow2::datatypes::DataType::Extension(
+                        "rerun.components.Text".into(),
+                        Box::new(array.data_type().clone()),
+                        Some("rerun.label".into()),
+                    );
+                    (
+                        ::arrow2::datatypes::Field::new("body", datatype, false),
+                        array,
+                    )
                 })
-                .transpose()
-                .with_context("rerun.archetypes.TextDocument#body")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.TextDocumentIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.TextDocumentIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.TextDocumentIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
-            },
-        ]
+            })
+            .transpose()
+            .with_context("rerun.archetypes.TextDocument#body")?
+        }]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -76,10 +76,10 @@ impl crate::Archetype for TextDocument {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.body as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.body as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -84,7 +84,7 @@ impl crate::Archetype for TextLog {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.body as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -84,16 +84,16 @@ impl crate::Archetype for TextLog {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.body as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.body as &dyn crate::ComponentBatch).into()),
             self.level
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.color
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -119,7 +119,7 @@ impl crate::Archetype for Transform3D {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.transform as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -119,10 +119,10 @@ impl crate::Archetype for Transform3D {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.transform as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.transform as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -65,20 +65,30 @@ pub struct Transform3D {
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.transform3d".into()]);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.components.Transform3DIndicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.transform3d".into()]);
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [
+            "rerun.transform3d".into(),
+            "rerun.components.Transform3DIndicator".into(),
+        ]
+    });
 
 impl Transform3D {
-    pub const NUM_COMPONENTS: usize = 1usize;
+    pub const NUM_COMPONENTS: usize = 2usize;
 }
 
+/// Indicator component for the [`Transform3D`] [`crate::Archetype`]
+pub type Transform3DIndicator = crate::GenericIndicatorComponent<Transform3D>;
+
 impl crate::Archetype for Transform3D {
+    type Indicator = Transform3DIndicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.archetypes.Transform3D".into()
@@ -105,20 +115,18 @@ impl crate::Archetype for Transform3D {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.components.Transform3DIndicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
-        [Some(&self.transform as &dyn crate::ComponentList)]
-            .into_iter()
-            .flatten()
-            .collect()
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+        [
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.transform as &dyn crate::ComponentList).into()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     #[inline]
@@ -128,46 +136,24 @@ impl crate::Archetype for Transform3D {
         Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     > {
         use crate::{Loggable as _, ResultExt as _};
-        Ok([
-            {
-                Some({
-                    let array = <crate::components::Transform3D>::try_to_arrow([&self.transform]);
-                    array.map(|array| {
-                        let datatype = ::arrow2::datatypes::DataType::Extension(
-                            "rerun.components.Transform3D".into(),
-                            Box::new(array.data_type().clone()),
-                            Some("rerun.transform3d".into()),
-                        );
-                        (
-                            ::arrow2::datatypes::Field::new("transform", datatype, false),
-                            array,
-                        )
-                    })
+        Ok([{
+            Some({
+                let array = <crate::components::Transform3D>::try_to_arrow([&self.transform]);
+                array.map(|array| {
+                    let datatype = ::arrow2::datatypes::DataType::Extension(
+                        "rerun.components.Transform3D".into(),
+                        Box::new(array.data_type().clone()),
+                        Some("rerun.transform3d".into()),
+                    );
+                    (
+                        ::arrow2::datatypes::Field::new("transform", datatype, false),
+                        array,
+                    )
                 })
-                .transpose()
-                .with_context("rerun.archetypes.Transform3D#transform")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.components.Transform3DIndicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.components.Transform3DIndicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.components.Transform3DIndicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
-            },
-        ]
+            })
+            .transpose()
+            .with_context("rerun.archetypes.Transform3D#transform")?
+        }]
         .into_iter()
         .flatten()
         .collect())

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -10,7 +10,7 @@
 //! Rerun (and the underlying Arrow data framework) is designed to work with large arrays of
 //! [`Component`]s, as opposed to single instances.
 //! When multiple instances of a [`Component`] are put together in an array, they yield a
-//! [`ComponentList`]: the atomic unit of (de)serialization.
+//! [`ComponentBatch`]: the atomic unit of (de)serialization.
 //!
 //! Internally, [`Component`]s are implemented using many different [`Datatype`]s.
 //!
@@ -118,13 +118,13 @@ pub mod datatypes;
 
 mod archetype;
 mod loggable;
-mod loggable_list;
+mod loggable_batch;
 mod result;
 mod size_bytes;
 
 pub use self::archetype::{Archetype, ArchetypeName, GenericIndicatorComponent};
 pub use self::loggable::{Component, ComponentName, Datatype, DatatypeName, Loggable};
-pub use self::loggable_list::{AnyComponentList, ComponentList, DatatypeList, LoggableList};
+pub use self::loggable_batch::{AnyComponentBatch, ComponentBatch, DatatypeBatch, LoggableBatch};
 pub use self::result::{
     DeserializationError, DeserializationResult, ResultExt, SerializationError,
     SerializationResult, _Backtrace,

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -124,7 +124,7 @@ mod size_bytes;
 
 pub use self::archetype::{Archetype, ArchetypeName, GenericIndicatorComponent};
 pub use self::loggable::{Component, ComponentName, Datatype, DatatypeName, Loggable};
-pub use self::loggable_batch::{AnyComponentBatch, ComponentBatch, DatatypeBatch, LoggableBatch};
+pub use self::loggable_batch::{MaybeOwnedComponentBatch, ComponentBatch, DatatypeBatch, LoggableBatch};
 pub use self::result::{
     DeserializationError, DeserializationResult, ResultExt, SerializationError,
     SerializationResult, _Backtrace,

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -122,9 +122,9 @@ mod loggable_list;
 mod result;
 mod size_bytes;
 
-pub use self::archetype::{Archetype, ArchetypeName};
+pub use self::archetype::{Archetype, ArchetypeName, GenericIndicatorComponent};
 pub use self::loggable::{Component, ComponentName, Datatype, DatatypeName, Loggable};
-pub use self::loggable_list::{ComponentList, DatatypeList, LoggableList};
+pub use self::loggable_list::{AnyComponentList, ComponentList, DatatypeList, LoggableList};
 pub use self::result::{
     DeserializationError, DeserializationResult, ResultExt, SerializationError,
     SerializationResult, _Backtrace,

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -124,7 +124,9 @@ mod size_bytes;
 
 pub use self::archetype::{Archetype, ArchetypeName, GenericIndicatorComponent};
 pub use self::loggable::{Component, ComponentName, Datatype, DatatypeName, Loggable};
-pub use self::loggable_batch::{MaybeOwnedComponentBatch, ComponentBatch, DatatypeBatch, LoggableBatch};
+pub use self::loggable_batch::{
+    ComponentBatch, DatatypeBatch, LoggableBatch, MaybeOwnedComponentBatch,
+};
 pub use self::result::{
     DeserializationError, DeserializationResult, ResultExt, SerializationError,
     SerializationResult, _Backtrace,

--- a/crates/re_types/src/loggable.rs
+++ b/crates/re_types/src/loggable.rs
@@ -1,7 +1,7 @@
 use crate::{result::_Backtrace, DeserializationResult, ResultExt as _, SerializationResult};
 
 #[allow(unused_imports)] // used in docstrings
-use crate::{Archetype, ComponentList, DatatypeList, LoggableList};
+use crate::{Archetype, ComponentBatch, DatatypeBatch, LoggableBatch};
 
 // ---
 
@@ -14,8 +14,8 @@ use crate::{Archetype, ComponentList, DatatypeList, LoggableList};
 /// automatically implemented based on the type used for [`Loggable::Name`].
 ///
 /// Implementing the [`Loggable`] trait (and by extension [`Datatype`]/[`Component`])
-/// automatically derives the [`LoggableList`] implementation (and by extension
-/// [`DatatypeList`]/[`ComponentList`]), which makes it possible to work with lists' worth of data
+/// automatically derives the [`LoggableBatch`] implementation (and by extension
+/// [`DatatypeBatch`]/[`ComponentBatch`]), which makes it possible to work with lists' worth of data
 /// in a generic fashion.
 pub trait Loggable: Clone + Sized {
     type Name: std::fmt::Display;

--- a/crates/re_types/src/loggable_batch.rs
+++ b/crates/re_types/src/loggable_batch.rs
@@ -65,30 +65,30 @@ pub trait ComponentBatch: LoggableBatch<Name = ComponentName> {}
 ///
 /// This doesn't use [`std::borrow::Cow`] on purpose: `Cow` requires `Clone`, which would break
 /// object-safety, which would prevent us from erasing [`ComponentBatch`]s in the first place.
-pub enum AnyComponentBatch<'a> {
+pub enum MaybeOwnedComponentBatch<'a> {
     Owned(Box<dyn ComponentBatch>),
     Ref(&'a dyn ComponentBatch),
 }
 
-impl<'a> From<&'a dyn ComponentBatch> for AnyComponentBatch<'a> {
+impl<'a> From<&'a dyn ComponentBatch> for MaybeOwnedComponentBatch<'a> {
     #[inline]
     fn from(comp_batch: &'a dyn ComponentBatch) -> Self {
         Self::Ref(comp_batch)
     }
 }
 
-impl From<Box<dyn ComponentBatch>> for AnyComponentBatch<'_> {
+impl From<Box<dyn ComponentBatch>> for MaybeOwnedComponentBatch<'_> {
     #[inline]
     fn from(comp_batch: Box<dyn ComponentBatch>) -> Self {
         Self::Owned(comp_batch)
     }
 }
 
-impl<'a> AsRef<dyn ComponentBatch + 'a> for AnyComponentBatch<'a> {
+impl<'a> AsRef<dyn ComponentBatch + 'a> for MaybeOwnedComponentBatch<'a> {
     fn as_ref(&self) -> &(dyn ComponentBatch + 'a) {
         match self {
-            AnyComponentBatch::Owned(this) => &**this,
-            AnyComponentBatch::Ref(this) => *this,
+            MaybeOwnedComponentBatch::Owned(this) => &**this,
+            MaybeOwnedComponentBatch::Ref(this) => *this,
         }
     }
 }

--- a/crates/re_types/src/loggable_batch.rs
+++ b/crates/re_types/src/loggable_batch.rs
@@ -7,112 +7,112 @@ use crate::Archetype;
 
 // ---
 
-/// A [`LoggableList`] represents an array's worth of [`Loggable`] instances, ready to be
+/// A [`LoggableBatch`] represents an array's worth of [`Loggable`] instances, ready to be
 /// serialized.
 ///
-/// [`LoggableList`] is carefully designed to be erasable ("object-safe"), so that it is possible
-/// to build heterogeneous collections of [`LoggableList`]s (e.g. `Vec<dyn LoggableList>`).
+/// [`LoggableBatch`] is carefully designed to be erasable ("object-safe"), so that it is possible
+/// to build heterogeneous collections of [`LoggableBatch`]s (e.g. `Vec<dyn LoggableBatch>`).
 /// This erasability is what makes extending [`Archetype`]s possible with little effort.
 ///
-/// You should almost never need to implement [`LoggableList`] manually, as it is already
+/// You should almost never need to implement [`LoggableBatch`] manually, as it is already
 /// blanket implemented for most common use cases (arrays/vectors/slices of loggables, etc).
-pub trait LoggableList {
+pub trait LoggableBatch {
     type Name;
 
     // NOTE: It'd be tempting to have the following associated type, but that'd be
     // counterproductive, the whole point of this is to allow for heterogeneous collections!
     // type Loggable: Loggable;
 
-    /// The fully-qualified name of this list, e.g. `rerun.datatypes.Vec2D`.
+    /// The fully-qualified name of this batch, e.g. `rerun.datatypes.Vec2D`.
     fn name(&self) -> Self::Name;
 
-    /// The number of component instances stored into this list.
+    /// The number of component instances stored into this batch.
     fn num_instances(&self) -> usize;
 
     /// The underlying [`arrow2::datatypes::Field`], including datatype extensions.
     fn arrow_field(&self) -> arrow2::datatypes::Field;
 
-    /// Serializes the list into an Arrow array.
+    /// Serializes the batch into an Arrow array.
     ///
-    /// This will _never_ fail for Rerun's built-in [`LoggableList`].
-    /// For the non-fallible version, see [`LoggableList::to_arrow`].
+    /// This will _never_ fail for Rerun's built-in [`LoggableBatch`].
+    /// For the non-fallible version, see [`LoggableBatch::to_arrow`].
     fn try_to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>>;
 
-    /// Serializes the list into an Arrow array.
+    /// Serializes the batch into an Arrow array.
     ///
     /// Panics on failure.
-    /// This will _never_ fail for Rerun's built-in [`LoggableList`]s.
+    /// This will _never_ fail for Rerun's built-in [`LoggableBatch`]s.
     ///
-    /// For the fallible version, see [`LoggableList::try_to_arrow`].
+    /// For the fallible version, see [`LoggableBatch::try_to_arrow`].
     fn to_arrow(&self) -> Box<dyn ::arrow2::array::Array> {
         self.try_to_arrow().detailed_unwrap()
     }
 }
 
-/// A [`DatatypeList`] represents an array's worth of [`Datatype`] instances.
+/// A [`DatatypeBatch`] represents an array's worth of [`Datatype`] instances.
 ///
-/// Any [`LoggableList`] with a [`Loggable::Name`] set to [`DatatypeName`] automatically
-/// implements [`DatatypeList`].
-pub trait DatatypeList: LoggableList<Name = DatatypeName> {}
+/// Any [`LoggableBatch`] with a [`Loggable::Name`] set to [`DatatypeName`] automatically
+/// implements [`DatatypeBatch`].
+pub trait DatatypeBatch: LoggableBatch<Name = DatatypeName> {}
 
-/// A [`ComponentList`] represents an array's worth of [`Component`] instances.
+/// A [`ComponentBatch`] represents an array's worth of [`Component`] instances.
 ///
-/// Any [`LoggableList`] with a [`Loggable::Name`] set to [`ComponentName`] automatically
-/// implements [`ComponentList`].
-pub trait ComponentList: LoggableList<Name = ComponentName> {}
+/// Any [`LoggableBatch`] with a [`Loggable::Name`] set to [`ComponentName`] automatically
+/// implements [`ComponentBatch`].
+pub trait ComponentBatch: LoggableBatch<Name = ComponentName> {}
 
-/// Holds either an owned [`ComponentList`] that lives on heap, or a reference to one.
+/// Holds either an owned [`ComponentBatch`] that lives on heap, or a reference to one.
 ///
 /// This doesn't use [`std::borrow::Cow`] on purpose: `Cow` requires `Clone`, which would break
-/// object-safety, which would prevent us from erasing [`ComponentList`]s in the first place.
-pub enum AnyComponentList<'a> {
-    Owned(Box<dyn ComponentList>),
-    Ref(&'a dyn ComponentList),
+/// object-safety, which would prevent us from erasing [`ComponentBatch`]s in the first place.
+pub enum AnyComponentBatch<'a> {
+    Owned(Box<dyn ComponentBatch>),
+    Ref(&'a dyn ComponentBatch),
 }
 
-impl<'a> From<&'a dyn ComponentList> for AnyComponentList<'a> {
+impl<'a> From<&'a dyn ComponentBatch> for AnyComponentBatch<'a> {
     #[inline]
-    fn from(comp_list: &'a dyn ComponentList) -> Self {
-        Self::Ref(comp_list)
+    fn from(comp_batch: &'a dyn ComponentBatch) -> Self {
+        Self::Ref(comp_batch)
     }
 }
 
-impl From<Box<dyn ComponentList>> for AnyComponentList<'_> {
+impl From<Box<dyn ComponentBatch>> for AnyComponentBatch<'_> {
     #[inline]
-    fn from(comp_list: Box<dyn ComponentList>) -> Self {
-        Self::Owned(comp_list)
+    fn from(comp_batch: Box<dyn ComponentBatch>) -> Self {
+        Self::Owned(comp_batch)
     }
 }
 
-impl<'a> AnyComponentList<'a> {
-    /// Returns a reference to the inner [`ComponentList`], no matter where it lives.
+impl<'a> AnyComponentBatch<'a> {
+    /// Returns a reference to the inner [`ComponentBatch`], no matter where it lives.
     ///
     /// This doesn't use [`std::ops::Deref`] on purpose: it's associated `Target` type is not
     /// generic over lifetimes, which we need in this case.
     #[inline]
-    pub fn as_list(&'a self) -> &dyn ComponentList {
+    pub fn as_batch(&'a self) -> &dyn ComponentBatch {
         match self {
-            AnyComponentList::Owned(this) => &**this,
-            AnyComponentList::Ref(this) => *this,
+            AnyComponentBatch::Owned(this) => &**this,
+            AnyComponentBatch::Ref(this) => *this,
         }
     }
 }
 
 // NOTE: Cannot do this since `Deref::Target` is not generic over lifetimes.
-// impl<'a> std::ops::Deref for AnyComponentList<'a> {
-//     type Target = dyn ComponentList;
+// impl<'a> std::ops::Deref for AnyComponentBatch<'a> {
+//     type Target = dyn ComponentBatch;
 //
 //     fn deref(&self) -> &Self::Target {
 //         match self {
-//             AnyComponentList::Owned(this) => &**this,
-//             AnyComponentList::Ref(this) => *this,
+//             AnyComponentBatch::Owned(this) => &**this,
+//             AnyComponentBatch::Ref(this) => *this,
 //         }
 //     }
 // }
 
 // --- Unary ---
 
-impl<L: Clone + Loggable> LoggableList for L {
+impl<L: Clone + Loggable> LoggableBatch for L {
     type Name = L::Name;
 
     #[inline]
@@ -136,13 +136,13 @@ impl<L: Clone + Loggable> LoggableList for L {
     }
 }
 
-impl<D: Datatype> DatatypeList for D {}
+impl<D: Datatype> DatatypeBatch for D {}
 
-impl<C: Component> ComponentList for C {}
+impl<C: Component> ComponentBatch for C {}
 
 // --- Vec ---
 
-impl<L: Clone + Loggable> LoggableList for Vec<L> {
+impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
     type Name = L::Name;
 
     #[inline]
@@ -166,13 +166,13 @@ impl<L: Clone + Loggable> LoggableList for Vec<L> {
     }
 }
 
-impl<D: Datatype> DatatypeList for Vec<D> {}
+impl<D: Datatype> DatatypeBatch for Vec<D> {}
 
-impl<C: Component> ComponentList for Vec<C> {}
+impl<C: Component> ComponentBatch for Vec<C> {}
 
 // --- Vec<Option> ---
 
-impl<L: Loggable> LoggableList for Vec<Option<L>> {
+impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
     type Name = L::Name;
 
     #[inline]
@@ -199,13 +199,13 @@ impl<L: Loggable> LoggableList for Vec<Option<L>> {
     }
 }
 
-impl<D: Datatype> DatatypeList for Vec<Option<D>> {}
+impl<D: Datatype> DatatypeBatch for Vec<Option<D>> {}
 
-impl<C: Component> ComponentList for Vec<Option<C>> {}
+impl<C: Component> ComponentBatch for Vec<Option<C>> {}
 
 // --- Array ---
 
-impl<L: Loggable, const N: usize> LoggableList for [L; N] {
+impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
     type Name = L::Name;
 
     #[inline]
@@ -229,13 +229,13 @@ impl<L: Loggable, const N: usize> LoggableList for [L; N] {
     }
 }
 
-impl<D: Datatype, const N: usize> DatatypeList for [D; N] {}
+impl<D: Datatype, const N: usize> DatatypeBatch for [D; N] {}
 
-impl<C: Component, const N: usize> ComponentList for [C; N] {}
+impl<C: Component, const N: usize> ComponentBatch for [C; N] {}
 
 // --- Array<Option> ---
 
-impl<L: Loggable, const N: usize> LoggableList for [Option<L>; N] {
+impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
     type Name = L::Name;
 
     #[inline]
@@ -262,13 +262,13 @@ impl<L: Loggable, const N: usize> LoggableList for [Option<L>; N] {
     }
 }
 
-impl<D: Datatype, const N: usize> DatatypeList for [Option<D>; N] {}
+impl<D: Datatype, const N: usize> DatatypeBatch for [Option<D>; N] {}
 
-impl<C: Component, const N: usize> ComponentList for [Option<C>; N] {}
+impl<C: Component, const N: usize> ComponentBatch for [Option<C>; N] {}
 
 // --- Slice ---
 
-impl<'a, L: Loggable> LoggableList for &'a [L] {
+impl<'a, L: Loggable> LoggableBatch for &'a [L] {
     type Name = L::Name;
 
     #[inline]
@@ -292,13 +292,13 @@ impl<'a, L: Loggable> LoggableList for &'a [L] {
     }
 }
 
-impl<'a, D: Datatype> DatatypeList for &'a [D] {}
+impl<'a, D: Datatype> DatatypeBatch for &'a [D] {}
 
-impl<'a, C: Component> ComponentList for &'a [C] {}
+impl<'a, C: Component> ComponentBatch for &'a [C] {}
 
 // --- Slice<Option> ---
 
-impl<'a, L: Loggable> LoggableList for &'a [Option<L>] {
+impl<'a, L: Loggable> LoggableBatch for &'a [Option<L>] {
     type Name = L::Name;
 
     #[inline]
@@ -325,13 +325,13 @@ impl<'a, L: Loggable> LoggableList for &'a [Option<L>] {
     }
 }
 
-impl<'a, D: Datatype> DatatypeList for &'a [Option<D>] {}
+impl<'a, D: Datatype> DatatypeBatch for &'a [Option<D>] {}
 
-impl<'a, C: Component> ComponentList for &'a [Option<C>] {}
+impl<'a, C: Component> ComponentBatch for &'a [Option<C>] {}
 
 // --- ArrayRef ---
 
-impl<'a, L: Loggable, const N: usize> LoggableList for &'a [L; N] {
+impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [L; N] {
     type Name = L::Name;
 
     #[inline]
@@ -355,13 +355,13 @@ impl<'a, L: Loggable, const N: usize> LoggableList for &'a [L; N] {
     }
 }
 
-impl<'a, D: Datatype, const N: usize> DatatypeList for &'a [D; N] {}
+impl<'a, D: Datatype, const N: usize> DatatypeBatch for &'a [D; N] {}
 
-impl<'a, C: Component, const N: usize> ComponentList for &'a [C; N] {}
+impl<'a, C: Component, const N: usize> ComponentBatch for &'a [C; N] {}
 
 // --- ArrayRef<Option> ---
 
-impl<'a, L: Loggable, const N: usize> LoggableList for &'a [Option<L>; N] {
+impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [Option<L>; N] {
     type Name = L::Name;
 
     #[inline]
@@ -388,6 +388,6 @@ impl<'a, L: Loggable, const N: usize> LoggableList for &'a [Option<L>; N] {
     }
 }
 
-impl<'a, D: Datatype, const N: usize> DatatypeList for &'a [Option<D>; N] {}
+impl<'a, D: Datatype, const N: usize> DatatypeBatch for &'a [Option<D>; N] {}
 
-impl<'a, C: Component, const N: usize> ComponentList for &'a [Option<C>; N] {}
+impl<'a, C: Component, const N: usize> ComponentBatch for &'a [Option<C>; N] {}

--- a/crates/re_types/src/loggable_batch.rs
+++ b/crates/re_types/src/loggable_batch.rs
@@ -84,31 +84,14 @@ impl From<Box<dyn ComponentBatch>> for AnyComponentBatch<'_> {
     }
 }
 
-impl<'a> AnyComponentBatch<'a> {
-    /// Returns a reference to the inner [`ComponentBatch`], no matter where it lives.
-    ///
-    /// This doesn't use [`std::ops::Deref`] on purpose: it's associated `Target` type is not
-    /// generic over lifetimes, which we need in this case.
-    #[inline]
-    pub fn as_batch(&'a self) -> &dyn ComponentBatch {
+impl<'a> AsRef<dyn ComponentBatch + 'a> for AnyComponentBatch<'a> {
+    fn as_ref(&self) -> &(dyn ComponentBatch + 'a) {
         match self {
             AnyComponentBatch::Owned(this) => &**this,
             AnyComponentBatch::Ref(this) => *this,
         }
     }
 }
-
-// NOTE: Cannot do this since `Deref::Target` is not generic over lifetimes.
-// impl<'a> std::ops::Deref for AnyComponentBatch<'a> {
-//     type Target = dyn ComponentBatch;
-//
-//     fn deref(&self) -> &Self::Target {
-//         match self {
-//             AnyComponentBatch::Owned(this) => &**this,
-//             AnyComponentBatch::Ref(this) => *this,
-//         }
-//     }
-// }
 
 // --- Unary ---
 

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -301,155 +301,155 @@ impl crate::Archetype for AffixFuzzer1 {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.fuzz1001 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1002 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1003 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1004 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1005 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1006 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1007 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1008 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1009 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1010 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1011 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1012 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1013 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1014 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1015 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1016 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1017 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1018 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1019 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1020 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1101 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1102 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1103 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1104 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1105 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1106 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1107 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1108 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1109 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1110 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1111 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1112 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1113 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1114 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1115 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1116 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1117 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1118 as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.fuzz1001 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1002 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1003 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1004 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1005 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1006 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1007 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1008 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1009 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1010 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1011 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1012 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1013 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1014 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1015 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1016 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1017 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1018 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1019 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1020 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1101 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1102 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1103 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1104 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1105 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1106 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1107 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1108 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1109 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1110 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1111 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1112 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1113 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1114 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1115 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1116 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1117 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1118 as &dyn crate::ComponentBatch).into()),
             self.fuzz2001
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2002
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2003
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2004
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2005
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2006
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2007
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2008
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2009
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2010
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2011
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2012
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2013
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2014
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2015
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2016
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2017
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2018
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2101
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2102
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2103
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2104
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2105
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2106
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2107
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2108
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2109
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2110
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2111
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2112
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2113
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2114
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2115
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2116
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2117
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2118
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -135,8 +135,8 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 38usize
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.testing.components.AffixFuzzer1Indicator".into()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize]> =
     once_cell::sync::Lazy::new(|| {
@@ -180,7 +180,7 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 74usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 75usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
@@ -221,6 +221,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 74usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
+            "rerun.testing.components.AffixFuzzer1Indicator".into(),
             "rerun.testing.components.AffixFuzzer1".into(),
             "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer3".into(),
@@ -261,10 +262,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 74usize]> =
     });
 
 impl AffixFuzzer1 {
-    pub const NUM_COMPONENTS: usize = 74usize;
+    pub const NUM_COMPONENTS: usize = 75usize;
 }
 
+/// Indicator component for the [`AffixFuzzer1`] [`crate::Archetype`]
+pub type AffixFuzzer1Indicator = crate::GenericIndicatorComponent<AffixFuzzer1>;
+
 impl crate::Archetype for AffixFuzzer1 {
+    type Indicator = AffixFuzzer1Indicator;
+
     #[inline]
     fn name() -> crate::ArchetypeName {
         "rerun.testing.archetypes.AffixFuzzer1".into()
@@ -291,163 +297,159 @@ impl crate::Archetype for AffixFuzzer1 {
     }
 
     #[inline]
-    fn indicator_component() -> crate::ComponentName {
-        "rerun.testing.archetypes.AffixFuzzer1Indicator".into()
-    }
-
-    #[inline]
     fn num_instances(&self) -> usize {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
         [
-            Some(&self.fuzz1001 as &dyn crate::ComponentList),
-            Some(&self.fuzz1002 as &dyn crate::ComponentList),
-            Some(&self.fuzz1003 as &dyn crate::ComponentList),
-            Some(&self.fuzz1004 as &dyn crate::ComponentList),
-            Some(&self.fuzz1005 as &dyn crate::ComponentList),
-            Some(&self.fuzz1006 as &dyn crate::ComponentList),
-            Some(&self.fuzz1007 as &dyn crate::ComponentList),
-            Some(&self.fuzz1008 as &dyn crate::ComponentList),
-            Some(&self.fuzz1009 as &dyn crate::ComponentList),
-            Some(&self.fuzz1010 as &dyn crate::ComponentList),
-            Some(&self.fuzz1011 as &dyn crate::ComponentList),
-            Some(&self.fuzz1012 as &dyn crate::ComponentList),
-            Some(&self.fuzz1013 as &dyn crate::ComponentList),
-            Some(&self.fuzz1014 as &dyn crate::ComponentList),
-            Some(&self.fuzz1015 as &dyn crate::ComponentList),
-            Some(&self.fuzz1016 as &dyn crate::ComponentList),
-            Some(&self.fuzz1017 as &dyn crate::ComponentList),
-            Some(&self.fuzz1018 as &dyn crate::ComponentList),
-            Some(&self.fuzz1019 as &dyn crate::ComponentList),
-            Some(&self.fuzz1020 as &dyn crate::ComponentList),
-            Some(&self.fuzz1101 as &dyn crate::ComponentList),
-            Some(&self.fuzz1102 as &dyn crate::ComponentList),
-            Some(&self.fuzz1103 as &dyn crate::ComponentList),
-            Some(&self.fuzz1104 as &dyn crate::ComponentList),
-            Some(&self.fuzz1105 as &dyn crate::ComponentList),
-            Some(&self.fuzz1106 as &dyn crate::ComponentList),
-            Some(&self.fuzz1107 as &dyn crate::ComponentList),
-            Some(&self.fuzz1108 as &dyn crate::ComponentList),
-            Some(&self.fuzz1109 as &dyn crate::ComponentList),
-            Some(&self.fuzz1110 as &dyn crate::ComponentList),
-            Some(&self.fuzz1111 as &dyn crate::ComponentList),
-            Some(&self.fuzz1112 as &dyn crate::ComponentList),
-            Some(&self.fuzz1113 as &dyn crate::ComponentList),
-            Some(&self.fuzz1114 as &dyn crate::ComponentList),
-            Some(&self.fuzz1115 as &dyn crate::ComponentList),
-            Some(&self.fuzz1116 as &dyn crate::ComponentList),
-            Some(&self.fuzz1117 as &dyn crate::ComponentList),
-            Some(&self.fuzz1118 as &dyn crate::ComponentList),
+            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
+            Some((&self.fuzz1001 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1002 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1003 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1004 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1005 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1006 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1007 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1008 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1009 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1010 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1011 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1012 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1013 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1014 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1015 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1016 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1017 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1018 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1019 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1020 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1101 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1102 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1103 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1104 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1105 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1106 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1107 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1108 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1109 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1110 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1111 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1112 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1113 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1114 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1115 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1116 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1117 as &dyn crate::ComponentList).into()),
+            Some((&self.fuzz1118 as &dyn crate::ComponentList).into()),
             self.fuzz2001
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2002
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2003
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2004
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2005
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2006
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2007
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2008
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2009
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2010
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2011
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2012
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2013
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2014
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2015
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2016
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2017
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2018
                 .as_ref()
-                .map(|comp| comp as &dyn crate::ComponentList),
+                .map(|comp| (comp as &dyn crate::ComponentList).into()),
             self.fuzz2101
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2102
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2103
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2104
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2105
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2106
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2107
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2108
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2109
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2110
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2111
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2112
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2113
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2114
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2115
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2116
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2117
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
             self.fuzz2118
                 .as_ref()
-                .map(|comp_list| comp_list as &dyn crate::ComponentList),
+                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
         ]
         .into_iter()
         .flatten()
@@ -1957,26 +1959,6 @@ impl crate::Archetype for AffixFuzzer1 {
                     })
                     .transpose()
                     .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz2118")?
-            },
-            {
-                let datatype = ::arrow2::datatypes::DataType::Extension(
-                    "rerun.testing.archetypes.AffixFuzzer1Indicator".to_owned(),
-                    Box::new(::arrow2::datatypes::DataType::Null),
-                    Some("rerun.testing.archetypes.AffixFuzzer1Indicator".to_owned()),
-                );
-                let array = ::arrow2::array::NullArray::new(
-                    datatype.to_logical_type().clone(),
-                    self.num_instances(),
-                )
-                .boxed();
-                Some((
-                    ::arrow2::datatypes::Field::new(
-                        "rerun.testing.archetypes.AffixFuzzer1Indicator",
-                        datatype,
-                        false,
-                    ),
-                    array,
-                ))
             },
         ]
         .into_iter()

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -301,7 +301,7 @@ impl crate::Archetype for AffixFuzzer1 {
         1
     }
 
-    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
             Some(Self::Indicator::batch(self.num_instances() as _).into()),
             Some((&self.fuzz1001 as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -1031,7 +1031,7 @@ fn quote_trait_impls_from_obj(
                         #num_instances
                     }
 
-                    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+                    fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
                         [#(#all_component_batches,)*].into_iter().flatten().collect()
                     }
 

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -29,6 +29,8 @@ use crate::{
 
 use super::{arrow::quote_fqname_as_type_path, util::string_from_quoted};
 
+// ---
+
 // TODO(cmc): it'd be nice to be able to generate vanilla comments (as opposed to doc-comments)
 // once again at some point (`TokenStream` strips them)… nothing too urgent though.
 
@@ -762,6 +764,7 @@ fn quote_trait_impls_from_obj(
                 obj: &Object,
                 attr: &'static str,
                 objects: &Objects,
+                extras: impl IntoIterator<Item = String>,
             ) -> (usize, TokenStream) {
                 let components = iter_archetype_components(obj, attr)
                     .map(|fqname| {
@@ -769,6 +772,7 @@ fn quote_trait_impls_from_obj(
                             .try_get_attr::<String>(crate::ATTR_RERUN_LEGACY_FQNAME)
                             .unwrap_or(fqname)
                     })
+                    .chain(extras)
                     .collect::<Vec<_>>();
                 let num_components = components.len();
                 let quoted_components = quote!(#(#components.into(),)*);
@@ -793,12 +797,24 @@ fn quote_trait_impls_from_obj(
                 quote!(1)
             };
 
+            let indicator_name = format!("{}Indicator", obj.name);
+            let indicator_fqname =
+                format!("{}Indicator", obj.fqname).replace("archetypes", "components");
+
+            let quoted_indicator_name = format_ident!("{indicator_name}");
+            let quoted_indicator_doc =
+                format!("Indicator component for the [`{name}`] [`crate::Archetype`]");
+
             let (num_required, required) =
-                compute_components(obj, ATTR_RERUN_COMPONENT_REQUIRED, objects);
-            let (num_recommended, recommended) =
-                compute_components(obj, ATTR_RERUN_COMPONENT_RECOMMENDED, objects);
+                compute_components(obj, ATTR_RERUN_COMPONENT_REQUIRED, objects, []);
+            let (num_recommended, recommended) = compute_components(
+                obj,
+                ATTR_RERUN_COMPONENT_RECOMMENDED,
+                objects,
+                [indicator_fqname],
+            );
             let (num_optional, optional) =
-                compute_components(obj, ATTR_RERUN_COMPONENT_OPTIONAL, objects);
+                compute_components(obj, ATTR_RERUN_COMPONENT_OPTIONAL, objects, []);
 
             let num_all = num_required + num_recommended + num_optional;
 
@@ -809,7 +825,9 @@ fn quote_trait_impls_from_obj(
                 .collect::<Vec<_>>();
 
             let all_component_lists = {
-                obj.fields.iter().map(|obj_field| {
+                std::iter::once(quote!{
+                    Some(Self::Indicator::new_list(self.num_instances() as _).into())
+                }).chain(obj.fields.iter().map(|obj_field| {
                     let field_name = format_ident!("{}", obj_field.name);
                     let is_plural = obj_field.typ.is_plural();
                     let is_nullable = obj_field.is_nullable;
@@ -818,17 +836,17 @@ fn quote_trait_impls_from_obj(
                     // dealing with here is the nullability of an entire array of components, not
                     // the nullability of individual elements (i.e. instances)!
                     match (is_plural, is_nullable) {
-                        (true, true) => {
-                            quote! { self.#field_name.as_ref().map(|comp_list| comp_list as &dyn crate::ComponentList) }
-                        }
-                        (false, true) => {
-                            quote! { self.#field_name.as_ref().map(|comp| comp as &dyn crate::ComponentList) }
-                        }
-                        (_, false) => {
-                            quote! { Some(&self.#field_name as &dyn crate::ComponentList) }
+                        (true, true) => quote! {
+                            self.#field_name.as_ref().map(|comp_list| (comp_list as &dyn crate::ComponentList).into())
+                        },
+                        (false, true) => quote! {
+                            self.#field_name.as_ref().map(|comp| (comp as &dyn crate::ComponentList).into())
+                        },
+                        (_, false) => quote! {
+                            Some((&self.#field_name as &dyn crate::ComponentList).into())
                         }
                     }
-                })
+                }))
             };
 
             let all_serializers = {
@@ -959,9 +977,6 @@ fn quote_trait_impls_from_obj(
                 })
             };
 
-            let indicator_fqname =
-                format!("{}Indicator", obj.fqname).replace("rerun.archetypes", "rerun.components");
-
             quote! {
                 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; #num_required]> =
                     once_cell::sync::Lazy::new(|| {[#required]});
@@ -979,7 +994,12 @@ fn quote_trait_impls_from_obj(
                     pub const NUM_COMPONENTS: usize = #num_all;
                 }
 
+                #[doc = #quoted_indicator_doc]
+                pub type #quoted_indicator_name = crate::GenericIndicatorComponent<#name>;
+
                 impl crate::Archetype for #name {
+                    type Indicator = #quoted_indicator_name;
+
                     #[inline]
                     fn name() -> crate::ArchetypeName {
                         #fqname.into()
@@ -1006,47 +1026,21 @@ fn quote_trait_impls_from_obj(
                         ALL_COMPONENTS.as_slice().into()
                     }
 
-                    // NOTE: Don't rely on default implementation so that we can avoid runtime formatting.
-                    #[inline]
-                    fn indicator_component() -> crate::ComponentName  {
-                        #indicator_fqname.into()
-                    }
-
                     #[inline]
                     fn num_instances(&self) -> usize {
                         #num_instances
                     }
 
-                    fn as_component_lists(&self) -> Vec<&dyn crate::ComponentList> {
+                    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
                         [#(#all_component_lists,)*].into_iter().flatten().collect()
                     }
 
-                    // TODO(#3159): Make indicator components first class and return them through `as_component_lists`,
-                    // at which point we can rely on the default implementation and remove this altogether.
                     #[inline]
                     fn try_to_arrow(
                         &self,
                     ) -> crate::SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>> {
                         use crate::{Loggable as _, ResultExt as _};
-                        Ok([
-                            #({ #all_serializers }),*,
-                            // Inject the indicator component.
-                            {
-                                let datatype = ::arrow2::datatypes::DataType::Extension(
-                                    #indicator_fqname.to_owned(),
-                                    Box::new(::arrow2::datatypes::DataType::Null),
-                                    // NOTE: Mandatory during migration to codegen.
-                                    Some(#indicator_fqname.to_owned()),
-                                );
-                                let array = ::arrow2::array::NullArray::new(
-                                    datatype.to_logical_type().clone(), self.num_instances(),
-                                ).boxed();
-                                Some((
-                                    ::arrow2::datatypes::Field::new(#indicator_fqname, datatype, false),
-                                    array,
-                                ))
-                            },
-                        ].into_iter().flatten().collect())
+                        Ok([ #({ #all_serializers }),*, ].into_iter().flatten().collect())
                     }
 
                     #[inline]

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -824,9 +824,9 @@ fn quote_trait_impls_from_obj(
                 .map(|field| format_ident!("{}", field.name))
                 .collect::<Vec<_>>();
 
-            let all_component_lists = {
+            let all_component_batches = {
                 std::iter::once(quote!{
-                    Some(Self::Indicator::new_list(self.num_instances() as _).into())
+                    Some(Self::Indicator::batch(self.num_instances() as _).into())
                 }).chain(obj.fields.iter().map(|obj_field| {
                     let field_name = format_ident!("{}", obj_field.name);
                     let is_plural = obj_field.typ.is_plural();
@@ -837,13 +837,13 @@ fn quote_trait_impls_from_obj(
                     // the nullability of individual elements (i.e. instances)!
                     match (is_plural, is_nullable) {
                         (true, true) => quote! {
-                            self.#field_name.as_ref().map(|comp_list| (comp_list as &dyn crate::ComponentList).into())
+                            self.#field_name.as_ref().map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into())
                         },
                         (false, true) => quote! {
-                            self.#field_name.as_ref().map(|comp| (comp as &dyn crate::ComponentList).into())
+                            self.#field_name.as_ref().map(|comp| (comp as &dyn crate::ComponentBatch).into())
                         },
                         (_, false) => quote! {
-                            Some((&self.#field_name as &dyn crate::ComponentList).into())
+                            Some((&self.#field_name as &dyn crate::ComponentBatch).into())
                         }
                     }
                 }))
@@ -1031,8 +1031,8 @@ fn quote_trait_impls_from_obj(
                         #num_instances
                     }
 
-                    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
-                        [#(#all_component_lists,)*].into_iter().flatten().collect()
+                    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+                        [#(#all_component_batches,)*].into_iter().flatten().collect()
                     }
 
                     #[inline]

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log a batch of 2 rectangles with different class IDs
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "detections",
         false,
         2,
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
 
     // TODO(#2786): Box3D archetype
-    rec.log_component_lists("simple", false, 1, [&Box3D::new(2.0, 2.0, 1.0) as _])?;
+    rec.log_component_batches("simple", false, 1, [&Box3D::new(2.0, 2.0, 1.0) as _])?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (width, height) = (image.shape()[1] as f32, image.shape()[0] as f32);
     let focal_length = 200.;
     #[allow(clippy::tuple_array_conversions)]
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/camera",
         false,
         1,

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/mesh_simple.rs
+++ b/docs/code-examples/mesh_simple.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // TODO(#2788): Mesh archetype
-    rec.log_component_lists("triangle", false, 1, [&Mesh3D::Raw(mesh) as _])?;
+    rec.log_component_batches("triangle", false, 1, [&Mesh3D::Raw(mesh) as _])?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     image.map_inplace(|x| *x = rand::random());
 
     // TODO(#2816): Pinhole archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/image",
         false,
         1,

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/rect2d_simple.rs
+++ b/docs/code-examples/rect2d_simple.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_rect2d").memory()?;
 
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "simple",
         false,
         1,
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut value = 1.0;
     for step in 0..100 {
         rec.set_time_sequence("step", step);
-        rec.log_component_lists("scalar", false, 1, [&Scalar::from(value) as _])?;
+        rec.log_component_batches("scalar", false, 1, [&Scalar::from(value) as _])?;
         value += thread_rng().sample::<f64, _>(StandardNormal);
     }
 

--- a/examples/rust/clock/src/main.rs
+++ b/examples/rust/clock/src/main.rs
@@ -40,10 +40,10 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
         SignedAxis3::POSITIVE_Y,
         rerun::coordinates::Handedness::Right,
     );
-    rec.log_component_lists("world", true, 1, [&view_coords as _])?;
+    rec.log_component_batches("world", true, 1, [&view_coords as _])?;
 
     // TODO(#2786): Box3D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/frame",
         true,
         1,

--- a/examples/rust/custom_data/src/main.rs
+++ b/examples/rust/custom_data/src/main.rs
@@ -5,7 +5,7 @@ use rerun::{
     datatypes::Float32,
     demo_util::grid,
     external::{arrow2, glam, re_types},
-    AnyComponentList, Archetype, ArchetypeName, ComponentList, ComponentName,
+    AnyComponentBatch, Archetype, ArchetypeName, ComponentBatch, ComponentName,
     GenericIndicatorComponent, Loggable, RecordingStreamBuilder,
 };
 
@@ -48,16 +48,16 @@ impl Archetype for CustomPoints3D {
         self.points3d.num_instances()
     }
 
-    fn as_component_lists(&self) -> Vec<AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<AnyComponentBatch<'_>> {
         self.points3d
-            .as_component_lists()
+            .as_component_batches()
             .into_iter()
             .chain(
                 [
-                    Some(Self::Indicator::new_list(self.num_instances()).into()),
+                    Some(Self::Indicator::batch(self.num_instances()).into()),
                     self.confidences
                         .as_ref()
-                        .map(|v| (v as &dyn ComponentList).into()),
+                        .map(|v| (v as &dyn ComponentBatch).into()),
                 ]
                 .into_iter()
                 .flatten(),

--- a/examples/rust/custom_data/src/main.rs
+++ b/examples/rust/custom_data/src/main.rs
@@ -5,10 +5,13 @@ use rerun::{
     datatypes::Float32,
     demo_util::grid,
     external::{arrow2, glam, re_types},
-    Archetype, ArchetypeName, ComponentList, ComponentName, Loggable, RecordingStreamBuilder,
+    AnyComponentList, Archetype, ArchetypeName, ComponentList, ComponentName,
+    GenericIndicatorComponent, Loggable, RecordingStreamBuilder,
 };
 
 // ---
+
+type CustomPoints3DIndicator = GenericIndicatorComponent<CustomPoints3D>;
 
 /// A custom [`Archetype`] that extends Rerun's builtin [`Points3D`] archetype with extra
 /// [`rerun::Component`]s.
@@ -18,6 +21,8 @@ struct CustomPoints3D {
 }
 
 impl Archetype for CustomPoints3D {
+    type Indicator = CustomPoints3DIndicator;
+
     fn name() -> ArchetypeName {
         "user.CustomPoints3D".into()
     }
@@ -43,14 +48,19 @@ impl Archetype for CustomPoints3D {
         self.points3d.num_instances()
     }
 
-    fn as_component_lists(&self) -> Vec<&dyn ComponentList> {
-        // TODO(#3159): need an easy way to get a CustomPoints3DIndicator component in here!
+    fn as_component_lists(&self) -> Vec<AnyComponentList<'_>> {
         self.points3d
             .as_component_lists()
             .into_iter()
             .chain(
-                std::iter::once(self.confidences.as_ref().map(|v| v as &dyn ComponentList))
-                    .flatten(),
+                [
+                    Some(Self::Indicator::new_list(self.num_instances()).into()),
+                    self.confidences
+                        .as_ref()
+                        .map(|v| (v as &dyn ComponentList).into()),
+                ]
+                .into_iter()
+                .flatten(),
             )
             .collect()
     }

--- a/examples/rust/custom_data/src/main.rs
+++ b/examples/rust/custom_data/src/main.rs
@@ -5,7 +5,7 @@ use rerun::{
     datatypes::Float32,
     demo_util::grid,
     external::{arrow2, glam, re_types},
-    AnyComponentBatch, Archetype, ArchetypeName, ComponentBatch, ComponentName,
+    MaybeOwnedComponentBatch, Archetype, ArchetypeName, ComponentBatch, ComponentName,
     GenericIndicatorComponent, Loggable, RecordingStreamBuilder,
 };
 
@@ -48,7 +48,7 @@ impl Archetype for CustomPoints3D {
         self.points3d.num_instances()
     }
 
-    fn as_component_batches(&self) -> Vec<AnyComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
         self.points3d
             .as_component_batches()
             .into_iter()

--- a/examples/rust/custom_data/src/main.rs
+++ b/examples/rust/custom_data/src/main.rs
@@ -5,8 +5,8 @@ use rerun::{
     datatypes::Float32,
     demo_util::grid,
     external::{arrow2, glam, re_types},
-    MaybeOwnedComponentBatch, Archetype, ArchetypeName, ComponentBatch, ComponentName,
-    GenericIndicatorComponent, Loggable, RecordingStreamBuilder,
+    Archetype, ArchetypeName, ComponentBatch, ComponentName, GenericIndicatorComponent, Loggable,
+    MaybeOwnedComponentBatch, RecordingStreamBuilder,
 };
 
 // ---

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -31,11 +31,7 @@ impl re_types::Archetype for ColorArchetype {
     }
 
     fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
-        vec![
-            Self::indicator_component(),
-            re_types::components::Color::name(),
-        ]
-        .into()
+        vec![re_types::components::Color::name()].into()
     }
 }
 

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -23,14 +23,19 @@ pub struct ColorWithInstanceKey {
 
 struct ColorArchetype;
 
-// TODO(#2778): The introduction of ArchetypeInfo should make this much much nicer.
 impl re_types::Archetype for ColorArchetype {
+    type Indicator = re_types::GenericIndicatorComponent<Self>;
+
     fn name() -> re_types::ArchetypeName {
         "InstanceColor".into()
     }
 
     fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
-        vec![re_types::components::Color::name()].into()
+        vec![
+            Self::indicator_component(),
+            re_types::components::Color::name(),
+        ]
+        .into()
     }
 }
 

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -23,7 +23,7 @@ use rerun::{
     datatypes::TranslationRotationScale3D,
     external::re_log,
     time::{Time, TimePoint, TimeType, Timeline},
-    ComponentList, RecordingStream,
+    ComponentBatch, RecordingStream,
 };
 
 // --- Rerun logging ---
@@ -83,7 +83,7 @@ fn log_coordinate_space(
     let view_coords: rerun::components::ViewCoordinates = axes
         .parse()
         .map_err(|err| anyhow!("couldn't parse {axes:?} as ViewCoordinates: {err}"))?;
-    rec.log_component_lists(ent_path, true, 1, [&view_coords as _])
+    rec.log_component_batches(ent_path, true, 1, [&view_coords as _])
         .map_err(Into::into)
 }
 
@@ -137,12 +137,12 @@ fn log_baseline_objects(
     });
 
     for (id, bbox, transform, label) in boxes {
-        rec.log_component_lists(
+        rec.log_component_batches(
             format!("world/annotations/box-{id}"),
             true,
             1,
             [
-                &bbox as &dyn ComponentList,
+                &bbox as &dyn ComponentBatch,
                 &transform,
                 &label,
                 &Color::from_rgb(160, 230, 130),
@@ -198,7 +198,7 @@ fn log_ar_camera(
     )?;
 
     // TODO(#2816): Pinhole archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/camera",
         false,
         1,

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -81,7 +81,7 @@ fn log_node(rec: &RecordingStream, node: GltfNode) -> anyhow::Result<()> {
         .into_iter()
         .map(Mesh3D::from)
         .collect::<Vec<_>>();
-    rec.log_component_lists(
+    rec.log_component_batches(
         node.name.as_str(),
         false,
         primitives.len() as _,
@@ -107,7 +107,7 @@ fn log_coordinate_space(
         .parse()
         .map_err(|err| anyhow!("couldn't parse {axes:?} as ViewCoordinates: {err}"))?;
 
-    rec.log_component_lists(ent_path, true, 1, [&view_coords as _])
+    rec.log_component_batches(ent_path, true, 1, [&view_coords as _])
         .map_err(Into::into)
 }
 

--- a/tests/rust/roundtrips/line_strips2d/src/main.rs
+++ b/tests/rust/roundtrips/line_strips2d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 
     // Hack to establish 2d view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "rect",
         false,
         1,

--- a/tests/rust/roundtrips/points2d/src/main.rs
+++ b/tests/rust/roundtrips/points2d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 
     // Hack to establish 2d view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "rect",
         false,
         1,

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -32,7 +32,7 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
 
     rec.set_time_seconds("sim_time", 0f64);
     // TODO(#2786): Box3D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bbox_test/bbox",
         false,
         1,
@@ -52,7 +52,7 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     rec.set_time_seconds("sim_time", 1f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bbox_test/bbox",
         false,
         1,
@@ -85,7 +85,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
 
     rec.set_time_seconds("sim_time", 1f64);
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/0",
         false,
         1,
@@ -95,7 +95,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
             &Text("Rect1".into()) as _,
         ],
     )?;
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/1",
         false,
         1,
@@ -113,7 +113,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
     log_cleared(rec, "null_test/rect", true);
 
     rec.set_time_seconds("sim_time", 4f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/0",
         false,
         1,
@@ -121,7 +121,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     rec.set_time_seconds("sim_time", 5f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/1",
         false,
         1,
@@ -218,7 +218,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
         .collect_vec();
 
     rec.set_time_seconds("sim_time", 2f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "rects_test/rects",
         false,
         rects.len() as _,
@@ -227,7 +227,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
 
     // Clear the rectangles by logging an empty set
     rec.set_time_seconds("sim_time", 3f64);
-    rec.log_component_lists("rects_test/rects", false, 0, [&Vec::<Rect2D>::new() as _])?;
+    rec.log_component_batches("rects_test/rects", false, 0, [&Vec::<Rect2D>::new() as _])?;
 
     Ok(())
 }
@@ -287,7 +287,7 @@ fn test_2d_layering(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     // Rectangle in between the top and the middle.
-    rec.log_component_lists(
+    rec.log_component_batches(
         "2d_layering/rect_between_top_and_middle",
         false,
         1,
@@ -470,7 +470,7 @@ fn test_transforms_3d(rec: &RecordingStream) -> anyhow::Result<()> {
             SignedAxis3::POSITIVE_Z,
             rerun::coordinates::Handedness::Right,
         );
-        rec.log_component_lists(
+        rec.log_component_batches(
             ent_path,
             true,
             1,


### PR DESCRIPTION
Implements & exposes first-class indicator components, effectively completing the "custom user data" story for Rust.

In the end, indicator components are neither materialized in the IDL nor in the generated code, as both alternatives proved to be dead-ends (void data really doesn't fit well into our traits and overall model).
Rather, they are materialized as a single `GenericIndicatorComponent<Archetype>` which directly implements `ComponentList` instead of `Component`, giving it the necessary leeway to bypass all the iterator machinery.

---

Loading from files now automatically inject indicators:
```sh
$ rerun ~/Downloads/image0.jpeg
```
![image](https://github.com/rerun-io/rerun/assets/2910679/3df60dd5-f79d-42f3-b6e4-abbb4d372379)


`custom_data` now injects custom user-defined indicators:
![image](https://github.com/rerun-io/rerun/assets/2910679/6213bdf2-3570-448c-af44-9dccfdb93a90)


---

Fixes #3252 
Part of #3260

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3251) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3251)
- [Docs preview](https://rerun.io/preview/fecd15154b4973e29939307ff8c805eb776b13cb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fecd15154b4973e29939307ff8c805eb776b13cb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)