### PR TITLE
Speed up startup of viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,6 +4237,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "re_format",
  "re_log",
+ "re_tracing",
  "smallvec",
  "sysinfo",
  "wasm-bindgen",

--- a/crates/re_data_source/src/data_source.rs
+++ b/crates/re_data_source/src/data_source.rs
@@ -103,6 +103,7 @@ impl DataSource {
         self,
         on_msg: Option<Box<dyn Fn() + Send + Sync>>,
     ) -> anyhow::Result<Receiver<LogMsg>> {
+        re_tracing::profile_function!();
         match self {
             DataSource::RrdHttpUrl(url) => Ok(
                 re_log_encoding::stream_rrd_from_http::stream_rrd_from_http_to_channel(url, on_msg),

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -6,6 +6,8 @@ use re_viewer_context::{ComponentUiRegistry, UiVerbosity, ViewerContext};
 use super::{DataUi, EntityDataUi};
 
 pub fn create_component_ui_registry() -> ComponentUiRegistry {
+    re_tracing::profile_function!();
+
     /// Registers how to show a given component in the ui.
     pub fn add<C: EntityDataUi + re_types::Component>(registry: &mut ComponentUiRegistry) {
         registry.add(

--- a/crates/re_memory/Cargo.toml
+++ b/crates/re_memory/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 [dependencies]
 re_format.workspace = true
 re_log.workspace = true
+re_tracing.workspace = true
 
 ahash.workspace = true
 emath.workspace = true

--- a/crates/re_memory/src/ram_warner.rs
+++ b/crates/re_memory/src/ram_warner.rs
@@ -1,6 +1,7 @@
 /// Amount of available RAM on this machine.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn total_ram_in_bytes() -> u64 {
+    re_tracing::profile_function!();
     use sysinfo::SystemExt as _;
 
     let mut sys = sysinfo::System::new_all();

--- a/crates/re_memory/src/ram_warner.rs
+++ b/crates/re_memory/src/ram_warner.rs
@@ -2,10 +2,15 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub fn total_ram_in_bytes() -> u64 {
     re_tracing::profile_function!();
-    use sysinfo::SystemExt as _;
 
-    let mut sys = sysinfo::System::new_all();
-    sys.refresh_all();
+    use sysinfo::{RefreshKind, SystemExt as _};
+
+    let mut sys = sysinfo::System::new_with_specifics(RefreshKind::new().with_memory());
+
+    {
+        re_tracing::profile_scope!("refresh_memory");
+        sys.refresh_memory();
+    }
 
     sys.total_memory()
 }

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -68,7 +68,6 @@ pub async fn host_web_viewer(
     open_browser: bool,
     source_url: String,
 ) -> anyhow::Result<()> {
-    re_tracing::profile_function!();
     let web_server = re_web_viewer_server::WebViewerServer::new(&bind_ip, web_port)?;
     let http_web_viewer_url = web_server.server_url();
     let web_server_handle = web_server.serve();

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -68,6 +68,7 @@ pub async fn host_web_viewer(
     open_browser: bool,
     source_url: String,
 ) -> anyhow::Result<()> {
+    re_tracing::profile_function!();
     let web_server = re_web_viewer_server::WebViewerServer::new(&bind_ip, web_port)?;
     let http_web_viewer_url = web_server.server_url();
     let web_server_handle = web_server.serve();

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -25,9 +25,9 @@ server = []
 
 
 [dependencies]
-re_log.workspace = true
 re_log_encoding.workspace = true
 re_log_types = { workspace = true, features = ["serde"] }
+re_log.workspace = true
 re_smart_channel.workspace = true
 
 ahash.workspace = true

--- a/crates/re_tracing/src/server.rs
+++ b/crates/re_tracing/src/server.rs
@@ -16,6 +16,7 @@ impl Drop for Profiler {
 impl Profiler {
     pub fn start(&mut self) {
         puffin::set_scopes_on(true);
+        crate::profile_function!();
 
         if self.server.is_none() {
             self.start_server();
@@ -24,6 +25,7 @@ impl Profiler {
     }
 
     fn start_server(&mut self) {
+        crate::profile_function!();
         let bind_addr = format!("0.0.0.0:{PORT}");
         self.server = match puffin_http::Server::new(&bind_addr) {
             Ok(puffin_server) => {
@@ -41,6 +43,7 @@ impl Profiler {
 }
 
 fn start_puffin_viewer() {
+    crate::profile_function!();
     let url = format!("0.0.0.0:{PORT}");
     let child = std::process::Command::new("puffin_viewer")
         .arg("--url")

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-7d2e57af8be6ee15c7c1a9a8f1e09968d8ce5e53f153f334b19ae5e9aea59245
+069e2d61e3f3b561fe2340e0105977034ee4635f285021b41f709fdfe0ca234b

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -150,6 +150,8 @@ impl App {
         re_ui: re_ui::ReUi,
         storage: Option<&dyn eframe::Storage>,
     ) -> Self {
+        re_tracing::profile_function!();
+
         let (logger, text_log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Info);
         if re_log::add_boxed_logger(Box::new(logger)).is_err() {
             // This can happen when `rerun` crate users call `spawn`. TODO(emilk): make `spawn` spawn a new process.
@@ -202,6 +204,8 @@ impl App {
 
         let (command_sender, command_receiver) = command_channel();
 
+        let component_ui_registry = re_data_ui::create_component_ui_registry();
+
         Self {
             build_info,
             startup_options,
@@ -213,7 +217,7 @@ impl App {
             profiler: Default::default(),
 
             text_log_rx,
-            component_ui_registry: re_data_ui::create_component_ui_registry(),
+            component_ui_registry,
             rx: Default::default(),
             #[cfg(target_arch = "wasm32")]
             open_files_promise: Default::default(),
@@ -1099,6 +1103,7 @@ impl eframe::App for App {
 fn populate_space_view_class_registry_with_builtin(
     space_view_class_registry: &mut SpaceViewClassRegistry,
 ) -> Result<(), SpaceViewClassRegistryError> {
+    re_tracing::profile_function!();
     space_view_class_registry.add_class::<re_space_view_bar_chart::BarChartSpaceView>()?;
     space_view_class_registry.add_class::<re_space_view_spatial::SpatialSpaceView2D>()?;
     space_view_class_registry.add_class::<re_space_view_spatial::SpatialSpaceView3D>()?;

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -118,6 +118,7 @@ impl AppEnvironment {
 // ---------------------------------------------------------------------------
 
 pub(crate) fn wgpu_options() -> egui_wgpu::WgpuConfiguration {
+    re_tracing::profile_function!();
     egui_wgpu::WgpuConfiguration {
             // When running wgpu on native debug builds, we want some extra control over how
             // and when a poisoned surface gets recreated.
@@ -146,6 +147,7 @@ pub(crate) fn wgpu_options() -> egui_wgpu::WgpuConfiguration {
 /// Customize eframe and egui to suit the rerun viewer.
 #[must_use]
 pub fn customize_eframe(cc: &eframe::CreationContext<'_>) -> re_ui::ReUi {
+    re_tracing::profile_function!();
     if let Some(render_state) = &cc.wgpu_render_state {
         use re_renderer::{config::RenderContextConfig, RenderContext};
 

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -23,6 +23,7 @@ pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
 }
 
 fn check_graphics_driver(wgpu_render_state: Option<&egui_wgpu::RenderState>) {
+    re_tracing::profile_function!();
     let wgpu_render_state = wgpu_render_state.expect("Expected wgpu to be enabled");
     let info = wgpu_render_state.adapter.get_info();
 
@@ -77,6 +78,7 @@ fn check_graphics_driver(wgpu_render_state: Option<&egui_wgpu::RenderState>) {
 }
 
 pub fn eframe_options() -> eframe::NativeOptions {
+    re_tracing::profile_function!();
     eframe::NativeOptions {
         // Controls where on disk the app state is persisted.
         app_id: Some(APP_ID.to_owned()),
@@ -108,6 +110,8 @@ pub fn eframe_options() -> eframe::NativeOptions {
 
 #[allow(clippy::unnecessary_wraps)]
 fn icon_data() -> Option<eframe::IconData> {
+    re_tracing::profile_function!();
+
     cfg_if::cfg_if! {
         if #[cfg(target_os = "macos")] {
             let app_icon_png_bytes = include_bytes!("../data/app_icon_mac.png");

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -57,6 +57,7 @@ impl StoreHub {
     /// by `[StoreHub::welcome_screen_app_id]`. It should be used as a marker to display the welcome
     /// screen.
     pub fn new() -> Self {
+        re_tracing::profile_function!();
         let mut blueprints = HashMap::new();
         blueprints.insert(
             Self::welcome_screen_app_id(),

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -25,6 +25,8 @@ pub struct ViewerAnalytics {
 impl ViewerAnalytics {
     #[allow(unused_mut, clippy::let_and_return)]
     pub fn new(startup_options: &StartupOptions) -> Self {
+        re_tracing::profile_function!();
+
         // We only want to have analytics on `*.rerun.io`,
         // so we early-out if we detect we're running in a notebook.
         if startup_options.is_in_notebook {
@@ -87,6 +89,7 @@ impl ViewerAnalytics {
         build_info: &re_build_info::BuildInfo,
         app_env: &crate::AppEnvironment,
     ) {
+        re_tracing::profile_function!();
         use crate::AppEnvironment;
         let app_env_str = match app_env {
             AppEnvironment::CSdk => "c_sdk",

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -414,21 +414,24 @@ async fn run_impl(
     let profiler = profiler(&args);
 
     #[cfg(feature = "native_viewer")]
-    let startup_options = re_viewer::StartupOptions {
-        memory_limit: re_memory::MemoryLimit::parse(&args.memory_limit)
-            .unwrap_or_else(|err| panic!("Bad --memory-limit: {err}")),
-        persist_state: args.persist_state,
-        is_in_notebook: false,
-        screenshot_to_path_then_quit: args.screenshot_to.clone(),
+    let startup_options = {
+        re_tracing::profile_scope!("StartupOptions");
+        re_viewer::StartupOptions {
+            memory_limit: re_memory::MemoryLimit::parse(&args.memory_limit)
+                .unwrap_or_else(|err| panic!("Bad --memory-limit: {err}")),
+            persist_state: args.persist_state,
+            is_in_notebook: false,
+            screenshot_to_path_then_quit: args.screenshot_to.clone(),
 
-        skip_welcome_screen: args.skip_welcome_screen,
+            skip_welcome_screen: args.skip_welcome_screen,
 
-        // TODO(emilk): make it easy to set this on eframe instead
-        resolution_in_points: if let Some(size) = &args.window_size {
-            Some(parse_size(size)?)
-        } else {
-            None
-        },
+            // TODO(emilk): make it easy to set this on eframe instead
+            resolution_in_points: if let Some(size) = &args.window_size {
+                Some(parse_size(size)?)
+            } else {
+                None
+            },
+        }
     };
 
     // Where do we get the data from?


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3313

It could take up to a second to start the viewer on Mac.

The problem was that reading the total RAM usage of the system could be very slow on Mac.
This was due to my lazy usage of the `sysinfo` crate, where I asked it to refresh all the system info, and then only accessed the memory limit.
The PR adds a bunch of profiling scopes, and then tells `sysinfo` to only look up the memory info, which is much MUCH faster.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3314) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3314)
- [Docs preview](https://rerun.io/preview/3012ea123f359f23a6beac522337066a2a552a69/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3012ea123f359f23a6beac522337066a2a552a69/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)