### PR TITLE
Boxes2D archetype unit tests

### DIFF
--- a/crates/re_types/tests/box2d.rs
+++ b/crates/re_types/tests/box2d.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+
+use re_types::{archetypes::Boxes2D, components, Archetype as _};
+
+#[test]
+fn roundtrip() {
+    let expected = Boxes2D {
+        half_sizes: vec![
+            components::HalfSizes2D::new(1.0, 2.0), //
+            components::HalfSizes2D::new(3.0, 4.0),
+        ],
+        centers: Some(vec![
+            components::Origin2D::new(1.0, 2.0), //
+            components::Origin2D::new(3.0, 4.0),
+        ]),
+        colors: Some(vec![
+            components::Color::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC), //
+            components::Color::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD),
+        ]),
+        radii: Some(vec![
+            components::Radius(42.0), //
+            components::Radius(43.0),
+        ]),
+        labels: Some(vec![
+            "hello".into(),  //
+            "friend".into(), //
+        ]),
+        draw_order: Some(components::DrawOrder(300.0)),
+        class_ids: Some(vec![
+            components::ClassId::from(126), //
+            components::ClassId::from(127), //
+        ]),
+        instance_keys: Some(vec![
+            components::InstanceKey(u64::MAX - 1), //
+            components::InstanceKey(u64::MAX),
+        ]),
+    };
+
+    let arch = Boxes2D::from_half_sizes([(1.0, 2.0), (3.0, 4.0)])
+        .with_centers([(1.0, 2.0), (3.0, 4.0)])
+        .with_colors([0xAA0000CC, 0x00BB00DD])
+        .with_radii([42.0, 43.0])
+        .with_labels(["hello", "friend"])
+        .with_draw_order(300.0)
+        .with_class_ids([126, 127])
+        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+    similar_asserts::assert_eq!(expected, arch);
+
+    let expected_extensions: HashMap<_, _> = [
+        ("half_sizes", vec!["rerun.components.HalfSize2D"]),
+        ("centers", vec!["rerun.components.Origin2D"]),
+        ("colors", vec!["rerun.components.Color"]),
+        ("radii", vec!["rerun.components.Radius"]),
+        ("labels", vec!["rerun.components.Label"]),
+        ("draw_order", vec!["rerun.components.DrawOrder"]),
+        ("class_ids", vec!["rerun.components.ClassId"]),
+        ("instance_keys", vec!["rerun.components.InstanceKey"]),
+    ]
+    .into();
+
+    eprintln!("arch = {arch:#?}");
+    let serialized = arch.to_arrow();
+    for (field, array) in &serialized {
+        // NOTE: Keep those around please, very useful when debugging.
+        // eprintln!("field = {field:#?}");
+        // eprintln!("array = {array:#?}");
+        eprintln!("{} = {array:#?}", field.name);
+
+        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
+        // has been fully replaced.
+        if false {
+            util::assert_extensions(
+                &**array,
+                expected_extensions[field.name.as_str()].as_slice(),
+            );
+        }
+    }
+
+    let deserialized = Boxes2D::try_from_arrow(serialized).unwrap();
+    similar_asserts::assert_eq!(expected, deserialized);
+}
+
+#[test]
+fn from_centers_and_half_sizes() {
+    let from_centers_and_half_sizes = Boxes2D::from_centers_and_half_sizes([(1., 2.)], [(4., 6.)]);
+    let from_half_sizes = Boxes2D::from_half_sizes([(4., 6.)]).with_centers([(1., 2.)]);
+    similar_asserts::assert_eq!(from_half_sizes, from_centers_and_half_sizes);
+}
+
+#[test]
+fn from_sizes() {
+    let from_sizes = Boxes2D::from_sizes([(4., 6.)]);
+    let from_half_sizes = Boxes2D::from_half_sizes([(2., 3.)]);
+    similar_asserts::assert_eq!(from_half_sizes, from_sizes);
+}
+
+#[test]
+fn from_centers_and_sizes() {
+    let from_centers_and_sizes = Boxes2D::from_centers_and_sizes([(1., 2.)], [(4., 6.)]);
+    let from_half_sizes = Boxes2D::from_half_sizes([(2., 3.)]).with_centers([(1., 2.)]);
+    similar_asserts::assert_eq!(from_half_sizes, from_centers_and_sizes);
+}
+
+#[test]
+fn from_mins_and_sizes() {
+    let from_mins_and_sizes = Boxes2D::from_mins_and_sizes([(-1., -1.)], [(2., 4.)]);
+    let from_half_sizes = Boxes2D::from_half_sizes([(1., 2.)]).with_centers([(0., 1.)]);
+    similar_asserts::assert_eq!(from_half_sizes, from_mins_and_sizes);
+}
+
+mod util;

