### PR TITLE
Show currently loading recordings in Recordings menu

### DIFF
--- a/crates/re_renderer/examples/framework.rs
+++ b/crates/re_renderer/examples/framework.rs
@@ -246,7 +246,7 @@ impl<E: Example + 'static> Application<E> {
                             return;
                         }
                         Err(err) => {
-                            re_log::warn!(%err, "dropped frame");
+                            re_log::warn!("Dropped frame: {err}");
                             return;
                         }
                     };

--- a/crates/re_smart_channel/src/receive_set.rs
+++ b/crates/re_smart_channel/src/receive_set.rs
@@ -31,6 +31,11 @@ impl<T: Send> ReceiveSet<T> {
         rx.push(r);
     }
 
+    /// Diconnect from any channel with the given source.
+    pub fn remove(&self, source: &SmartChannelSource) {
+        self.receivers.lock().retain(|r| r.source() != source);
+    }
+
     /// List of connected receiver sources.
     ///
     /// This gets culled after calling one of the `recv` methods.

--- a/crates/re_smart_channel/src/receive_set.rs
+++ b/crates/re_smart_channel/src/receive_set.rs
@@ -31,7 +31,7 @@ impl<T: Send> ReceiveSet<T> {
         rx.push(r);
     }
 
-    /// Diconnect from any channel with the given source.
+    /// Disconnect from any channel with the given source.
     pub fn remove(&self, source: &SmartChannelSource) {
         self.receivers.lock().retain(|r| r.source() != source);
     }

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -703,11 +703,10 @@ impl ReUi {
 
     /// Two-column grid to be used in selection view.
     #[allow(clippy::unused_self)]
-    pub fn selection_grid(&self, ui: &mut egui::Ui, id: &str) -> egui::Grid {
+    pub fn selection_grid(&self, _ui: &mut egui::Ui, id: &str) -> egui::Grid {
         // Spread rows a bit to make it easier to see the groupings
-        egui::Grid::new(id)
-            .num_columns(2)
-            .spacing(ui.style().spacing.item_spacing + egui::vec2(0.0, 8.0))
+        let spacing = egui::vec2(8.0, 16.0);
+        egui::Grid::new(id).num_columns(2).spacing(spacing)
     }
 
     /// Draws a shadow into the given rect with the shadow direction given from dark to light

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -702,6 +702,8 @@ impl ReUi {
     }
 
     /// Two-column grid to be used in selection view.
+    ///
+    /// Use this when you expect the right column to have multi-line entries.
     #[allow(clippy::unused_self)]
     pub fn selection_grid(&self, _ui: &mut egui::Ui, id: &str) -> egui::Grid {
         // Spread rows a bit to make it easier to see the groupings

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -712,9 +712,9 @@ impl App {
                 re_smart_channel::SmartMessagePayload::Msg(msg) => msg,
                 re_smart_channel::SmartMessagePayload::Quit(err) => {
                     if let Some(err) = err {
-                        re_log::warn!(%msg.source, err, "data source has left unexpectedly");
+                        re_log::warn!("Data source {} has left unexpectedly: {err}", msg.source);
                     } else {
-                        re_log::debug!(%msg.source, "data source has left");
+                        re_log::debug!("Data source {} has left", msg.source);
                     }
                     continue;
                 }

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -171,7 +171,7 @@ impl AppState {
                         // before drawing the blueprint panel.
                         ui.spacing_mut().item_spacing.y = 0.0;
 
-                        let recording_shown = recordings_panel_ui(&mut ctx, ui);
+                        let recording_shown = recordings_panel_ui(&mut ctx, rx, ui);
 
                         if recording_shown {
                             ui.add_space(4.0);

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -108,7 +108,7 @@ impl StoreHub {
                 StoreContext {
                     blueprint,
                     recording,
-                    alternate_recordings: self.store_dbs.recordings().collect_vec(),
+                    all_recordings: self.store_dbs.recordings().collect_vec(),
                 }
             })
     }

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -66,14 +66,19 @@ fn loading_receivers_ui(
     for source in rx.sources() {
         let (always_show, string) = match source.as_ref() {
             SmartChannelSource::File(path) => (false, format!("Loading {}…", path.display())),
+
             SmartChannelSource::RrdHttpStream { url } => (false, format!("Loading {url}…")),
+
             SmartChannelSource::RrdWebEventListener => {
                 (false, "Waiting on Web Event Listener…".to_owned())
             }
+
             SmartChannelSource::Sdk => (false, "Waiting on SDK…".to_owned()),
+
             SmartChannelSource::WsClient { ws_server_url } => {
                 (false, format!("Loading from {ws_server_url}…"))
             }
+
             SmartChannelSource::TcpServer { port } => {
                 // We have a TcpServer when running just `cargo rerun`
                 (true, format!("Hosting a TCP Server on port {port}"))
@@ -86,7 +91,10 @@ fn loading_receivers_ui(
         // but it is possible to send multiple recordings over the same channel.
         if always_show || !sources_with_stores.contains(&source) {
             any_shown = true;
-            ctx.re_ui.list_item(string).show(ui);
+            let response = ctx.re_ui.list_item(string).show(ui);
+            if let SmartChannelSource::TcpServer { .. } = source.as_ref() {
+                response.on_hover_text("You can connect to this viewer from a Rerun SDK");
+            }
         }
     }
 

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -243,8 +243,8 @@ fn recording_ui(
 }
 
 fn recording_hover_ui(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, store_db: &re_data_store::StoreDb) {
-    re_ui
-        .selection_grid(ui, "recording_hover_ui")
+    egui::Grid::new("recording_hover_ui")
+        .num_columns(2)
         .show(ui, |ui| {
             re_ui.grid_left_hand_label(ui, "Store ID");
             ui.label(store_db.store_id().to_string());

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -91,7 +91,19 @@ fn loading_receivers_ui(
         // but it is possible to send multiple recordings over the same channel.
         if always_show || !sources_with_stores.contains(&source) {
             any_shown = true;
-            let response = ctx.re_ui.list_item(string).show(ui);
+            let response = ctx
+                .re_ui
+                .list_item(string)
+                .with_buttons(|re_ui, ui| {
+                    let resp = re_ui
+                        .small_icon_button(ui, &re_ui::icons::REMOVE)
+                        .on_hover_text("Disconnect from this source");
+                    if resp.clicked() {
+                        rx.remove(&source);
+                    }
+                    resp
+                })
+                .show(ui);
             if let SmartChannelSource::TcpServer { .. } = source.as_ref() {
                 response.on_hover_text("You can connect to this viewer from a Rerun SDK");
             }

--- a/crates/re_viewer_context/src/store_context.rs
+++ b/crates/re_viewer_context/src/store_context.rs
@@ -4,5 +4,5 @@ use re_data_store::StoreDb;
 pub struct StoreContext<'a> {
     pub blueprint: &'a StoreDb,
     pub recording: Option<&'a StoreDb>,
-    pub alternate_recordings: Vec<&'a StoreDb>,
+    pub all_recordings: Vec<&'a StoreDb>,
 }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -165,9 +165,9 @@ fn to_broadcast_stream(
                 }
                 re_smart_channel::SmartMessagePayload::Quit(err) => {
                     if let Some(err) = err {
-                        re_log::warn!(%msg.source, err, "sender has left unexpectedly");
+                        re_log::warn!("Sender {} has left unexpectedly: {err}", msg.source);
                     } else {
-                        re_log::debug!(%msg.source, "sender has left");
+                        re_log::debug!("Sender {} has left", msg.source);
                     }
                 }
             }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3192

Shows currently loading receivers in the recordings panel until they actually receive some data.

This is a blink-and-you'll-miss-it sort of thing (especially with a good internet connection), but take a look at the top-left of the screen:

![loading-msg](https://github.com/rerun-io/rerun/assets/1148717/20e133ed-8164-4c73-9057-82ba7bfd5d8e)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3307) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3307)
- [Docs preview](https://rerun.io/preview/44f7f8d87b7f656725e3eb7698eee8cd3947ecfb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/44f7f8d87b7f656725e3eb7698eee8cd3947ecfb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)