### PR TITLE
Update all uses of `actions/checkout` to use explicit `ref`

### DIFF
--- a/.github/workflows/checkboxes.yml
+++ b/.github/workflows/checkboxes.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
       - uses: streetsidesoftware/cspell-action@v2
         with:
           config: "docs/cspell.json"
@@ -24,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
       - uses: jprochazk/linkinator-action@main
         with:
           paths: "docs/**/*.md"

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -60,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
+          ref: ${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha) }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -148,6 +148,8 @@ jobs:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -42,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_build_web_demo.yml
+++ b/.github/workflows/reusable_build_web_demo.yml
@@ -44,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha }}
 
       - name: Download Web Viewer
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -52,6 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
+
       - uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,6 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -113,6 +118,8 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -196,6 +203,8 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -227,6 +236,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Install taplo-cli
         uses: taiki-e/install-action@v2
@@ -244,6 +255,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -274,6 +287,8 @@ jobs:
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Check spelling of entire workspace
         uses: crate-ci/typos@master
@@ -287,6 +302,8 @@ jobs:
       image: rerunio/ci_docker:0.9
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Cargo Deny
         shell: bash
@@ -300,6 +317,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Run clang format on all relevant files
         uses: jidicula/clang-format-action@v4.11.0
@@ -317,6 +336,8 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -338,3 +359,4 @@ jobs:
       - name: Build code examples
         shell: bash
         run: ./docs/code-examples/build_all.sh --werror
+

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Don't do a shallow clone
-          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
+          ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha) }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Don't do a shallow clone since we need to push gh-pages
-          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
+          ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha) }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.COMMIT || github.sha }}
+          ref: ${{ inputs.COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha) }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
+          ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha) }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Download Wheel
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Get context
         id: context

--- a/.github/workflows/reusable_update_pr_body.yml
+++ b/.github/workflows/reusable_update_pr_body.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Download RRD
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_upload_web_demo.yml
+++ b/.github/workflows/reusable_upload_web_demo.yml
@@ -51,6 +51,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Download web demo assets
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_upload_wheels.yml
+++ b/.github/workflows/reusable_upload_wheels.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.RELEASE_COMMIT || github.sha }}
+          ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha) }}
 
       - name: Download RRD
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

`actions/checkout` uses `GITHUB_SHA` by default for the `ref` which it checks out. This sometimes leads to confusing issues, because the `pull_request` commit actually operates not on the latest commit of a pull request, but on the latest _merge_ commit of a pull request. This causes a lot of confusion and even actual bugs.

In this PR, I'm setting all the `ref` values explicitly to whatever is available:
- Some reusable workflows already require a commit, .e.g `reusable_build_and_publish_web` has a `release-commit` input
- If the workflow can be triggered from a PR, then we use `github.event.pull_request.head.ref`, which points to the HEAD of the PR branch.
- In all other cases we fall back to `github.sha`. For example a `push` to `main` will still use `github.sha`, which is fine.

**There are caveats**. With these changes, we no longer test PRs on the merge commit. That means if your PR is out-of-date with the target branch (e.g. `main`), and someone pushes to `main`, you are less likely to find out about any potential incompatibility if it doesn't cause a merge conflict. This means we need to be careful about merging without being up-to-date with `main`. Worst case scenario it will result in more failures on `main` which we'll be notified about on Slack.

The main benefit of this is less confusion about which commit we're on when viewing the web demo, which is an essential part of our overall workflow at this point. Once we get over the `source_hash` situation and have the ability to turn on merge queue, we'll once again have much more "main safety".

Before: 
![image](https://github.com/rerun-io/rerun/assets/1665677/df572ccf-1a4b-44f3-ac1d-99d4f224ec1f)


After:
![image](https://github.com/rerun-io/rerun/assets/1665677/ee220ba0-ef62-4f85-a58a-43b8a5d8b146)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3322) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3322)
- [Docs preview](https://rerun.io/preview/99f0bc92ea87cfc1868d11173b632ba6d8801e72/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/99f0bc92ea87cfc1868d11173b632ba6d8801e72/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)