### PR TITLE
Silently ignore .blueprint files from old Rerun versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,6 +4721,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "thiserror",
  "time",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/re_data_source/src/load_file_contents.rs
+++ b/crates/re_data_source/src/load_file_contents.rs
@@ -1,3 +1,4 @@
+use re_log_encoding::decoder::VersionPolicy;
 use re_log_types::LogMsg;
 use re_smart_channel::Sender;
 
@@ -106,7 +107,7 @@ fn load_rrd_sync(file_contents: &FileContents, tx: &Sender<LogMsg>) -> Result<()
     re_tracing::profile_function!(file_contents.name.as_str());
 
     let bytes: &[u8] = &file_contents.bytes;
-    let decoder = re_log_encoding::decoder::Decoder::new(bytes)?;
+    let decoder = re_log_encoding::decoder::Decoder::new(VersionPolicy::Warn, bytes)?;
     for msg in decoder {
         tx.send(msg?)?;
     }

--- a/crates/re_data_source/src/load_file_path.rs
+++ b/crates/re_data_source/src/load_file_path.rs
@@ -101,8 +101,9 @@ fn stream_rrd_file(
     path: std::path::PathBuf,
     tx: re_smart_channel::Sender<LogMsg>,
 ) -> anyhow::Result<()> {
+    let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
     let file = std::fs::File::open(&path).context("Failed to open file")?;
-    let decoder = re_log_encoding::decoder::Decoder::new(file)?;
+    let decoder = re_log_encoding::decoder::Decoder::new(version_policy, file)?;
 
     rayon::spawn(move || {
         re_tracing::profile_scope!("stream_rrd_file");

--- a/crates/re_data_store/examples/memory_usage.rs
+++ b/crates/re_data_store/examples/memory_usage.rs
@@ -70,7 +70,8 @@ fn log_messages() {
     }
 
     fn decode_log_msg(mut bytes: &[u8]) -> LogMsg {
-        let mut messages = re_log_encoding::decoder::Decoder::new(&mut bytes)
+        let version_policy = re_log_encoding::decoder::VersionPolicy::Error;
+        let mut messages = re_log_encoding::decoder::Decoder::new(version_policy, &mut bytes)
             .unwrap()
             .collect::<Result<Vec<LogMsg>, _>>()
             .unwrap();

--- a/crates/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -36,7 +36,8 @@ fn encode_log_msgs(messages: &[LogMsg]) -> Vec<u8> {
 }
 
 fn decode_log_msgs(mut bytes: &[u8]) -> Vec<LogMsg> {
-    let messages = re_log_encoding::decoder::Decoder::new(&mut bytes)
+    let version_policy = re_log_encoding::decoder::VersionPolicy::Error;
+    let messages = re_log_encoding::decoder::Decoder::new(version_policy, &mut bytes)
         .unwrap()
         .collect::<Result<Vec<LogMsg>, _>>()
         .unwrap();

--- a/crates/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/re_log_encoding/src/stream_rrd_from_http.rs
@@ -52,7 +52,8 @@ pub fn stream_rrd_from_http(url: String, on_msg: Arc<HttpMessageCallback>) {
     re_log::debug!("Downloading .rrd file from {url:?}…");
 
     ehttp::streaming::fetch(ehttp::Request::get(&url), {
-        let decoder = RefCell::new(StreamDecoder::new());
+        let version_policy = crate::decoder::VersionPolicy::Warn;
+        let decoder = RefCell::new(StreamDecoder::new(version_policy));
         move |part| match part {
             Ok(part) => match part {
                 ehttp::streaming::Part::Response(ehttp::PartialResponse {

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -199,7 +199,8 @@ async fn run_client(
 
         congestion_manager.register_latency(tx.latency_sec());
 
-        for msg in re_log_encoding::decoder::decode_bytes(&packet)? {
+        let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
+        for msg in re_log_encoding::decoder::decode_bytes(version_policy, &packet)? {
             if congestion_manager.should_send(&msg) {
                 tx.send(msg)?;
             } else {

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -94,6 +94,7 @@ rfd.workspace = true
 ron = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror.workspace = true
 time = { workspace = true, features = ["formatting"] }
 web-time.workspace = true
 wgpu.workspace = true

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -9,6 +9,7 @@ mod app_state;
 mod background_tasks;
 pub mod blueprint_components;
 pub mod env_vars;
+#[cfg(not(target_arch = "wasm32"))]
 mod loading;
 mod saving;
 mod screenshotter;

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -339,7 +339,8 @@ fn run_compare(path_to_rrd1: &Path, path_to_rrd2: &Path, full_dump: bool) -> any
             .with_context(|| format!("couldn't open rrd file contents at {path_to_rrd:?}"))?;
 
         let mut stores: std::collections::HashMap<StoreId, StoreDb> = Default::default();
-        let decoder = re_log_encoding::decoder::Decoder::new(rrd_file)?;
+        let version_policy = re_log_encoding::decoder::VersionPolicy::Error;
+        let decoder = re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)?;
         for msg in decoder {
             let msg = msg
                 .with_context(|| format!("couldn't decode rrd file contents at {path_to_rrd:?}"))?;


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/2830

This means old .blueprint files in the user's rerun directory will no longer produce confusing warnings, nor result in semi-loaded blueprints that may make no sense anymore.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
