### PR TITLE
Now that types have been migrated, remove the old overrides implementation.

### DIFF
--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -1,7 +1,5 @@
 //! Generates Rust & Python code from flatbuffers definitions.
 
-use std::path::PathBuf;
-
 use re_build_tools::{
     compute_crate_hash, compute_dir_filtered_hash, compute_dir_hash, compute_strings_hash,
     is_tracked_env_var_set, iter_dir, read_versioning_hash, rerun_if_changed,
@@ -17,11 +15,6 @@ const DOC_EXAMPLES_DIR_PATH: &str = "../../docs/code-examples";
 const CPP_OUTPUT_DIR_PATH: &str = "../../rerun_cpp";
 const RUST_OUTPUT_DIR_PATH: &str = ".";
 const PYTHON_OUTPUT_DIR_PATH: &str = "../../rerun_py/rerun_sdk/rerun/_rerun2";
-
-// located in PYTHON_OUTPUT_DIR_PATH
-const ARCHETYPE_OVERRIDES_SUB_DIR_PATH: &str = "archetypes/_overrides";
-const COMPONENT_OVERRIDES_SUB_DIR_PATH: &str = "components/_overrides";
-const DATATYPE_OVERRIDES_SUB_DIR_PATH: &str = "datatypes/_overrides";
 
 fn main() {
     if cfg!(target_os = "windows") {
@@ -50,18 +43,9 @@ fn main() {
     let re_types_builder_hash = compute_crate_hash("re_types_builder");
     let definitions_hash = compute_dir_hash(DEFINITIONS_DIR_PATH, Some(&["fbs"]));
     let doc_examples_hash = compute_dir_hash(DOC_EXAMPLES_DIR_PATH, Some(&["rs", "py", "cpp"]));
-    let python_archetype_overrides_hash = compute_dir_hash(
-        PathBuf::from(PYTHON_OUTPUT_DIR_PATH).join(ARCHETYPE_OVERRIDES_SUB_DIR_PATH),
-        Some(&["py"]),
-    );
-    let python_component_overrides_hash = compute_dir_hash(
-        PathBuf::from(PYTHON_OUTPUT_DIR_PATH).join(COMPONENT_OVERRIDES_SUB_DIR_PATH),
-        Some(&["py"]),
-    );
-    let python_datatype_overrides_hash = compute_dir_hash(
-        PathBuf::from(PYTHON_OUTPUT_DIR_PATH).join(DATATYPE_OVERRIDES_SUB_DIR_PATH),
-        Some(&["py"]),
-    );
+    let python_extensions_hash = compute_dir_filtered_hash(PYTHON_OUTPUT_DIR_PATH, |path| {
+        path.to_str().unwrap().ends_with("_ext.py")
+    });
     let cpp_extensions_hash = compute_dir_filtered_hash(CPP_OUTPUT_DIR_PATH, |path| {
         path.to_str().unwrap().ends_with("_ext.cpp")
     });
@@ -70,9 +54,7 @@ fn main() {
         &re_types_builder_hash,
         &definitions_hash,
         &doc_examples_hash,
-        &python_archetype_overrides_hash,
-        &python_component_overrides_hash,
-        &python_datatype_overrides_hash,
+        &python_extensions_hash,
         &cpp_extensions_hash,
     ]);
 
@@ -80,9 +62,7 @@ fn main() {
     eprintln!("re_types_builder_hash: {re_types_builder_hash:?}");
     eprintln!("definitions_hash: {definitions_hash:?}");
     eprintln!("doc_examples_hash: {doc_examples_hash:?}");
-    eprintln!("python_archetype_overrides_hash: {python_archetype_overrides_hash:?}");
-    eprintln!("python_component_overrides_hash: {python_component_overrides_hash:?}");
-    eprintln!("python_datatype_overrides_hash: {python_datatype_overrides_hash:?}");
+    eprintln!("python_extensions_hash: {python_extensions_hash:?}");
     eprintln!("cpp_extensions_hash: {cpp_extensions_hash:?}");
     eprintln!("new_hash: {new_hash:?}");
     eprintln!("cur_hash: {cur_hash:?}");

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-3b41f850c4bda86da7ad32b64b26f118d8ba7dd6aeb4bcb3a260aa7ccf74a4c0
+1ffc3283285df99aa0dd1a4c3f7dfafcd3ef31e9dbc1ecdf36b86066f4c371bf

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-1ffc3283285df99aa0dd1a4c3f7dfafcd3ef31e9dbc1ecdf36b86066f4c371bf
+f1fffafcb5c451716a6a74d369fee53886e3d8fce049eecc2f3bfbad2522f7cd

--- a/rerun_py/rerun_sdk/rerun/_rerun2/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/_baseclasses.py
@@ -106,7 +106,7 @@ class BaseExtensionArray(NamedExtensionArray, Generic[T]):  # type: ignore[misc]
         that the top-level datatype implements it.
 
         A hand-coded override must be provided for the code generator to implement this method. The override must be
-        namd `native_to_pa_array_override()` and exist as a static member of the `<TYPE>Ext` class located in
+        named `native_to_pa_array_override()` and exist as a static member of the `<TYPE>Ext` class located in
         `<type>_ext.py`.
 
         `ColorExt.native_to_pa_array_override()` in `color_ext.py` is a good example of how to implement this method, in

--- a/rerun_py/rerun_sdk/rerun/_rerun2/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/_baseclasses.py
@@ -106,13 +106,12 @@ class BaseExtensionArray(NamedExtensionArray, Generic[T]):  # type: ignore[misc]
         that the top-level datatype implements it.
 
         A hand-coded override must be provided for the code generator to implement this method. The override must be
-        named `xxx__native_to_pa_array_override()`, where `xxx` is the lowercase name of the datatype. The override must be
-        located in the `_overrides` subpackage and *explicitly* imported by `_overrides/__init__.py` (to be noticed
-        by the code generator).
+        namd `native_to_pa_array_override()` and exist as a static member of the `<TYPE>Ext` class located in
+        `<type>_ext.py`.
 
-        `color__native_to_pa_array_override()` in `_overrides/color.py` is a good example of how to implement this method, in
-        conjunction with the native type's converter (see `color_converter()`, used to construct the native `Color`
-        object).
+        `ColorExt.native_to_pa_array_override()` in `color_ext.py` is a good example of how to implement this method, in
+        conjunction with the native type's converter (see `rgba__field_converter_override()`, used to construct the
+        native `Color` object).
 
         Parameters
         ----------

--- a/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/_overrides/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/archetypes/_overrides/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/_overrides/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/_overrides/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations


### PR DESCRIPTION
### What
https://github.com/rerun-io/rerun/pull/3304
https://github.com/rerun-io/rerun/pull/3316
https://github.com/rerun-io/rerun/pull/3317
Updated all of the python types to the new `_ext.py` override system.

Kill off the dead-code and cleanup the hash logic.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3318) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3318)
- [Docs preview](https://rerun.io/preview/ffc47bbc4250d8b2fded1ed778b383f8dd9b1aae/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ffc47bbc4250d8b2fded1ed778b383f8dd9b1aae/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)