### PR TITLE
Rebrand all lists as batches instead

### DIFF
--- a/crates/re_components/src/load_file.rs
+++ b/crates/re_components/src/load_file.rs
@@ -48,7 +48,7 @@ pub fn data_cells_from_file_path(
         #[cfg(feature = "image")]
         _ => {
             use re_types::Archetype;
-            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::new_list(1);
+            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
                 re_types::archetypes::Image::indicator_component(),
                 indicator.to_arrow(),
@@ -100,7 +100,7 @@ pub fn data_cells_from_file_contents(
             };
 
             use re_types::Archetype;
-            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::new_list(1);
+            let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
                 re_types::archetypes::Image::indicator_component(),
                 indicator.to_arrow(),

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -67,7 +67,7 @@ pub mod time {
 /// These are the different _components_ you can log.
 ///
 /// They all implement the [`Component`][`re_types::Component`] trait,
-/// and can be used in [`RecordingStream::log_component_lists`].
+/// and can be used in [`RecordingStream::log_component_batches`].
 pub mod components {
     pub use re_components::{
         Box3D, EncodedMesh3D, Mesh3D, MeshFormat, Pinhole, Quaternion, RawMesh3D, Rect2D, Scalar,
@@ -94,8 +94,8 @@ pub mod coordinates {
 }
 
 pub use re_types::{
-    archetypes, datatypes, AnyComponentList, Archetype, ArchetypeName, Component, ComponentList,
-    ComponentName, Datatype, DatatypeList, DatatypeName, GenericIndicatorComponent, Loggable,
+    archetypes, datatypes, AnyComponentBatch, Archetype, ArchetypeName, Component, ComponentBatch,
+    ComponentName, Datatype, DatatypeBatch, DatatypeName, GenericIndicatorComponent, Loggable,
 };
 
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -652,7 +652,7 @@ impl RecordingStream {
         )
     }
 
-    /// Logs a set of [`ComponentBatch`]s into Rerun.
+    /// Logs a set of [`ComponentBatch`]es into Rerun.
     ///
     /// If `timeless` is set to `false`, all timestamp data associated with this message will be
     /// dropped right before sending it to Rerun.

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-d1b9d947576b9f2fe0026be84d78772b4b77f0f94c642b9c03c78b66178370ba
+997cd365fa8f7c5f16578b372cf633316af540f53e07e5924fc26db05229349b

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -47,7 +47,7 @@
 ///
 ///    // Log a batch of 2 rectangles with different class IDs
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "detections",
 ///        false,
 ///        2,
@@ -62,7 +62,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -135,10 +135,10 @@ impl crate::Archetype for AnnotationContext {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.context as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.context as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -153,28 +153,28 @@ impl crate::Archetype for Arrows3D {
         self.vectors.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.vectors as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.vectors as &dyn crate::ComponentBatch).into()),
             self.origins
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -120,16 +120,16 @@ impl crate::Archetype for DepthImage {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.meter
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -107,10 +107,10 @@ impl crate::Archetype for DisconnectedSpace {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.disconnected_space as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.disconnected_space as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -112,13 +112,13 @@ impl crate::Archetype for Image {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -40,7 +40,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -68,7 +68,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -182,28 +182,28 @@ impl crate::Archetype for LineStrips2D {
         self.strips.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.strips as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -171,25 +171,25 @@ impl crate::Archetype for LineStrips3D {
         self.strips.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.strips as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -28,7 +28,7 @@
 ///
 ///    // Log an extra rect to set the view bounds
 ///    // TODO(#2786): Rect2D archetype
-///    rec.log_component_lists(
+///    rec.log_component_batches(
 ///        "bounds",
 ///        false,
 ///        1,
@@ -154,31 +154,31 @@ impl crate::Archetype for Points2D {
         self.points.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.points as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.points as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.keypoint_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -139,28 +139,28 @@ impl crate::Archetype for Points3D {
         self.points.len()
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.points as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.points as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.colors
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.class_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.keypoint_ids
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.instance_keys
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -124,13 +124,13 @@ impl crate::Archetype for SegmentationImage {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -98,10 +98,10 @@ impl crate::Archetype for Tensor {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.data as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.data as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -75,10 +75,10 @@ impl crate::Archetype for TextDocument {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.body as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.body as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -118,10 +118,10 @@ impl crate::Archetype for Transform3D {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.transform as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.transform as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -10,7 +10,7 @@
 //! Rerun (and the underlying Arrow data framework) is designed to work with large arrays of
 //! [`Component`]s, as opposed to single instances.
 //! When multiple instances of a [`Component`] are put together in an array, they yield a
-//! [`ComponentList`]: the atomic unit of (de)serialization.
+//! [`ComponentBatch`]: the atomic unit of (de)serialization.
 //!
 //! Internally, [`Component`]s are implemented using many different [`Datatype`]s.
 //!
@@ -118,13 +118,13 @@ pub mod datatypes;
 
 mod archetype;
 mod loggable;
-mod loggable_list;
+mod loggable_batch;
 mod result;
 mod size_bytes;
 
 pub use self::archetype::{Archetype, ArchetypeName, GenericIndicatorComponent};
 pub use self::loggable::{Component, ComponentName, Datatype, DatatypeName, Loggable};
-pub use self::loggable_list::{AnyComponentList, ComponentList, DatatypeList, LoggableList};
+pub use self::loggable_batch::{AnyComponentBatch, ComponentBatch, DatatypeBatch, LoggableBatch};
 pub use self::result::{
     DeserializationError, DeserializationResult, ResultExt, SerializationError,
     SerializationResult, _Backtrace,

--- a/crates/re_types/src/loggable.rs
+++ b/crates/re_types/src/loggable.rs
@@ -1,7 +1,7 @@
 use crate::{result::_Backtrace, DeserializationResult, ResultExt as _, SerializationResult};
 
 #[allow(unused_imports)] // used in docstrings
-use crate::{Archetype, ComponentList, DatatypeList, LoggableList};
+use crate::{Archetype, ComponentBatch, DatatypeBatch, LoggableBatch};
 
 // ---
 
@@ -14,8 +14,8 @@ use crate::{Archetype, ComponentList, DatatypeList, LoggableList};
 /// automatically implemented based on the type used for [`Loggable::Name`].
 ///
 /// Implementing the [`Loggable`] trait (and by extension [`Datatype`]/[`Component`])
-/// automatically derives the [`LoggableList`] implementation (and by extension
-/// [`DatatypeList`]/[`ComponentList`]), which makes it possible to work with lists' worth of data
+/// automatically derives the [`LoggableBatch`] implementation (and by extension
+/// [`DatatypeBatch`]/[`ComponentBatch`]), which makes it possible to work with lists' worth of data
 /// in a generic fashion.
 pub trait Loggable: Clone + Sized {
     type Name: std::fmt::Display;

--- a/crates/re_types/src/loggable_batch.rs
+++ b/crates/re_types/src/loggable_batch.rs
@@ -7,112 +7,112 @@ use crate::Archetype;
 
 // ---
 
-/// A [`LoggableList`] represents an array's worth of [`Loggable`] instances, ready to be
+/// A [`LoggableBatch`] represents an array's worth of [`Loggable`] instances, ready to be
 /// serialized.
 ///
-/// [`LoggableList`] is carefully designed to be erasable ("object-safe"), so that it is possible
-/// to build heterogeneous collections of [`LoggableList`]s (e.g. `Vec<dyn LoggableList>`).
+/// [`LoggableBatch`] is carefully designed to be erasable ("object-safe"), so that it is possible
+/// to build heterogeneous collections of [`LoggableBatch`]s (e.g. `Vec<dyn LoggableBatch>`).
 /// This erasability is what makes extending [`Archetype`]s possible with little effort.
 ///
-/// You should almost never need to implement [`LoggableList`] manually, as it is already
+/// You should almost never need to implement [`LoggableBatch`] manually, as it is already
 /// blanket implemented for most common use cases (arrays/vectors/slices of loggables, etc).
-pub trait LoggableList {
+pub trait LoggableBatch {
     type Name;
 
     // NOTE: It'd be tempting to have the following associated type, but that'd be
     // counterproductive, the whole point of this is to allow for heterogeneous collections!
     // type Loggable: Loggable;
 
-    /// The fully-qualified name of this list, e.g. `rerun.datatypes.Vec2D`.
+    /// The fully-qualified name of this batch, e.g. `rerun.datatypes.Vec2D`.
     fn name(&self) -> Self::Name;
 
-    /// The number of component instances stored into this list.
+    /// The number of component instances stored into this batch.
     fn num_instances(&self) -> usize;
 
     /// The underlying [`arrow2::datatypes::Field`], including datatype extensions.
     fn arrow_field(&self) -> arrow2::datatypes::Field;
 
-    /// Serializes the list into an Arrow array.
+    /// Serializes the batch into an Arrow array.
     ///
-    /// This will _never_ fail for Rerun's built-in [`LoggableList`].
-    /// For the non-fallible version, see [`LoggableList::to_arrow`].
+    /// This will _never_ fail for Rerun's built-in [`LoggableBatch`].
+    /// For the non-fallible version, see [`LoggableBatch::to_arrow`].
     fn try_to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>>;
 
-    /// Serializes the list into an Arrow array.
+    /// Serializes the batch into an Arrow array.
     ///
     /// Panics on failure.
-    /// This will _never_ fail for Rerun's built-in [`LoggableList`]s.
+    /// This will _never_ fail for Rerun's built-in [`LoggableBatch`]s.
     ///
-    /// For the fallible version, see [`LoggableList::try_to_arrow`].
+    /// For the fallible version, see [`LoggableBatch::try_to_arrow`].
     fn to_arrow(&self) -> Box<dyn ::arrow2::array::Array> {
         self.try_to_arrow().detailed_unwrap()
     }
 }
 
-/// A [`DatatypeList`] represents an array's worth of [`Datatype`] instances.
+/// A [`DatatypeBatch`] represents an array's worth of [`Datatype`] instances.
 ///
-/// Any [`LoggableList`] with a [`Loggable::Name`] set to [`DatatypeName`] automatically
-/// implements [`DatatypeList`].
-pub trait DatatypeList: LoggableList<Name = DatatypeName> {}
+/// Any [`LoggableBatch`] with a [`Loggable::Name`] set to [`DatatypeName`] automatically
+/// implements [`DatatypeBatch`].
+pub trait DatatypeBatch: LoggableBatch<Name = DatatypeName> {}
 
-/// A [`ComponentList`] represents an array's worth of [`Component`] instances.
+/// A [`ComponentBatch`] represents an array's worth of [`Component`] instances.
 ///
-/// Any [`LoggableList`] with a [`Loggable::Name`] set to [`ComponentName`] automatically
-/// implements [`ComponentList`].
-pub trait ComponentList: LoggableList<Name = ComponentName> {}
+/// Any [`LoggableBatch`] with a [`Loggable::Name`] set to [`ComponentName`] automatically
+/// implements [`ComponentBatch`].
+pub trait ComponentBatch: LoggableBatch<Name = ComponentName> {}
 
-/// Holds either an owned [`ComponentList`] that lives on heap, or a reference to one.
+/// Holds either an owned [`ComponentBatch`] that lives on heap, or a reference to one.
 ///
 /// This doesn't use [`std::borrow::Cow`] on purpose: `Cow` requires `Clone`, which would break
-/// object-safety, which would prevent us from erasing [`ComponentList`]s in the first place.
-pub enum AnyComponentList<'a> {
-    Owned(Box<dyn ComponentList>),
-    Ref(&'a dyn ComponentList),
+/// object-safety, which would prevent us from erasing [`ComponentBatch`]s in the first place.
+pub enum AnyComponentBatch<'a> {
+    Owned(Box<dyn ComponentBatch>),
+    Ref(&'a dyn ComponentBatch),
 }
 
-impl<'a> From<&'a dyn ComponentList> for AnyComponentList<'a> {
+impl<'a> From<&'a dyn ComponentBatch> for AnyComponentBatch<'a> {
     #[inline]
-    fn from(comp_list: &'a dyn ComponentList) -> Self {
-        Self::Ref(comp_list)
+    fn from(comp_batch: &'a dyn ComponentBatch) -> Self {
+        Self::Ref(comp_batch)
     }
 }
 
-impl From<Box<dyn ComponentList>> for AnyComponentList<'_> {
+impl From<Box<dyn ComponentBatch>> for AnyComponentBatch<'_> {
     #[inline]
-    fn from(comp_list: Box<dyn ComponentList>) -> Self {
-        Self::Owned(comp_list)
+    fn from(comp_batch: Box<dyn ComponentBatch>) -> Self {
+        Self::Owned(comp_batch)
     }
 }
 
-impl<'a> AnyComponentList<'a> {
-    /// Returns a reference to the inner [`ComponentList`], no matter where it lives.
+impl<'a> AnyComponentBatch<'a> {
+    /// Returns a reference to the inner [`ComponentBatch`], no matter where it lives.
     ///
     /// This doesn't use [`std::ops::Deref`] on purpose: it's associated `Target` type is not
     /// generic over lifetimes, which we need in this case.
     #[inline]
-    pub fn as_list(&'a self) -> &dyn ComponentList {
+    pub fn as_batch(&'a self) -> &dyn ComponentBatch {
         match self {
-            AnyComponentList::Owned(this) => &**this,
-            AnyComponentList::Ref(this) => *this,
+            AnyComponentBatch::Owned(this) => &**this,
+            AnyComponentBatch::Ref(this) => *this,
         }
     }
 }
 
 // NOTE: Cannot do this since `Deref::Target` is not generic over lifetimes.
-// impl<'a> std::ops::Deref for AnyComponentList<'a> {
-//     type Target = dyn ComponentList;
+// impl<'a> std::ops::Deref for AnyComponentBatch<'a> {
+//     type Target = dyn ComponentBatch;
 //
 //     fn deref(&self) -> &Self::Target {
 //         match self {
-//             AnyComponentList::Owned(this) => &**this,
-//             AnyComponentList::Ref(this) => *this,
+//             AnyComponentBatch::Owned(this) => &**this,
+//             AnyComponentBatch::Ref(this) => *this,
 //         }
 //     }
 // }
 
 // --- Unary ---
 
-impl<L: Clone + Loggable> LoggableList for L {
+impl<L: Clone + Loggable> LoggableBatch for L {
     type Name = L::Name;
 
     #[inline]
@@ -136,13 +136,13 @@ impl<L: Clone + Loggable> LoggableList for L {
     }
 }
 
-impl<D: Datatype> DatatypeList for D {}
+impl<D: Datatype> DatatypeBatch for D {}
 
-impl<C: Component> ComponentList for C {}
+impl<C: Component> ComponentBatch for C {}
 
 // --- Vec ---
 
-impl<L: Clone + Loggable> LoggableList for Vec<L> {
+impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
     type Name = L::Name;
 
     #[inline]
@@ -166,13 +166,13 @@ impl<L: Clone + Loggable> LoggableList for Vec<L> {
     }
 }
 
-impl<D: Datatype> DatatypeList for Vec<D> {}
+impl<D: Datatype> DatatypeBatch for Vec<D> {}
 
-impl<C: Component> ComponentList for Vec<C> {}
+impl<C: Component> ComponentBatch for Vec<C> {}
 
 // --- Vec<Option> ---
 
-impl<L: Loggable> LoggableList for Vec<Option<L>> {
+impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
     type Name = L::Name;
 
     #[inline]
@@ -199,13 +199,13 @@ impl<L: Loggable> LoggableList for Vec<Option<L>> {
     }
 }
 
-impl<D: Datatype> DatatypeList for Vec<Option<D>> {}
+impl<D: Datatype> DatatypeBatch for Vec<Option<D>> {}
 
-impl<C: Component> ComponentList for Vec<Option<C>> {}
+impl<C: Component> ComponentBatch for Vec<Option<C>> {}
 
 // --- Array ---
 
-impl<L: Loggable, const N: usize> LoggableList for [L; N] {
+impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
     type Name = L::Name;
 
     #[inline]
@@ -229,13 +229,13 @@ impl<L: Loggable, const N: usize> LoggableList for [L; N] {
     }
 }
 
-impl<D: Datatype, const N: usize> DatatypeList for [D; N] {}
+impl<D: Datatype, const N: usize> DatatypeBatch for [D; N] {}
 
-impl<C: Component, const N: usize> ComponentList for [C; N] {}
+impl<C: Component, const N: usize> ComponentBatch for [C; N] {}
 
 // --- Array<Option> ---
 
-impl<L: Loggable, const N: usize> LoggableList for [Option<L>; N] {
+impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
     type Name = L::Name;
 
     #[inline]
@@ -262,13 +262,13 @@ impl<L: Loggable, const N: usize> LoggableList for [Option<L>; N] {
     }
 }
 
-impl<D: Datatype, const N: usize> DatatypeList for [Option<D>; N] {}
+impl<D: Datatype, const N: usize> DatatypeBatch for [Option<D>; N] {}
 
-impl<C: Component, const N: usize> ComponentList for [Option<C>; N] {}
+impl<C: Component, const N: usize> ComponentBatch for [Option<C>; N] {}
 
 // --- Slice ---
 
-impl<'a, L: Loggable> LoggableList for &'a [L] {
+impl<'a, L: Loggable> LoggableBatch for &'a [L] {
     type Name = L::Name;
 
     #[inline]
@@ -292,13 +292,13 @@ impl<'a, L: Loggable> LoggableList for &'a [L] {
     }
 }
 
-impl<'a, D: Datatype> DatatypeList for &'a [D] {}
+impl<'a, D: Datatype> DatatypeBatch for &'a [D] {}
 
-impl<'a, C: Component> ComponentList for &'a [C] {}
+impl<'a, C: Component> ComponentBatch for &'a [C] {}
 
 // --- Slice<Option> ---
 
-impl<'a, L: Loggable> LoggableList for &'a [Option<L>] {
+impl<'a, L: Loggable> LoggableBatch for &'a [Option<L>] {
     type Name = L::Name;
 
     #[inline]
@@ -325,13 +325,13 @@ impl<'a, L: Loggable> LoggableList for &'a [Option<L>] {
     }
 }
 
-impl<'a, D: Datatype> DatatypeList for &'a [Option<D>] {}
+impl<'a, D: Datatype> DatatypeBatch for &'a [Option<D>] {}
 
-impl<'a, C: Component> ComponentList for &'a [Option<C>] {}
+impl<'a, C: Component> ComponentBatch for &'a [Option<C>] {}
 
 // --- ArrayRef ---
 
-impl<'a, L: Loggable, const N: usize> LoggableList for &'a [L; N] {
+impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [L; N] {
     type Name = L::Name;
 
     #[inline]
@@ -355,13 +355,13 @@ impl<'a, L: Loggable, const N: usize> LoggableList for &'a [L; N] {
     }
 }
 
-impl<'a, D: Datatype, const N: usize> DatatypeList for &'a [D; N] {}
+impl<'a, D: Datatype, const N: usize> DatatypeBatch for &'a [D; N] {}
 
-impl<'a, C: Component, const N: usize> ComponentList for &'a [C; N] {}
+impl<'a, C: Component, const N: usize> ComponentBatch for &'a [C; N] {}
 
 // --- ArrayRef<Option> ---
 
-impl<'a, L: Loggable, const N: usize> LoggableList for &'a [Option<L>; N] {
+impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [Option<L>; N] {
     type Name = L::Name;
 
     #[inline]
@@ -388,6 +388,6 @@ impl<'a, L: Loggable, const N: usize> LoggableList for &'a [Option<L>; N] {
     }
 }
 
-impl<'a, D: Datatype, const N: usize> DatatypeList for &'a [Option<D>; N] {}
+impl<'a, D: Datatype, const N: usize> DatatypeBatch for &'a [Option<D>; N] {}
 
-impl<'a, C: Component, const N: usize> ComponentList for &'a [Option<C>; N] {}
+impl<'a, C: Component, const N: usize> ComponentBatch for &'a [Option<C>; N] {}

--- a/crates/re_types/src/testing/archetypes/fuzzy.rs
+++ b/crates/re_types/src/testing/archetypes/fuzzy.rs
@@ -300,155 +300,155 @@ impl crate::Archetype for AffixFuzzer1 {
         1
     }
 
-    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
         [
-            Some(Self::Indicator::new_list(self.num_instances() as _).into()),
-            Some((&self.fuzz1001 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1002 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1003 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1004 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1005 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1006 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1007 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1008 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1009 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1010 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1011 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1012 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1013 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1014 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1015 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1016 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1017 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1018 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1019 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1020 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1101 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1102 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1103 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1104 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1105 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1106 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1107 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1108 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1109 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1110 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1111 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1112 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1113 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1114 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1115 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1116 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1117 as &dyn crate::ComponentList).into()),
-            Some((&self.fuzz1118 as &dyn crate::ComponentList).into()),
+            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some((&self.fuzz1001 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1002 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1003 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1004 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1005 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1006 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1007 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1008 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1009 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1010 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1011 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1012 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1013 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1014 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1015 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1016 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1017 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1018 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1019 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1020 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1101 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1102 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1103 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1104 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1105 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1106 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1107 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1108 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1109 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1110 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1111 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1112 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1113 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1114 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1115 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1116 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1117 as &dyn crate::ComponentBatch).into()),
+            Some((&self.fuzz1118 as &dyn crate::ComponentBatch).into()),
             self.fuzz2001
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2002
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2003
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2004
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2005
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2006
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2007
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2008
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2009
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2010
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2011
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2012
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2013
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2014
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2015
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2016
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2017
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2018
                 .as_ref()
-                .map(|comp| (comp as &dyn crate::ComponentList).into()),
+                .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
             self.fuzz2101
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2102
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2103
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2104
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2105
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2106
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2107
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2108
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2109
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2110
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2111
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2112
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2113
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2114
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2115
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2116
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2117
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.fuzz2118
                 .as_ref()
-                .map(|comp_list| (comp_list as &dyn crate::ComponentList).into()),
+                .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -904,9 +904,9 @@ fn quote_trait_impls_from_obj(
                 .map(|field| format_ident!("{}", field.name))
                 .collect::<Vec<_>>();
 
-            let all_component_lists = {
+            let all_component_batches = {
                 std::iter::once(quote!{
-                    Some(Self::Indicator::new_list(self.num_instances() as _).into())
+                    Some(Self::Indicator::batch(self.num_instances() as _).into())
                 }).chain(obj.fields.iter().map(|obj_field| {
                     let field_name = format_ident!("{}", obj_field.name);
                     let is_plural = obj_field.typ.is_plural();
@@ -917,13 +917,13 @@ fn quote_trait_impls_from_obj(
                     // the nullability of individual elements (i.e. instances)!
                     match (is_plural, is_nullable) {
                         (true, true) => quote! {
-                            self.#field_name.as_ref().map(|comp_list| (comp_list as &dyn crate::ComponentList).into())
+                            self.#field_name.as_ref().map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into())
                         },
                         (false, true) => quote! {
-                            self.#field_name.as_ref().map(|comp| (comp as &dyn crate::ComponentList).into())
+                            self.#field_name.as_ref().map(|comp| (comp as &dyn crate::ComponentBatch).into())
                         },
                         (_, false) => quote! {
-                            Some((&self.#field_name as &dyn crate::ComponentList).into())
+                            Some((&self.#field_name as &dyn crate::ComponentBatch).into())
                         }
                     }
                 }))
@@ -1111,8 +1111,8 @@ fn quote_trait_impls_from_obj(
                         #num_instances
                     }
 
-                    fn as_component_lists(&self) -> Vec<crate::AnyComponentList<'_>> {
-                        [#(#all_component_lists,)*].into_iter().flatten().collect()
+                    fn as_component_batches(&self) -> Vec<crate::AnyComponentBatch<'_>> {
+                        [#(#all_component_batches,)*].into_iter().flatten().collect()
                     }
 
                     #[inline]

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log a batch of 2 rectangles with different class IDs
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "detections",
         false,
         2,
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
 
     // TODO(#2786): Box3D archetype
-    rec.log_component_lists("simple", false, 1, [&Box3D::new(2.0, 2.0, 1.0) as _])?;
+    rec.log_component_batches("simple", false, 1, [&Box3D::new(2.0, 2.0, 1.0) as _])?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (width, height) = (image.shape()[1] as f32, image.shape()[0] as f32);
     let focal_length = 200.;
     #[allow(clippy::tuple_array_conversions)]
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/camera",
         false,
         1,

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/mesh_simple.rs
+++ b/docs/code-examples/mesh_simple.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // TODO(#2788): Mesh archetype
-    rec.log_component_lists("triangle", false, 1, [&Mesh3D::Raw(mesh) as _])?;
+    rec.log_component_batches("triangle", false, 1, [&Mesh3D::Raw(mesh) as _])?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     image.map_inplace(|x| *x = rand::random());
 
     // TODO(#2816): Pinhole archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/image",
         false,
         1,

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/rect2d_simple.rs
+++ b/docs/code-examples/rect2d_simple.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_rect2d").memory()?;
 
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "simple",
         false,
         1,
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log an extra rect to set the view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bounds",
         false,
         1,

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut value = 1.0;
     for step in 0..100 {
         rec.set_time_sequence("step", step);
-        rec.log_component_lists("scalar", false, 1, [&Scalar::from(value) as _])?;
+        rec.log_component_batches("scalar", false, 1, [&Scalar::from(value) as _])?;
         value += thread_rng().sample::<f64, _>(StandardNormal);
     }
 

--- a/docs/code-examples/text_entry_simple.rs
+++ b/docs/code-examples/text_entry_simple.rs
@@ -6,13 +6,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_text_entry").memory()?;
 
     // TODO(#2793): TextLog archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "logs",
         false,
         1,
         [&TextEntry::new("this entry has loglevel TRACE", Some("TRACE".into())) as _],
     )?;
-    rec.log_component_lists(
+    rec.log_component_batches(
         "logs",
         false,
         1,

--- a/examples/rust/clock/src/main.rs
+++ b/examples/rust/clock/src/main.rs
@@ -40,10 +40,10 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
         SignedAxis3::POSITIVE_Y,
         rerun::coordinates::Handedness::Right,
     );
-    rec.log_component_lists("world", true, 1, [&view_coords as _])?;
+    rec.log_component_batches("world", true, 1, [&view_coords as _])?;
 
     // TODO(#2786): Box3D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/frame",
         true,
         1,

--- a/examples/rust/custom_data/src/main.rs
+++ b/examples/rust/custom_data/src/main.rs
@@ -5,7 +5,7 @@ use rerun::{
     datatypes::Float32,
     demo_util::grid,
     external::{arrow2, glam, re_types},
-    AnyComponentList, Archetype, ArchetypeName, ComponentList, ComponentName,
+    AnyComponentBatch, Archetype, ArchetypeName, ComponentBatch, ComponentName,
     GenericIndicatorComponent, Loggable, RecordingStreamBuilder,
 };
 
@@ -48,16 +48,16 @@ impl Archetype for CustomPoints3D {
         self.points3d.num_instances()
     }
 
-    fn as_component_lists(&self) -> Vec<AnyComponentList<'_>> {
+    fn as_component_batches(&self) -> Vec<AnyComponentBatch<'_>> {
         self.points3d
-            .as_component_lists()
+            .as_component_batches()
             .into_iter()
             .chain(
                 [
-                    Some(Self::Indicator::new_list(self.num_instances()).into()),
+                    Some(Self::Indicator::batch(self.num_instances()).into()),
                     self.confidences
                         .as_ref()
-                        .map(|v| (v as &dyn ComponentList).into()),
+                        .map(|v| (v as &dyn ComponentBatch).into()),
                 ]
                 .into_iter()
                 .flatten(),

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -23,7 +23,7 @@ use rerun::{
     datatypes::TranslationRotationScale3D,
     external::re_log,
     time::{Time, TimePoint, TimeType, Timeline},
-    ComponentList, RecordingStream,
+    ComponentBatch, RecordingStream,
 };
 
 // --- Rerun logging ---
@@ -83,7 +83,7 @@ fn log_coordinate_space(
     let view_coords: rerun::components::ViewCoordinates = axes
         .parse()
         .map_err(|err| anyhow!("couldn't parse {axes:?} as ViewCoordinates: {err}"))?;
-    rec.log_component_lists(ent_path, true, 1, [&view_coords as _])
+    rec.log_component_batches(ent_path, true, 1, [&view_coords as _])
         .map_err(Into::into)
 }
 
@@ -137,12 +137,12 @@ fn log_baseline_objects(
     });
 
     for (id, bbox, transform, label) in boxes {
-        rec.log_component_lists(
+        rec.log_component_batches(
             format!("world/annotations/box-{id}"),
             true,
             1,
             [
-                &bbox as &dyn ComponentList,
+                &bbox as &dyn ComponentBatch,
                 &transform,
                 &label,
                 &Color::from_rgb(160, 230, 130),
@@ -198,7 +198,7 @@ fn log_ar_camera(
     )?;
 
     // TODO(#2816): Pinhole archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "world/camera",
         false,
         1,

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -81,7 +81,7 @@ fn log_node(rec: &RecordingStream, node: GltfNode) -> anyhow::Result<()> {
         .into_iter()
         .map(Mesh3D::from)
         .collect::<Vec<_>>();
-    rec.log_component_lists(
+    rec.log_component_batches(
         node.name.as_str(),
         false,
         primitives.len() as _,
@@ -107,7 +107,7 @@ fn log_coordinate_space(
         .parse()
         .map_err(|err| anyhow!("couldn't parse {axes:?} as ViewCoordinates: {err}"))?;
 
-    rec.log_component_lists(ent_path, true, 1, [&view_coords as _])
+    rec.log_component_batches(ent_path, true, 1, [&view_coords as _])
         .map_err(Into::into)
 }
 

--- a/tests/rust/roundtrips/line_strips2d/src/main.rs
+++ b/tests/rust/roundtrips/line_strips2d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 
     // Hack to establish 2d view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "rect",
         false,
         1,

--- a/tests/rust/roundtrips/points2d/src/main.rs
+++ b/tests/rust/roundtrips/points2d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 
     // Hack to establish 2d view bounds
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "rect",
         false,
         1,

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -28,7 +28,7 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
 
     rec.set_time_seconds("sim_time", 0f64);
     // TODO(#2786): Box3D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bbox_test/bbox",
         false,
         1,
@@ -48,7 +48,7 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     rec.set_time_seconds("sim_time", 1f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "bbox_test/bbox",
         false,
         1,
@@ -81,7 +81,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
 
     rec.set_time_seconds("sim_time", 1f64);
     // TODO(#2786): Rect2D archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/0",
         false,
         1,
@@ -91,7 +91,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
             &Text("Rect1".into()) as _,
         ],
     )?;
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/1",
         false,
         1,
@@ -109,7 +109,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
     log_cleared(rec, "null_test/rect", true);
 
     rec.set_time_seconds("sim_time", 4f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/0",
         false,
         1,
@@ -117,7 +117,7 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     rec.set_time_seconds("sim_time", 5f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "null_test/rect/1",
         false,
         1,
@@ -214,7 +214,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
         .collect_vec();
 
     rec.set_time_seconds("sim_time", 2f64);
-    rec.log_component_lists(
+    rec.log_component_batches(
         "rects_test/rects",
         false,
         rects.len() as _,
@@ -223,7 +223,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
 
     // Clear the rectangles by logging an empty set
     rec.set_time_seconds("sim_time", 3f64);
-    rec.log_component_lists("rects_test/rects", false, 0, [&Vec::<Rect2D>::new() as _])?;
+    rec.log_component_batches("rects_test/rects", false, 0, [&Vec::<Rect2D>::new() as _])?;
 
     Ok(())
 }
@@ -283,7 +283,7 @@ fn test_2d_layering(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     // Rectangle in between the top and the middle.
-    rec.log_component_lists(
+    rec.log_component_batches(
         "2d_layering/rect_between_top_and_middle",
         false,
         1,
@@ -326,7 +326,7 @@ fn test_segmentation(rec: &RecordingStream) -> anyhow::Result<()> {
     // python SDK does.
     fn log_info(rec: &RecordingStream, text: &str) -> anyhow::Result<()> {
         // TODO(#2793): TextLog archetype
-        rec.log_component_lists(
+        rec.log_component_batches(
             "logs/seg_test_log",
             false,
             1,
@@ -437,7 +437,7 @@ fn test_text_logs(rec: &RecordingStream) -> anyhow::Result<()> {
     rec.set_time_seconds("sim_time", 0f64);
 
     // TODO(#2793): TextLog archetype
-    rec.log_component_lists(
+    rec.log_component_batches(
         "logs",
         false,
         1,
@@ -447,7 +447,7 @@ fn test_text_logs(rec: &RecordingStream) -> anyhow::Result<()> {
         ],
     )?;
 
-    rec.log_component_lists(
+    rec.log_component_batches(
         "logs",
         false,
         1,
@@ -480,7 +480,7 @@ fn test_transforms_3d(rec: &RecordingStream) -> anyhow::Result<()> {
             SignedAxis3::POSITIVE_Z,
             rerun::coordinates::Handedness::Right,
         );
-        rec.log_component_lists(
+        rec.log_component_batches(
             ent_path,
             true,
             1,


### PR DESCRIPTION
Just a lot of renaming all around.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3262) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3262)
- [Docs preview](https://rerun.io/preview/fadea691f065a580e7dec805140bc47b8c8d8c90/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fadea691f065a580e7dec805140bc47b8c8d8c90/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)