### PR TITLE
Seed the random number generators in examples

### DIFF
--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -51,6 +51,7 @@ def main() -> None:
     args = parser.parse_args()
 
     rr.script_setup(args, "rerun_example_dna_abacus")
+    np.random.seed(0)  # For deterministic results
     log_data()
     rr.script_teardown(args)
 

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -87,6 +87,7 @@ def main() -> None:
     args = parser.parse_args()
 
     rr.script_setup(args, "rerun_example_plot")
+    random.seed(0)  # For deterministic results
 
     log_parabola()
     log_trig()

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -37,7 +37,7 @@ def log_parabola() -> None:
         rr.set_time_sequence("frame_nr", t)
 
         f_of_t = (t * 0.01 - 5) ** 3 + 1
-        radius = clamp(abs(f_of_t) * 0.1, 0.5, 10.0)  # type: ignore[no-untyped-call]
+        radius = clamp(abs(f_of_t) * 0.1, 0.5, 10.0)
         color = [255, 255, 0]
         if f_of_t < -10.0:
             color = [255, 0, 0]

--- a/rerun_py/rerun_sdk/rerun/recording.py
+++ b/rerun_py/rerun_sdk/rerun/recording.py
@@ -24,7 +24,7 @@ class MemoryRecording:
 
     def reset_blueprint(self, add_to_app_default_blueprint: bool = False) -> None:
         """Reset the blueprint in the MemoryRecording."""
-        self.storage.reset_blueprint(add_to_app_default_blueprint)  # type: ignore[no-untyped-def]
+        self.storage.reset_blueprint(add_to_app_default_blueprint)
 
     def as_html(
         self,

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -14,6 +14,7 @@ import argparse
 import logging
 import math
 import os
+import random
 import threading
 from typing import Callable
 
@@ -285,8 +286,6 @@ def run_2d_lines(experimental_api: bool) -> None:
 
 
 def run_3d_points(experimental_api: bool) -> None:
-    import random
-
     rr.set_time_seconds("sim_time", 1)
     rr.log_point("3d_points/single_point_unlabeled", np.array([10.0, 0.0, 0.0]))
     rr.log_point("3d_points/single_point_labeled", np.array([0.0, 0.0, 0.0]), label="labeled point")
@@ -313,8 +312,6 @@ def raw_mesh(experimental_api: bool) -> None:
 
 
 def run_rects(experimental_api: bool) -> None:
-    import random
-
     rr.set_time_seconds("sim_time", 1)
 
     # Add an image
@@ -580,6 +577,9 @@ def main() -> None:
         action="store_true",
         help="If specified run tests using the new experimental APIs",
     )
+
+    random.seed(0)  # For deterministic results
+    np.random.seed(0)  # For deterministic results
 
     rr.script_add_args(parser)
     args = parser.parse_args()


### PR DESCRIPTION
### What
This should stop the random fluctuation in the size of `plots.rrd` that the size bot reports on each PR.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
