### PR TITLE
Always codegen queries that contain `InstanceKey`

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-07f507c7fe5a4f0c38f590221674c40d782f77902f6ed20fad90c4cf8ccecd9d
+45a1cd7e47ccc94eb3240065e29bc6a29c95846be7de00de9821185042efdf75

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -73,19 +73,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.AnnotationContextIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.annotation_context".into(),
             "rerun.components.AnnotationContextIndicator".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl AnnotationContext {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
 /// Indicator component for the [`AnnotationContext`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -84,19 +84,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Origin3D".into(),
             "rerun.components.Arrows3DIndicator".into(),
+            "rerun.components.Origin3D".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.radius".into(),
-            "rerun.colorrgba".into(),
-            "rerun.label".into(),
             "rerun.class_id".into(),
+            "rerun.colorrgba".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
+            "rerun.radius".into(),
         ]
     });
 
@@ -104,13 +104,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Vector3D".into(),
-            "rerun.components.Origin3D".into(),
             "rerun.components.Arrows3DIndicator".into(),
-            "rerun.radius".into(),
-            "rerun.colorrgba".into(),
-            "rerun.label".into(),
+            "rerun.components.Origin3D".into(),
             "rerun.class_id".into(),
+            "rerun.colorrgba".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
+            "rerun.radius".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -76,20 +76,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Origin2D".into(),
             "rerun.colorrgba".into(),
             "rerun.components.Boxes2DIndicator".into(),
+            "rerun.components.Origin2D".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.radius".into(),
-            "rerun.label".into(),
-            "rerun.draw_order".into(),
             "rerun.class_id".into(),
+            "rerun.draw_order".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
+            "rerun.radius".into(),
         ]
     });
 
@@ -97,14 +97,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.HalfSizes2D".into(),
-            "rerun.components.Origin2D".into(),
             "rerun.colorrgba".into(),
             "rerun.components.Boxes2DIndicator".into(),
-            "rerun.radius".into(),
-            "rerun.label".into(),
-            "rerun.draw_order".into(),
+            "rerun.components.Origin2D".into(),
             "rerun.class_id".into(),
+            "rerun.draw_order".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
+            "rerun.radius".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/clear.rs
+++ b/crates/re_types/src/archetypes/clear.rs
@@ -106,19 +106,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.ClearIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.ClearSettings".into(),
             "rerun.components.ClearIndicator".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl Clear {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
 /// Indicator component for the [`Clear`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -63,26 +63,28 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.DepthImageIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.DepthMeter".into(),
             "rerun.draw_order".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
             "rerun.components.DepthImageIndicator".into(),
             "rerun.components.DepthMeter".into(),
             "rerun.draw_order".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl DepthImage {
-    pub const NUM_COMPONENTS: usize = 4usize;
+    pub const NUM_COMPONENTS: usize = 5usize;
 }
 
 /// Indicator component for the [`DepthImage`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -57,19 +57,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.DisconnectedSpaceIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.disconnected_space".into(),
             "rerun.components.DisconnectedSpaceIndicator".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl DisconnectedSpace {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
 /// Indicator component for the [`DisconnectedSpace`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -61,20 +61,21 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.ImageIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.draw_order".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.draw_order".into(), "rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
             "rerun.components.ImageIndicator".into(),
             "rerun.draw_order".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl Image {
-    pub const NUM_COMPONENTS: usize = 3usize;
+    pub const NUM_COMPONENTS: usize = 4usize;
 }
 
 /// Indicator component for the [`Image`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -109,19 +109,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.LineStrips2DIndicator".into(),
+            "rerun.radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.label".into(),
-            "rerun.draw_order".into(),
             "rerun.class_id".into(),
+            "rerun.draw_order".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
         ]
     });
 
@@ -129,13 +129,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.linestrip2d".into(),
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.LineStrips2DIndicator".into(),
-            "rerun.label".into(),
-            "rerun.draw_order".into(),
+            "rerun.radius".into(),
             "rerun.class_id".into(),
+            "rerun.draw_order".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -104,18 +104,18 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.LineStrips3DIndicator".into(),
+            "rerun.radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.label".into(),
             "rerun.class_id".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
         ]
     });
 
@@ -123,12 +123,12 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.linestrip3d".into(),
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.LineStrips3DIndicator".into(),
-            "rerun.label".into(),
+            "rerun.radius".into(),
             "rerun.class_id".into(),
             "rerun.instance_key".into(),
+            "rerun.label".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -80,20 +80,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.Points2DIndicator".into(),
+            "rerun.radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.label".into(),
-            "rerun.draw_order".into(),
             "rerun.class_id".into(),
-            "rerun.keypoint_id".into(),
+            "rerun.draw_order".into(),
             "rerun.instance_key".into(),
+            "rerun.keypoint_id".into(),
+            "rerun.label".into(),
         ]
     });
 
@@ -101,14 +101,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.point2d".into(),
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.Points2DIndicator".into(),
-            "rerun.label".into(),
-            "rerun.draw_order".into(),
+            "rerun.radius".into(),
             "rerun.class_id".into(),
-            "rerun.keypoint_id".into(),
+            "rerun.draw_order".into(),
             "rerun.instance_key".into(),
+            "rerun.keypoint_id".into(),
+            "rerun.label".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -70,19 +70,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.Points3DIndicator".into(),
+            "rerun.radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.label".into(),
             "rerun.class_id".into(),
-            "rerun.keypoint_id".into(),
             "rerun.instance_key".into(),
+            "rerun.keypoint_id".into(),
+            "rerun.label".into(),
         ]
     });
 
@@ -90,13 +90,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.point3d".into(),
-            "rerun.radius".into(),
             "rerun.colorrgba".into(),
             "rerun.components.Points3DIndicator".into(),
