### PR TITLE
Fix typo: recoding -> recording in how-to guide

### DIFF
--- a/docs/content/howto/short-lived-entities.md
+++ b/docs/content/howto/short-lived-entities.md
@@ -3,7 +3,7 @@ title: Log short lived data
 order: 5
 description: How to log data that isn't valid for the whole recording
 ---
-In order to create coherent views of streaming data, the Rerun Viewer shows the latest values for each visible entity at the current timepoint. But some data may not be valid for the entire recoding even if there are no updated values. How do you tell Rerun that something you've logged should no longer be shown?
+In order to create coherent views of streaming data, the Rerun Viewer shows the latest values for each visible entity at the current timepoint. But some data may not be valid for the entire recording even if there are no updated values. How do you tell Rerun that something you've logged should no longer be shown?
 
 ## Log entities as cleared
 The most straight forward option is to explicitly log that an entity has been cleared. Rerun allows you to do this by logging a special `ClearEntity` to any path. The timepoint at which the `ClearEntity` is logged is the time point after which that entity will no longer be visible in your views.


### PR DESCRIPTION
Fix a typo in the "Log short lived data" how-to guide.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3259) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3259)
- [Docs preview](https://rerun.io/preview/7415b458d0cac5e016cadd15a20b7cd29de2487f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7415b458d0cac5e016cadd15a20b7cd29de2487f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)