### PR TITLE
Fix lurking bug in datastore bucket sorting routines

### DIFF
--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -945,7 +945,10 @@ impl IndexedBucketInner {
         let swaps = {
             re_tracing::profile_scope!("swaps");
             let mut swaps = (0..col_time.len()).collect::<Vec<_>>();
-            swaps.sort_by_key(|&i| &col_time[i]);
+            // NOTE: Within a single timestamp, we must use the Row ID as tie-breaker!
+            // The Row ID is how we define ordering within a client's thread, and our public APIs
+            // guarantee that logging order is respected within a single thread!
+            swaps.sort_by_key(|&i| (&col_time[i], &col_row_id[i]));
             swaps
                 .iter()
                 .copied()

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -448,15 +448,9 @@ impl IndexedBucket {
 
         // append time to primary column and update time range appropriately
 
-        if let Some(last_time) = col_time.last() {
-            if time.as_i64() < *last_time {
-                *is_sorted = false;
-            }
-        }
-        if let Some(row_id) = col_row_id.last() {
-            if row.row_id() < *row_id {
-                *is_sorted = false;
-            }
+        if let (Some(last_time), Some(last_row_id)) = (col_time.last(), col_row_id.last()) {
+            // NOTE: Within a single timestamp, we use the Row ID as tie-breaker
+            *is_sorted &= (*last_time, *last_row_id) <= (time.as_i64(), row.row_id());
         }
 
         col_time.push(time.as_i64());

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -453,6 +453,11 @@ impl IndexedBucket {
                 *is_sorted = false;
             }
         }
+        if let Some(row_id) = col_row_id.last() {
+            if row.row_id() < *row_id {
+                *is_sorted = false;
+            }
+        }
 
         col_time.push(time.as_i64());
         *time_range = TimeRange::new(time_range.min.min(time), time_range.max.max(time));

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -1117,7 +1117,8 @@ fn row_id_ordering() {
     store.insert_row(&row1).unwrap();
     store.insert_row(&row2).unwrap();
 
-    store.sort_indices_if_needed();
+    // NOTE: Don't sort, let's see if the dirtiness bit got flipped.. as it should have!
+    // store.sort_indices_if_needed();
 
     let (row_id, results) = store
         .latest_at(

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -4,7 +4,10 @@
 //!
 //! Testing & demonstrating expected usage of the datastore APIs, no funny stuff.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    eprint, eprintln,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use nohash_hasher::IntMap;
 use polars_core::{prelude::*, series::Series};
@@ -1087,4 +1090,54 @@ pub fn init_logs() {
     {
         re_log::setup_native_logging();
     }
+}
+
+// ---
+
+#[test]
+fn row_id_ordering() {
+    init_logs();
+
+    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+
+    let timeline = re_log_types::Timeline::new("frame_nr", re_log_types::TimeType::Sequence);
+    let ent_path = EntityPath::from("this/that");
+
+    let frame1 = TimeInt::from(1);
+
+    let (instances1, points1, points2) = (
+        build_some_instances(3),
+        build_some_point2d(3),
+        build_some_point2d(3),
+    );
+    let row1 = test_row!(ent_path @ [build_frame_nr(frame1)] => 3; [instances1.clone(), &points1]);
+
+    let mut row2 =
+        test_row!(ent_path @ [build_frame_nr(frame1)] => 3; [instances1.clone(), points2]);
+    // NOTE: This should always come before `row1` in frame #1.
+    row2.row_id = re_log_types::RowId::ZERO;
+
+    store.insert_row(&row1).unwrap();
+    store.insert_row(&row2).unwrap();
+
+    store.sort_indices_if_needed();
+
+    let (row_id, results) = store
+        .latest_at(
+            &re_arrow_store::LatestAtQuery::latest(timeline),
+            &ent_path,
+            re_types::components::Point2D::name(),
+            &[re_types::components::Point2D::name()],
+        )
+        .unwrap();
+
+    // The results should come from `row1`!
+
+    assert_eq!(row1.row_id, row_id);
+
+    let points = results[0]
+        .as_ref()
+        .unwrap()
+        .to_native::<re_types::components::Point2D>();
+    assert_eq!(points1, points);
 }

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -4,10 +4,7 @@
 //!
 //! Testing & demonstrating expected usage of the datastore APIs, no funny stuff.
 
-use std::{
-    eprint, eprintln,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use nohash_hasher::IntMap;
 use polars_core::{prelude::*, series::Series};


### PR DESCRIPTION
_Commit A demonstrates the bug, commit B fixes it and passes the test._

Our public API exposes a well-defined order when logging from a single-thread, and that order is encoded into our `RowId`s.

As such it is expected that:
1. An incoming non-monotically increasing `RowId` (however it got there) toggles the dirty bit.
This shouldn't be possible with the current clients since we do not yet have reordering retries (as far as I remember), but it'll be coming at some point and we can't trust the clients anyhow.
2. The `RowId` must be used as tie-breaker when sorting the buckets.
We use a stable sort so this shouldn't be an issue as of today, but this is a nasty bug waiting to happen nonetheless.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3281) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3281)
- [Docs preview](https://rerun.io/preview/e2add35a57c644320124a2a73686ce03f0f99508/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e2add35a57c644320124a2a73686ce03f0f99508/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)