--- a/rerun_cpp/tests/archetypes/boxes2d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes2d.cpp
@@ -1,0 +1,75 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/boxes2d.hpp>
+
+using namespace rerun::archetypes;
+
+#define TEST_TAG "[boxes2d][archetypes]"
+
+SCENARIO(
+    "Boxes2D archetype can be serialized with the same result for manually built instances and "
+    "the builder pattern",
+    TEST_TAG
+) {
+    GIVEN("Constructed from builder via from_half_sizes and manually") {
+        auto from_builder = Boxes2D::from_half_sizes({{10.f, 9.f}, {5.f, -5.f}})
+                                .with_centers({{0.f, 0.f}, {-1.f, 1.f}})
+                                .with_colors({0xAA0000CC, 0x00BB00DD})
+                                .with_labels({"hello", "friend"})
+                                .with_radii({0.1f, 1.0f})
+                                .with_draw_order(300.0f)
+                                .with_class_ids({126, 127})
+                                .with_instance_keys({66, 666});
+
+        Boxes2D from_manual;
+        from_manual.half_sizes = {{10.f, 9.f}, {5.f, -5.f}};
+        from_manual.centers = {{0.f, 0.f}, {-1.f, 1.f}};
+        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+        from_manual.labels = {"hello", "friend"};
+        from_manual.radii = {0.1f, 1.0f};
+        from_manual.draw_order = 300.0f;
+        from_manual.class_ids = {126, 127};
+        from_manual.instance_keys = {66ull, 666ull};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+
+    GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
+        auto from_builder = Boxes2D::from_centers_and_half_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
+
+        Boxes2D from_manual;
+        from_manual.centers = {{1.f, 2.f}};
+        from_manual.half_sizes = {{4.f, 6.f}};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+
+    GIVEN("Constructed from via from_sizes and manually") {
+        auto from_builder = Boxes2D::from_sizes({{1.f, 2.f}});
+
+        Boxes2D from_manual;
+        from_manual.half_sizes = {{0.5f, 1.f}};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+
+    GIVEN("Constructed from via from_centers_and_sizes and manually") {
+        auto from_builder = Boxes2D::from_centers_and_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
+
+        Boxes2D from_manual;
+        from_manual.centers = {{1.f, 2.f}};
+        from_manual.half_sizes = {{2.f, 3.f}};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+
+    GIVEN("Constructed from via from_mins_and_sizes and manually") {
+        auto from_builder = Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 4.f}});
+
+        Boxes2D from_manual;
+        from_manual.centers = {{0.f, 1.f}};
+        from_manual.half_sizes = {{1.f, 2.f}};
+
+        test_serialization_for_manual_and_builder(from_manual, from_builder);
+    }
+}

--- a/rerun_py/tests/unit/test_box2d.py
+++ b/rerun_py/tests/unit/test_box2d.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import itertools
+from typing import Optional, cast
+
+import rerun.experimental as rr2
+from rerun.experimental import cmp as rrc
+from rerun.experimental import dt as rrd
+
+from .common_arrays import (
+    class_ids_arrays,
+    class_ids_expected,
+    colors_arrays,
+    colors_expected,
+    draw_order_expected,
+    draw_orders,
+    instance_keys_arrays,
+    instance_keys_expected,
+    is_empty,
+    labels_arrays,
+    labels_expected,
+    radii_arrays,
+    radii_expected,
+)
+from .common_arrays import (
+    vec2ds_arrays as centers_arrays,
+)
+from .common_arrays import (
+    vec2ds_arrays as half_sizes_arrays,
+)
+from .common_arrays import (
+    vec2ds_expected as centers_expected,
+)
+from .common_arrays import (
+    vec2ds_expected as half_sizes_expected,
+)
+
+
+def test_boxes2d() -> None:
+    all_arrays = itertools.zip_longest(
+        half_sizes_arrays,
+        centers_arrays,
+        colors_arrays,
+        radii_arrays,
+        labels_arrays,
+        draw_orders,
+        class_ids_arrays,
+        instance_keys_arrays,
+    )
+
+    for half_sizes, centers, colors, radii, labels, draw_order, class_ids, instance_keys in all_arrays:
+        half_sizes = half_sizes if half_sizes is not None else half_sizes_arrays[-1]
+
+        # make Pyright happy as it's apparently not able to track typing info trough zip_longest
+        half_sizes = cast(rrd.Vec2DArrayLike, half_sizes)
+        centers = cast(rrd.Vec2DArrayLike, centers)
+        radii = cast(Optional[rrc.RadiusArrayLike], radii)
+        colors = cast(Optional[rrd.ColorArrayLike], colors)
+        labels = cast(Optional[rrd.Utf8ArrayLike], labels)
+        draw_order = cast(Optional[rrc.DrawOrderArrayLike], draw_order)
+        class_ids = cast(Optional[rrd.ClassIdArrayLike], class_ids)
+        instance_keys = cast(Optional[rrc.InstanceKeyArrayLike], instance_keys)
+
+        print(
+            f"rr2.Boxes2D(\n"
+            f"    half_sizes={half_sizes}\n"
+            f"    centers={centers}\n"
+            f"    radii={radii}\n"
+            f"    colors={colors}\n"
+            f"    labels={labels}\n"
+            f"    draw_order={draw_order}\n"
+            f"    class_ids={class_ids}\n"
+            f"    instance_keys={instance_keys}\n"
+            f")"
+        )
+        arch = rr2.Boxes2D(
+            half_sizes=half_sizes,
+            centers=centers,
+            radii=radii,
+            colors=colors,
+            labels=labels,
+            draw_order=draw_order,
+            class_ids=class_ids,
+            instance_keys=instance_keys,
+        )
+        print(f"{arch}\n")
+
+        assert arch.half_sizes == half_sizes_expected(is_empty(half_sizes), rrc.HalfSizes2DArray)
+        assert arch.centers == centers_expected(is_empty(centers), rrc.Origin2DArray)
+        assert arch.colors == colors_expected(is_empty(colors))
+        assert arch.radii == radii_expected(is_empty(radii))
+        assert arch.labels == labels_expected(is_empty(labels))
+        assert arch.draw_order == draw_order_expected(is_empty(draw_order))
+        assert arch.class_ids == class_ids_expected(is_empty(class_ids))
+        assert arch.instance_keys == instance_keys_expected(is_empty(instance_keys))
+
+
+if __name__ == "__main__":
+    test_boxes2d()


### PR DESCRIPTION
### What

Adds the usual unit tests to all three languages for the Box2D archetype

* Follow up of #3282

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3293) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3293)
- [Docs preview](https://rerun.io/preview/400d4b02ebc7fec7a8c1b175d883c4b958f71e44/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/400d4b02ebc7fec7a8c1b175d883c4b958f71e44/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)