-            "rerun.label".into(),
+            "rerun.radius".into(),
             "rerun.class_id".into(),
-            "rerun.keypoint_id".into(),
             "rerun.instance_key".into(),
+            "rerun.keypoint_id".into(),
+            "rerun.label".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -73,20 +73,21 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.SegmentationImageIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.draw_order".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.draw_order".into(), "rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
             "rerun.components.SegmentationImageIndicator".into(),
             "rerun.draw_order".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl SegmentationImage {
-    pub const NUM_COMPONENTS: usize = 3usize;
+    pub const NUM_COMPONENTS: usize = 4usize;
 }
 
 /// Indicator component for the [`SegmentationImage`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -48,19 +48,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.TensorIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.TensorData".into(),
             "rerun.components.TensorIndicator".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl Tensor {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
 /// Indicator component for the [`Tensor`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -25,19 +25,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.TextDocumentIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.label".into(),
             "rerun.components.TextDocumentIndicator".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl TextDocument {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
 /// Indicator component for the [`TextDocument`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -27,25 +27,26 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.TextLogLevel".into(),
             "rerun.components.TextLogIndicator".into(),
+            "rerun.components.TextLogLevel".into(),
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.label".into(),
-            "rerun.components.TextLogLevel".into(),
             "rerun.components.TextLogIndicator".into(),
+            "rerun.components.TextLogLevel".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl TextLog {
-    pub const NUM_COMPONENTS: usize = 3usize;
+    pub const NUM_COMPONENTS: usize = 4usize;
 }
 
 /// Indicator component for the [`TextLog`] [`crate::Archetype`]

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -68,19 +68,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.components.Transform3DIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 0usize]> =
-    once_cell::sync::Lazy::new(|| []);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
+    once_cell::sync::Lazy::new(|| ["rerun.instance_key".into()]);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.transform3d".into(),
             "rerun.components.Transform3DIndicator".into(),
+            "rerun.instance_key".into(),
         ]
     });
 
 impl Transform3D {
-    pub const NUM_COMPONENTS: usize = 2usize;
+    pub const NUM_COMPONENTS: usize = 3usize;
 }
 
 /// Indicator component for the [`Transform3D`] [`crate::Archetype`]

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -91,18 +91,10 @@ pub struct AffixFuzzer1 {
     pub fuzz2118: Option<Vec<crate::testing::components::AffixFuzzer18>>,
 }
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 38usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 20usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -113,9 +105,8 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 38usize
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
             "rerun.testing.components.AffixFuzzer19".into(),
-            "rerun.testing.components.AffixFuzzer20".into(),
-            "rerun.testing.components.AffixFuzzer1".into(),
             "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer20".into(),
             "rerun.testing.components.AffixFuzzer3".into(),
             "rerun.testing.components.AffixFuzzer4".into(),
             "rerun.testing.components.AffixFuzzer5".into(),
@@ -123,33 +114,17 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 38usize
             "rerun.testing.components.AffixFuzzer7".into(),
             "rerun.testing.components.AffixFuzzer8".into(),
             "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
         ]
     });
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.testing.components.AffixFuzzer1Indicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.instance_key".into(),
             "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -159,7 +134,6 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer1".into(),
             "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer3".into(),
             "rerun.testing.components.AffixFuzzer4".into(),
@@ -168,30 +142,13 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 36usize
             "rerun.testing.components.AffixFuzzer7".into(),
             "rerun.testing.components.AffixFuzzer8".into(),
             "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 75usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 40usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -202,9 +159,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 75usize]> =
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
             "rerun.testing.components.AffixFuzzer19".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer20".into(),
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer3".into(),
             "rerun.testing.components.AffixFuzzer4".into(),
             "rerun.testing.components.AffixFuzzer5".into(),
@@ -212,25 +168,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 75usize]> =
             "rerun.testing.components.AffixFuzzer7".into(),
             "rerun.testing.components.AffixFuzzer8".into(),
             "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
             "rerun.testing.components.AffixFuzzer1Indicator".into(),
+            "rerun.instance_key".into(),
             "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -240,7 +180,6 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 75usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer1".into(),
             "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer3".into(),
             "rerun.testing.components.AffixFuzzer4".into(),
@@ -249,20 +188,11 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[crate::ComponentName; 75usize]> =
             "rerun.testing.components.AffixFuzzer7".into(),
             "rerun.testing.components.AffixFuzzer8".into(),
             "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
         ]
     });
 
 impl AffixFuzzer1 {
-    pub const NUM_COMPONENTS: usize = 75usize;
+    pub const NUM_COMPONENTS: usize = 40usize;
 }
 
 /// Indicator component for the [`AffixFuzzer1`] [`crate::Archetype`]

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -775,9 +775,7 @@ fn quote_trait_impls_from_obj(
                             .unwrap_or(fqname)
                     })
                     .chain(extras)
-                    .collect::<Vec<_>>();
-                components.sort();
-                components.dedup();
+                    .collect::<BTreeSet<_>>();
 
                 let num_components = components.len();
                 let quoted_components = quote!(#(#components.into(),)*);


### PR DESCRIPTION
All our internal queries expect instance keys to be present in the results, whether they use them or not.
And since queries have to be crafted at compile-time, we need to make sure it's there when codegen'ing our builtin archetypes.

Fixes:
- #3294

![image](https://github.com/rerun-io/rerun/assets/2910679/74543996-1c06-46e1-b851-ed5480c0e9ab)


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3310) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3310)
- [Docs preview](https://rerun.io/preview/4549fb5e2ed3bba0102083c6f8076283bf97faec/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4549fb5e2ed3bba0102083c6f8076283bf97faec/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)