### PR TITLE
Document our encoding of `Color` datatype and component

### DIFF
--- a/crates/re_types/definitions/rerun/components/color.fbs
+++ b/crates/re_types/definitions/rerun/components/color.fbs
@@ -9,7 +9,10 @@ namespace rerun.components;
 
 // ---
 
-/// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+/// An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+///
+/// The color is stored as a 32-bit integer, where the most significant
+/// byte is `R` and the least significant byte is `A`.
 ///
 /// \py Float colors are assumed to be in 0-1 gamma sRGB space.
 /// \py All other colors are assumed to be in 0-255 gamma sRGB space.

--- a/crates/re_types/definitions/rerun/datatypes/color.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/color.fbs
@@ -8,7 +8,10 @@ namespace rerun.datatypes;
 
 // ---
 
-/// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+/// An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+///
+/// The color is stored as a 32-bit integer, where the most significant
+/// byte is `R` and the least significant byte is `A`.
 ///
 /// \py Float colors are assumed to be in 0-1 gamma sRGB space.
 /// \py All other colors are assumed to be in 0-255 gamma sRGB space.

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-49163642a5197a447e930f12c06c164da3a3cc2cd4d60e803412c985f2512260
+6e365cf2abe8e6cc13177655a7c2a6133ffcb98b612e294413463f7e7f5a7a0e

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -13,7 +13,10 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+/// An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+///
+/// The color is stored as a 32-bit integer, where the most significant
+/// byte is `R` and the least significant byte is `A`.
 #[derive(
     Clone,
     Debug,

--- a/crates/re_types/src/datatypes/color.rs
+++ b/crates/re_types/src/datatypes/color.rs
@@ -13,7 +13,10 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+/// An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+///
+/// The color is stored as a 32-bit integer, where the most significant
+/// byte is `R` and the least significant byte is `A`.
 #[derive(
     Clone,
     Debug,

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -23,8 +23,10 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear
-        /// alpha.
+        /// An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+        ///
+        /// The color is stored as a 32-bit integer, where the most significant
+        /// byte is `R` and the least significant byte is `A`.
         struct Color {
             rerun::datatypes::Color rgba;
 

--- a/rerun_cpp/src/rerun/datatypes/color.hpp
+++ b/rerun_cpp/src/rerun/datatypes/color.hpp
@@ -21,8 +21,10 @@ namespace arrow {
 
 namespace rerun {
     namespace datatypes {
-        /// An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear
-        /// alpha.
+        /// An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+        ///
+        /// The color is stored as a 32-bit integer, where the most significant
+        /// byte is `R` and the least significant byte is `A`.
         struct Color {
             uint32_t rgba;
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/color.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/color.py
@@ -23,7 +23,10 @@ __all__ = ["Color", "ColorArray", "ColorArrayLike", "ColorLike", "ColorType"]
 @define
 class Color:
     """
-    An RGBA color tuple with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+    An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+
+    The color is stored as a 32-bit integer, where the most significant
+    byte is `R` and the least significant byte is `A`.
 
     Float colors are assumed to be in 0-1 gamma sRGB space.
     All other colors are assumed to be in 0-255 gamma sRGB space.


### PR DESCRIPTION
### What
* Related to https://github.com/rerun-io/rerun/issues/2782

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3289) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3289)
- [Docs preview](https://rerun.io/preview/cbd599a8e94ff31bff87f7ab42d5a6ac441b3d0d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/cbd599a8e94ff31bff87f7ab42d5a6ac441b3d0d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)