### PR TITLE
C++ as_components style & splatting

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-18cce613f1d395d1a503a0c4b3e26005cdcd5dbf9a1a0d118f9e4f36a952f5fc
+691d89977c42da0bd4ee074ed641969b12f7c2ef173f10bd1f2e1ee81402ed84

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-5d7dadd19a8cf8c0388d09ccc866e78787d3f69bf1b4475962f9f835334d0e6b
+18cce613f1d395d1a503a0c4b3e26005cdcd5dbf9a1a0d118f9e4f36a952f5fc

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-d52bf64a55c34eaf6080c0b95ef0f2407fd0c768dad400bb40a29730e8fe6921
+09643f08596fcd0661dcd2c1d24ad287701e7e49a30289664358b0fe7452bb16

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-09643f08596fcd0661dcd2c1d24ad287701e7e49a30289664358b0fe7452bb16
+5d7dadd19a8cf8c0388d09ccc866e78787d3f69bf1b4475962f9f835334d0e6b

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1732,7 +1732,8 @@ fn quote_constants_header_and_cpp(
             cpp.push(quote!(const char #obj_type_ident::NAME[] = #legacy_fqname));
         }
         ObjectKind::Archetype => {
-            let indicator_fqname = format!("rerun.components.{}Indicator", obj.name);
+            let indicator_fqname =
+                format!("{}Indicator", obj.fqname).replace("archetypes", "components");
             let comment = quote_doc_comment("Name of the indicator component, used to identify the archetype when converting to a list of components.");
             hpp.push(quote! {
                 #NEWLINE_TOKEN

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1234,8 +1234,6 @@ fn archetype_as_component_lists(
     cpp_includes.insert_rerun("indicator_component.hpp");
     hpp_includes.insert_system("vector"); // std::vector
 
-    // TODO(andreas): Splats need to be handled separately.
-
     let num_fields = quote_integer(obj.fields.len());
     let push_cells = obj.fields.iter().map(|field| {
         let field_name = format_ident!("{}", field.name);

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -540,7 +540,8 @@ impl QuotedObject {
                     });
                 }
 
-                methods.push(archetype_to_data_cells(
+                methods.push(archetype_as_component_lists(
+                    &type_ident,
                     obj,
                     &mut hpp_includes,
                     &mut cpp_includes,
@@ -1221,86 +1222,52 @@ fn component_to_data_cell_method(
     }
 }
 
-fn archetype_to_data_cells(
+fn archetype_as_component_lists(
+    type_ident: &Ident,
     obj: &Object,
     hpp_includes: &mut Includes,
     cpp_includes: &mut Includes,
 ) -> Method {
     hpp_includes.insert_rerun("data_cell.hpp");
-    hpp_includes.insert_rerun("result.hpp");
     hpp_includes.insert_rerun("arrow.hpp");
+    hpp_includes.insert_rerun("component_list.hpp");
+    cpp_includes.insert_rerun("indicator_component.hpp");
     hpp_includes.insert_system("vector"); // std::vector
 
     // TODO(andreas): Splats need to be handled separately.
 
     let num_fields = quote_integer(obj.fields.len());
     let push_cells = obj.fields.iter().map(|field| {
-        let field_type_fqname = match &field.typ {
-            Type::Vector { elem_type } => elem_type.fqname().unwrap(),
-            Type::Object(fqname) => fqname,
-            _ => unreachable!(
-                "Archetypes are not expected to have any fields other than objects and vectors"
-            ),
-        };
-        let field_type = quote_fqname_as_type_path(cpp_includes, field_type_fqname);
         let field_name = format_ident!("{}", field.name);
-
         if field.is_nullable {
-            let to_data_cell = if field.typ.is_plural() {
-                quote!(#field_type::to_data_cell(value.data(), value.size()))
-            } else {
-                quote!(#field_type::to_data_cell(&value, 1))
-            };
             quote! {
                 if (#field_name.has_value()) {
-                    const auto& value  = #field_name.value();
-                    const auto result = #to_data_cell;
-                    if (result.is_err()) {
-                        return result.error;
-                    }
-                    cells.emplace_back(std::move(result.value));
+                    cells.emplace_back(#field_name.value());
                 }
             }
         } else {
-            let to_data_cell = if field.typ.is_plural() {
-                quote!(#field_type::to_data_cell(#field_name.data(), #field_name.size()))
-            } else {
-                quote!(#field_type::to_data_cell(&#field_name, 1))
-            };
             quote! {
-                {
-                    const auto result = #to_data_cell;
-                    if (result.is_err()) {
-                        return result.error;
-                    }
-                    cells.emplace_back(std::move(result.value));
-                }
+                cells.emplace_back(#field_name);
             }
         }
     });
 
-    let indicator_fqname = format!("rerun.components.{}Indicator", obj.name);
     Method {
-        docs: "Creates a list of Rerun DataCell from this archetype.".into(),
+        docs: "Collections all component lists into a list of component collections. \
+        *Attention:* The returned vector references this instance and does not take ownership of any data. \
+        Adding any new components to this archetype will invalidate the returned component lists!".into(),
         declaration: MethodDeclaration {
             is_static: false,
-            return_type: quote!(Result<std::vector<rerun::DataCell>>),
-            name_and_parameters: quote!(to_data_cells() const),
+            return_type: quote!(std::vector<AnonymousComponentList>),
+            name_and_parameters: quote!(as_component_lists() const),
         },
         definition_body: quote! {
-            std::vector<rerun::DataCell> cells;
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(#num_fields);
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             #(#push_cells)*
-            {
-                const auto result =
-                    create_indicator_component(#indicator_fqname, num_instances());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(components::IndicatorComponent<#type_ident::INDICATOR_COMPONENT_NAME>());
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             return cells;
@@ -1762,11 +1729,24 @@ fn quote_constants_header_and_cpp(
                 #NEWLINE_TOKEN
                 #NEWLINE_TOKEN
                 #comment
-                static const char* NAME
+                static const char NAME[]
             });
-            cpp.push(quote!(const char* #obj_type_ident::NAME = #legacy_fqname));
+            cpp.push(quote!(const char #obj_type_ident::NAME[] = #legacy_fqname));
         }
-        ObjectKind::Archetype | ObjectKind::Datatype => {}
+        ObjectKind::Archetype => {
+            let indicator_fqname = format!("rerun.components.{}Indicator", obj.name);
+            let comment = quote_doc_comment("Name of the indicator component, used to identify the archetype when converting to a list of components.");
+            hpp.push(quote! {
+                #NEWLINE_TOKEN
+                #NEWLINE_TOKEN
+                #comment
+                static const char INDICATOR_COMPONENT_NAME[]
+            });
+            cpp.push(
+                quote!(const char #obj_type_ident::INDICATOR_COMPONENT_NAME[] = #indicator_fqname),
+            );
+        }
+        ObjectKind::Datatype => {}
     }
 
     (hpp, cpp)

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1230,7 +1230,7 @@ fn archetype_as_component_lists(
 ) -> Method {
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("arrow.hpp");
-    hpp_includes.insert_rerun("component_list.hpp");
+    hpp_includes.insert_rerun("component_batch.hpp");
     cpp_includes.insert_rerun("indicator_component.hpp");
     hpp_includes.insert_system("vector"); // std::vector
 
@@ -1256,16 +1256,16 @@ fn archetype_as_component_lists(
         Adding any new components to this archetype will invalidate the returned component lists!".into(),
         declaration: MethodDeclaration {
             is_static: false,
-            return_type: quote!(std::vector<AnonymousComponentList>),
+            return_type: quote!(std::vector<AnonymousComponentBatch>),
             name_and_parameters: quote!(as_component_lists() const),
         },
         definition_body: quote! {
-            std::vector<AnonymousComponentList> cells;
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(#num_fields);
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             #(#push_cells)*
-            cells.emplace_back(ComponentList<components::IndicatorComponent<#type_ident::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances()));
+            cells.emplace_back(ComponentBatch<components::IndicatorComponent<#type_ident::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances()));
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             return cells;

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1265,7 +1265,7 @@ fn archetype_as_component_lists(
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             #(#push_cells)*
-            cells.emplace_back(components::IndicatorComponent<#type_ident::INDICATOR_COMPONENT_NAME>());
+            cells.emplace_back(ComponentList<components::IndicatorComponent<#type_ident::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances()));
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             return cells;

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -33,6 +33,7 @@ int main(int argc, char** argv) {
     rrc::Text c_style_array[3] = {rrc::Text("hello"), rrc::Text("friend"), rrc::Text("yo")};
     rr_stream.log_component_batches(
         "2d/points",
+        3,
         std::vector{rrc::Point2D(0.0f, 0.0f), rrc::Point2D(1.0f, 3.0f), rrc::Point2D(5.0f, 5.0f)},
         std::array{rrc::Color(0xFF0000FF), rrc::Color(0x00FF00FF), rrc::Color(0x0000FFFF)},
         c_style_array

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
     // Log points with the components api - this is the advanced way of logging components in a
     // fine-grained matter. It supports passing various types of containers.
     rrc::Text c_style_array[3] = {rrc::Text("hello"), rrc::Text("friend"), rrc::Text("yo")};
-    rr_stream.log_components(
+    rr_stream.log_component_batches(
         "2d/points",
         std::vector{rrc::Point2D(0.0f, 0.0f), rrc::Point2D(1.0f, 3.0f), rrc::Point2D(5.0f, 5.0f)},
         std::array{rrc::Color(0xFF0000FF), rrc::Color(0x00FF00FF), rrc::Color(0x0000FFFF)},

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -3,31 +3,25 @@
 
 #include "annotation_context.hpp"
 
-#include "../components/annotation_context.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> AnnotationContext::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.AnnotationContextIndicator";
+
+        std::vector<AnonymousComponentList> AnnotationContext::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(1);
 
-            {
-                const auto result = rerun::components::AnnotationContext::to_data_cell(&context, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.AnnotationContextIndicator",
+            cells.emplace_back(context);
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -10,12 +10,12 @@ namespace rerun {
         const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AnnotationContextIndicator";
 
-        std::vector<AnonymousComponentBatch> AnnotationContext::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(1);
+        std::vector<AnonymousComponentBatch> AnnotationContext::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(1);
 
-            cells.emplace_back(context);
-            cells.emplace_back(
+            comp_batches.emplace_back(context);
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -23,7 +23,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -10,13 +10,13 @@ namespace rerun {
         const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AnnotationContextIndicator";
 
-        std::vector<AnonymousComponentList> AnnotationContext::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> AnnotationContext::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(1);
 
             cells.emplace_back(context);
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/annotation_context.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -54,6 +55,10 @@ namespace rerun {
         struct AnnotationContext {
             rerun::components::AnnotationContext context;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             AnnotationContext() = default;
 
@@ -65,8 +70,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/annotation_context.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -74,7 +74,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -74,7 +74,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -9,8 +9,8 @@ namespace rerun {
     namespace archetypes {
         const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
 
-        std::vector<AnonymousComponentList> Arrows3D::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> Arrows3D::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(7);
 
             cells.emplace_back(vectors);
@@ -33,7 +33,7 @@ namespace rerun {
                 cells.emplace_back(instance_keys.value());
             }
             cells.emplace_back(
-                ComponentList<components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(
+                ComponentBatch<components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -3,92 +3,41 @@
 
 #include "arrows3d.hpp"
 
-#include "../components/class_id.hpp"
-#include "../components/color.hpp"
-#include "../components/instance_key.hpp"
-#include "../components/origin3d.hpp"
-#include "../components/radius.hpp"
-#include "../components/text.hpp"
-#include "../components/vector3d.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> Arrows3D::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
+
+        std::vector<AnonymousComponentList> Arrows3D::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(7);
 
-            {
-                const auto result =
-                    rerun::components::Vector3D::to_data_cell(vectors.data(), vectors.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(vectors);
             if (origins.has_value()) {
-                const auto& value = origins.value();
-                const auto result =
-                    rerun::components::Origin3D::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(origins.value());
             }
             if (radii.has_value()) {
-                const auto& value = radii.value();
-                const auto result =
-                    rerun::components::Radius::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                const auto& value = colors.value();
-                const auto result =
-                    rerun::components::Color::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                const auto& value = labels.value();
-                const auto result =
-                    rerun::components::Text::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(labels.value());
             }
             if (class_ids.has_value()) {
-                const auto& value = class_ids.value();
-                const auto result =
-                    rerun::components::ClassId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(class_ids.value());
             }
             if (instance_keys.has_value()) {
-                const auto& value = instance_keys.value();
-                const auto result =
-                    rerun::components::InstanceKey::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(instance_keys.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.Arrows3DIndicator",
+            cells.emplace_back(
+                ComponentList<components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -9,37 +9,37 @@ namespace rerun {
     namespace archetypes {
         const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
 
-        std::vector<AnonymousComponentBatch> Arrows3D::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(7);
+        std::vector<AnonymousComponentBatch> Arrows3D::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(7);
 
-            cells.emplace_back(vectors);
+            comp_batches.emplace_back(vectors);
             if (origins.has_value()) {
-                cells.emplace_back(origins.value());
+                comp_batches.emplace_back(origins.value());
             }
             if (radii.has_value()) {
-                cells.emplace_back(radii.value());
+                comp_batches.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                cells.emplace_back(colors.value());
+                comp_batches.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                cells.emplace_back(labels.value());
+                comp_batches.emplace_back(labels.value());
             }
             if (class_ids.has_value()) {
-                cells.emplace_back(class_ids.value());
+                comp_batches.emplace_back(class_ids.value());
             }
             if (instance_keys.has_value()) {
-                cells.emplace_back(instance_keys.value());
+                comp_batches.emplace_back(instance_keys.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -186,7 +186,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"
@@ -186,7 +186,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"
@@ -80,6 +81,10 @@ namespace rerun {
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
 
           public:
             Arrows3D() = default;
@@ -177,8 +182,11 @@ namespace rerun {
                 return vectors.size();
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -9,22 +9,26 @@ namespace rerun {
     namespace archetypes {
         const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
 
-        std::vector<AnonymousComponentBatch> DepthImage::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(3);
+        std::vector<AnonymousComponentBatch> DepthImage::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(3);
 
-            cells.emplace_back(data);
+            comp_batches.emplace_back(data);
             if (meter.has_value()) {
-                cells.emplace_back(meter.value());
+                comp_batches.emplace_back(meter.value());
             }
             if (draw_order.has_value()) {
-                cells.emplace_back(draw_order.value());
+                comp_batches.emplace_back(draw_order.value());
             }
-            cells.emplace_back(ComponentBatch<components::IndicatorComponent<
-                                   DepthImage::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances())
+            comp_batches.emplace_back(
+                ComponentBatch<
+                    components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
+                    num_instances()
+                )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -3,49 +3,29 @@
 
 #include "depth_image.hpp"
 
-#include "../components/depth_meter.hpp"
-#include "../components/draw_order.hpp"
-#include "../components/tensor_data.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> DepthImage::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
+
+        std::vector<AnonymousComponentList> DepthImage::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(3);
 
-            {
-                const auto result = rerun::components::TensorData::to_data_cell(&data, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(data);
             if (meter.has_value()) {
-                const auto& value = meter.value();
-                const auto result = rerun::components::DepthMeter::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(meter.value());
             }
             if (draw_order.has_value()) {
-                const auto& value = draw_order.value();
-                const auto result = rerun::components::DrawOrder::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(draw_order.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.DepthImageIndicator",
+            cells.emplace_back(
+                ComponentList<components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -9,8 +9,8 @@ namespace rerun {
     namespace archetypes {
         const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
 
-        std::vector<AnonymousComponentList> DepthImage::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> DepthImage::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(3);
 
             cells.emplace_back(data);
@@ -20,11 +20,8 @@ namespace rerun {
             if (draw_order.has_value()) {
                 cells.emplace_back(draw_order.value());
             }
-            cells.emplace_back(
-                ComponentList<components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
+            cells.emplace_back(ComponentBatch<components::IndicatorComponent<
+                                   DepthImage::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances())
             );
 
             return cells;

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/depth_meter.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
@@ -72,7 +72,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/depth_meter.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
@@ -36,6 +37,10 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             DepthImage() = default;
 
@@ -63,8 +68,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -72,7 +72,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -10,12 +10,12 @@ namespace rerun {
         const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.DisconnectedSpaceIndicator";
 
-        std::vector<AnonymousComponentBatch> DisconnectedSpace::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(1);
+        std::vector<AnonymousComponentBatch> DisconnectedSpace::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(1);
 
-            cells.emplace_back(disconnected_space);
-            cells.emplace_back(
+            comp_batches.emplace_back(disconnected_space);
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -23,7 +23,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -10,13 +10,13 @@ namespace rerun {
         const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.DisconnectedSpaceIndicator";
 
-        std::vector<AnonymousComponentList> DisconnectedSpace::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> DisconnectedSpace::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(1);
 
             cells.emplace_back(disconnected_space);
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -3,32 +3,25 @@
 
 #include "disconnected_space.hpp"
 
-#include "../components/disconnected_space.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> DisconnectedSpace::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.DisconnectedSpaceIndicator";
+
+        std::vector<AnonymousComponentList> DisconnectedSpace::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(1);
 
-            {
-                const auto result =
-                    rerun::components::DisconnectedSpace::to_data_cell(&disconnected_space, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.DisconnectedSpaceIndicator",
+            cells.emplace_back(disconnected_space);
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/disconnected_space.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -67,7 +67,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -67,7 +67,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/disconnected_space.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -47,6 +48,10 @@ namespace rerun {
         struct DisconnectedSpace {
             rerun::components::DisconnectedSpace disconnected_space;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             DisconnectedSpace() = default;
 
@@ -58,8 +63,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -9,8 +9,8 @@ namespace rerun {
     namespace archetypes {
         const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
 
-        std::vector<AnonymousComponentList> Image::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> Image::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(2);
 
             cells.emplace_back(data);
@@ -18,7 +18,7 @@ namespace rerun {
                 cells.emplace_back(draw_order.value());
             }
             cells.emplace_back(
-                ComponentList<components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME>>(
+                ComponentBatch<components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -9,22 +9,22 @@ namespace rerun {
     namespace archetypes {
         const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
 
-        std::vector<AnonymousComponentBatch> Image::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(2);
+        std::vector<AnonymousComponentBatch> Image::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(2);
 
-            cells.emplace_back(data);
+            comp_batches.emplace_back(data);
             if (draw_order.has_value()) {
-                cells.emplace_back(draw_order.value());
+                comp_batches.emplace_back(draw_order.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -3,38 +3,26 @@
 
 #include "image.hpp"
 
-#include "../components/draw_order.hpp"
-#include "../components/tensor_data.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> Image::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
+
+        std::vector<AnonymousComponentList> Image::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(2);
 
-            {
-                const auto result = rerun::components::TensorData::to_data_cell(&data, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(data);
             if (draw_order.has_value()) {
-                const auto& value = draw_order.value();
-                const auto result = rerun::components::DrawOrder::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(draw_order.value());
             }
-            {
-                const auto result =
-                    create_indicator_component("rerun.components.ImageIndicator", num_instances());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(
+                ComponentList<components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
+                    num_instances()
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -59,7 +59,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
@@ -33,6 +34,10 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             Image() = default;
 
@@ -50,8 +55,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
@@ -59,7 +59,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -3,91 +3,43 @@
 
 #include "line_strips2d.hpp"
 
-#include "../components/class_id.hpp"
-#include "../components/color.hpp"
-#include "../components/draw_order.hpp"
-#include "../components/instance_key.hpp"
-#include "../components/line_strip2d.hpp"
-#include "../components/radius.hpp"
-#include "../components/text.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> LineStrips2D::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.LineStrips2DIndicator";
+
+        std::vector<AnonymousComponentList> LineStrips2D::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(7);
 
-            {
-                const auto result =
-                    rerun::components::LineStrip2D::to_data_cell(strips.data(), strips.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(strips);
             if (radii.has_value()) {
-                const auto& value = radii.value();
-                const auto result =
-                    rerun::components::Radius::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                const auto& value = colors.value();
-                const auto result =
-                    rerun::components::Color::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                const auto& value = labels.value();
-                const auto result =
-                    rerun::components::Text::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(labels.value());
             }
             if (draw_order.has_value()) {
-                const auto& value = draw_order.value();
-                const auto result = rerun::components::DrawOrder::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(draw_order.value());
             }
             if (class_ids.has_value()) {
-                const auto& value = class_ids.value();
-                const auto result =
-                    rerun::components::ClassId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(class_ids.value());
             }
             if (instance_keys.has_value()) {
-                const auto& value = instance_keys.value();
-                const auto result =
-                    rerun::components::InstanceKey::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(instance_keys.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.LineStrips2DIndicator",
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -10,30 +10,30 @@ namespace rerun {
         const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips2DIndicator";
 
-        std::vector<AnonymousComponentBatch> LineStrips2D::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(7);
+        std::vector<AnonymousComponentBatch> LineStrips2D::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(7);
 
-            cells.emplace_back(strips);
+            comp_batches.emplace_back(strips);
             if (radii.has_value()) {
-                cells.emplace_back(radii.value());
+                comp_batches.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                cells.emplace_back(colors.value());
+                comp_batches.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                cells.emplace_back(labels.value());
+                comp_batches.emplace_back(labels.value());
             }
             if (draw_order.has_value()) {
-                cells.emplace_back(draw_order.value());
+                comp_batches.emplace_back(draw_order.value());
             }
             if (class_ids.has_value()) {
-                cells.emplace_back(class_ids.value());
+                comp_batches.emplace_back(class_ids.value());
             }
             if (instance_keys.has_value()) {
-                cells.emplace_back(instance_keys.value());
+                comp_batches.emplace_back(instance_keys.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -41,7 +41,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -10,8 +10,8 @@ namespace rerun {
         const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips2DIndicator";
 
-        std::vector<AnonymousComponentList> LineStrips2D::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> LineStrips2D::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(7);
 
             cells.emplace_back(strips);
@@ -34,7 +34,7 @@ namespace rerun {
                 cells.emplace_back(instance_keys.value());
             }
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
@@ -104,6 +105,10 @@ namespace rerun {
             /// Unique identifiers for each individual line strip in the batch.
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             LineStrips2D() = default;
 
@@ -190,8 +195,11 @@ namespace rerun {
                 return strips.size();
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
@@ -199,7 +199,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -199,7 +199,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -10,27 +10,27 @@ namespace rerun {
         const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips3DIndicator";
 
-        std::vector<AnonymousComponentBatch> LineStrips3D::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(6);
+        std::vector<AnonymousComponentBatch> LineStrips3D::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(6);
 
-            cells.emplace_back(strips);
+            comp_batches.emplace_back(strips);
             if (radii.has_value()) {
-                cells.emplace_back(radii.value());
+                comp_batches.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                cells.emplace_back(colors.value());
+                comp_batches.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                cells.emplace_back(labels.value());
+                comp_batches.emplace_back(labels.value());
             }
             if (class_ids.has_value()) {
-                cells.emplace_back(class_ids.value());
+                comp_batches.emplace_back(class_ids.value());
             }
             if (instance_keys.has_value()) {
-                cells.emplace_back(instance_keys.value());
+                comp_batches.emplace_back(instance_keys.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -38,7 +38,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -10,8 +10,8 @@ namespace rerun {
         const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips3DIndicator";
 
-        std::vector<AnonymousComponentList> LineStrips3D::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> LineStrips3D::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(6);
 
             cells.emplace_back(strips);
@@ -31,7 +31,7 @@ namespace rerun {
                 cells.emplace_back(instance_keys.value());
             }
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -3,82 +3,40 @@
 
 #include "line_strips3d.hpp"
 
-#include "../components/class_id.hpp"
-#include "../components/color.hpp"
-#include "../components/instance_key.hpp"
-#include "../components/line_strip3d.hpp"
-#include "../components/radius.hpp"
-#include "../components/text.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> LineStrips3D::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.LineStrips3DIndicator";
+
+        std::vector<AnonymousComponentList> LineStrips3D::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(6);
 
-            {
-                const auto result =
-                    rerun::components::LineStrip3D::to_data_cell(strips.data(), strips.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(strips);
             if (radii.has_value()) {
-                const auto& value = radii.value();
-                const auto result =
-                    rerun::components::Radius::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                const auto& value = colors.value();
-                const auto result =
-                    rerun::components::Color::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                const auto& value = labels.value();
-                const auto result =
-                    rerun::components::Text::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(labels.value());
             }
             if (class_ids.has_value()) {
-                const auto& value = class_ids.value();
-                const auto result =
-                    rerun::components::ClassId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(class_ids.value());
             }
             if (instance_keys.has_value()) {
-                const auto& value = instance_keys.value();
-                const auto result =
-                    rerun::components::InstanceKey::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(instance_keys.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.LineStrips3DIndicator",
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"
@@ -111,6 +112,10 @@ namespace rerun {
             /// Unique identifiers for each individual line strip in the batch.
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             LineStrips3D() = default;
 
@@ -190,8 +195,11 @@ namespace rerun {
                 return strips.size();
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -199,7 +199,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"
@@ -199,7 +199,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -9,40 +9,40 @@ namespace rerun {
     namespace archetypes {
         const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
 
-        std::vector<AnonymousComponentBatch> Points2D::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(8);
+        std::vector<AnonymousComponentBatch> Points2D::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(8);
 
-            cells.emplace_back(points);
+            comp_batches.emplace_back(points);
             if (radii.has_value()) {
-                cells.emplace_back(radii.value());
+                comp_batches.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                cells.emplace_back(colors.value());
+                comp_batches.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                cells.emplace_back(labels.value());
+                comp_batches.emplace_back(labels.value());
             }
             if (draw_order.has_value()) {
-                cells.emplace_back(draw_order.value());
+                comp_batches.emplace_back(draw_order.value());
             }
             if (class_ids.has_value()) {
-                cells.emplace_back(class_ids.value());
+                comp_batches.emplace_back(class_ids.value());
             }
             if (keypoint_ids.has_value()) {
-                cells.emplace_back(keypoint_ids.value());
+                comp_batches.emplace_back(keypoint_ids.value());
             }
             if (instance_keys.has_value()) {
-                cells.emplace_back(instance_keys.value());
+                comp_batches.emplace_back(instance_keys.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -3,101 +3,44 @@
 
 #include "points2d.hpp"
 
-#include "../components/class_id.hpp"
-#include "../components/color.hpp"
-#include "../components/draw_order.hpp"
-#include "../components/instance_key.hpp"
-#include "../components/keypoint_id.hpp"
-#include "../components/point2d.hpp"
-#include "../components/radius.hpp"
-#include "../components/text.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> Points2D::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
+
+        std::vector<AnonymousComponentList> Points2D::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(8);
 
-            {
-                const auto result =
-                    rerun::components::Point2D::to_data_cell(points.data(), points.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(points);
             if (radii.has_value()) {
-                const auto& value = radii.value();
-                const auto result =
-                    rerun::components::Radius::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                const auto& value = colors.value();
-                const auto result =
-                    rerun::components::Color::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                const auto& value = labels.value();
-                const auto result =
-                    rerun::components::Text::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(labels.value());
             }
             if (draw_order.has_value()) {
-                const auto& value = draw_order.value();
-                const auto result = rerun::components::DrawOrder::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(draw_order.value());
             }
             if (class_ids.has_value()) {
-                const auto& value = class_ids.value();
-                const auto result =
-                    rerun::components::ClassId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(class_ids.value());
             }
             if (keypoint_ids.has_value()) {
-                const auto& value = keypoint_ids.value();
-                const auto result =
-                    rerun::components::KeypointId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(keypoint_ids.value());
             }
             if (instance_keys.has_value()) {
-                const auto& value = instance_keys.value();
-                const auto result =
-                    rerun::components::InstanceKey::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(instance_keys.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.Points2DIndicator",
+            cells.emplace_back(
+                ComponentList<components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -9,8 +9,8 @@ namespace rerun {
     namespace archetypes {
         const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
 
-        std::vector<AnonymousComponentList> Points2D::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> Points2D::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(8);
 
             cells.emplace_back(points);
@@ -36,7 +36,7 @@ namespace rerun {
                 cells.emplace_back(instance_keys.value());
             }
             cells.emplace_back(
-                ComponentList<components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(
+                ComponentBatch<components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
@@ -175,7 +175,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
@@ -56,6 +57,10 @@ namespace rerun {
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
 
           public:
             Points2D() = default;
@@ -166,8 +171,11 @@ namespace rerun {
                 return points.size();
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -175,7 +175,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -9,37 +9,37 @@ namespace rerun {
     namespace archetypes {
         const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
 
-        std::vector<AnonymousComponentBatch> Points3D::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(7);
+        std::vector<AnonymousComponentBatch> Points3D::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(7);
 
-            cells.emplace_back(points);
+            comp_batches.emplace_back(points);
             if (radii.has_value()) {
-                cells.emplace_back(radii.value());
+                comp_batches.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                cells.emplace_back(colors.value());
+                comp_batches.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                cells.emplace_back(labels.value());
+                comp_batches.emplace_back(labels.value());
             }
             if (class_ids.has_value()) {
-                cells.emplace_back(class_ids.value());
+                comp_batches.emplace_back(class_ids.value());
             }
             if (keypoint_ids.has_value()) {
-                cells.emplace_back(keypoint_ids.value());
+                comp_batches.emplace_back(keypoint_ids.value());
             }
             if (instance_keys.has_value()) {
-                cells.emplace_back(instance_keys.value());
+                comp_batches.emplace_back(instance_keys.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -9,8 +9,8 @@ namespace rerun {
     namespace archetypes {
         const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
 
-        std::vector<AnonymousComponentList> Points3D::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> Points3D::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(7);
 
             cells.emplace_back(points);
@@ -33,7 +33,7 @@ namespace rerun {
                 cells.emplace_back(instance_keys.value());
             }
             cells.emplace_back(
-                ComponentList<components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(
+                ComponentBatch<components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -3,92 +3,41 @@
 
 #include "points3d.hpp"
 
-#include "../components/class_id.hpp"
-#include "../components/color.hpp"
-#include "../components/instance_key.hpp"
-#include "../components/keypoint_id.hpp"
-#include "../components/point3d.hpp"
-#include "../components/radius.hpp"
-#include "../components/text.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> Points3D::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
+
+        std::vector<AnonymousComponentList> Points3D::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(7);
 
-            {
-                const auto result =
-                    rerun::components::Point3D::to_data_cell(points.data(), points.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(points);
             if (radii.has_value()) {
-                const auto& value = radii.value();
-                const auto result =
-                    rerun::components::Radius::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(radii.value());
             }
             if (colors.has_value()) {
-                const auto& value = colors.value();
-                const auto result =
-                    rerun::components::Color::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(colors.value());
             }
             if (labels.has_value()) {
-                const auto& value = labels.value();
-                const auto result =
-                    rerun::components::Text::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(labels.value());
             }
             if (class_ids.has_value()) {
-                const auto& value = class_ids.value();
-                const auto result =
-                    rerun::components::ClassId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(class_ids.value());
             }
             if (keypoint_ids.has_value()) {
-                const auto& value = keypoint_ids.value();
-                const auto result =
-                    rerun::components::KeypointId::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(keypoint_ids.value());
             }
             if (instance_keys.has_value()) {
-                const auto& value = instance_keys.value();
-                const auto result =
-                    rerun::components::InstanceKey::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(instance_keys.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.Points3DIndicator",
+            cells.emplace_back(
+                ComponentList<components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"
@@ -68,6 +69,10 @@ namespace rerun {
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
 
           public:
             Points3D() = default;
@@ -171,8 +176,11 @@ namespace rerun {
                 return points.size();
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -180,7 +180,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/instance_key.hpp"
@@ -180,7 +180,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -3,40 +3,28 @@
 
 #include "segmentation_image.hpp"
 
-#include "../components/draw_order.hpp"
-#include "../components/tensor_data.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> SegmentationImage::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.SegmentationImageIndicator";
+
+        std::vector<AnonymousComponentList> SegmentationImage::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(2);
 
-            {
-                const auto result = rerun::components::TensorData::to_data_cell(&data, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(data);
             if (draw_order.has_value()) {
-                const auto& value = draw_order.value();
-                const auto result = rerun::components::DrawOrder::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(draw_order.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.SegmentationImageIndicator",
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<SegmentationImage::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -10,15 +10,15 @@ namespace rerun {
         const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.SegmentationImageIndicator";
 
-        std::vector<AnonymousComponentBatch> SegmentationImage::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(2);
+        std::vector<AnonymousComponentBatch> SegmentationImage::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(2);
 
-            cells.emplace_back(data);
+            comp_batches.emplace_back(data);
             if (draw_order.has_value()) {
-                cells.emplace_back(draw_order.value());
+                comp_batches.emplace_back(draw_order.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<SegmentationImage::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -26,7 +26,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -10,8 +10,8 @@ namespace rerun {
         const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.SegmentationImageIndicator";
 
-        std::vector<AnonymousComponentList> SegmentationImage::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> SegmentationImage::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(2);
 
             cells.emplace_back(data);
@@ -19,7 +19,7 @@ namespace rerun {
                 cells.emplace_back(draw_order.value());
             }
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<SegmentationImage::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -57,7 +57,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
@@ -57,7 +57,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
@@ -31,6 +32,10 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             SegmentationImage() = default;
 
@@ -48,8 +53,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -9,19 +9,19 @@ namespace rerun {
     namespace archetypes {
         const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
 
-        std::vector<AnonymousComponentBatch> Tensor::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(1);
+        std::vector<AnonymousComponentBatch> Tensor::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(1);
 
-            cells.emplace_back(data);
-            cells.emplace_back(
+            comp_batches.emplace_back(data);
+            comp_batches.emplace_back(
                 ComponentBatch<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -3,29 +3,23 @@
 
 #include "tensor.hpp"
 
-#include "../components/tensor_data.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> Tensor::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
+
+        std::vector<AnonymousComponentList> Tensor::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(1);
 
-            {
-                const auto result = rerun::components::TensorData::to_data_cell(&data, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    create_indicator_component("rerun.components.TensorIndicator", num_instances());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(data);
+            cells.emplace_back(
+                ComponentList<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
+                    num_instances()
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -9,13 +9,13 @@ namespace rerun {
     namespace archetypes {
         const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
 
-        std::vector<AnonymousComponentList> Tensor::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> Tensor::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(1);
 
             cells.emplace_back(data);
             cells.emplace_back(
-                ComponentList<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
+                ComponentBatch<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()
                 )

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -38,7 +38,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -38,7 +38,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -19,6 +20,10 @@ namespace rerun {
             /// The tensor data
             rerun::components::TensorData data;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             Tensor() = default;
 
@@ -29,8 +34,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -3,31 +3,25 @@
 
 #include "text_document.hpp"
 
-#include "../components/text.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> TextDocument::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char TextDocument::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.TextDocumentIndicator";
+
+        std::vector<AnonymousComponentList> TextDocument::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(1);
 
-            {
-                const auto result = rerun::components::Text::to_data_cell(&body, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.TextDocumentIndicator",
+            cells.emplace_back(body);
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<TextDocument::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -10,13 +10,13 @@ namespace rerun {
         const char TextDocument::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TextDocumentIndicator";
 
-        std::vector<AnonymousComponentList> TextDocument::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> TextDocument::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(1);
 
             cells.emplace_back(body);
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<TextDocument::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -10,12 +10,12 @@ namespace rerun {
         const char TextDocument::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TextDocumentIndicator";
 
-        std::vector<AnonymousComponentBatch> TextDocument::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(1);
+        std::vector<AnonymousComponentBatch> TextDocument::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(1);
 
-            cells.emplace_back(body);
-            cells.emplace_back(
+            comp_batches.emplace_back(body);
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<TextDocument::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -23,7 +23,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -18,6 +19,10 @@ namespace rerun {
         struct TextDocument {
             rerun::components::Text body;
 
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
+
           public:
             TextDocument() = default;
 
@@ -28,8 +33,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -37,7 +37,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -37,7 +37,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -3,31 +3,21 @@
 
 #include "transform3d.hpp"
 
-#include "../components/transform3d.hpp"
+#include "../indicator_component.hpp"
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> Transform3D::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char Transform3D::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.Transform3DIndicator";
+
+        std::vector<AnonymousComponentList> Transform3D::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(1);
 
-            {
-                const auto result = rerun::components::Transform3D::to_data_cell(&transform, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.Transform3DIndicator",
-                    num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(transform);
+            cells.emplace_back(ComponentList<components::IndicatorComponent<
+                                   Transform3D::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances())
+            );
 
             return cells;
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -10,16 +10,20 @@ namespace rerun {
         const char Transform3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.Transform3DIndicator";
 
-        std::vector<AnonymousComponentBatch> Transform3D::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(1);
+        std::vector<AnonymousComponentBatch> Transform3D::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(1);
 
-            cells.emplace_back(transform);
-            cells.emplace_back(ComponentBatch<components::IndicatorComponent<
-                                   Transform3D::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances())
+            comp_batches.emplace_back(transform);
+            comp_batches.emplace_back(
+                ComponentBatch<
+                    components::IndicatorComponent<Transform3D::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
+                    num_instances()
+                )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -10,12 +10,12 @@ namespace rerun {
         const char Transform3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.Transform3DIndicator";
 
-        std::vector<AnonymousComponentList> Transform3D::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> Transform3D::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(1);
 
             cells.emplace_back(transform);
-            cells.emplace_back(ComponentList<components::IndicatorComponent<
+            cells.emplace_back(ComponentBatch<components::IndicatorComponent<
                                    Transform3D::INDICATOR_COMPONENT_NAME>>(nullptr, num_instances())
             );
 

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
-#include "../component_list.hpp"
+#include "../component_batch.hpp"
 #include "../components/transform3d.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -252,7 +252,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -252,7 +252,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../arrow.hpp"
+#include "../component_list.hpp"
 #include "../components/transform3d.hpp"
 #include "../data_cell.hpp"
 #include "../result.hpp"
@@ -54,6 +55,10 @@ namespace rerun {
         struct Transform3D {
             /// The transform
             rerun::components::Transform3D transform;
+
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
 
           public:
             // Extensions to generated type defined in 'transform3d_ext.cpp'
@@ -243,8 +248,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -12,7 +12,7 @@ namespace rerun {
     /// Does *not* own the data, user is responsible for the lifetime independent of how it was
     /// passed in.
     template <typename ComponentType>
-    class ComponentList {
+    class ComponentBatch {
       public:
         const ComponentType* data;
         size_t size;
@@ -22,10 +22,10 @@ namespace rerun {
         ///
         /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
         /// you need to ensure that the data outlives the component list.
-        ComponentList(const ComponentType& one_and_only) : data(&one_and_only), size(1) {}
+        ComponentBatch(const ComponentType& one_and_only) : data(&one_and_only), size(1) {}
 
         /// Construct from a raw pointer and size.
-        ComponentList(const ComponentType* _data, size_t _size) : data(_data), size(_size) {}
+        ComponentBatch(const ComponentType* _data, size_t _size) : data(_data), size(_size) {}
 
         /// Construct from an std::vector.
         ///
@@ -33,7 +33,7 @@ namespace rerun {
         /// you need to ensure that the data outlives the component list.
         /// In particular, manipulating the passed vector after constructing the component list,
         /// will invalidate it, similar to iterator invalidation.
-        ComponentList(const std::vector<ComponentType>& _data)
+        ComponentBatch(const std::vector<ComponentType>& _data)
             : data(_data.data()), size(_data.size()) {}
 
         /// Construct from an std::array.
@@ -41,7 +41,7 @@ namespace rerun {
         /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
         /// you need to ensure that the data outlives the component list.
         template <size_t Size>
-        ComponentList(const std::array<ComponentType, Size>& _data)
+        ComponentBatch(const std::array<ComponentType, Size>& _data)
             : data(_data.data()), size(Size) {}
 
         /// Construct from a C-Array.
@@ -49,7 +49,7 @@ namespace rerun {
         /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
         /// you need to ensure that the data outlives the component list.
         template <size_t Size>
-        ComponentList(const ComponentType (&_data)[Size]) : data(_data), size(Size) {}
+        ComponentBatch(const ComponentType (&_data)[Size]) : data(_data), size(Size) {}
 
         /// Creates a Rerun DataCell from this list of components.
         Result<rerun::DataCell> to_data_cell() const {
@@ -57,21 +57,21 @@ namespace rerun {
         }
     };
 
-    /// A type erased version of `ComponentList`.
-    class AnonymousComponentList {
+    /// A type erased version of `ComponentBatch`.
+    class AnonymousComponentBatch {
       public:
         const void* data;
         size_t size;
 
       public:
         /// Construct from any parameter that can be converted to a strongly typed component list.
-        template <typename ComponentListLikeType>
-        AnonymousComponentList(const ComponentListLikeType& component_list_like)
-            : AnonymousComponentList(ComponentList(component_list_like)) {}
+        template <typename ComponentBatchLikeType>
+        AnonymousComponentBatch(const ComponentBatchLikeType& component_list_like)
+            : AnonymousComponentBatch(ComponentBatch(component_list_like)) {}
 
         /// Construct from a strongly typed component list.
         template <typename ComponentType>
-        AnonymousComponentList(const ComponentList<ComponentType>& component_list)
+        AnonymousComponentBatch(const ComponentBatch<ComponentType>& component_list)
             : data(component_list.data),
               size(component_list.size),
               to_data_cell_func([](const void* _data, size_t _size) {

--- a/rerun_cpp/src/rerun/component_list.hpp
+++ b/rerun_cpp/src/rerun/component_list.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "data_cell.hpp"
+#include "result.hpp"
+
+namespace rerun {
+    /// Generic list of components that are contigious in memory.
+    ///
+    /// Does *not* own the data, user is responsible for the lifetime independent of how it was
+    /// passed in.
+    template <typename ComponentType>
+    struct ComponentList {
+        const ComponentType* data;
+        size_t size;
+
+        /// Construct from a raw pointer and size.
+        ComponentList(const ComponentType* _data, size_t _size) : data(_data), size(_size) {}
+
+        /// Construct from an std::vector.
+        ComponentList(const std::vector<ComponentType>& _data)
+            : data(_data.data()), size(_data.size()) {}
+
+        /// Construct from an std::array.
+        template <size_t Size>
+        ComponentList(const std::array<ComponentType, Size>& _data)
+            : data(_data.data()), size(Size) {}
+
+        /// Construct from a C-Array.
+        template <size_t Size>
+        ComponentList(const ComponentType (&_data)[Size]) : data(_data), size(Size) {}
+
+        /// Creates a Rerun DataCell from this list of components.
+        Result<rerun::DataCell> to_data_cell() {
+            return ComponentType::to_data_cell(data, size);
+        }
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/component_list.hpp
+++ b/rerun_cpp/src/rerun/component_list.hpp
@@ -7,7 +7,7 @@
 #include "result.hpp"
 
 namespace rerun {
-    /// Generic list of components that are contigious in memory.
+    /// Generic list of components that are contiguous in memory.
     ///
     /// Does *not* own the data, user is responsible for the lifetime independent of how it was
     /// passed in.

--- a/rerun_cpp/src/rerun/component_list.hpp
+++ b/rerun_cpp/src/rerun/component_list.hpp
@@ -18,19 +18,36 @@ namespace rerun {
         size_t size;
 
       public:
+        /// Construct from a single component.
+        ///
+        /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
+        /// you need to ensure that the data outlives the component list.
+        ComponentList(const ComponentType& one_and_only) : data(&one_and_only), size(1) {}
+
         /// Construct from a raw pointer and size.
         ComponentList(const ComponentType* _data, size_t _size) : data(_data), size(_size) {}
 
         /// Construct from an std::vector.
+        ///
+        /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
+        /// you need to ensure that the data outlives the component list.
+        /// In particular, manipulating the passed vector after constructing the component list,
+        /// will invalidate it, similar to iterator invalidation.
         ComponentList(const std::vector<ComponentType>& _data)
             : data(_data.data()), size(_data.size()) {}
 
         /// Construct from an std::array.
+        ///
+        /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
+        /// you need to ensure that the data outlives the component list.
         template <size_t Size>
         ComponentList(const std::array<ComponentType, Size>& _data)
             : data(_data.data()), size(Size) {}
 
         /// Construct from a C-Array.
+        ///
+        /// *Attention*: As with all other constructors, this does *not* take ownership of the data,
+        /// you need to ensure that the data outlives the component list.
         template <size_t Size>
         ComponentList(const ComponentType (&_data)[Size]) : data(_data), size(Size) {}
 

--- a/rerun_cpp/src/rerun/component_list.hpp
+++ b/rerun_cpp/src/rerun/component_list.hpp
@@ -12,10 +12,12 @@ namespace rerun {
     /// Does *not* own the data, user is responsible for the lifetime independent of how it was
     /// passed in.
     template <typename ComponentType>
-    struct ComponentList {
+    class ComponentList {
+      public:
         const ComponentType* data;
         size_t size;
 
+      public:
         /// Construct from a raw pointer and size.
         ComponentList(const ComponentType* _data, size_t _size) : data(_data), size(_size) {}
 
@@ -33,8 +35,41 @@ namespace rerun {
         ComponentList(const ComponentType (&_data)[Size]) : data(_data), size(Size) {}
 
         /// Creates a Rerun DataCell from this list of components.
-        Result<rerun::DataCell> to_data_cell() {
+        Result<rerun::DataCell> to_data_cell() const {
             return ComponentType::to_data_cell(data, size);
         }
+    };
+
+    /// A type erased version of `ComponentList`.
+    class AnonymousComponentList {
+      public:
+        const void* data;
+        size_t size;
+
+      public:
+        /// Construct from any parameter that can be converted to a strongly typed component list.
+        template <typename ComponentListLikeType>
+        AnonymousComponentList(const ComponentListLikeType& component_list_like)
+            : AnonymousComponentList(ComponentList(component_list_like)) {}
+
+        /// Construct from a strongly typed component list.
+        template <typename ComponentType>
+        AnonymousComponentList(const ComponentList<ComponentType>& component_list)
+            : data(component_list.data),
+              size(component_list.size),
+              to_data_cell_func([](const void* _data, size_t _size) {
+                  return ComponentType::to_data_cell(
+                      reinterpret_cast<const ComponentType*>(_data),
+                      _size
+                  );
+              }) {}
+
+        /// Creates a Rerun DataCell from this list of components.
+        Result<rerun::DataCell> to_data_cell() const {
+            return to_data_cell_func(data, size);
+        }
+
+      private:
+        Result<rerun::DataCell> (*to_data_cell_func)(const void*, size_t);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AnnotationContext::NAME = "rerun.annotation_context";
+        const char AnnotationContext::NAME[] = "rerun.annotation_context";
 
         const std::shared_ptr<arrow::DataType> &AnnotationContext::arrow_datatype() {
             static const auto datatype = arrow::list(arrow::field(

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -31,7 +31,7 @@ namespace rerun {
             std::vector<rerun::datatypes::ClassDescriptionMapElem> class_map;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'annotation_context_ext.cpp'

--- a/rerun_cpp/src/rerun/components/class_id.cpp
+++ b/rerun_cpp/src/rerun/components/class_id.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *ClassId::NAME = "rerun.class_id";
+        const char ClassId::NAME[] = "rerun.class_id";
 
         const std::shared_ptr<arrow::DataType> &ClassId::arrow_datatype() {
             static const auto datatype = rerun::datatypes::ClassId::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -28,7 +28,7 @@ namespace rerun {
             rerun::datatypes::ClassId id;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             ClassId() = default;

--- a/rerun_cpp/src/rerun/components/color.cpp
+++ b/rerun_cpp/src/rerun/components/color.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Color::NAME = "rerun.colorrgba";
+        const char Color::NAME[] = "rerun.colorrgba";
 
         const std::shared_ptr<arrow::DataType> &Color::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Color::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -29,7 +29,7 @@ namespace rerun {
             rerun::datatypes::Color rgba;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'color_ext.cpp'

--- a/rerun_cpp/src/rerun/components/depth_meter.cpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.cpp
@@ -11,7 +11,7 @@
 
 namespace rerun {
     namespace components {
-        const char* DepthMeter::NAME = "rerun.components.DepthMeter";
+        const char DepthMeter::NAME[] = "rerun.components.DepthMeter";
 
         const std::shared_ptr<arrow::DataType>& DepthMeter::arrow_datatype() {
             static const auto datatype = arrow::float32();

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -27,7 +27,7 @@ namespace rerun {
             float value;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             DepthMeter() = default;

--- a/rerun_cpp/src/rerun/components/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.cpp
@@ -11,7 +11,7 @@
 
 namespace rerun {
     namespace components {
-        const char *DisconnectedSpace::NAME = "rerun.disconnected_space";
+        const char DisconnectedSpace::NAME[] = "rerun.disconnected_space";
 
         const std::shared_ptr<arrow::DataType> &DisconnectedSpace::arrow_datatype() {
             static const auto datatype = arrow::boolean();

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -27,7 +27,7 @@ namespace rerun {
             bool is_disconnected;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             DisconnectedSpace() = default;

--- a/rerun_cpp/src/rerun/components/draw_order.cpp
+++ b/rerun_cpp/src/rerun/components/draw_order.cpp
@@ -11,7 +11,7 @@
 
 namespace rerun {
     namespace components {
-        const char* DrawOrder::NAME = "rerun.draw_order";
+        const char DrawOrder::NAME[] = "rerun.draw_order";
 
         const std::shared_ptr<arrow::DataType>& DrawOrder::arrow_datatype() {
             static const auto datatype = arrow::float32();

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -33,7 +33,7 @@ namespace rerun {
             float value;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             DrawOrder() = default;

--- a/rerun_cpp/src/rerun/components/instance_key.cpp
+++ b/rerun_cpp/src/rerun/components/instance_key.cpp
@@ -11,7 +11,7 @@
 
 namespace rerun {
     namespace components {
-        const char* InstanceKey::NAME = "rerun.instance_key";
+        const char InstanceKey::NAME[] = "rerun.instance_key";
 
         const std::shared_ptr<arrow::DataType>& InstanceKey::arrow_datatype() {
             static const auto datatype = arrow::uint64();

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -27,7 +27,7 @@ namespace rerun {
             uint64_t value;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             InstanceKey() = default;

--- a/rerun_cpp/src/rerun/components/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *KeypointId::NAME = "rerun.keypoint_id";
+        const char KeypointId::NAME[] = "rerun.keypoint_id";
 
         const std::shared_ptr<arrow::DataType> &KeypointId::arrow_datatype() {
             static const auto datatype = rerun::datatypes::KeypointId::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -28,7 +28,7 @@ namespace rerun {
             rerun::datatypes::KeypointId id;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             KeypointId() = default;

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *LineStrip2D::NAME = "rerun.linestrip2d";
+        const char LineStrip2D::NAME[] = "rerun.linestrip2d";
 
         const std::shared_ptr<arrow::DataType> &LineStrip2D::arrow_datatype() {
             static const auto datatype =

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -36,7 +36,7 @@ namespace rerun {
             std::vector<rerun::datatypes::Vec2D> points;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             LineStrip2D() = default;

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *LineStrip3D::NAME = "rerun.linestrip3d";
+        const char LineStrip3D::NAME[] = "rerun.linestrip3d";
 
         const std::shared_ptr<arrow::DataType> &LineStrip3D::arrow_datatype() {
             static const auto datatype =

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -36,7 +36,7 @@ namespace rerun {
             std::vector<rerun::datatypes::Vec3D> points;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             LineStrip3D() = default;

--- a/rerun_cpp/src/rerun/components/origin3d.cpp
+++ b/rerun_cpp/src/rerun/components/origin3d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Origin3D::NAME = "rerun.components.Origin3D";
+        const char Origin3D::NAME[] = "rerun.components.Origin3D";
 
         const std::shared_ptr<arrow::DataType> &Origin3D::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Vec3D::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/origin3d.hpp
+++ b/rerun_cpp/src/rerun/components/origin3d.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             rerun::datatypes::Vec3D origin;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'origin3d_ext.cpp'

--- a/rerun_cpp/src/rerun/components/point2d.cpp
+++ b/rerun_cpp/src/rerun/components/point2d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Point2D::NAME = "rerun.point2d";
+        const char Point2D::NAME[] = "rerun.point2d";
 
         const std::shared_ptr<arrow::DataType> &Point2D::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Vec2D::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/point2d.hpp
+++ b/rerun_cpp/src/rerun/components/point2d.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             rerun::datatypes::Vec2D xy;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'point2d_ext.cpp'

--- a/rerun_cpp/src/rerun/components/point3d.cpp
+++ b/rerun_cpp/src/rerun/components/point3d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Point3D::NAME = "rerun.point3d";
+        const char Point3D::NAME[] = "rerun.point3d";
 
         const std::shared_ptr<arrow::DataType> &Point3D::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Vec3D::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/point3d.hpp
+++ b/rerun_cpp/src/rerun/components/point3d.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             rerun::datatypes::Vec3D xyz;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'point3d_ext.cpp'

--- a/rerun_cpp/src/rerun/components/radius.cpp
+++ b/rerun_cpp/src/rerun/components/radius.cpp
@@ -11,7 +11,7 @@
 
 namespace rerun {
     namespace components {
-        const char* Radius::NAME = "rerun.radius";
+        const char Radius::NAME[] = "rerun.radius";
 
         const std::shared_ptr<arrow::DataType>& Radius::arrow_datatype() {
             static const auto datatype = arrow::float32();

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -27,7 +27,7 @@ namespace rerun {
             float value;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             Radius() = default;

--- a/rerun_cpp/src/rerun/components/tensor_data.cpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *TensorData::NAME = "rerun.components.TensorData";
+        const char TensorData::NAME[] = "rerun.components.TensorData";
 
         const std::shared_ptr<arrow::DataType> &TensorData::arrow_datatype() {
             static const auto datatype = rerun::datatypes::TensorData::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             rerun::datatypes::TensorData data;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             TensorData() = default;

--- a/rerun_cpp/src/rerun/components/text.cpp
+++ b/rerun_cpp/src/rerun/components/text.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Text::NAME = "rerun.label";
+        const char Text::NAME[] = "rerun.label";
 
         const std::shared_ptr<arrow::DataType> &Text::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Utf8::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/text.hpp
+++ b/rerun_cpp/src/rerun/components/text.hpp
@@ -25,7 +25,7 @@ namespace rerun {
             rerun::datatypes::Utf8 value;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'text_ext.cpp'

--- a/rerun_cpp/src/rerun/components/transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/transform3d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Transform3D::NAME = "rerun.transform3d";
+        const char Transform3D::NAME[] = "rerun.transform3d";
 
         const std::shared_ptr<arrow::DataType> &Transform3D::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Transform3D::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -25,7 +25,7 @@ namespace rerun {
             rerun::datatypes::Transform3D repr;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             Transform3D() = default;

--- a/rerun_cpp/src/rerun/components/vector3d.cpp
+++ b/rerun_cpp/src/rerun/components/vector3d.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *Vector3D::NAME = "rerun.components.Vector3D";
+        const char Vector3D::NAME[] = "rerun.components.Vector3D";
 
         const std::shared_ptr<arrow::DataType> &Vector3D::arrow_datatype() {
             static const auto datatype = rerun::datatypes::Vec3D::arrow_datatype();

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             rerun::datatypes::Vec3D vector;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             // Extensions to generated type defined in 'vector3d_ext.cpp'

--- a/rerun_cpp/src/rerun/indicator_component.hpp
+++ b/rerun_cpp/src/rerun/indicator_component.hpp
@@ -14,11 +14,6 @@ namespace rerun {
             IndicatorComponent() = default;
 
             /// Creates a Rerun DataCell from an array of IndicatorComponent components.
-            ///
-            /// Typically only a single indicator component is ever used. `num_instances` is merely
-            /// there to match the commonly used interface.
-            /// Since indicator components have no data, strongly typed null can be passed in
-            /// instead of a valid pointer.
             static Result<rerun::DataCell> to_data_cell(
                 const IndicatorComponent<Name>*, size_t num_instances
             ) {

--- a/rerun_cpp/src/rerun/indicator_component.hpp
+++ b/rerun_cpp/src/rerun/indicator_component.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "arrow.hpp"
+#include "data_cell.hpp"
+
+namespace rerun {
+    namespace components {
+        /// Indicator component used by archetypes when converting them to component lists.
+        ///
+        /// This is done in order to track how a collection of component was logged.
+        template <const char Name[]>
+        struct IndicatorComponent {
+          public:
+            IndicatorComponent() = default;
+
+            /// Creates a Rerun DataCell from an array of IndicatorComponent components.
+            ///
+            /// Typically only a single indicator component is ever used. `num_instances` is merely
+            /// there to match the commonly used interface.
+            /// Since indicator components have no data, strongly typed null can be passed in
+            /// instead of a valid pointer.
+            static Result<rerun::DataCell> to_data_cell(
+                const IndicatorComponent<Name>*, size_t num_instances
+            ) {
+                return rerun::create_indicator_component(Name, num_instances);
+            }
+        };
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -110,7 +110,7 @@ namespace rerun {
             if (result.is_err()) {
                 return result.error;
             }
-            if (num_instances > 1 && component_list.size == 1) {
+            if (num_instances > 1 && component_list.num_instances == 1) {
                 splatted.push_back(result.value);
             } else {
                 instanced.push_back(result.value);

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -95,7 +95,7 @@ namespace rerun {
     }
 
     Error RecordingStream::try_log_components(
-        const char* entity_path, const std::vector<AnonymousComponentList> component_lists
+        const char* entity_path, const std::vector<AnonymousComponentBatch> component_lists
     ) {
         if (component_lists.size() == 0) {
             return Error::ok();

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -94,8 +94,8 @@ namespace rerun {
         rr_recording_stream_flush_blocking(_id);
     }
 
-    Error RecordingStream::try_log_components(
-        const char* entity_path, const std::vector<AnonymousComponentBatch> component_lists
+    Error RecordingStream::try_log_component_batches(
+        const char* entity_path, const std::vector<AnonymousComponentBatch>& component_lists
     ) {
         if (component_lists.size() == 0) {
             return Error::ok();

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -95,13 +95,12 @@ namespace rerun {
     }
 
     Error RecordingStream::try_log_component_batches(
-        const char* entity_path, const std::vector<AnonymousComponentBatch>& component_lists
+        const char* entity_path, size_t num_instances,
+        const std::vector<AnonymousComponentBatch>& component_lists
     ) {
-        if (component_lists.size() == 0) {
+        if (num_instances == 0) {
             return Error::ok();
         }
-
-        auto num_instances = component_lists[0].size;
 
         std::vector<DataCell> instanced;
         std::vector<DataCell> splatted;

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -1,4 +1,5 @@
 #include "recording_stream.hpp"
+#include "components/instance_key.hpp"
 
 #include <rerun.h>
 
@@ -6,6 +7,8 @@
 #include <vector>
 
 namespace rerun {
+    static const auto splat_key = components::InstanceKey(std::numeric_limits<uint64_t>::max());
+
     static rr_store_kind store_kind_to_c(StoreKind store_kind) {
         switch (store_kind) {
             case StoreKind::Recording:
@@ -89,6 +92,41 @@ namespace rerun {
 
     void RecordingStream::flush_blocking() {
         rr_recording_stream_flush_blocking(_id);
+    }
+
+    Error RecordingStream::try_log_components(
+        const char* entity_path, const std::vector<AnonymousComponentList> component_lists
+    ) {
+        if (component_lists.size() == 0) {
+            return Error::ok();
+        }
+
+        auto num_instances = component_lists[0].size;
+
+        std::vector<DataCell> instanced;
+        std::vector<DataCell> splatted;
+
+        for (const auto& component_list : component_lists) {
+            const auto result = component_list.to_data_cell();
+            if (result.is_err()) {
+                return result.error;
+            }
+            if (num_instances > 1 && component_list.size == 1) {
+                splatted.push_back(result.value);
+            } else {
+                instanced.push_back(result.value);
+            }
+        }
+
+        if (!splatted.empty()) {
+            splatted.push_back(components::InstanceKey::to_data_cell(&splat_key, 1).value);
+            auto result = try_log_data_row(entity_path, 1, splatted.size(), splatted.data());
+            if (result.is_err()) {
+                return result;
+            }
+        }
+
+        return try_log_data_row(entity_path, num_instances, instanced.size(), instanced.data());
     }
 
     Error RecordingStream::try_log_data_row(

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint> // uint32_t etc.
+#include <vector>
 
 #include "component_list.hpp"
 #include "data_cell.hpp"
@@ -142,17 +143,7 @@ namespace rerun {
         /// @see log_archetype
         template <typename T>
         Error try_log_archetype(const char* entity_path, const T& archetype) {
-            const auto data_cells_result = archetype.to_data_cells();
-            if (data_cells_result.is_ok()) {
-                return try_log_data_row(
-                    entity_path,
-                    archetype.num_instances(),
-                    data_cells_result.value.size(),
-                    data_cells_result.value.data()
-                );
-            } else {
-                return data_cells_result.error;
-            }
+            return try_log_components(entity_path, archetype.as_component_lists());
         }
 
         /// Logs a list of component arrays.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -142,7 +142,7 @@ namespace rerun {
         /// @see log_archetype
         template <typename T>
         Error try_log_archetype(const char* entity_path, const T& archetype) {
-            return try_log_components(entity_path, archetype.as_component_lists());
+            return try_log_components(entity_path, archetype.as_component_batches());
         }
 
         /// Logs a list of component arrays.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -115,11 +115,12 @@ namespace rerun {
 
         /// Logs an archetype.
         ///
-        /// Prefer this interface for ease of use over the more general `log_components` interface.
+        /// Prefer this interface for ease of use over the more general `log_component_batches`
+        /// interface.
         ///
         /// Alias for `log_archetype`.
         /// TODO(andreas): Would be nice if this were able to combine both log_archetype and
-        /// log_components!
+        /// log_component_batches!
         ///
         /// Logs any failure via `Error::log_on_failure`
         template <typename T>
@@ -129,7 +130,8 @@ namespace rerun {
 
         /// Logs an archetype.
         ///
-        /// Prefer this interface for ease of use over the more general `log_components` interface.
+        /// Prefer this interface for ease of use over the more general `log_component_batches`
+        /// interface.
         ///
         /// Logs any failure via `Error::log_on_failure`
         template <typename T>
@@ -142,10 +144,10 @@ namespace rerun {
         /// @see log_archetype
         template <typename T>
         Error try_log_archetype(const char* entity_path, const T& archetype) {
-            return try_log_components(entity_path, archetype.as_component_batches());
+            return try_log_component_batches(entity_path, archetype.as_component_batches());
         }
 
-        /// Logs a list of component arrays.
+        /// Logs several component batches.
         ///
         /// This forms the "medium level API", for easy to use high level api, prefer `log` to log
         /// built-in archetypes.
@@ -156,23 +158,26 @@ namespace rerun {
         ///
         /// Logs any failure via `Error::log_on_failure`
         template <typename... Ts>
-        void log_components(const char* entity_path, const Ts&... component_arrays) {
-            try_log_components(entity_path, component_arrays...).log_on_failure();
+        void log_component_batches(const char* entity_path, const Ts&... component_arrays) {
+            try_log_component_batches(entity_path, component_arrays...).log_on_failure();
         }
 
-        /// Logs a list of component arrays, returning an error on failure.
+        /// Logs several component batches, returning an error on failure.
         ///
-        /// @see log_components
+        /// @see log_component_batches
         template <typename... Ts>
-        Error try_log_components(const char* entity_path, const Ts&... component_arrays) {
-            return try_log_components(entity_path, {AnonymousComponentBatch(component_arrays)...});
+        Error try_log_component_batches(const char* entity_path, const Ts&... component_arrays) {
+            return try_log_component_batches(
+                entity_path,
+                {AnonymousComponentBatch(component_arrays)...}
+            );
         }
 
         /// Logs a list of component batches, returning an error on failure.
         ///
-        /// @see log_components
-        Error try_log_components(
-            const char* entity_path, const std::vector<AnonymousComponentBatch> component_lists
+        /// @see log_component_batches
+        Error try_log_component_batches(
+            const char* entity_path, const std::vector<AnonymousComponentBatch>& component_lists
         );
 
         /// Low level API that logs raw data cells to the recording stream.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -166,14 +166,14 @@ namespace rerun {
         /// @see log_components
         template <typename... Ts>
         Error try_log_components(const char* entity_path, const Ts&... component_arrays) {
-            return try_log_components(entity_path, {AnonymousComponentList(component_arrays)...});
+            return try_log_components(entity_path, {AnonymousComponentBatch(component_arrays)...});
         }
 
         /// Logs a list of component arrays, returning an error on failure.
         ///
         /// @see log_components
         Error try_log_components(
-            const char* entity_path, const std::vector<AnonymousComponentList> component_lists
+            const char* entity_path, const std::vector<AnonymousComponentBatch> component_lists
         );
 
         /// Low level API that logs raw data cells to the recording stream.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -3,8 +3,7 @@
 #include <cstdint> // uint32_t etc.
 #include <vector>
 
-#include "component_list.hpp"
-#include "data_cell.hpp"
+#include "component_batch.hpp"
 #include "error.hpp"
 
 namespace rerun {

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <cstddef> // size_t
-#include <cstdint> // uint32_t etc
-#include <vector>
+#include <cstdint> // uint32_t etc.
 
+#include "component_list.hpp"
 #include "data_cell.hpp"
 #include "error.hpp"
 
@@ -205,50 +204,16 @@ namespace rerun {
 
       private:
         template <typename C, typename... Ts>
-        static size_t size_of_first_collection(const std::vector<C>& first, const Ts&...) {
-            return first.size();
-        }
-
-        template <size_t N, typename C, typename... Ts>
-        static size_t size_of_first_collection(const std::array<C, N>& first, const Ts&...) {
-            return first.size();
-        }
-
-        template <size_t N, typename C, typename... Ts>
-        static size_t size_of_first_collection(const C (&)[N], const Ts&...) {
-            return N;
+        static size_t size_of_first_collection(const C& first, const Ts&...) {
+            return ComponentList(first).size;
         }
 
         template <typename C, typename... Ts>
         static Error push_data_cells(
-            std::vector<DataCell>& data_cells, const std::vector<C>& first, const Ts&... rest
+            std::vector<DataCell>& data_cells, const C& first, const Ts&... rest
         ) {
-            const auto cell_result = C::to_data_cell(first.data(), first.size());
+            const auto cell_result = ComponentList(first).to_data_cell();
             if (cell_result.is_err()) {
-                return cell_result.error;
-            }
-            data_cells.push_back(cell_result.value);
-            return push_data_cells(data_cells, rest...);
-        }
-
-        template <size_t N, typename C, typename... Ts>
-        static Error push_data_cells(
-            std::vector<DataCell>& data_cells, const std::array<C, N>& first, const Ts&... rest
-        ) {
-            const auto cell_result = C::to_data_cell(first.data(), N);
-            if (!cell_result.is_ok()) {
-                return cell_result.error;
-            }
-            data_cells.push_back(cell_result.value);
-            return push_data_cells(data_cells, rest...);
-        }
-
-        template <size_t N, typename C, typename... Ts>
-        static Error push_data_cells(
-            std::vector<DataCell>& data_cells, const C (&first)[N], const Ts&... rest
-        ) {
-            const auto cell_result = C::to_data_cell(first, N);
-            if (!cell_result.is_ok()) {
                 return cell_result.error;
             }
             data_cells.push_back(cell_result.value);

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -169,7 +169,7 @@ namespace rerun {
             return try_log_components(entity_path, {AnonymousComponentBatch(component_arrays)...});
         }
 
-        /// Logs a list of component arrays, returning an error on failure.
+        /// Logs a list of component batches, returning an error on failure.
         ///
         /// @see log_components
         Error try_log_components(

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -166,7 +166,7 @@ namespace rerun {
         template <typename T>
         void log_component_batch(const char* entity_path, const T& component_batch) {
             const auto batch = AnonymousComponentBatch(component_batch);
-            try_log_component_batches(entity_path, batch.size, batch).log_on_failure();
+            try_log_component_batches(entity_path, batch.num_instances, batch).log_on_failure();
         }
 
         /// Logs a single component batch.
@@ -181,7 +181,7 @@ namespace rerun {
         template <typename T>
         Error try_log_component_batch(const char* entity_path, const T& component_batch) {
             const auto batch = AnonymousComponentBatch(component_batch);
-            return try_log_component_batches(entity_path, batch.size, batch);
+            return try_log_component_batches(entity_path, batch.num_instances, batch);
         }
 
         /// Logs several component batches.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -174,29 +174,7 @@ namespace rerun {
         /// @see log_components
         Error try_log_components(
             const char* entity_path, const std::vector<AnonymousComponentList> component_lists
-        ) {
-            if (component_lists.size() == 0) {
-                return Error::ok();
-            }
-
-            // TODO: splats
-            std::vector<DataCell> data_cells;
-            data_cells.reserve(component_lists.size());
-            for (const auto& component_list : component_lists) {
-                const auto result = component_list.to_data_cell();
-                if (result.is_err()) {
-                    return result.error;
-                }
-                data_cells.push_back(result.value);
-            }
-
-            return try_log_data_row(
-                entity_path,
-                component_lists[0].size,
-                data_cells.size(),
-                data_cells.data()
-            );
-        }
+        );
 
         /// Low level API that logs raw data cells to the recording stream.
         ///

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -3,16 +3,16 @@
 #include <arrow/buffer.h>
 #include <catch2/catch_test_macros.hpp>
 
-#include <rerun/component_list.hpp>
+#include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 
 template <typename T>
 void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
     THEN("convert to component lists") {
         std::vector<rerun::AnonymousComponentBatch> from_builder_lists =
-            from_builder.as_component_lists();
+            from_builder.as_component_batches();
         std::vector<rerun::AnonymousComponentBatch> from_manual_lists =
-            from_manual.as_component_lists();
+            from_manual.as_component_batches();
 
         REQUIRE(from_builder_lists.size() == from_manual_lists.size());
 

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -9,9 +9,9 @@
 template <typename T>
 void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
     THEN("convert to component lists") {
-        std::vector<rerun::AnonymousComponentList> from_builder_lists =
+        std::vector<rerun::AnonymousComponentBatch> from_builder_lists =
             from_builder.as_component_lists();
-        std::vector<rerun::AnonymousComponentList> from_manual_lists =
+        std::vector<rerun::AnonymousComponentBatch> from_manual_lists =
             from_manual.as_component_lists();
 
         REQUIRE(from_builder_lists.size() == from_manual_lists.size());

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -1,26 +1,42 @@
 #pragma once
 
+#include <arrow/buffer.h>
 #include <catch2/catch_test_macros.hpp>
 
-#include <arrow/buffer.h>
+#include <rerun/component_list.hpp>
+#include <rerun/data_cell.hpp>
 
 template <typename T>
 void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
-    THEN("serialization succeeds") {
-        auto from_builder_serialized = from_builder.to_data_cells();
-        REQUIRE(from_builder_serialized.is_ok());
+    THEN("convert to component lists") {
+        std::vector<rerun::AnonymousComponentList> from_builder_lists =
+            from_builder.as_component_lists();
+        std::vector<rerun::AnonymousComponentList> from_manual_lists =
+            from_manual.as_component_lists();
 
-        auto from_manual_serialized = from_manual.to_data_cells();
-        REQUIRE(from_manual_serialized.is_ok());
+        REQUIRE(from_builder_lists.size() == from_manual_lists.size());
 
-        AND_THEN("the serialized data is the same") {
-            auto from_builder_cells = from_builder_serialized.value;
-            auto from_manual_cells = from_manual_serialized.value;
+        AND_THEN("serializing each list succeeds") {
+            std::vector<rerun::DataCell> from_builder_cells;
+            std::vector<rerun::DataCell> from_manual_cells;
+            for (size_t i = 0; i < from_builder_lists.size(); ++i) {
+                auto from_builder_cell = from_builder_lists[i].to_data_cell();
+                auto from_manual_cell = from_manual_lists[i].to_data_cell();
 
-            CHECK(from_builder_cells.size() == from_manual_cells.size());
-            for (size_t i = 0; i < from_builder_cells.size(); ++i) {
-                CHECK(from_builder_cells[i].component_name == from_manual_cells[i].component_name);
-                CHECK(from_builder_cells[i].buffer->Equals(*from_manual_cells[i].buffer));
+                REQUIRE(from_builder_cell.is_ok());
+                REQUIRE(from_manual_cell.is_ok());
+
+                from_builder_cells.push_back(from_builder_cell.value);
+                from_manual_cells.push_back(from_manual_cell.value);
+            }
+
+            AND_THEN("the serialized data is the same") {
+                for (size_t i = 0; i < from_builder_lists.size(); ++i) {
+                    CHECK(
+                        from_builder_cells[i].component_name == from_manual_cells[i].component_name
+                    );
+                    CHECK(from_builder_cells[i].buffer->Equals(*from_manual_cells[i].buffer));
+                }
             }
         }
     }

--- a/rerun_cpp/tests/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/tests/archetypes/disconnected_space.cpp
@@ -11,7 +11,9 @@ SCENARIO("disconnected_space archetype can be serialized" TEST_TAG) {
         auto from_builder = DisconnectedSpace(true);
 
         THEN("serialization succeeds") {
-            CHECK(from_builder.to_data_cells().is_ok());
+            for (auto& list : from_builder.as_component_lists()) {
+                CHECK(list.to_data_cell().is_ok());
+            }
         }
     }
 }

--- a/rerun_cpp/tests/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/tests/archetypes/disconnected_space.cpp
@@ -11,7 +11,7 @@ SCENARIO("disconnected_space archetype can be serialized" TEST_TAG) {
         auto from_builder = DisconnectedSpace(true);
 
         THEN("serialization succeeds") {
-            for (auto& list : from_builder.as_component_lists()) {
+            for (auto& list : from_builder.as_component_batches()) {
                 CHECK(list.to_data_cell().is_ok());
             }
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -10,8 +10,8 @@ namespace rerun {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AffixFuzzer1Indicator";
 
-        std::vector<AnonymousComponentList> AffixFuzzer1::as_component_lists() const {
-            std::vector<AnonymousComponentList> cells;
+        std::vector<AnonymousComponentBatch> AffixFuzzer1::as_component_lists() const {
+            std::vector<AnonymousComponentBatch> cells;
             cells.reserve(74);
 
             cells.emplace_back(fuzz1001);
@@ -161,7 +161,7 @@ namespace rerun {
                 cells.emplace_back(fuzz2118.value());
             }
             cells.emplace_back(
-                ComponentList<
+                ComponentBatch<
                     components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
                     num_instances()

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -10,157 +10,157 @@ namespace rerun {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AffixFuzzer1Indicator";
 
-        std::vector<AnonymousComponentBatch> AffixFuzzer1::as_component_lists() const {
-            std::vector<AnonymousComponentBatch> cells;
-            cells.reserve(74);
+        std::vector<AnonymousComponentBatch> AffixFuzzer1::as_component_batches() const {
+            std::vector<AnonymousComponentBatch> comp_batches;
+            comp_batches.reserve(74);
 
-            cells.emplace_back(fuzz1001);
-            cells.emplace_back(fuzz1002);
-            cells.emplace_back(fuzz1003);
-            cells.emplace_back(fuzz1004);
-            cells.emplace_back(fuzz1005);
-            cells.emplace_back(fuzz1006);
-            cells.emplace_back(fuzz1007);
-            cells.emplace_back(fuzz1008);
-            cells.emplace_back(fuzz1009);
-            cells.emplace_back(fuzz1010);
-            cells.emplace_back(fuzz1011);
-            cells.emplace_back(fuzz1012);
-            cells.emplace_back(fuzz1013);
-            cells.emplace_back(fuzz1014);
-            cells.emplace_back(fuzz1015);
-            cells.emplace_back(fuzz1016);
-            cells.emplace_back(fuzz1017);
-            cells.emplace_back(fuzz1018);
-            cells.emplace_back(fuzz1019);
-            cells.emplace_back(fuzz1020);
-            cells.emplace_back(fuzz1101);
-            cells.emplace_back(fuzz1102);
-            cells.emplace_back(fuzz1103);
-            cells.emplace_back(fuzz1104);
-            cells.emplace_back(fuzz1105);
-            cells.emplace_back(fuzz1106);
-            cells.emplace_back(fuzz1107);
-            cells.emplace_back(fuzz1108);
-            cells.emplace_back(fuzz1109);
-            cells.emplace_back(fuzz1110);
-            cells.emplace_back(fuzz1111);
-            cells.emplace_back(fuzz1112);
-            cells.emplace_back(fuzz1113);
-            cells.emplace_back(fuzz1114);
-            cells.emplace_back(fuzz1115);
-            cells.emplace_back(fuzz1116);
-            cells.emplace_back(fuzz1117);
-            cells.emplace_back(fuzz1118);
+            comp_batches.emplace_back(fuzz1001);
+            comp_batches.emplace_back(fuzz1002);
+            comp_batches.emplace_back(fuzz1003);
+            comp_batches.emplace_back(fuzz1004);
+            comp_batches.emplace_back(fuzz1005);
+            comp_batches.emplace_back(fuzz1006);
+            comp_batches.emplace_back(fuzz1007);
+            comp_batches.emplace_back(fuzz1008);
+            comp_batches.emplace_back(fuzz1009);
+            comp_batches.emplace_back(fuzz1010);
+            comp_batches.emplace_back(fuzz1011);
+            comp_batches.emplace_back(fuzz1012);
+            comp_batches.emplace_back(fuzz1013);
+            comp_batches.emplace_back(fuzz1014);
+            comp_batches.emplace_back(fuzz1015);
+            comp_batches.emplace_back(fuzz1016);
+            comp_batches.emplace_back(fuzz1017);
+            comp_batches.emplace_back(fuzz1018);
+            comp_batches.emplace_back(fuzz1019);
+            comp_batches.emplace_back(fuzz1020);
+            comp_batches.emplace_back(fuzz1101);
+            comp_batches.emplace_back(fuzz1102);
+            comp_batches.emplace_back(fuzz1103);
+            comp_batches.emplace_back(fuzz1104);
+            comp_batches.emplace_back(fuzz1105);
+            comp_batches.emplace_back(fuzz1106);
+            comp_batches.emplace_back(fuzz1107);
+            comp_batches.emplace_back(fuzz1108);
+            comp_batches.emplace_back(fuzz1109);
+            comp_batches.emplace_back(fuzz1110);
+            comp_batches.emplace_back(fuzz1111);
+            comp_batches.emplace_back(fuzz1112);
+            comp_batches.emplace_back(fuzz1113);
+            comp_batches.emplace_back(fuzz1114);
+            comp_batches.emplace_back(fuzz1115);
+            comp_batches.emplace_back(fuzz1116);
+            comp_batches.emplace_back(fuzz1117);
+            comp_batches.emplace_back(fuzz1118);
             if (fuzz2001.has_value()) {
-                cells.emplace_back(fuzz2001.value());
+                comp_batches.emplace_back(fuzz2001.value());
             }
             if (fuzz2002.has_value()) {
-                cells.emplace_back(fuzz2002.value());
+                comp_batches.emplace_back(fuzz2002.value());
             }
             if (fuzz2003.has_value()) {
-                cells.emplace_back(fuzz2003.value());
+                comp_batches.emplace_back(fuzz2003.value());
             }
             if (fuzz2004.has_value()) {
-                cells.emplace_back(fuzz2004.value());
+                comp_batches.emplace_back(fuzz2004.value());
             }
             if (fuzz2005.has_value()) {
-                cells.emplace_back(fuzz2005.value());
+                comp_batches.emplace_back(fuzz2005.value());
             }
             if (fuzz2006.has_value()) {
-                cells.emplace_back(fuzz2006.value());
+                comp_batches.emplace_back(fuzz2006.value());
             }
             if (fuzz2007.has_value()) {
-                cells.emplace_back(fuzz2007.value());
+                comp_batches.emplace_back(fuzz2007.value());
             }
             if (fuzz2008.has_value()) {
-                cells.emplace_back(fuzz2008.value());
+                comp_batches.emplace_back(fuzz2008.value());
             }
             if (fuzz2009.has_value()) {
-                cells.emplace_back(fuzz2009.value());
+                comp_batches.emplace_back(fuzz2009.value());
             }
             if (fuzz2010.has_value()) {
-                cells.emplace_back(fuzz2010.value());
+                comp_batches.emplace_back(fuzz2010.value());
             }
             if (fuzz2011.has_value()) {
-                cells.emplace_back(fuzz2011.value());
+                comp_batches.emplace_back(fuzz2011.value());
             }
             if (fuzz2012.has_value()) {
-                cells.emplace_back(fuzz2012.value());
+                comp_batches.emplace_back(fuzz2012.value());
             }
             if (fuzz2013.has_value()) {
-                cells.emplace_back(fuzz2013.value());
+                comp_batches.emplace_back(fuzz2013.value());
             }
             if (fuzz2014.has_value()) {
-                cells.emplace_back(fuzz2014.value());
+                comp_batches.emplace_back(fuzz2014.value());
             }
             if (fuzz2015.has_value()) {
-                cells.emplace_back(fuzz2015.value());
+                comp_batches.emplace_back(fuzz2015.value());
             }
             if (fuzz2016.has_value()) {
-                cells.emplace_back(fuzz2016.value());
+                comp_batches.emplace_back(fuzz2016.value());
             }
             if (fuzz2017.has_value()) {
-                cells.emplace_back(fuzz2017.value());
+                comp_batches.emplace_back(fuzz2017.value());
             }
             if (fuzz2018.has_value()) {
-                cells.emplace_back(fuzz2018.value());
+                comp_batches.emplace_back(fuzz2018.value());
             }
             if (fuzz2101.has_value()) {
-                cells.emplace_back(fuzz2101.value());
+                comp_batches.emplace_back(fuzz2101.value());
             }
             if (fuzz2102.has_value()) {
-                cells.emplace_back(fuzz2102.value());
+                comp_batches.emplace_back(fuzz2102.value());
             }
             if (fuzz2103.has_value()) {
-                cells.emplace_back(fuzz2103.value());
+                comp_batches.emplace_back(fuzz2103.value());
             }
             if (fuzz2104.has_value()) {
-                cells.emplace_back(fuzz2104.value());
+                comp_batches.emplace_back(fuzz2104.value());
             }
             if (fuzz2105.has_value()) {
-                cells.emplace_back(fuzz2105.value());
+                comp_batches.emplace_back(fuzz2105.value());
             }
             if (fuzz2106.has_value()) {
-                cells.emplace_back(fuzz2106.value());
+                comp_batches.emplace_back(fuzz2106.value());
             }
             if (fuzz2107.has_value()) {
-                cells.emplace_back(fuzz2107.value());
+                comp_batches.emplace_back(fuzz2107.value());
             }
             if (fuzz2108.has_value()) {
-                cells.emplace_back(fuzz2108.value());
+                comp_batches.emplace_back(fuzz2108.value());
             }
             if (fuzz2109.has_value()) {
-                cells.emplace_back(fuzz2109.value());
+                comp_batches.emplace_back(fuzz2109.value());
             }
             if (fuzz2110.has_value()) {
-                cells.emplace_back(fuzz2110.value());
+                comp_batches.emplace_back(fuzz2110.value());
             }
             if (fuzz2111.has_value()) {
-                cells.emplace_back(fuzz2111.value());
+                comp_batches.emplace_back(fuzz2111.value());
             }
             if (fuzz2112.has_value()) {
-                cells.emplace_back(fuzz2112.value());
+                comp_batches.emplace_back(fuzz2112.value());
             }
             if (fuzz2113.has_value()) {
-                cells.emplace_back(fuzz2113.value());
+                comp_batches.emplace_back(fuzz2113.value());
             }
             if (fuzz2114.has_value()) {
-                cells.emplace_back(fuzz2114.value());
+                comp_batches.emplace_back(fuzz2114.value());
             }
             if (fuzz2115.has_value()) {
-                cells.emplace_back(fuzz2115.value());
+                comp_batches.emplace_back(fuzz2115.value());
             }
             if (fuzz2116.has_value()) {
-                cells.emplace_back(fuzz2116.value());
+                comp_batches.emplace_back(fuzz2116.value());
             }
             if (fuzz2117.has_value()) {
-                cells.emplace_back(fuzz2117.value());
+                comp_batches.emplace_back(fuzz2117.value());
             }
             if (fuzz2118.has_value()) {
-                cells.emplace_back(fuzz2118.value());
+                comp_batches.emplace_back(fuzz2118.value());
             }
-            cells.emplace_back(
+            comp_batches.emplace_back(
                 ComponentBatch<
                     components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME>>(
                     nullptr,
@@ -168,7 +168,7 @@ namespace rerun {
                 )
             );
 
-            return cells;
+            return comp_batches;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -3,651 +3,170 @@
 
 #include "affix_fuzzer1.hpp"
 
-#include "../components/affix_fuzzer1.hpp"
-#include "../components/affix_fuzzer10.hpp"
-#include "../components/affix_fuzzer11.hpp"
-#include "../components/affix_fuzzer12.hpp"
-#include "../components/affix_fuzzer13.hpp"
-#include "../components/affix_fuzzer14.hpp"
-#include "../components/affix_fuzzer15.hpp"
-#include "../components/affix_fuzzer16.hpp"
-#include "../components/affix_fuzzer17.hpp"
-#include "../components/affix_fuzzer18.hpp"
-#include "../components/affix_fuzzer19.hpp"
-#include "../components/affix_fuzzer2.hpp"
-#include "../components/affix_fuzzer20.hpp"
-#include "../components/affix_fuzzer3.hpp"
-#include "../components/affix_fuzzer4.hpp"
-#include "../components/affix_fuzzer5.hpp"
-#include "../components/affix_fuzzer6.hpp"
-#include "../components/affix_fuzzer7.hpp"
-#include "../components/affix_fuzzer8.hpp"
-#include "../components/affix_fuzzer9.hpp"
+#include <rerun/indicator_component.hpp>
 
 namespace rerun {
     namespace archetypes {
-        Result<std::vector<rerun::DataCell>> AffixFuzzer1::to_data_cells() const {
-            std::vector<rerun::DataCell> cells;
+        const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
+            "rerun.components.AffixFuzzer1Indicator";
+
+        std::vector<AnonymousComponentList> AffixFuzzer1::as_component_lists() const {
+            std::vector<AnonymousComponentList> cells;
             cells.reserve(74);
 
-            {
-                const auto result = rerun::components::AffixFuzzer1::to_data_cell(&fuzz1001, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer2::to_data_cell(&fuzz1002, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer3::to_data_cell(&fuzz1003, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer4::to_data_cell(&fuzz1004, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer5::to_data_cell(&fuzz1005, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer6::to_data_cell(&fuzz1006, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer7::to_data_cell(&fuzz1007, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer8::to_data_cell(&fuzz1008, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer9::to_data_cell(&fuzz1009, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer10::to_data_cell(&fuzz1010, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer11::to_data_cell(&fuzz1011, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer12::to_data_cell(&fuzz1012, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer13::to_data_cell(&fuzz1013, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer14::to_data_cell(&fuzz1014, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer15::to_data_cell(&fuzz1015, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer16::to_data_cell(&fuzz1016, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer17::to_data_cell(&fuzz1017, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer18::to_data_cell(&fuzz1018, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer19::to_data_cell(&fuzz1019, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer20::to_data_cell(&fuzz1020, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer1::to_data_cell(fuzz1101.data(), fuzz1101.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer2::to_data_cell(fuzz1102.data(), fuzz1102.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer3::to_data_cell(fuzz1103.data(), fuzz1103.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer4::to_data_cell(fuzz1104.data(), fuzz1104.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer5::to_data_cell(fuzz1105.data(), fuzz1105.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer6::to_data_cell(fuzz1106.data(), fuzz1106.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer7::to_data_cell(fuzz1107.data(), fuzz1107.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer8::to_data_cell(fuzz1108.data(), fuzz1108.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result =
-                    rerun::components::AffixFuzzer9::to_data_cell(fuzz1109.data(), fuzz1109.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer10::to_data_cell(
-                    fuzz1110.data(),
-                    fuzz1110.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer11::to_data_cell(
-                    fuzz1111.data(),
-                    fuzz1111.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer12::to_data_cell(
-                    fuzz1112.data(),
-                    fuzz1112.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer13::to_data_cell(
-                    fuzz1113.data(),
-                    fuzz1113.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer14::to_data_cell(
-                    fuzz1114.data(),
-                    fuzz1114.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer15::to_data_cell(
-                    fuzz1115.data(),
-                    fuzz1115.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer16::to_data_cell(
-                    fuzz1116.data(),
-                    fuzz1116.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer17::to_data_cell(
-                    fuzz1117.data(),
-                    fuzz1117.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                const auto result = rerun::components::AffixFuzzer18::to_data_cell(
-                    fuzz1118.data(),
-                    fuzz1118.size()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+            cells.emplace_back(fuzz1001);
+            cells.emplace_back(fuzz1002);
+            cells.emplace_back(fuzz1003);
+            cells.emplace_back(fuzz1004);
+            cells.emplace_back(fuzz1005);
+            cells.emplace_back(fuzz1006);
+            cells.emplace_back(fuzz1007);
+            cells.emplace_back(fuzz1008);
+            cells.emplace_back(fuzz1009);
+            cells.emplace_back(fuzz1010);
+            cells.emplace_back(fuzz1011);
+            cells.emplace_back(fuzz1012);
+            cells.emplace_back(fuzz1013);
+            cells.emplace_back(fuzz1014);
+            cells.emplace_back(fuzz1015);
+            cells.emplace_back(fuzz1016);
+            cells.emplace_back(fuzz1017);
+            cells.emplace_back(fuzz1018);
+            cells.emplace_back(fuzz1019);
+            cells.emplace_back(fuzz1020);
+            cells.emplace_back(fuzz1101);
+            cells.emplace_back(fuzz1102);
+            cells.emplace_back(fuzz1103);
+            cells.emplace_back(fuzz1104);
+            cells.emplace_back(fuzz1105);
+            cells.emplace_back(fuzz1106);
+            cells.emplace_back(fuzz1107);
+            cells.emplace_back(fuzz1108);
+            cells.emplace_back(fuzz1109);
+            cells.emplace_back(fuzz1110);
+            cells.emplace_back(fuzz1111);
+            cells.emplace_back(fuzz1112);
+            cells.emplace_back(fuzz1113);
+            cells.emplace_back(fuzz1114);
+            cells.emplace_back(fuzz1115);
+            cells.emplace_back(fuzz1116);
+            cells.emplace_back(fuzz1117);
+            cells.emplace_back(fuzz1118);
             if (fuzz2001.has_value()) {
-                const auto& value = fuzz2001.value();
-                const auto result = rerun::components::AffixFuzzer1::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2001.value());
             }
             if (fuzz2002.has_value()) {
-                const auto& value = fuzz2002.value();
-                const auto result = rerun::components::AffixFuzzer2::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2002.value());
             }
             if (fuzz2003.has_value()) {
-                const auto& value = fuzz2003.value();
-                const auto result = rerun::components::AffixFuzzer3::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2003.value());
             }
             if (fuzz2004.has_value()) {
-                const auto& value = fuzz2004.value();
-                const auto result = rerun::components::AffixFuzzer4::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2004.value());
             }
             if (fuzz2005.has_value()) {
-                const auto& value = fuzz2005.value();
-                const auto result = rerun::components::AffixFuzzer5::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2005.value());
             }
             if (fuzz2006.has_value()) {
-                const auto& value = fuzz2006.value();
-                const auto result = rerun::components::AffixFuzzer6::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2006.value());
             }
             if (fuzz2007.has_value()) {
-                const auto& value = fuzz2007.value();
-                const auto result = rerun::components::AffixFuzzer7::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2007.value());
             }
             if (fuzz2008.has_value()) {
-                const auto& value = fuzz2008.value();
-                const auto result = rerun::components::AffixFuzzer8::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2008.value());
             }
             if (fuzz2009.has_value()) {
-                const auto& value = fuzz2009.value();
-                const auto result = rerun::components::AffixFuzzer9::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2009.value());
             }
             if (fuzz2010.has_value()) {
-                const auto& value = fuzz2010.value();
-                const auto result = rerun::components::AffixFuzzer10::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2010.value());
             }
             if (fuzz2011.has_value()) {
-                const auto& value = fuzz2011.value();
-                const auto result = rerun::components::AffixFuzzer11::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2011.value());
             }
             if (fuzz2012.has_value()) {
-                const auto& value = fuzz2012.value();
-                const auto result = rerun::components::AffixFuzzer12::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2012.value());
             }
             if (fuzz2013.has_value()) {
-                const auto& value = fuzz2013.value();
-                const auto result = rerun::components::AffixFuzzer13::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2013.value());
             }
             if (fuzz2014.has_value()) {
-                const auto& value = fuzz2014.value();
-                const auto result = rerun::components::AffixFuzzer14::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2014.value());
             }
             if (fuzz2015.has_value()) {
-                const auto& value = fuzz2015.value();
-                const auto result = rerun::components::AffixFuzzer15::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2015.value());
             }
             if (fuzz2016.has_value()) {
-                const auto& value = fuzz2016.value();
-                const auto result = rerun::components::AffixFuzzer16::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2016.value());
             }
             if (fuzz2017.has_value()) {
-                const auto& value = fuzz2017.value();
-                const auto result = rerun::components::AffixFuzzer17::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2017.value());
             }
             if (fuzz2018.has_value()) {
-                const auto& value = fuzz2018.value();
-                const auto result = rerun::components::AffixFuzzer18::to_data_cell(&value, 1);
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2018.value());
             }
             if (fuzz2101.has_value()) {
-                const auto& value = fuzz2101.value();
-                const auto result =
-                    rerun::components::AffixFuzzer1::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2101.value());
             }
             if (fuzz2102.has_value()) {
-                const auto& value = fuzz2102.value();
-                const auto result =
-                    rerun::components::AffixFuzzer2::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2102.value());
             }
             if (fuzz2103.has_value()) {
-                const auto& value = fuzz2103.value();
-                const auto result =
-                    rerun::components::AffixFuzzer3::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2103.value());
             }
             if (fuzz2104.has_value()) {
-                const auto& value = fuzz2104.value();
-                const auto result =
-                    rerun::components::AffixFuzzer4::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2104.value());
             }
             if (fuzz2105.has_value()) {
-                const auto& value = fuzz2105.value();
-                const auto result =
-                    rerun::components::AffixFuzzer5::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2105.value());
             }
             if (fuzz2106.has_value()) {
-                const auto& value = fuzz2106.value();
-                const auto result =
-                    rerun::components::AffixFuzzer6::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2106.value());
             }
             if (fuzz2107.has_value()) {
-                const auto& value = fuzz2107.value();
-                const auto result =
-                    rerun::components::AffixFuzzer7::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2107.value());
             }
             if (fuzz2108.has_value()) {
-                const auto& value = fuzz2108.value();
-                const auto result =
-                    rerun::components::AffixFuzzer8::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2108.value());
             }
             if (fuzz2109.has_value()) {
-                const auto& value = fuzz2109.value();
-                const auto result =
-                    rerun::components::AffixFuzzer9::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2109.value());
             }
             if (fuzz2110.has_value()) {
-                const auto& value = fuzz2110.value();
-                const auto result =
-                    rerun::components::AffixFuzzer10::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2110.value());
             }
             if (fuzz2111.has_value()) {
-                const auto& value = fuzz2111.value();
-                const auto result =
-                    rerun::components::AffixFuzzer11::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2111.value());
             }
             if (fuzz2112.has_value()) {
-                const auto& value = fuzz2112.value();
-                const auto result =
-                    rerun::components::AffixFuzzer12::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2112.value());
             }
             if (fuzz2113.has_value()) {
-                const auto& value = fuzz2113.value();
-                const auto result =
-                    rerun::components::AffixFuzzer13::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2113.value());
             }
             if (fuzz2114.has_value()) {
-                const auto& value = fuzz2114.value();
-                const auto result =
-                    rerun::components::AffixFuzzer14::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2114.value());
             }
             if (fuzz2115.has_value()) {
-                const auto& value = fuzz2115.value();
-                const auto result =
-                    rerun::components::AffixFuzzer15::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2115.value());
             }
             if (fuzz2116.has_value()) {
-                const auto& value = fuzz2116.value();
-                const auto result =
-                    rerun::components::AffixFuzzer16::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2116.value());
             }
             if (fuzz2117.has_value()) {
-                const auto& value = fuzz2117.value();
-                const auto result =
-                    rerun::components::AffixFuzzer17::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2117.value());
             }
             if (fuzz2118.has_value()) {
-                const auto& value = fuzz2118.value();
-                const auto result =
-                    rerun::components::AffixFuzzer18::to_data_cell(value.data(), value.size());
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
+                cells.emplace_back(fuzz2118.value());
             }
-            {
-                const auto result = create_indicator_component(
-                    "rerun.components.AffixFuzzer1Indicator",
+            cells.emplace_back(
+                ComponentList<
+                    components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME>>(
+                    nullptr,
                     num_instances()
-                );
-                if (result.is_err()) {
-                    return result.error;
-                }
-                cells.emplace_back(std::move(result.value));
-            }
+                )
+            );
 
             return cells;
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -8,7 +8,7 @@
 namespace rerun {
     namespace archetypes {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
-            "rerun.components.AffixFuzzer1Indicator";
+            "rerun.testing.components.AffixFuzzer1Indicator";
 
         std::vector<AnonymousComponentBatch> AffixFuzzer1::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -628,7 +628,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_batches() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <optional>
 #include <rerun/arrow.hpp>
+#include <rerun/component_list.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
@@ -182,6 +183,10 @@ namespace rerun {
             std::optional<std::vector<rerun::components::AffixFuzzer17>> fuzz2117;
 
             std::optional<std::vector<rerun::components::AffixFuzzer18>> fuzz2118;
+
+            /// Name of the indicator component, used to identify the archetype when converting to a
+            /// list of components.
+            static const char INDICATOR_COMPONENT_NAME[];
 
           public:
             AffixFuzzer1() = default;
@@ -619,8 +624,11 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates a list of Rerun DataCell from this archetype.
-            Result<std::vector<rerun::DataCell>> to_data_cells() const;
+            /// Collections all component lists into a list of component collections. *Attention:*
+            /// The returned vector references this instance and does not take ownership of any
+            /// data. Adding any new components to this archetype will invalidate the returned
+            /// component lists!
+            std::vector<AnonymousComponentList> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -27,7 +27,7 @@
 #include <cstdint>
 #include <optional>
 #include <rerun/arrow.hpp>
-#include <rerun/component_list.hpp>
+#include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
@@ -628,7 +628,7 @@ namespace rerun {
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned
             /// component lists!
-            std::vector<AnonymousComponentList> as_component_lists() const;
+            std::vector<AnonymousComponentBatch> as_component_lists() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer1::NAME = "rerun.testing.components.AffixFuzzer1";
+        const char AffixFuzzer1::NAME[] = "rerun.testing.components.AffixFuzzer1";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer1::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             rerun::datatypes::AffixFuzzer1 single_required;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer1() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
@@ -10,7 +10,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer10::NAME = "rerun.testing.components.AffixFuzzer10";
+        const char AffixFuzzer10::NAME[] = "rerun.testing.components.AffixFuzzer10";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer10::arrow_datatype() {
             static const auto datatype = arrow::utf8();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             std::optional<std::string> single_string_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer10() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
@@ -10,7 +10,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer11::NAME = "rerun.testing.components.AffixFuzzer11";
+        const char AffixFuzzer11::NAME[] = "rerun.testing.components.AffixFuzzer11";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer11::arrow_datatype() {
             static const auto datatype = arrow::list(arrow::field("item", arrow::float32(), false));

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             std::optional<std::vector<float>> many_floats_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer11() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
@@ -10,7 +10,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer12::NAME = "rerun.testing.components.AffixFuzzer12";
+        const char AffixFuzzer12::NAME[] = "rerun.testing.components.AffixFuzzer12";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer12::arrow_datatype() {
             static const auto datatype = arrow::list(arrow::field("item", arrow::utf8(), false));

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             std::vector<std::string> many_strings_required;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer12() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
@@ -10,7 +10,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer13::NAME = "rerun.testing.components.AffixFuzzer13";
+        const char AffixFuzzer13::NAME[] = "rerun.testing.components.AffixFuzzer13";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer13::arrow_datatype() {
             static const auto datatype = arrow::list(arrow::field("item", arrow::utf8(), false));

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             std::optional<std::vector<std::string>> many_strings_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer13() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer14::NAME = "rerun.testing.components.AffixFuzzer14";
+        const char AffixFuzzer14::NAME[] = "rerun.testing.components.AffixFuzzer14";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer14::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer3::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             rerun::datatypes::AffixFuzzer3 single_required_union;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer14() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer15::NAME = "rerun.testing.components.AffixFuzzer15";
+        const char AffixFuzzer15::NAME[] = "rerun.testing.components.AffixFuzzer15";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer15::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer3::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             std::optional<rerun::datatypes::AffixFuzzer3> single_optional_union;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer15() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer16::NAME = "rerun.testing.components.AffixFuzzer16";
+        const char AffixFuzzer16::NAME[] = "rerun.testing.components.AffixFuzzer16";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer16::arrow_datatype() {
             static const auto datatype = arrow::list(

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             std::vector<rerun::datatypes::AffixFuzzer3> many_required_unions;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer16() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer17::NAME = "rerun.testing.components.AffixFuzzer17";
+        const char AffixFuzzer17::NAME[] = "rerun.testing.components.AffixFuzzer17";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer17::arrow_datatype() {
             static const auto datatype = arrow::list(

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
@@ -25,7 +25,7 @@ namespace rerun {
             std::optional<std::vector<rerun::datatypes::AffixFuzzer3>> many_optional_unions;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer17() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer18::NAME = "rerun.testing.components.AffixFuzzer18";
+        const char AffixFuzzer18::NAME[] = "rerun.testing.components.AffixFuzzer18";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer18::arrow_datatype() {
             static const auto datatype = arrow::list(

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
@@ -25,7 +25,7 @@ namespace rerun {
             std::optional<std::vector<rerun::datatypes::AffixFuzzer4>> many_optional_unions;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer18() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer19::NAME = "rerun.testing.components.AffixFuzzer19";
+        const char AffixFuzzer19::NAME[] = "rerun.testing.components.AffixFuzzer19";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer19::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer5::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -25,7 +25,7 @@ namespace rerun {
             rerun::datatypes::AffixFuzzer5 just_a_table_nothing_shady;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer19() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer2::NAME = "rerun.testing.components.AffixFuzzer2";
+        const char AffixFuzzer2::NAME[] = "rerun.testing.components.AffixFuzzer2";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer2::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             rerun::datatypes::AffixFuzzer1 single_required;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer2() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer20::NAME = "rerun.testing.components.AffixFuzzer20";
+        const char AffixFuzzer20::NAME[] = "rerun.testing.components.AffixFuzzer20";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer20::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer20::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             rerun::datatypes::AffixFuzzer20 nested_transparent;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer20() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer3::NAME = "rerun.testing.components.AffixFuzzer3";
+        const char AffixFuzzer3::NAME[] = "rerun.testing.components.AffixFuzzer3";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer3::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -23,7 +23,7 @@ namespace rerun {
             rerun::datatypes::AffixFuzzer1 single_required;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer3() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer4::NAME = "rerun.testing.components.AffixFuzzer4";
+        const char AffixFuzzer4::NAME[] = "rerun.testing.components.AffixFuzzer4";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer4::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             std::optional<rerun::datatypes::AffixFuzzer1> single_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer4() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer5::NAME = "rerun.testing.components.AffixFuzzer5";
+        const char AffixFuzzer5::NAME[] = "rerun.testing.components.AffixFuzzer5";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer5::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             std::optional<rerun::datatypes::AffixFuzzer1> single_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer5() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer6::NAME = "rerun.testing.components.AffixFuzzer6";
+        const char AffixFuzzer6::NAME[] = "rerun.testing.components.AffixFuzzer6";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer6::arrow_datatype() {
             static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
@@ -24,7 +24,7 @@ namespace rerun {
             std::optional<rerun::datatypes::AffixFuzzer1> single_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer6() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
@@ -12,7 +12,7 @@
 
 namespace rerun {
     namespace components {
-        const char *AffixFuzzer7::NAME = "rerun.testing.components.AffixFuzzer7";
+        const char AffixFuzzer7::NAME[] = "rerun.testing.components.AffixFuzzer7";
 
         const std::shared_ptr<arrow::DataType> &AffixFuzzer7::arrow_datatype() {
             static const auto datatype = arrow::list(

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
@@ -25,7 +25,7 @@ namespace rerun {
             std::optional<std::vector<rerun::datatypes::AffixFuzzer1>> many_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer7() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
@@ -10,7 +10,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer8::NAME = "rerun.testing.components.AffixFuzzer8";
+        const char AffixFuzzer8::NAME[] = "rerun.testing.components.AffixFuzzer8";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer8::arrow_datatype() {
             static const auto datatype = arrow::float32();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
@@ -26,7 +26,7 @@ namespace rerun {
             std::optional<float> single_float_optional;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer8() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
@@ -10,7 +10,7 @@
 
 namespace rerun {
     namespace components {
-        const char* AffixFuzzer9::NAME = "rerun.testing.components.AffixFuzzer9";
+        const char AffixFuzzer9::NAME[] = "rerun.testing.components.AffixFuzzer9";
 
         const std::shared_ptr<arrow::DataType>& AffixFuzzer9::arrow_datatype() {
             static const auto datatype = arrow::utf8();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
@@ -22,7 +22,7 @@ namespace rerun {
             std::string single_string_required;
 
             /// Name of the component, used for serialization.
-            static const char* NAME;
+            static const char NAME[];
 
           public:
             AffixFuzzer9() = default;

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -40,7 +40,7 @@ struct BadArchetype {
         return 1;
     }
 
-    std::vector<rerun::AnonymousComponentList> as_component_lists() const {
+    std::vector<rerun::AnonymousComponentBatch> as_component_lists() const {
         return {BadComponent()};
     }
 };

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -137,7 +137,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 rr::RecordingStream stream("test", kind);
 
                 THEN("single components can be logged") {
-                    stream.log_components(
+                    stream.log_component_batches(
                         "single-components",
                         rrc::Point2D{1.0, 2.0},
                         rrc::Color(0x00FF00FF)
@@ -150,10 +150,10 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                         rr::datatypes::Vec2D{4.0, 5.0},
                     };
 
-                    stream.log_components("as-carray", c_style_array);
+                    stream.log_component_batches("as-carray", c_style_array);
                 }
                 THEN("components as std::array can be logged") {
-                    stream.log_components(
+                    stream.log_component_batches(
                         "as-array",
                         std::array<rrc::Point2D, 2>{
                             rr::datatypes::Vec2D{1.0, 2.0},
@@ -162,7 +162,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     );
                 }
                 THEN("components as std::vector can be logged") {
-                    stream.log_components(
+                    stream.log_component_batches(
                         "as-vector",
                         std::vector<rrc::Point2D>{
                             rr::datatypes::Vec2D{1.0, 2.0},
@@ -176,7 +176,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                         rrc::Text("friend"),
                         rrc::Text("yo"),
                     };
-                    stream.log_components(
+                    stream.log_component_batches(
                         "as-mix",
                         std::vector{
                             rrc::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
@@ -193,8 +193,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 }
 
                 THEN("components with splatting some of them can be logged") {
-                    stream.log_components(
-                        "log_components-splat",
+                    stream.log_component_batches(
+                        "log_component_batches-splat",
                         std::vector{
                             rrc::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
                             rrc::Point2D(rr::datatypes::Vec2D{1.0, 3.0}),
@@ -262,7 +262,7 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
 
                         WHEN("logging a component to the second stream") {
                             check_logged_error([&] {
-                                stream1->log_components(
+                                stream1->log_component_batches(
                                     "as-array",
                                     std::array<rrc::Point2D, 2>{
                                         rr::datatypes::Vec2D{1.0, 2.0},
@@ -321,7 +321,7 @@ void test_logging_to_connection(const char* address, rr::RecordingStream& stream
 
             WHEN("logging a component and then flushing") {
                 check_logged_error([&] {
-                    stream.log_components(
+                    stream.log_component_batches(
                         "as-array",
                         std::array<rrc::Point2D, 2>{
                             rr::datatypes::Vec2D{1.0, 2.0},
@@ -391,18 +391,22 @@ SCENARIO("Recording stream handles invalid logging gracefully", TEST_TAG) {
             THEN("try_log_data_row returns the correct error") {
                 CHECK(stream.try_log_data_row(path, 0, 0, nullptr).code == error);
             }
-            THEN("try_log_components returns the correct error") {
+            THEN("try_log_component_batches returns the correct error") {
                 CHECK(
-                    stream.try_log_components(path, std::array<rrc::Point2D, 1>{v}).code == error
+                    stream.try_log_component_batches(path, std::array<rrc::Point2D, 1>{v}).code ==
+                    error
                 );
             }
             THEN("try_log_archetypes returns the correct error") {
                 CHECK(stream.try_log_archetype(path, rr::archetypes::Points2D(v)).code == error);
             }
-            THEN("log_components logs the correct error") {
+            THEN("log_component_batches logs the correct error") {
                 check_logged_error(
                     [&] {
-                        stream.log_components(std::get<0>(variant), std::array<rrc::Point2D, 1>{v});
+                        stream.log_component_batches(
+                            std::get<0>(variant),
+                            std::array<rrc::Point2D, 1>{v}
+                        );
                     },
                     error
                 );
@@ -475,44 +479,47 @@ SCENARIO("Recording stream handles serialization failure during logging graceful
             BadComponent::error.code =
                 GENERATE(rr::ErrorCode::Unknown, rr::ErrorCode::ArrowStatusCode_TypeError);
 
-            THEN("calling log_components with an array logs the serialization error") {
+            THEN("calling log_component_batches with an array logs the serialization error") {
                 check_logged_error(
                     [&] {
-                        stream.log_components(path, std::array{component, component});
+                        stream.log_component_batches(path, std::array{component, component});
                     },
                     component.error.code
                 );
             }
-            THEN("calling log_components with a vector logs the serialization error") {
+            THEN("calling log_component_batches with a vector logs the serialization error") {
                 check_logged_error(
                     [&] {
-                        stream.log_components(path, std::vector{component, component});
+                        stream.log_component_batches(path, std::vector{component, component});
                     },
                     component.error.code
                 );
             }
-            THEN("calling log_components with a c array logs the serialization error") {
+            THEN("calling log_component_batches with a c array logs the serialization error") {
                 const BadComponent components[] = {component, component};
                 check_logged_error(
-                    [&] { stream.log_components(path, components); },
+                    [&] { stream.log_component_batches(path, components); },
                     component.error.code
                 );
             }
-            THEN("calling try_log_components with an array forwards the serialization error") {
+            THEN("calling try_log_component_batches with an array forwards the serialization error"
+            ) {
                 CHECK(
-                    stream.try_log_components(path, std::array{component, component}) ==
+                    stream.try_log_component_batches(path, std::array{component, component}) ==
                     component.error
                 );
             }
-            THEN("calling try_log_components with a vector forwards the serialization error") {
+            THEN("calling try_log_component_batches with a vector forwards the serialization error"
+            ) {
                 CHECK(
-                    stream.try_log_components(path, std::vector{component, component}) ==
+                    stream.try_log_component_batches(path, std::vector{component, component}) ==
                     component.error
                 );
             }
-            THEN("calling try_log_components with a c array forwards the serialization error") {
+            THEN("calling try_log_component_batches with a c array forwards the serialization error"
+            ) {
                 const BadComponent components[] = {component, component};
-                CHECK(stream.try_log_components(path, components) == component.error);
+                CHECK(stream.try_log_component_batches(path, components) == component.error);
             }
         }
         AND_GIVEN("an archetype that fails serialization") {

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -36,14 +36,12 @@ const char* BadComponent::NAME = "bad!";
 rr::Error BadComponent::error = rr::Error(rr::ErrorCode::Unknown, "BadComponent");
 
 struct BadArchetype {
-    rr::Error error = rr::Error(rr::ErrorCode::Unknown, "BadArchetype");
-
     size_t num_instances() const {
         return 1;
     }
 
-    rr::Result<std::vector<rerun::DataCell>> to_data_cells() const {
-        return error;
+    std::vector<rerun::AnonymousComponentList> as_component_lists() const {
+        return {BadComponent()};
     }
 };
 
@@ -501,17 +499,17 @@ SCENARIO("Recording stream handles serialization failure during logging graceful
         }
         AND_GIVEN("an archetype that fails serialization") {
             auto archetype = BadArchetype();
-            archetype.error.code =
+            BadComponent::error.code =
                 GENERATE(rr::ErrorCode::Unknown, rr::ErrorCode::ArrowStatusCode_TypeError);
 
             THEN("calling log_archetype logs the serialization error") {
                 check_logged_error(
                     [&] { stream.log_archetype(path, archetype); },
-                    archetype.error.code
+                    BadComponent::error.code
                 );
             }
             THEN("calling log_archetype forwards the serialization error") {
-                CHECK(stream.try_log_archetype(path, archetype) == archetype.error);
+                CHECK(stream.try_log_archetype(path, archetype) == BadComponent::error);
             }
         }
     }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -40,7 +40,7 @@ struct BadArchetype {
         return 1;
     }
 
-    std::vector<rerun::AnonymousComponentBatch> as_component_lists() const {
+    std::vector<rerun::AnonymousComponentBatch> as_component_batches() const {
         return {BadComponent()};
     }
 };

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -136,6 +136,14 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
             WHEN("creating a new stream") {
                 rr::RecordingStream stream("test", kind);
 
+                THEN("single components can be logged") {
+                    stream.log_components(
+                        "single-components",
+                        rrc::Point2D{1.0, 2.0},
+                        rrc::Color(0x00FF00FF)
+                    );
+                }
+
                 THEN("components as c-array can be logged") {
                     rrc::Point2D c_style_array[2] = {
                         rr::datatypes::Vec2D{1.0, 2.0},
@@ -184,13 +192,23 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     );
                 }
 
+                THEN("components with splatting some of them can be logged") {
+                    stream.log_components(
+                        "log_components-splat",
+                        std::vector{
+                            rrc::Point2D(rr::datatypes::Vec2D{0.0, 0.0}),
+                            rrc::Point2D(rr::datatypes::Vec2D{1.0, 3.0}),
+                        },
+                        rrc::Color(0xFF0000FF)
+                    );
+                }
+
                 THEN("an archetype can be logged") {
                     stream.log_archetype(
-                        "archetype",
-                        rr::archetypes::Points2D({
-                            rr::datatypes::Vec2D{1.0, 2.0},
-                            rr::datatypes::Vec2D{4.0, 5.0},
-                        })
+                        "log_archetype-splat",
+                        rr::archetypes::Points2D(
+                            {rr::datatypes::Vec2D{1.0, 2.0}, rr::datatypes::Vec2D{4.0, 5.0}}
+                        ).with_colors(rrc::Color(0xFF0000FF))
                     );
                 }
 


### PR DESCRIPTION
### What

* Part of: #2919 
* Fixes #3256
   * just like in Rust it's actually `as_component_lists`, we return a vector of type erased component arrays that know how to serialize themselves, dubbed `AnonymousComponentList` for now.
   * I'm not happy with naming and internals of `AnonymousComponentList`. This smells very much like we should have actual inheritance somewhere, but it's a bit tricky since we want to extract pointer out of arbitrary list types, giving rise to the type aware `ComponentList`. Overall the approach here tries to mimic Rust but ultimately misses the target, since, well this is not Rust.  To be revisited, maybe it is just a naming issue!
* Fixes #3255
    * indicators are regular components now, their handling in `as_component_lists` is very slightly dubious since they're not backed by data but ofc indicator components don't have any data to begin with 🤷 
* Fixes #3040
* First step towards #3050


Trigger of this PR was the inability to deal with mono components like `DrawOrder` -> need splatting -> don't want to implement splatting separately for components & archetype -> implement as_components-style

Quick throw-away test for splatting radius on the random point demo:
<img width="943" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/d256b281-34c7-4d6c-a143-b4d604a13b75">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3258) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3258)
- [Docs preview](https://rerun.io/preview/f732aad18515476d81d57b89108e08f787729ae6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f732aad18515476d81d57b89108e08f787729ae6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)