### PR TITLE
Fix row ordering flakiness when using clear APIs

### DIFF
--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -133,10 +133,8 @@ impl EntityDb {
                 let cell =
                     DataCell::from_arrow_empty(component_path.component_name, data_type.clone());
 
-                // NOTE(cmc): The fact that this inserts data to multiple entity paths using a
-                // single `RowId` is… interesting. Keep it in mind.
                 let row = DataRow::from_cells1(
-                    row_id,
+                    RowId::random(),
                     component_path.entity_path.clone(),
                     time_point.clone(),
                     cell.num_instances(),

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -123,27 +123,40 @@ impl EntityDb {
     fn add_path_op(&mut self, row_id: RowId, time_point: &TimePoint, path_op: &PathOp) {
         let cleared_paths = self.tree.add_path_op(row_id, time_point, path_op);
 
+        // NOTE: Btree! We need a stable ordering here!
+        let mut cells = BTreeMap::<EntityPath, Vec<DataCell>>::default();
         for component_path in cleared_paths {
             if let Some(data_type) = self
                 .data_store
                 .lookup_datatype(&component_path.component_name)
             {
-                // Create and insert an empty component into the arrow store
-                // TODO(jleibs): Faster empty-array creation
-                let cell =
-                    DataCell::from_arrow_empty(component_path.component_name, data_type.clone());
+                let cells = cells
+                    .entry(component_path.entity_path.clone())
+                    .or_insert_with(Vec::new);
 
-                let row = DataRow::from_cells1(
-                    RowId::random(),
-                    component_path.entity_path.clone(),
-                    time_point.clone(),
-                    cell.num_instances(),
-                    cell,
-                );
-                self.data_store.insert_row(&row).ok();
-                // Also update the tree with the clear-event
+                cells.push(DataCell::from_arrow_empty(
+                    component_path.component_name,
+                    data_type.clone(),
+                ));
+
+                // Update the tree with the clear-event.
                 self.tree.add_data_msg(time_point, &component_path);
             }
+        }
+
+        // Create and insert empty components into the arrow store.
+        let mut row_id = row_id;
+        for (ent_path, cells) in cells {
+            // NOTE: It is important we insert all those empty components using a single row (id)!
+            // 1. It'll be much more efficient when querying that data back.
+            // 2. Otherwise we will end up with a flaky row ordering, as we have no way to tie-break
+            //    these rows! This flaky ordering will in turn leak through the public
+            //    API (e.g. range queries)!!
+            let row = DataRow::from_cells(row_id, time_point.clone(), ent_path, 0, cells);
+            self.data_store.insert_row(&row).ok();
+
+            // Don't reuse the same row ID for the next entity!
+            row_id = row_id.next();
         }
     }
 

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -130,7 +130,7 @@ impl RowId {
     /// Returns the next logical `RowId`.
     ///
     /// Beware: wrong usage can easily lead to conflicts.
-    /// Prefer [`Tuid::random`] when unsure.
+    /// Prefer [`RowId::random`] when unsure.
     #[inline]
     pub fn next(&self) -> Self {
         Self(self.0.next())

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -126,6 +126,15 @@ impl RowId {
     pub fn random() -> Self {
         Self(re_tuid::Tuid::random())
     }
+
+    /// Returns the next logical `RowId`.
+    ///
+    /// Beware: wrong usage can easily lead to conflicts.
+    /// Prefer [`Tuid::random`] when unsure.
+    #[inline]
+    pub fn next(&self) -> Self {
+        Self(self.0.next())
+    }
 }
 
 impl SizeBytes for RowId {

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -97,6 +97,22 @@ impl Tuid {
         ((self.time_ns as u128) << 64) | (self.inc as u128)
     }
 
+    /// Returns the next logical `Tuid`.
+    ///
+    /// Wraps the monotonically increasing back to zero on overflow.
+    ///
+    /// Beware: wrong usage can easily lead to conflicts.
+    /// Prefer [`Tuid::random`] when unsure.
+    #[inline]
+    pub fn next(&self) -> Self {
+        let Self { time_ns, inc } = *self;
+
+        Self {
+            time_ns,
+            inc: inc.wrapping_add(1),
+        }
+    }
+
     #[inline]
     pub fn nanoseconds_since_epoch(&self) -> u64 {
         self.time_ns


### PR DESCRIPTION
The clear APIs insert multiple rows worth of data (1 per component) that all re-use the same `RowId` (the `RowId` that was used to do the log_clear() call itself).
This leads to a flaky ordering of these rows internally, as there is no way to tie-break between them.
It is also less performant than it should be as all of this data could and should live on the same row.

The problem is accentuated when doing recursive clears, since in that case the row ID is not only shared between multiple rows of the same entity, but also multiple rows across multiple entities: even more ordering flakiness.

This flaky ordering then leaks through the public APIs (e.g. range queries) and, importantly, through roundtrip tests.
This is how I first encoutered this issue: #3023 is blocked by this because the roundtrip tests for recursive clears are flaky. This PR fixes that.

Unfortunately we don't have a test suite in place for clear APIs (AFAIK), and I'm not even sure what the expected behavior is in all cases, so I cannot write that test suite for now. I've opened an issue for this:
- #3287 

In the meantime, the roundtrip tests introduced in #3023 will act as a regression test at the very least.


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3288) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3288)
- [Docs preview](https://rerun.io/preview/7faa657db390c43112be6366b8c125f1a30a512c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7faa657db390c43112be6366b8c125f1a30a512c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)