### PR TITLE
Deterministically seed Python RNGs for all rerun examples

### DIFF
--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -51,7 +51,6 @@ def main() -> None:
     args = parser.parse_args()
 
     rr.script_setup(args, "rerun_example_dna_abacus")
-    np.random.seed(0)  # For deterministic results
     log_data()
     rr.script_teardown(args)
 

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -87,7 +87,6 @@ def main() -> None:
     args = parser.parse_args()
 
     rr.script_setup(args, "rerun_example_plot")
-    random.seed(0)  # For deterministic results
 
     log_parabola()
     log_trig()

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import functools
+import random
 from typing import Any, Callable, TypeVar, cast
+
+import numpy as np
 
 # =====================================
 # API RE-EXPORTS
@@ -197,6 +200,11 @@ def init(
         For example, if you have one application doing object detection
         and another doing camera calibration, you could have
         `rerun.init("object_detector")` and `rerun.init("calibrator")`.
+
+        Application ids starting with `rerun_example_` are reserved for Rerun examples,
+        and will be treated specially by the Rerun Viewer.
+        In particular, it will opt-in to more analytics, and will also
+        seed the global random number generator deterministically.
     recording_id : Optional[str]
         Set the recording ID that this process is logging to, as a UUIDv4.
 
@@ -227,6 +235,11 @@ def init(
         (Experimental) Should the blueprint append to the existing app-default blueprint instead of creating a new one.
 
     """
+
+    if application_id.startswith("rerun_example_"):
+        # Make all our example code deterministic.
+        random.seed(0)
+        np.random.seed(0)
 
     global _strict_mode
     _strict_mode = strict

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -578,9 +578,6 @@ def main() -> None:
         help="If specified run tests using the new experimental APIs",
     )
 
-    random.seed(0)  # For deterministic results
-    np.random.seed(0)  # For deterministic results
-
     rr.script_add_args(parser)
     args = parser.parse_args()
 

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -585,7 +585,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if not args.split_recordings:
-        rec = rr.script_setup(args, f"test_api_{args.test}")
+        rec = rr.script_setup(args, f"rerun_example_test_api_{args.test}")
 
     if args.test in ["most", "all"]:
         print(f"Running {args.test} tests…")
@@ -597,7 +597,7 @@ def main() -> None:
                 continue
 
             if args.split_recordings:
-                rec = rr.script_setup(args, f"test_api/{name}")
+                rec = rr.script_setup(args, f"rerun_example_test_api/{name}")
 
             if args.multithread:
                 t = threading.Thread(
@@ -618,7 +618,7 @@ def main() -> None:
             t.join()
     else:
         if args.split_recordings:
-            with rr.script_setup(args, f"test_api/{args.test}"):
+            with rr.script_setup(args, f"rerun_example_test_api/{args.test}"):
                 tests[args.test](args.experimental_api)
         else:
             tests[args.test](args.experimental_api)


### PR DESCRIPTION
### What
* Follow-up to https://github.com/rerun-io/rerun/pull/3284

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3286) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3286)
- [Docs preview](https://rerun.io/preview/68ea49c1b5229e1dd70b86c8a384416085a01ec6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/68ea49c1b5229e1dd70b86c8a384416085a01ec6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)