### PR TITLE
Get rid of spurious warning and creating of TextDocumentView when using TextLogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,6 +4497,7 @@ version = "0.9.0-alpha.4"
 dependencies = [
  "egui",
  "re_arrow_store",
+ "re_log",
  "re_query",
  "re_renderer",
  "re_types",

--- a/crates/re_space_view_text_document/Cargo.toml
+++ b/crates/re_space_view_text_document/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [dependencies]
 re_arrow_store.workspace = true
+re_log.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_types.workspace = true

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -46,7 +46,7 @@ impl ViewPartSystem for TextDocumentSystem {
         let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 
         for (ent_path, _props) in query.iter_entities_for_system(Self::name()) {
-            // TOOD(jleibs): this match can go away once we resolve:
+            // TODO(jleibs): this match can go away once we resolve:
             // https://github.com/rerun-io/rerun/issues/3320
             match query_archetype::<re_types::archetypes::TextDocument>(
                 store,

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -1,6 +1,6 @@
 use re_arrow_store::LatestAtQuery;
 use re_query::{query_archetype, QueryError};
-use re_types::Archetype as _;
+use re_types::{Archetype as _, Loggable as _};
 use re_viewer_context::{
     ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
     ViewPartSystem, ViewQuery, ViewerContext,
@@ -27,9 +27,12 @@ impl NamedViewSystem for TextDocumentSystem {
 
 impl ViewPartSystem for TextDocumentSystem {
     fn archetype(&self) -> ArchetypeDefinition {
-        re_types::archetypes::TextDocument::all_components()
-            .try_into()
-            .unwrap()
+        // TODO(#3159): use actual archetype definition
+        // TextDocument::all_components().try_into().unwrap()
+        vec1::vec1![
+            re_types::archetypes::TextDocument::indicator_component(),
+            re_types::components::Text::name(),
+        ]
     }
 
     fn execute(


### PR DESCRIPTION
### What
Specifies the indicator component int he TextDocumentSystem to avoid creating the view when we aren't loggined TextDocuments.

Also handles the case of PrimaryComponentNotFound is the way the other views do until we resolve https://github.com/rerun-io/rerun/issues/3320

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3321) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3321)
- [Docs preview](https://rerun.io/preview/1b5002ff0195065dd12728b693321c4b7481e96e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1b5002ff0195065dd12728b693321c4b7481e96e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)