### PR TITLE
Rethink view selection & filtering + make all views opt-in

### DIFF
--- a/crates/re_arrow_store/src/store.rs
+++ b/crates/re_arrow_store/src/store.rs
@@ -3,9 +3,9 @@ use std::sync::atomic::AtomicU64;
 
 use ahash::HashMap;
 use arrow2::datatypes::DataType;
-use nohash_hasher::{IntMap, IntSet};
+use nohash_hasher::IntMap;
 use parking_lot::RwLock;
-use re_types::ComponentName;
+use re_types::{ComponentName, ComponentNameSet};
 use smallvec::SmallVec;
 
 use re_log_types::{
@@ -400,7 +400,7 @@ pub struct IndexedTable {
     /// Note that this set will never be purged and will continue to return components that may
     /// have been set in the past even if all instances of that component have since been purged
     /// to free up space.
-    pub all_components: IntSet<ComponentName>,
+    pub all_components: ComponentNameSet,
 
     /// The number of rows stored in this table, across all of its buckets.
     pub buckets_num_rows: u64,

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -1,10 +1,9 @@
 use std::{ops::RangeBounds, sync::atomic::Ordering};
 
 use itertools::Itertools;
-use nohash_hasher::IntSet;
 use re_log::trace;
 use re_log_types::{DataCell, EntityPath, RowId, TimeInt, TimePoint, TimeRange, Timeline};
-use re_types::ComponentName;
+use re_types::{ComponentName, ComponentNameSet};
 use smallvec::SmallVec;
 
 use crate::{DataStore, IndexedBucket, IndexedBucketInner, IndexedTable, PersistentIndexedTable};
@@ -107,7 +106,7 @@ impl DataStore {
             "query started…"
         );
 
-        let timeless: Option<IntSet<_>> = self
+        let timeless: Option<ComponentNameSet> = self
             .timeless_tables
             .get(&ent_path_hash)
             .map(|table| table.columns.keys().cloned().collect());

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -9,7 +9,7 @@ use re_log_types::{
     DataCell, DataCellColumn, DataCellError, DataRow, DataTable, RowId, SizeBytes as _, TimeInt,
     TimePoint, TimeRange,
 };
-use re_types::{components::InstanceKey, ComponentName, Loggable};
+use re_types::{components::InstanceKey, ComponentName, ComponentNameSet, Loggable};
 
 use crate::{
     store::MetadataRegistry, DataStore, DataStoreConfig, IndexedBucket, IndexedBucketInner,
@@ -283,7 +283,7 @@ impl IndexedTable {
     ) {
         re_tracing::profile_function!();
 
-        let components: IntSet<_> = row.component_names().collect();
+        let components: ComponentNameSet = row.component_names().collect();
 
         // borrowck workaround
         let timeline = self.timeline;
@@ -427,7 +427,7 @@ impl IndexedBucket {
         time: TimeInt,
         generated_cluster_cell: Option<DataCell>,
         row: &DataRow,
-        components: &IntSet<ComponentName>,
+        components: &ComponentNameSet,
     ) -> u64 {
         re_tracing::profile_function!();
 

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeMap;
 use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
 use re_log_types::{TimeInt, Timeline};
-use re_types::{
-    archetypes::Tensor, datatypes::TensorData, Archetype, ComponentName, Loggable as _,
-};
+use re_types::{archetypes::Tensor, datatypes::TensorData, Archetype, ComponentName};
 use re_viewer_context::{
     external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
@@ -31,15 +29,13 @@ impl ViewPartSystem for BarChartViewPartSystem {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
-        components: &[ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
-        if !components.contains(&re_types::archetypes::Tensor::indicator_component())
-            || !components.contains(&re_types::components::TensorData::name())
-        {
+        if !components.contains(&re_types::archetypes::Tensor::indicator_component()) {
             return false;
         }
 

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -34,7 +34,9 @@ impl ViewPartSystem for BarChartViewPartSystem {
         ent_path: &EntityPath,
         components: &[ComponentName],
     ) -> bool {
-        if !components.contains(&re_types::components::TensorData::name()) {
+        if !components.contains(&re_types::archetypes::Tensor::indicator_component())
+            || !components.contains(&re_types::components::TensorData::name())
+        {
             return false;
         }
 

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -7,8 +7,8 @@ use re_types::{
     archetypes::Tensor, datatypes::TensorData, Archetype, ComponentName, Loggable as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 /// A bar chart system, with everything needed to render it.
@@ -24,8 +24,11 @@ impl NamedViewSystem for BarChartViewPartSystem {
 }
 
 impl ViewPartSystem for BarChartViewPartSystem {
-    fn archetype(&self) -> ArchetypeDefinition {
-        Tensor::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Tensor::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/contexts/annotation_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/annotation_context.rs
@@ -1,5 +1,4 @@
-use nohash_hasher::IntSet;
-use re_types::{components::AnnotationContext, ComponentName, Loggable};
+use re_types::{archetypes::AnnotationContext, Archetype, ComponentNameSet};
 use re_viewer_context::{AnnotationMap, NamedViewSystem, ViewContextSystem, ViewSystemName};
 
 #[derive(Default)]
@@ -12,8 +11,13 @@ impl NamedViewSystem for AnnotationSceneContext {
 }
 
 impl ViewContextSystem for AnnotationSceneContext {
-    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
-        vec![std::iter::once(AnnotationContext::name()).collect()]
+    fn compatible_component_sets(&self) -> Vec<ComponentNameSet> {
+        vec![
+            AnnotationContext::required_components()
+                .iter()
+                .map(ToOwned::to_owned)
+                .collect(), //
+        ]
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/contexts/annotation_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/annotation_context.rs
@@ -1,7 +1,6 @@
-use re_types::{components::AnnotationContext, Loggable};
-use re_viewer_context::{
-    AnnotationMap, ArchetypeDefinition, NamedViewSystem, ViewContextSystem, ViewSystemName,
-};
+use nohash_hasher::IntSet;
+use re_types::{components::AnnotationContext, ComponentName, Loggable};
+use re_viewer_context::{AnnotationMap, NamedViewSystem, ViewContextSystem, ViewSystemName};
 
 #[derive(Default)]
 pub struct AnnotationSceneContext(pub AnnotationMap);
@@ -13,8 +12,8 @@ impl NamedViewSystem for AnnotationSceneContext {
 }
 
 impl ViewContextSystem for AnnotationSceneContext {
-    fn archetypes(&self) -> Vec<ArchetypeDefinition> {
-        vec![vec1::vec1![AnnotationContext::name()]]
+    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
+        vec![std::iter::once(AnnotationContext::name()).collect()]
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use nohash_hasher::{IntMap, IntSet};
+use nohash_hasher::IntMap;
 
 use re_log_types::EntityPathHash;
-use re_types::{components::DrawOrder, ComponentName, Loggable as _};
+use re_types::{components::DrawOrder, ComponentNameSet, Loggable as _};
 use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 /// Context for creating a mapping from [`DrawOrder`] to [`re_renderer::DepthOffset`].
@@ -26,7 +26,7 @@ impl NamedViewSystem for EntityDepthOffsets {
 }
 
 impl ViewContextSystem for EntityDepthOffsets {
-    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
+    fn compatible_component_sets(&self) -> Vec<ComponentNameSet> {
         vec![std::iter::once(DrawOrder::name()).collect()]
     }
 

--- a/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
@@ -1,10 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use nohash_hasher::IntMap;
+use nohash_hasher::{IntMap, IntSet};
 
 use re_log_types::EntityPathHash;
-use re_types::{components::DrawOrder, Loggable as _};
-use re_viewer_context::{ArchetypeDefinition, NamedViewSystem, ViewContextSystem};
+use re_types::{components::DrawOrder, ComponentName, Loggable as _};
+use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 /// Context for creating a mapping from [`DrawOrder`] to [`re_renderer::DepthOffset`].
 #[derive(Default)]
@@ -26,8 +26,8 @@ impl NamedViewSystem for EntityDepthOffsets {
 }
 
 impl ViewContextSystem for EntityDepthOffsets {
-    fn archetypes(&self) -> Vec<ArchetypeDefinition> {
-        vec![vec1::vec1![DrawOrder::name()]]
+    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
+        vec![std::iter::once(DrawOrder::name()).collect()]
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -41,7 +41,7 @@ impl NamedViewSystem for PrimitiveCounter {
 }
 
 impl ViewContextSystem for PrimitiveCounter {
-    fn all_required_components(&self) -> Vec<nohash_hasher::IntSet<re_types::ComponentName>> {
+    fn compatible_component_sets(&self) -> Vec<re_types::ComponentNameSet> {
         Vec::new()
     }
 

--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -41,7 +41,7 @@ impl NamedViewSystem for PrimitiveCounter {
 }
 
 impl ViewContextSystem for PrimitiveCounter {
-    fn archetypes(&self) -> Vec<re_viewer_context::ArchetypeDefinition> {
+    fn all_required_components(&self) -> Vec<nohash_hasher::IntSet<re_types::ComponentName>> {
         Vec::new()
     }
 

--- a/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
+++ b/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
@@ -1,6 +1,6 @@
 use nohash_hasher::IntSet;
 use re_log_types::EntityPathHash;
-use re_types::ComponentName;
+use re_types::ComponentNameSet;
 use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 /// List of all non-interactive entities for lookup during picking evaluation.
@@ -16,7 +16,7 @@ impl NamedViewSystem for NonInteractiveEntities {
 }
 
 impl ViewContextSystem for NonInteractiveEntities {
-    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
+    fn compatible_component_sets(&self) -> Vec<ComponentNameSet> {
         Vec::new()
     }
 

--- a/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
+++ b/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
@@ -1,5 +1,6 @@
 use nohash_hasher::IntSet;
 use re_log_types::EntityPathHash;
+use re_types::ComponentName;
 use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 /// List of all non-interactive entities for lookup during picking evaluation.
@@ -15,7 +16,7 @@ impl NamedViewSystem for NonInteractiveEntities {
 }
 
 impl ViewContextSystem for NonInteractiveEntities {
-    fn archetypes(&self) -> Vec<re_viewer_context::ArchetypeDefinition> {
+    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
         Vec::new()
     }
 

--- a/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
+++ b/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
@@ -1,7 +1,6 @@
-use nohash_hasher::IntSet;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 use re_renderer::{LineStripSeriesBuilder, PointCloudBuilder, RenderContext};
-use re_types::ComponentName;
+use re_types::ComponentNameSet;
 use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 use crate::parts::{
@@ -65,7 +64,7 @@ impl SharedRenderBuilders {
 }
 
 impl ViewContextSystem for SharedRenderBuilders {
-    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
+    fn compatible_component_sets(&self) -> Vec<ComponentNameSet> {
         Vec::new()
     }
 

--- a/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
+++ b/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
@@ -1,6 +1,8 @@
+use nohash_hasher::IntSet;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 use re_renderer::{LineStripSeriesBuilder, PointCloudBuilder, RenderContext};
-use re_viewer_context::{ArchetypeDefinition, NamedViewSystem, ViewContextSystem};
+use re_types::ComponentName;
+use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 use crate::parts::{
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES, SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
@@ -63,7 +65,7 @@ impl SharedRenderBuilders {
 }
 
 impl ViewContextSystem for SharedRenderBuilders {
-    fn archetypes(&self) -> Vec<ArchetypeDefinition> {
+    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
         Vec::new()
     }
 

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -1,4 +1,4 @@
-use nohash_hasher::{IntMap, IntSet};
+use nohash_hasher::IntMap;
 
 use re_arrow_store::LatestAtQuery;
 use re_components::{Pinhole, ViewCoordinates};
@@ -6,7 +6,7 @@ use re_data_store::{EntityPath, EntityPropertyMap, EntityTree};
 use re_space_view::UnreachableTransformReason;
 use re_types::{
     components::{DisconnectedSpace, Transform3D},
-    ComponentName, Loggable as _,
+    ComponentNameSet, Loggable as _,
 };
 use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
@@ -64,7 +64,7 @@ impl Default for TransformContext {
 }
 
 impl ViewContextSystem for TransformContext {
-    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
+    fn compatible_component_sets(&self) -> Vec<ComponentNameSet> {
         vec![
             std::iter::once(Transform3D::name()).collect(),
             std::iter::once(Pinhole::name()).collect(),

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -1,4 +1,4 @@
-use nohash_hasher::IntMap;
+use nohash_hasher::{IntMap, IntSet};
 
 use re_arrow_store::LatestAtQuery;
 use re_components::{Pinhole, ViewCoordinates};
@@ -6,9 +6,9 @@ use re_data_store::{EntityPath, EntityPropertyMap, EntityTree};
 use re_space_view::UnreachableTransformReason;
 use re_types::{
     components::{DisconnectedSpace, Transform3D},
-    Loggable as _,
+    ComponentName, Loggable as _,
 };
-use re_viewer_context::{ArchetypeDefinition, NamedViewSystem, ViewContextSystem};
+use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 use crate::parts::image_view_coordinates;
 
@@ -64,11 +64,11 @@ impl Default for TransformContext {
 }
 
 impl ViewContextSystem for TransformContext {
-    fn archetypes(&self) -> Vec<ArchetypeDefinition> {
+    fn all_required_components(&self) -> Vec<IntSet<ComponentName>> {
         vec![
-            vec1::vec1![Transform3D::name()],
-            vec1::vec1![Pinhole::name()],
-            vec1::vec1![DisconnectedSpace::name()],
+            std::iter::once(Transform3D::name()).collect(),
+            std::iter::once(Pinhole::name()).collect(),
+            std::iter::once(DisconnectedSpace::name()).collect(),
         ]
     }
 

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -173,6 +173,15 @@ impl ViewPartSystem for Arrows3DPart {
         Arrows3D::all_components().try_into().unwrap()
     }
 
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&Arrows3D::indicator_component())
+    }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -177,11 +177,11 @@ impl ViewPartSystem for Arrows3DPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&Arrows3D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -1,11 +1,10 @@
-use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_renderer::renderer::LineStripFlags;
 use re_types::{
     archetypes::Arrows3D,
     components::{Origin3D, Text, Vector3D},
-    Archetype as _, ComponentName,
+    Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -170,20 +169,15 @@ impl NamedViewSystem for Arrows3DPart {
 }
 
 impl ViewPartSystem for Arrows3DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         Arrows3D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&Arrows3D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(Arrows3D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -1,14 +1,15 @@
+use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_renderer::renderer::LineStripFlags;
 use re_types::{
     archetypes::Arrows3D,
     components::{Origin3D, Text, Vector3D},
-    Archetype as _,
+    Archetype as _, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use super::{picking_id_from_instance_key, process_annotations, SpatialViewPartData};
@@ -169,8 +170,11 @@ impl NamedViewSystem for Arrows3DPart {
 }
 
 impl ViewPartSystem for Arrows3DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        Arrows3D::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Arrows3D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -121,6 +121,15 @@ impl ViewPartSystem for Boxes2DPart {
         Boxes2D::all_components().try_into().unwrap()
     }
 
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&Boxes2D::indicator_component())
+    }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -125,11 +125,11 @@ impl ViewPartSystem for Boxes2DPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&Boxes2D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -1,10 +1,9 @@
-use nohash_hasher::IntSet;
 use re_data_store::EntityPath;
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::Boxes2D,
     components::{HalfSizes2D, Position2D},
-    Archetype, ComponentName,
+    Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
@@ -118,20 +117,15 @@ impl NamedViewSystem for Boxes2DPart {
 }
 
 impl ViewPartSystem for Boxes2DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         Boxes2D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&Boxes2D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(Boxes2D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -1,13 +1,14 @@
+use nohash_hasher::IntSet;
 use re_data_store::EntityPath;
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::Boxes2D,
     components::{HalfSizes2D, Position2D},
-    Archetype,
+    Archetype, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
+    ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -117,8 +118,11 @@ impl NamedViewSystem for Boxes2DPart {
 }
 
 impl ViewPartSystem for Boxes2DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        Boxes2D::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Boxes2D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -112,18 +112,7 @@ impl NamedViewSystem for Boxes3DPart {
 
 impl ViewPartSystem for Boxes3DPart {
     fn required_components(&self) -> IntSet<ComponentName> {
-        [
-            Box3D::name(),
-            InstanceKey::name(),
-            LegacyVec3D::name(), // obb.position
-            Quaternion::name(),  // obb.rotation
-            Color::name(),
-            Radius::name(), // stroke_width
-            Text::name(),
-            ClassId::name(),
-        ]
-        .into_iter()
-        .collect()
+        std::iter::once(Box3D::name()).collect()
     }
 
     // TODO(#2786): use this instead
@@ -147,12 +136,23 @@ impl ViewPartSystem for Boxes3DPart {
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
+        let components = [
+            Box3D::name(),
+            InstanceKey::name(),
+            LegacyVec3D::name(), // obb.position
+            Quaternion::name(),  // obb.rotation
+            Color::name(),
+            Radius::name(), // stroke_width
+            Text::name(),
+            ClassId::name(),
+        ];
+
         process_entity_views::<Boxes3DPart, Box3D, 8, _>(
             ctx,
             query,
             view_ctx,
             0,
-            self.required_components().into_iter().collect(),
+            components.into_iter().collect(),
             |_ctx, ent_path, entity_view, ent_context| {
                 self.process_entity_view(query, &entity_view, ent_path, ent_context)
             },

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -132,7 +132,7 @@ impl ViewPartSystem for Boxes3DPart {
     // }
 
     // TODO(#2786): use this instead
-    // fn queries_any_components_of(
+    // fn heuristic_filter(
     //     &self,
     //     _store: &re_arrow_store::DataStore,
     //     _ent_path: &EntityPath,

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -1,14 +1,15 @@
+use nohash_hasher::IntSet;
 use re_components::{Box3D, LegacyVec3D, Quaternion};
 use re_data_store::EntityPath;
 use re_query::{EntityView, QueryError};
 use re_renderer::Size;
 use re_types::{
     components::{ClassId, Color, InstanceKey, Radius, Text},
-    Loggable as _,
+    ComponentName, Loggable as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -110,8 +111,8 @@ impl NamedViewSystem for Boxes3DPart {
 }
 
 impl ViewPartSystem for Boxes3DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        vec1::vec1![
+    fn required_components(&self) -> IntSet<ComponentName> {
+        [
             Box3D::name(),
             InstanceKey::name(),
             LegacyVec3D::name(), // obb.position
@@ -121,11 +122,13 @@ impl ViewPartSystem for Boxes3DPart {
             Text::name(),
             ClassId::name(),
         ]
+        .into_iter()
+        .collect()
     }
 
     // TODO(#2786): use this instead
-    // fn archetype(&self) -> ArchetypeDefinition {
-    //     Box3D::all_components().try_into().unwrap()
+    // fn required_components(&self) -> IntSet<ComponentName> {
+    //     Box3D::required_components().to_vec()
     // }
 
     // TODO(#2786): use this instead
@@ -149,7 +152,7 @@ impl ViewPartSystem for Boxes3DPart {
             query,
             view_ctx,
             0,
-            self.archetype(),
+            self.required_components().into_iter().collect(),
             |_ctx, ent_path, entity_view, ent_context| {
                 self.process_entity_view(query, &entity_view, ent_path, ent_context)
             },

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -1,11 +1,10 @@
-use nohash_hasher::IntSet;
 use re_components::{Box3D, LegacyVec3D, Quaternion};
 use re_data_store::EntityPath;
 use re_query::{EntityView, QueryError};
 use re_renderer::Size;
 use re_types::{
     components::{ClassId, Color, InstanceKey, Radius, Text},
-    ComponentName, Loggable as _,
+    ComponentNameSet, Loggable as _,
 };
 use re_viewer_context::{
     DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -111,12 +110,12 @@ impl NamedViewSystem for Boxes3DPart {
 }
 
 impl ViewPartSystem for Boxes3DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         std::iter::once(Box3D::name()).collect()
     }
 
     // TODO(#2786): use this instead
-    // fn required_components(&self) -> IntSet<ComponentName> {
+    // fn required_components(&self) -> ComponentNameSet {
     //     Box3D::required_components().to_vec()
     // }
 

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -123,6 +123,21 @@ impl ViewPartSystem for Boxes3DPart {
         ]
     }
 
+    // TODO(#2786): use this instead
+    // fn archetype(&self) -> ArchetypeDefinition {
+    //     Box3D::all_components().try_into().unwrap()
+    // }
+
+    // TODO(#2786): use this instead
+    // fn queries_any_components_of(
+    //     &self,
+    //     _store: &re_arrow_store::DataStore,
+    //     _ent_path: &EntityPath,
+    //     components: &[re_types::ComponentName],
+    // ) -> bool {
+    //     components.contains(&Box3D::indicator_component())
+    // }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -1,14 +1,15 @@
 use glam::vec3;
+use nohash_hasher::IntSet;
 use re_components::{Pinhole, ViewCoordinates};
 use re_data_store::{EntityPath, EntityProperties};
 use re_renderer::renderer::LineStripFlags;
 use re_types::{
     components::{InstanceKey, Transform3D},
-    Loggable as _,
+    ComponentName, Loggable as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use super::SpatialViewPartData;
@@ -174,13 +175,13 @@ impl CamerasPart {
 }
 
 impl ViewPartSystem for CamerasPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        vec1::vec1![Pinhole::name()]
+    fn required_components(&self) -> IntSet<ComponentName> {
+        std::iter::once(Pinhole::name()).collect()
     }
 
     // TODO(#2816): use this instead
-    // fn archetype(&self) -> ArchetypeDefinition {
-    //     Pinhole::all_components().try_into().unwrap()
+    // fn required_components(&self) -> IntSet<ComponentName> {
+    //     Pinhole::required_components().to_vec()
     // }
 
     // TODO(#2816): use this instead

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -175,8 +175,23 @@ impl CamerasPart {
 
 impl ViewPartSystem for CamerasPart {
     fn archetype(&self) -> ArchetypeDefinition {
-        vec1::vec1![Pinhole::name(),]
+        vec1::vec1![Pinhole::name()]
     }
+
+    // TODO(#2816): use this instead
+    // fn archetype(&self) -> ArchetypeDefinition {
+    //     Pinhole::all_components().try_into().unwrap()
+    // }
+
+    // TODO(#2816): use this instead
+    // fn queries_any_components_of(
+    //     &self,
+    //     _store: &re_arrow_store::DataStore,
+    //     _ent_path: &EntityPath,
+    //     components: &[re_types::ComponentName],
+    // ) -> bool {
+    //     components.contains(&Pinhole::indicator_component())
+    // }
 
     fn execute(
         &mut self,

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -185,7 +185,7 @@ impl ViewPartSystem for CamerasPart {
     // }
 
     // TODO(#2816): use this instead
-    // fn queries_any_components_of(
+    // fn heuristic_filter(
     //     &self,
     //     _store: &re_arrow_store::DataStore,
     //     _ent_path: &EntityPath,

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -1,11 +1,10 @@
 use glam::vec3;
-use nohash_hasher::IntSet;
 use re_components::{Pinhole, ViewCoordinates};
 use re_data_store::{EntityPath, EntityProperties};
 use re_renderer::renderer::LineStripFlags;
 use re_types::{
     components::{InstanceKey, Transform3D},
-    ComponentName, Loggable as _,
+    ComponentNameSet, Loggable as _,
 };
 use re_viewer_context::{
     NamedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -175,12 +174,12 @@ impl CamerasPart {
 }
 
 impl ViewPartSystem for CamerasPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         std::iter::once(Pinhole::name()).collect()
     }
 
     // TODO(#2816): use this instead
-    // fn required_components(&self) -> IntSet<ComponentName> {
+    // fn required_components(&self) -> ComponentNameSet {
     //     Pinhole::required_components().to_vec()
     // }
 

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -5,8 +5,7 @@ use re_query::{
 use re_renderer::DepthOffset;
 use re_types::{Archetype, ComponentName};
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
 };
 
 use crate::contexts::{
@@ -23,7 +22,7 @@ pub fn process_entity_views<'a, System: NamedViewSystem, Primary, const N: usize
     query: &ViewQuery<'_>,
     view_ctx: &ViewContextCollection,
     default_depth_offset: DepthOffset,
-    archetype: ArchetypeDefinition,
+    archetype: Vec<ComponentName>,
     mut fun: F,
 ) -> Result<(), SpaceViewSystemExecutionError>
 where

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -617,12 +617,11 @@ impl ViewPartSystem for ImagesPart {
             .collect()
     }
 
-    // TODO(jleibs): Once the above is working properly this can go away all together.
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
-        components: &[ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         let is_image = components.contains(&Image::indicator_component())
             || components.contains(&DepthImage::indicator_component())

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -1,9 +1,9 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use egui::NumExt;
-
 use itertools::Itertools as _;
 use nohash_hasher::IntSet;
+
 use re_arrow_store::LatestAtQuery;
 use re_components::Pinhole;
 use re_data_store::{EntityPath, EntityProperties, InstancePathHash, VersionedInstancePathHash};
@@ -20,8 +20,8 @@ use re_types::{
     Archetype as _,
 };
 use re_viewer_context::{
-    gpu_bridge, ArchetypeDefinition, DefaultColor, SpaceViewSystemExecutionError,
-    TensorDecodeCache, TensorStatsCache, ViewPartSystem, ViewQuery, ViewerContext,
+    gpu_bridge, DefaultColor, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 use re_viewer_context::{NamedViewSystem, ViewContextCollection};
 
@@ -608,17 +608,13 @@ impl NamedViewSystem for ImagesPart {
 }
 
 impl ViewPartSystem for ImagesPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        Image::all_components()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Image::required_components()
             .iter()
-            .chain(DepthImage::all_components().iter())
-            .chain(SegmentationImage::all_components().iter())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
+            .chain(DepthImage::required_components().iter())
+            .chain(SegmentationImage::required_components().iter())
             .map(ToOwned::to_owned)
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap()
+            .collect()
     }
 
     // TODO(jleibs): Once the above is working properly this can go away all together.

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -1,13 +1,14 @@
+use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::LineStrips2D,
     components::{LineStrip2D, Text},
-    Archetype as _,
+    Archetype as _, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -161,8 +162,11 @@ impl NamedViewSystem for Lines2DPart {
 }
 
 impl ViewPartSystem for Lines2DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        LineStrips2D::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        LineStrips2D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -165,6 +165,15 @@ impl ViewPartSystem for Lines2DPart {
         LineStrips2D::all_components().try_into().unwrap()
     }
 
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&LineStrips2D::indicator_component())
+    }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -169,11 +169,11 @@ impl ViewPartSystem for Lines2DPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&LineStrips2D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -1,10 +1,9 @@
-use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::LineStrips2D,
     components::{LineStrip2D, Text},
-    Archetype as _, ComponentName,
+    Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -162,20 +161,15 @@ impl NamedViewSystem for Lines2DPart {
 }
 
 impl ViewPartSystem for Lines2DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         LineStrips2D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&LineStrips2D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(LineStrips2D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -1,10 +1,9 @@
-use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::LineStrips3D,
     components::{LineStrip3D, Text},
-    Archetype as _, ComponentName,
+    Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -170,20 +169,15 @@ impl NamedViewSystem for Lines3DPart {
 }
 
 impl ViewPartSystem for Lines3DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         LineStrips3D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&LineStrips3D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(LineStrips3D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -1,13 +1,14 @@
+use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::LineStrips3D,
     components::{LineStrip3D, Text},
-    Archetype as _,
+    Archetype as _, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -169,8 +170,11 @@ impl NamedViewSystem for Lines3DPart {
 }
 
 impl ViewPartSystem for Lines3DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        LineStrips3D::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        LineStrips3D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -173,6 +173,15 @@ impl ViewPartSystem for Lines3DPart {
         LineStrips3D::all_components().try_into().unwrap()
     }
 
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&LineStrips3D::indicator_component())
+    }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -177,11 +177,11 @@ impl ViewPartSystem for Lines3DPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&LineStrips3D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -87,9 +87,7 @@ impl NamedViewSystem for MeshPart {
 
 impl ViewPartSystem for MeshPart {
     fn required_components(&self) -> IntSet<ComponentName> {
-        [Mesh3D::name(), InstanceKey::name(), Color::name()]
-            .into_iter()
-            .collect()
+        std::iter::once(Mesh3D::name()).collect()
     }
 
     // TODO(#2788): use this instead
@@ -115,12 +113,13 @@ impl ViewPartSystem for MeshPart {
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let mut instances = Vec::new();
 
+        let components = [Mesh3D::name(), InstanceKey::name(), Color::name()];
         process_entity_views::<MeshPart, _, 3, _>(
             ctx,
             query,
             view_ctx,
             0,
-            self.required_components().into_iter().collect(),
+            components.into_iter().collect(),
             |ctx, ent_path, entity_view, ent_context| {
                 self.process_entity_view(ctx, &mut instances, &entity_view, ent_path, ent_context)
             },

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -1,11 +1,10 @@
-use nohash_hasher::IntSet;
 use re_components::Mesh3D;
 use re_data_store::EntityPath;
 use re_query::{EntityView, QueryError};
 use re_renderer::renderer::MeshInstance;
 use re_types::{
     components::{Color, InstanceKey},
-    ComponentName, Loggable as _,
+    ComponentNameSet, Loggable as _,
 };
 use re_viewer_context::{
     DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -86,7 +85,7 @@ impl NamedViewSystem for MeshPart {
 }
 
 impl ViewPartSystem for MeshPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         std::iter::once(Mesh3D::name()).collect()
     }
 

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -98,7 +98,7 @@ impl ViewPartSystem for MeshPart {
     // }
 
     // TODO(#2788): use this instead
-    // fn queries_any_components_of(
+    // fn heuristic_filter(
     //     &self,
     //     _store: &re_arrow_store::DataStore,
     //     _ent_path: &EntityPath,

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -89,6 +89,21 @@ impl ViewPartSystem for MeshPart {
         vec1::vec1![Mesh3D::name(), InstanceKey::name(), Color::name()]
     }
 
+    // TODO(#2788): use this instead
+    // fn archetype(&self) -> ArchetypeDefinition {
+    //     Mesh3D::all_components().try_into().unwrap()
+    // }
+
+    // TODO(#2788): use this instead
+    // fn queries_any_components_of(
+    //     &self,
+    //     _store: &re_arrow_store::DataStore,
+    //     _ent_path: &EntityPath,
+    //     components: &[re_types::ComponentName],
+    // ) -> bool {
+    //     components.contains(&Mesh3D::indicator_component())
+    // }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -1,14 +1,15 @@
+use nohash_hasher::IntSet;
 use re_components::Mesh3D;
 use re_data_store::EntityPath;
 use re_query::{EntityView, QueryError};
 use re_renderer::renderer::MeshInstance;
 use re_types::{
     components::{Color, InstanceKey},
-    Loggable as _,
+    ComponentName, Loggable as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use super::SpatialViewPartData;
@@ -85,13 +86,15 @@ impl NamedViewSystem for MeshPart {
 }
 
 impl ViewPartSystem for MeshPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        vec1::vec1![Mesh3D::name(), InstanceKey::name(), Color::name()]
+    fn required_components(&self) -> IntSet<ComponentName> {
+        [Mesh3D::name(), InstanceKey::name(), Color::name()]
+            .into_iter()
+            .collect()
     }
 
     // TODO(#2788): use this instead
-    // fn archetype(&self) -> ArchetypeDefinition {
-    //     Mesh3D::all_components().try_into().unwrap()
+    // fn archetype(&self) -> Vec<ComponentName> {
+    //     Mesh3D::required_components().to_vec()
     // }
 
     // TODO(#2788): use this instead
@@ -117,7 +120,7 @@ impl ViewPartSystem for MeshPart {
             query,
             view_ctx,
             0,
-            self.archetype(),
+            self.required_components().into_iter().collect(),
             |ctx, ent_path, entity_view, ent_context| {
                 self.process_entity_view(ctx, &mut instances, &entity_view, ent_path, ent_context)
             },

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -192,6 +192,15 @@ impl ViewPartSystem for Points2DPart {
         Points2D::all_components().try_into().unwrap()
     }
 
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&Points2D::indicator_component())
+    }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -1,13 +1,14 @@
+use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::Points2D,
     components::{Position2D, Text},
-    Archetype,
+    Archetype, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -188,8 +189,11 @@ impl NamedViewSystem for Points2DPart {
 }
 
 impl ViewPartSystem for Points2DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        Points2D::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Points2D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -1,10 +1,9 @@
-use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::Points2D,
     components::{Position2D, Text},
-    Archetype, ComponentName,
+    Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -189,20 +188,15 @@ impl NamedViewSystem for Points2DPart {
 }
 
 impl ViewPartSystem for Points2DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         Points2D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&Points2D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(Points2D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -196,11 +196,11 @@ impl ViewPartSystem for Points2DPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&Points2D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -1,10 +1,9 @@
-use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::Points3D,
     components::{Position3D, Text},
-    Archetype as _, ComponentName,
+    Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -192,20 +191,15 @@ impl NamedViewSystem for Points3DPart {
 }
 
 impl ViewPartSystem for Points3DPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         Points3D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&Points3D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(Points3D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -195,6 +195,15 @@ impl ViewPartSystem for Points3DPart {
         Points3D::all_components().try_into().unwrap()
     }
 
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&Points3D::indicator_component())
+    }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -1,13 +1,14 @@
+use nohash_hasher::IntSet;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
     archetypes::Points3D,
     components::{Position3D, Text},
-    Archetype as _,
+    Archetype as _, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use itertools::Itertools as _;
@@ -191,8 +192,11 @@ impl NamedViewSystem for Points3DPart {
 }
 
 impl ViewPartSystem for Points3DPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        Points3D::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Points3D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -199,11 +199,11 @@ impl ViewPartSystem for Points3DPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&Points3D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -1,13 +1,14 @@
 use egui::Color32;
+use nohash_hasher::IntSet;
 use re_log_types::EntityPath;
 use re_renderer::LineStripSeriesBuilder;
 use re_types::{
     components::{InstanceKey, Transform3D},
-    Archetype,
+    Archetype, ComponentName,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
+    ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -32,10 +33,11 @@ impl NamedViewSystem for Transform3DArrowsPart {
 }
 
 impl ViewPartSystem for Transform3DArrowsPart {
-    fn archetype(&self) -> ArchetypeDefinition {
-        re_types::archetypes::Transform3D::all_components()
-            .try_into()
-            .unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        re_types::archetypes::Transform3D::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -3,7 +3,7 @@ use re_log_types::EntityPath;
 use re_renderer::LineStripSeriesBuilder;
 use re_types::{
     components::{InstanceKey, Transform3D},
-    Loggable as _,
+    Archetype,
 };
 use re_viewer_context::{
     ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
@@ -33,7 +33,18 @@ impl NamedViewSystem for Transform3DArrowsPart {
 
 impl ViewPartSystem for Transform3DArrowsPart {
     fn archetype(&self) -> ArchetypeDefinition {
-        vec1::vec1![Transform3D::name()]
+        re_types::archetypes::Transform3D::all_components()
+            .try_into()
+            .unwrap()
+    }
+
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&re_types::archetypes::Transform3D::indicator_component())
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -40,11 +40,11 @@ impl ViewPartSystem for Transform3DArrowsPart {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&re_types::archetypes::Transform3D::indicator_component())
     }

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -1,10 +1,9 @@
 use egui::Color32;
-use nohash_hasher::IntSet;
 use re_log_types::EntityPath;
 use re_renderer::LineStripSeriesBuilder;
 use re_types::{
     components::{InstanceKey, Transform3D},
-    Archetype, ComponentName,
+    Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
@@ -33,20 +32,15 @@ impl NamedViewSystem for Transform3DArrowsPart {
 }
 
 impl ViewPartSystem for Transform3DArrowsPart {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         re_types::archetypes::Transform3D::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&re_types::archetypes::Transform3D::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(re_types::archetypes::Transform3D::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -1,13 +1,15 @@
 use re_arrow_store::LatestAtQuery;
 use re_data_store::{EntityPath, EntityProperties, InstancePath, InstancePathHash};
 use re_log_types::{RowId, TimeInt, Timeline};
-use re_types::components::TensorData;
-use re_types::tensor_data::DecodedTensor;
-use re_types::Archetype;
-use re_types::{components::InstanceKey, ComponentName, Loggable as _};
+use re_types::{
+    archetypes::Tensor,
+    components::{InstanceKey, TensorData},
+    tensor_data::DecodedTensor,
+    Archetype, ComponentName, Loggable as _,
+};
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, TensorDecodeCache,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
+    TensorDecodeCache, ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 #[derive(Default)]
@@ -22,8 +24,11 @@ impl NamedViewSystem for TensorSystem {
 }
 
 impl ViewPartSystem for TensorSystem {
-    fn archetype(&self) -> ArchetypeDefinition {
-        vec1::vec1![TensorData::name()]
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Tensor::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     /// Tensor view doesn't handle 2D images, see [`TensorSystem::load_tensor_entity`]

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -5,7 +5,7 @@ use re_types::{
     archetypes::Tensor,
     components::{InstanceKey, TensorData},
     tensor_data::DecodedTensor,
-    Archetype, ComponentName, Loggable as _,
+    Archetype, ComponentName,
 };
 use re_viewer_context::{
     external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
@@ -32,19 +32,15 @@ impl ViewPartSystem for TensorSystem {
     }
 
     /// Tensor view doesn't handle 2D images, see [`TensorSystem::load_tensor_entity`]
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
-        components: &[ComponentName],
+        components: &IntSet<re_types::ComponentName>,
     ) -> bool {
-        if !components.contains(&re_types::archetypes::Tensor::indicator_component())
-            || !components.contains(&TensorData::name())
-        {
+        if !components.contains(&re_types::archetypes::Tensor::indicator_component()) {
             return false;
         }
-
-        // TODO(jleibs): Use indicator components
 
         if let Some(tensor) = store.query_latest_component::<TensorData>(
             ent_path,

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -3,6 +3,7 @@ use re_data_store::{EntityPath, EntityProperties, InstancePath, InstancePathHash
 use re_log_types::{RowId, TimeInt, Timeline};
 use re_types::components::TensorData;
 use re_types::tensor_data::DecodedTensor;
+use re_types::Archetype;
 use re_types::{components::InstanceKey, ComponentName, Loggable as _};
 use re_viewer_context::{
     ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, TensorDecodeCache,
@@ -32,7 +33,9 @@ impl ViewPartSystem for TensorSystem {
         ent_path: &EntityPath,
         components: &[ComponentName],
     ) -> bool {
-        if !components.contains(&TensorData::name()) {
+        if !components.contains(&re_types::archetypes::Tensor::indicator_component())
+            || !components.contains(&TensorData::name())
+        {
             return false;
         }
 

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -1,5 +1,5 @@
 use re_arrow_store::LatestAtQuery;
-use re_query::query_archetype;
+use re_query::{query_archetype, QueryError};
 use re_types::{archetypes::TextDocument, Archetype as _, ComponentNameSet};
 use re_viewer_context::{
     NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
@@ -48,16 +48,26 @@ impl ViewPartSystem for TextDocumentSystem {
         let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 
         for (ent_path, _props) in query.iter_entities_for_system(Self::name()) {
-            let arch_view = query_archetype::<re_types::archetypes::TextDocument>(
+            // TODO(jleibs): this match can go away once we resolve:
+            // https://github.com/rerun-io/rerun/issues/3320
+            match query_archetype::<re_types::archetypes::TextDocument>(
                 store,
                 &timeline_query,
                 ent_path,
-            )?;
-
-            for text_entry in arch_view.iter_required_component::<re_types::components::Text>()? {
-                let re_types::components::Text(text) = text_entry;
-                self.text_entries.push(TextDocumentEntry { body: text });
-            }
+            ) {
+                Ok(arch_view) => {
+                    for text_entry in
+                        arch_view.iter_required_component::<re_types::components::Text>()?
+                    {
+                        let re_types::components::Text(text) = text_entry;
+                        self.text_entries.push(TextDocumentEntry { body: text });
+                    }
+                }
+                Err(QueryError::PrimaryNotFound(_)) => {}
+                Err(err) => {
+                    re_log::error_once!("Unexpected error querying {ent_path:?}: {err}");
+                }
+            };
         }
 
         Ok(Vec::new())

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -1,9 +1,9 @@
 use re_arrow_store::LatestAtQuery;
 use re_query::query_archetype;
-use re_types::{archetypes::TextDocument, Archetype as _, ComponentName};
+use re_types::{archetypes::TextDocument, Archetype as _, ComponentNameSet};
 use re_viewer_context::{
-    external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
+    ViewQuery, ViewerContext,
 };
 
 // ---
@@ -26,20 +26,15 @@ impl NamedViewSystem for TextDocumentSystem {
 }
 
 impl ViewPartSystem for TextDocumentSystem {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         TextDocument::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &re_viewer_context::external::re_log_types::EntityPath,
-        components: &IntSet<re_types::ComponentName>,
-    ) -> bool {
-        components.contains(&TextDocument::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(TextDocument::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -1,9 +1,9 @@
 use re_arrow_store::LatestAtQuery;
 use re_query::query_archetype;
-use re_types::{archetypes::TextDocument, Archetype as _};
+use re_types::{archetypes::TextDocument, Archetype as _, ComponentName};
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 // ---
@@ -26,8 +26,11 @@ impl NamedViewSystem for TextDocumentSystem {
 }
 
 impl ViewPartSystem for TextDocumentSystem {
-    fn archetype(&self) -> ArchetypeDefinition {
-        TextDocument::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        TextDocument::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -33,11 +33,11 @@ impl ViewPartSystem for TextDocumentSystem {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &re_viewer_context::external::re_log_types::EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<re_types::ComponentName>,
     ) -> bool {
         components.contains(&TextDocument::indicator_component())
     }

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -49,11 +49,11 @@ impl ViewPartSystem for TextLogSystem {
             .collect()
     }
 
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[re_types::ComponentName],
+        components: &IntSet<ComponentName>,
     ) -> bool {
         components.contains(&TextLog::indicator_component())
     }

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -3,6 +3,7 @@ use re_data_store::EntityPath;
 use re_log_types::RowId;
 use re_query::{range_entity_with_primary, QueryError};
 use re_types::{
+    archetypes::TextLog,
     components::{Color, InstanceKey, Text, TextLogLevel},
     Archetype as _, Loggable as _,
 };
@@ -42,14 +43,16 @@ impl NamedViewSystem for TextLogSystem {
 
 impl ViewPartSystem for TextLogSystem {
     fn archetype(&self) -> ArchetypeDefinition {
-        // TODO(#3159): use actual archetype definition
-        // TextLog::all_components().try_into().unwrap()
-        vec1::vec1![
-            re_types::archetypes::TextLog::indicator_component(),
-            Text::name(),
-            TextLogLevel::name(),
-            Color::name(),
-        ]
+        TextLog::all_components().try_into().unwrap()
+    }
+
+    fn queries_any_components_of(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        components: &[re_types::ComponentName],
+    ) -> bool {
+        components.contains(&TextLog::indicator_component())
     }
 
     fn execute(

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -5,11 +5,11 @@ use re_query::{range_entity_with_primary, QueryError};
 use re_types::{
     archetypes::TextLog,
     components::{Color, InstanceKey, Text, TextLogLevel},
-    Archetype as _, Loggable as _,
+    Archetype as _, ComponentName, Loggable as _,
 };
 use re_viewer_context::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 #[derive(Debug, Clone)]
@@ -42,8 +42,11 @@ impl NamedViewSystem for TextLogSystem {
 }
 
 impl ViewPartSystem for TextLogSystem {
-    fn archetype(&self) -> ArchetypeDefinition {
-        TextLog::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        TextLog::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     fn queries_any_components_of(

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -5,11 +5,11 @@ use re_query::{range_entity_with_primary, QueryError};
 use re_types::{
     archetypes::TextLog,
     components::{Color, InstanceKey, Text, TextLogLevel},
-    Archetype as _, ComponentName, Loggable as _,
+    Archetype as _, ComponentNameSet, Loggable as _,
 };
 use re_viewer_context::{
-    external::nohash_hasher::IntSet, NamedViewSystem, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
+    ViewQuery, ViewerContext,
 };
 
 #[derive(Debug, Clone)]
@@ -42,20 +42,15 @@ impl NamedViewSystem for TextLogSystem {
 }
 
 impl ViewPartSystem for TextLogSystem {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         TextLog::required_components()
             .iter()
             .map(ToOwned::to_owned)
             .collect()
     }
 
-    fn heuristic_filter(
-        &self,
-        _store: &re_arrow_store::DataStore,
-        _ent_path: &EntityPath,
-        components: &IntSet<ComponentName>,
-    ) -> bool {
-        components.contains(&TextLog::indicator_component())
+    fn indicator_components(&self) -> ComponentNameSet {
+        std::iter::once(TextLog::indicator_component()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -2,8 +2,8 @@ use re_arrow_store::TimeRange;
 use re_query::{range_entity_with_primary, QueryError};
 use re_types::{components::InstanceKey, ComponentName, Loggable as _};
 use re_viewer_context::{
-    AnnotationMap, DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError, ViewPartSystem,
-    ViewQuery, ViewerContext,
+    external::nohash_hasher::IntSet, AnnotationMap, DefaultColor, NamedViewSystem,
+    SpaceViewSystemExecutionError, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 #[derive(Clone, Debug)]
@@ -67,20 +67,16 @@ impl NamedViewSystem for TimeSeriesSystem {
 }
 
 impl ViewPartSystem for TimeSeriesSystem {
-    fn archetype(&self) -> re_viewer_context::ArchetypeDefinition {
-        vec1::Vec1::try_from_vec(
-            Self::archetype_array()
-                .into_iter()
-                .skip(1) // Skip [`InstanceKey`]
-                .collect::<Vec<_>>(),
-        )
-        .unwrap()
-        // TODO(wumpf): `archetype` should return a fixed sized array.
+    fn required_components(&self) -> IntSet<ComponentName> {
+        Self::archetype_array()
+            .into_iter()
+            .skip(1) // Skip [`InstanceKey`]
+            .collect()
     }
 
     // TODO(#3174): use this instead
-    // fn archetype(&self) -> ArchetypeDefinition {
-    //     ScalarOrWhateverItllBeCalled::all_components().try_into().unwrap()
+    // fn required_components(&self) -> IntSet<ComponentName> {
+    //     ScalarOrWhateverItllBeCalled::required_components().to_vec()
     // }
 
     // TODO(#3174): use this instead

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -1,9 +1,9 @@
 use re_arrow_store::TimeRange;
 use re_query::{range_entity_with_primary, QueryError};
-use re_types::{components::InstanceKey, ComponentName, Loggable as _};
+use re_types::{components::InstanceKey, ComponentName, ComponentNameSet, Loggable as _};
 use re_viewer_context::{
-    external::nohash_hasher::IntSet, AnnotationMap, DefaultColor, NamedViewSystem,
-    SpaceViewSystemExecutionError, ViewPartSystem, ViewQuery, ViewerContext,
+    AnnotationMap, DefaultColor, NamedViewSystem, SpaceViewSystemExecutionError, ViewPartSystem,
+    ViewQuery, ViewerContext,
 };
 
 #[derive(Clone, Debug)]
@@ -67,7 +67,7 @@ impl NamedViewSystem for TimeSeriesSystem {
 }
 
 impl ViewPartSystem for TimeSeriesSystem {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         Self::archetype_array()
             .into_iter()
             .skip(1) // Skip [`InstanceKey`]
@@ -75,7 +75,7 @@ impl ViewPartSystem for TimeSeriesSystem {
     }
 
     // TODO(#3174): use this instead
-    // fn required_components(&self) -> IntSet<ComponentName> {
+    // fn required_components(&self) -> ComponentNameSet {
     //     ScalarOrWhateverItllBeCalled::required_components().to_vec()
     // }
 

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -80,7 +80,7 @@ impl ViewPartSystem for TimeSeriesSystem {
     // }
 
     // TODO(#3174): use this instead
-    // fn queries_any_components_of(
+    // fn heuristic_filter(
     //     &self,
     //     _store: &re_arrow_store::DataStore,
     //     _ent_path: &EntityPath,

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -68,10 +68,7 @@ impl NamedViewSystem for TimeSeriesSystem {
 
 impl ViewPartSystem for TimeSeriesSystem {
     fn required_components(&self) -> ComponentNameSet {
-        Self::archetype_array()
-            .into_iter()
-            .skip(1) // Skip [`InstanceKey`]
-            .collect()
+        std::iter::once(re_components::Scalar::name()).collect()
     }
 
     // TODO(#3174): use this instead

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -78,6 +78,21 @@ impl ViewPartSystem for TimeSeriesSystem {
         // TODO(wumpf): `archetype` should return a fixed sized array.
     }
 
+    // TODO(#3174): use this instead
+    // fn archetype(&self) -> ArchetypeDefinition {
+    //     ScalarOrWhateverItllBeCalled::all_components().try_into().unwrap()
+    // }
+
+    // TODO(#3174): use this instead
+    // fn queries_any_components_of(
+    //     &self,
+    //     _store: &re_arrow_store::DataStore,
+    //     _ent_path: &EntityPath,
+    //     components: &[re_types::ComponentName],
+    // ) -> bool {
+    //     components.contains(&ScalarOrWhateverItllBeCalled::indicator_component())
+    // }
+
     fn execute(
         &mut self,
         ctx: &mut ViewerContext<'_>,

--- a/crates/re_types/src/archetype.rs
+++ b/crates/re_types/src/archetype.rs
@@ -61,6 +61,8 @@ pub trait Archetype {
 
     // ---
 
+    // TODO(cmc): Should we also generate and return static IntSets?
+
     /// Returns the names of all components that _must_ be provided by the user when constructing
     /// this archetype.
     fn required_components() -> std::borrow::Cow<'static, [ComponentName]>;

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -123,7 +123,9 @@ mod result;
 mod size_bytes;
 
 pub use self::archetype::{Archetype, ArchetypeName, GenericIndicatorComponent};
-pub use self::loggable::{Component, ComponentName, Datatype, DatatypeName, Loggable};
+pub use self::loggable::{
+    Component, ComponentName, ComponentNameSet, Datatype, DatatypeName, Loggable,
+};
 pub use self::loggable_batch::{
     ComponentBatch, DatatypeBatch, LoggableBatch, MaybeOwnedComponentBatch,
 };

--- a/crates/re_types/src/loggable.rs
+++ b/crates/re_types/src/loggable.rs
@@ -183,6 +183,8 @@ impl<L: Loggable<Name = ComponentName>> Component for L {}
 
 // ---
 
+pub type ComponentNameSet = std::collections::BTreeSet<ComponentName>;
+
 re_string_interner::declare_new_type!(
     /// The fully-qualified name of a [`Component`], e.g. `rerun.components.Position2D`.
     pub struct ComponentName;

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -29,9 +29,9 @@ pub mod external {
     pub use re_data_ui;
     pub use {eframe, egui};
     pub use {
-        re_arrow_store, re_arrow_store::external::arrow2, re_components, re_data_store, re_log,
+        re_arrow_store, re_arrow_store::external::*, re_components, re_data_store, re_log,
         re_log_types, re_memory, re_renderer, re_types, re_ui, re_viewer_context,
-        re_viewer_context::external::re_query, re_viewport, re_viewport::external::re_space_view,
+        re_viewer_context::external::*, re_viewport, re_viewport::external::*,
     };
 }
 

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,8 +39,8 @@ pub use selection_state::{
     HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
 };
 pub use space_view::{
-    ArchetypeDefinition, AutoSpawnHeuristic, DynSpaceViewClass, NamedViewSystem, PerSystemEntities,
-    SpaceViewClass, SpaceViewClassLayoutPriority, SpaceViewClassName, SpaceViewClassRegistry,
+    AutoSpawnHeuristic, DynSpaceViewClass, NamedViewSystem, PerSystemEntities, SpaceViewClass,
+    SpaceViewClassLayoutPriority, SpaceViewClassName, SpaceViewClassRegistry,
     SpaceViewClassRegistryError, SpaceViewEntityHighlight, SpaceViewHighlights,
     SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError, SpaceViewSystemRegistry,
     ViewContextCollection, ViewContextSystem, ViewPartCollection, ViewPartSystem, ViewQuery,
@@ -58,6 +58,7 @@ mod clipboard;
 pub use clipboard::Clipboard;
 
 pub mod external {
+    pub use nohash_hasher;
     pub use {re_arrow_store, re_data_store, re_log_types, re_query, re_ui};
 }
 

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,12 +39,12 @@ pub use selection_state::{
     HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
 };
 pub use space_view::{
-    AutoSpawnHeuristic, DynSpaceViewClass, NamedViewSystem, PerSystemEntities, SpaceViewClass,
-    SpaceViewClassLayoutPriority, SpaceViewClassName, SpaceViewClassRegistry,
-    SpaceViewClassRegistryError, SpaceViewEntityHighlight, SpaceViewHighlights,
-    SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError, SpaceViewSystemRegistry,
-    ViewContextCollection, ViewContextSystem, ViewPartCollection, ViewPartSystem, ViewQuery,
-    ViewSystemName,
+    default_heuristic_filter, AutoSpawnHeuristic, DynSpaceViewClass, NamedViewSystem,
+    PerSystemEntities, SpaceViewClass, SpaceViewClassLayoutPriority, SpaceViewClassName,
+    SpaceViewClassRegistry, SpaceViewClassRegistryError, SpaceViewEntityHighlight,
+    SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError,
+    SpaceViewSystemRegistry, ViewContextCollection, ViewContextSystem, ViewPartCollection,
+    ViewPartSystem, ViewQuery, ViewSystemName,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -83,7 +83,7 @@ pub trait DynSpaceViewClass {
     /// Heuristic used to determine which space view is the best fit for a set of paths.
     ///
     /// For each path in `ent_paths`, at least one of the registered [`crate::ViewPartSystem`] for this class
-    /// returned true when calling [`crate::ViewPartSystem::queries_any_components_of`].
+    /// returned true when calling [`crate::ViewPartSystem::heuristic_filter`].
     fn auto_spawn_heuristic(
         &self,
         _ctx: &ViewerContext<'_>,

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -7,11 +7,6 @@ use crate::{
     SpaceViewSystemRegistry, ViewQuery, ViewerContext,
 };
 
-/// First element is the primary component, all others are optional.
-///
-/// TODO(andreas/clement): More formal definition of an archetype.
-pub type ArchetypeDefinition = vec1::Vec1<ComponentName>;
-
 re_string_interner::declare_new_type!(
     /// The unique name of a space view type.
     #[derive(serde::Deserialize, serde::Serialize)]
@@ -77,7 +72,7 @@ pub trait DynSpaceViewClass {
     /// Optional archetype of the Space View's blueprint properties.
     ///
     /// Blueprint components that only apply to the space view itself, not to the entities it displays.
-    fn blueprint_archetype(&self) -> Option<ArchetypeDefinition>;
+    fn blueprint_archetype(&self) -> Option<Vec<ComponentName>>;
 
     /// Preferred aspect ratio for the ui tiles of this space view.
     fn preferred_tile_aspect_ratio(&self, state: &dyn SpaceViewState) -> Option<f32>;

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -17,8 +17,7 @@ mod view_query;
 
 pub use auto_spawn_heuristic::AutoSpawnHeuristic;
 pub use dyn_space_view_class::{
-    ArchetypeDefinition, DynSpaceViewClass, SpaceViewClassLayoutPriority, SpaceViewClassName,
-    SpaceViewState,
+    DynSpaceViewClass, SpaceViewClassLayoutPriority, SpaceViewClassName, SpaceViewState,
 };
 pub use highlights::{SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks};
 pub use named_system::{NamedViewSystem, PerSystemEntities, ViewSystemName};

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -26,7 +26,7 @@ pub use space_view_class_registry::{
     SpaceViewClassRegistry, SpaceViewClassRegistryError, SpaceViewSystemRegistry,
 };
 pub use view_context_system::{ViewContextCollection, ViewContextSystem};
-pub use view_part_system::{ViewPartCollection, ViewPartSystem};
+pub use view_part_system::{default_heuristic_filter, ViewPartCollection, ViewPartSystem};
 pub use view_query::ViewQuery;
 
 // ---------------------------------------------------------------------------

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -48,7 +48,7 @@ pub trait SpaceViewClass: std::marker::Sized {
     /// Heuristic used to determine which space view is the best fit for a set of paths.
     ///
     /// For each path in `ent_paths`, at least one of the registered [`crate::ViewPartSystem`] for this class
-    /// returned true when calling [`crate::ViewPartSystem::queries_any_components_of`].
+    /// returned true when calling [`crate::ViewPartSystem::heuristic_filter`].
     fn auto_spawn_heuristic(
         &self,
         _ctx: &ViewerContext<'_>,

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -1,11 +1,11 @@
 use re_data_store::EntityPropertyMap;
 use re_log_types::EntityPath;
+use re_types::ComponentName;
 
 use crate::{
-    ArchetypeDefinition, AutoSpawnHeuristic, DynSpaceViewClass, PerSystemEntities,
-    SpaceViewClassName, SpaceViewClassRegistryError, SpaceViewId, SpaceViewState,
-    SpaceViewSystemExecutionError, SpaceViewSystemRegistry, ViewContextCollection,
-    ViewPartCollection, ViewQuery, ViewerContext,
+    AutoSpawnHeuristic, DynSpaceViewClass, PerSystemEntities, SpaceViewClassName,
+    SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewSystemExecutionError,
+    SpaceViewSystemRegistry, ViewContextCollection, ViewPartCollection, ViewQuery, ViewerContext,
 };
 
 /// Defines a class of space view.
@@ -61,7 +61,7 @@ pub trait SpaceViewClass: std::marker::Sized {
     /// Optional archetype of the Space View's blueprint properties.
     ///
     /// Blueprint components that only apply to the space view itself, not to the entities it displays.
-    fn blueprint_archetype(&self) -> Option<ArchetypeDefinition> {
+    fn blueprint_archetype(&self) -> Option<Vec<ComponentName>> {
         None
     }
 
@@ -163,7 +163,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
     }
 
     #[inline]
-    fn blueprint_archetype(&self) -> Option<ArchetypeDefinition> {
+    fn blueprint_archetype(&self) -> Option<Vec<ComponentName>> {
         self.blueprint_archetype()
     }
 

--- a/crates/re_viewer_context/src/space_view/view_context_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_context_system.rs
@@ -1,7 +1,6 @@
 use ahash::HashMap;
-use nohash_hasher::IntSet;
 
-use re_types::ComponentName;
+use re_types::ComponentNameSet;
 
 use crate::{
     NamedViewSystem, SpaceViewSystemExecutionError, ViewQuery, ViewSystemName, ViewerContext,
@@ -18,7 +17,7 @@ pub trait ViewContextSystem {
     ///
     /// A context may also not require any components at all and merely prepare caches or viewer
     /// related data instead.
-    fn all_required_components(&self) -> Vec<IntSet<ComponentName>>;
+    fn compatible_component_sets(&self) -> Vec<ComponentNameSet>;
 
     /// Queries the data store and performs data conversions to make it ready for consumption by scene elements.
     fn execute(&mut self, ctx: &mut ViewerContext<'_>, query: &ViewQuery<'_>);

--- a/crates/re_viewer_context/src/space_view/view_context_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_context_system.rs
@@ -10,13 +10,15 @@ use crate::{
 ///
 /// Is always populated before view part systems.
 pub trait ViewContextSystem {
-    /// Each scene context may _require_ several different set of components in order to be
-    /// instantiated.
+    /// Returns all the component sets that the system is compatible with.
     ///
-    /// This lists all sets that the context requires.
+    /// If an entity path satisfies any of these sets, then the system will automatically run for
+    /// that entity path.
     ///
-    /// A context may also not require any components at all and merely prepare caches or viewer
-    /// related data instead.
+    /// Return an empty vec to specify that the system should never run automatically for any
+    /// specific entities.
+    /// It may still run once per frame as part of the global context if it has been registered to
+    /// do so, see [`crate::SpaceViewSystemRegistry`].
     fn compatible_component_sets(&self) -> Vec<ComponentNameSet>;
 
     /// Queries the data store and performs data conversions to make it ready for consumption by scene elements.

--- a/crates/re_viewer_context/src/space_view/view_context_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_context_system.rs
@@ -1,19 +1,24 @@
 use ahash::HashMap;
+use nohash_hasher::IntSet;
+
+use re_types::ComponentName;
 
 use crate::{
-    ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewQuery, ViewSystemName,
-    ViewerContext,
+    NamedViewSystem, SpaceViewSystemExecutionError, ViewQuery, ViewSystemName, ViewerContext,
 };
 
 /// View context that can be used by view parts and ui methods to retrieve information about the scene as a whole.
 ///
 /// Is always populated before view part systems.
 pub trait ViewContextSystem {
-    /// Each scene context may query several archetypes.
+    /// Each scene context may _require_ several different set of components in order to be
+    /// instantiated.
     ///
-    /// This lists all archetypes that the context queries.
-    /// A context may also query no archetypes at all and prepare caches or viewer related data instead.
-    fn archetypes(&self) -> Vec<ArchetypeDefinition>;
+    /// This lists all sets that the context requires.
+    ///
+    /// A context may also not require any components at all and merely prepare caches or viewer
+    /// related data instead.
+    fn all_required_components(&self) -> Vec<IntSet<ComponentName>>;
 
     /// Queries the data store and performs data conversions to make it ready for consumption by scene elements.
     fn execute(&mut self, ctx: &mut ViewerContext<'_>, query: &ViewQuery<'_>);

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -23,13 +23,14 @@ pub trait ViewPartSystem {
     ///
     /// Override this method only if a more detailed condition is required to inform heuristics whether
     /// the given entity is relevant for this system.
+    //
+    // TODO(andreas): Use new archetype definitions which also allows for several primaries.
     fn queries_any_components_of(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
         components: &[ComponentName],
     ) -> bool {
-        // TODO(andreas): Use new archetype definitions which also allows for several primaries.
         let archetype = self.archetype();
         components.contains(archetype.first())
     }

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -1,7 +1,7 @@
 use ahash::HashMap;
-use nohash_hasher::IntSet;
 
-use re_log_types::{ComponentName, EntityPath};
+use re_log_types::EntityPath;
+use re_types::ComponentNameSet;
 
 use crate::{
     NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
@@ -15,7 +15,16 @@ pub trait ViewPartSystem {
     // TODO(andreas): This should be able to list out the ContextSystems it needs.
 
     /// Returns the minimal set of components that the system _requires_ in order to be instantiated.
-    fn required_components(&self) -> IntSet<ComponentName>;
+    ///
+    /// This does not include indicator components.
+    fn required_components(&self) -> ComponentNameSet;
+
+    /// These are not required, but if _any_ of these are found, it is a strong indication that this
+    /// system should be active (if also the `required_components` are found).
+    #[inline]
+    fn indicator_components(&self) -> ComponentNameSet {
+        Default::default()
+    }
 
     /// Implements a filter to heuristically determine whether or not to instantiate the system.
     ///
@@ -23,19 +32,22 @@ pub trait ViewPartSystem {
     /// the minimal set of required components), this method applies an arbitrary filter to determine whether
     /// or not the system should be instantiated by default.
     ///
-    /// The passed-in set of `components` corresponds to all the different component that have ever been logged
-    /// on the entity path.
+    /// The passed-in set of `entity_components` corresponds to all the different components that have ever
+    /// been logged on the entity path.
     ///
-    /// By default, this always returns true.
+    /// By default, this returns true if eiher [`Self::indicator_components`] is empty or
+    /// `entity_components` contains at least one of these indicator components.
+    ///
     /// Override this method only if a more detailed condition is required to inform heuristics whether or not
     /// the given entity is relevant for this system.
+    #[inline]
     fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        _components: &IntSet<ComponentName>,
+        entity_components: &ComponentNameSet,
     ) -> bool {
-        true
+        default_heuristic_filter(entity_components, &self.indicator_components())
     }
 
     /// Queries the data store and performs data conversions to make it ready for display.
@@ -62,6 +74,25 @@ pub trait ViewPartSystem {
     }
 
     fn as_any(&self) -> &dyn std::any::Any;
+}
+
+/// The default implementation for [`ViewPartSystem::heuristic_filter`].
+///
+/// Returns true if eiher `indicator_components` is empty or `entity_components` contains at least one
+/// of these indicator components.
+///
+/// Exported as a standalone function to simplify the implementation of custom filters.
+#[inline]
+pub fn default_heuristic_filter(
+    entity_components: &ComponentNameSet,
+    indicator_components: &ComponentNameSet,
+) -> bool {
+    if indicator_components.is_empty() {
+        true // if there are no indicator components, then show anything with the required compoonents
+    } else {
+        // do we have at least one of the indicator components?
+        entity_components.intersection(indicator_components).count() > 0
+    }
 }
 
 pub struct ViewPartCollection {

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -17,26 +17,25 @@ pub trait ViewPartSystem {
     /// Returns the minimal set of components that the system _requires_ in order to be instantiated.
     fn required_components(&self) -> IntSet<ComponentName>;
 
-    /// Returns true if the system queries given components on the given path in its [`Self::execute`] method.
+    /// Implements a filter to heuristically determine whether or not to instantiate the system.
     ///
-    /// List of components is expected to be all components that have ever been logged on the entity path.
-    /// By default, this only checks if the primary components of the archetype are contained
-    /// in the list of components.
+    /// If and when the system can be instantiated (i.e. because there is at least one entity that satisfies
+    /// the minimal set of required components), this method applies an arbitrary filter to determine whether
+    /// or not the system should be instantiated by default.
     ///
-    /// Override this method only if a more detailed condition is required to inform heuristics whether
+    /// The passed-in set of `components` corresponds to all the different component that have ever been logged
+    /// on the entity path.
+    ///
+    /// By default, this always returns true.
+    /// Override this method only if a more detailed condition is required to inform heuristics whether or not
     /// the given entity is relevant for this system.
-    //
-    // TODO(andreas): Use new archetype definitions which also allows for several primaries.
-    fn queries_any_components_of(
+    fn heuristic_filter(
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        components: &[ComponentName],
+        _components: &IntSet<ComponentName>,
     ) -> bool {
-        let required_components = self.required_components();
-        components
-            .iter()
-            .any(|comp_name| required_components.contains(comp_name))
+        true
     }
 
     /// Queries the data store and performs data conversions to make it ready for display.

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use ahash::HashMap;
 use itertools::Itertools;
 use nohash_hasher::{IntMap, IntSet};
@@ -501,7 +499,7 @@ pub fn identify_entities_per_system_per_class(
             continue;
         };
 
-        let all_components: BTreeSet<_> = components.into_iter().collect();
+        let all_components: ComponentNameSet = components.into_iter().collect();
 
         for (required_components, systems_per_class) in &systems_per_required_components {
             if !all_components.is_superset(required_components) {

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -444,8 +444,6 @@ pub fn identify_entities_per_system_per_class(
 ) -> EntitiesPerSystemPerClass {
     re_tracing::profile_function!();
 
-    // TODO(andreas): Handle several primary components.
-    // This code currently assumes the first component for each archetype is the primary.
     let system_collections_per_class: IntMap<
         SpaceViewClassName,
         (ViewContextCollection, ViewPartCollection),
@@ -460,26 +458,26 @@ pub fn identify_entities_per_system_per_class(
         })
         .collect();
 
-    let primary_component_per_system = {
-        re_tracing::profile_scope!("gather primary component per system");
+    let systems_per_required_components = {
+        re_tracing::profile_scope!("gather required components per systems");
 
-        let mut primary_component_per_system: IntMap<
-            ComponentName,
+        let mut systems_per_required_components: HashMap<
+            HashableIntSet<ComponentName>,
             IntMap<SpaceViewClassName, TinyVec<[ViewSystemName; 2]>>,
-        > = IntMap::default();
+        > = HashMap::default();
         for (class_name, (context_collection, part_collection)) in &system_collections_per_class {
             for (system_name, part) in part_collection.iter_with_names() {
-                primary_component_per_system
-                    .entry(*part.archetype().first())
+                systems_per_required_components
+                    .entry(HashableIntSet(part.required_components()))
                     .or_default()
                     .entry(*class_name)
                     .or_default()
                     .push(system_name);
             }
             for (system_name, part) in context_collection.iter_with_names() {
-                for archetype in part.archetypes() {
-                    primary_component_per_system
-                        .entry(*archetype.first())
+                for required_components in part.all_required_components() {
+                    systems_per_required_components
+                        .entry(HashableIntSet(required_components))
                         .or_default()
                         .entry(*class_name)
                         .or_default()
@@ -487,10 +485,10 @@ pub fn identify_entities_per_system_per_class(
                 }
             }
         }
-        primary_component_per_system
+        systems_per_required_components
     };
 
-    let mut per_class_per_system_entities = EntitiesPerSystemPerClass::default();
+    let mut entities_per_system_per_class = EntitiesPerSystemPerClass::default();
 
     let store = ctx.store_db.store();
     for ent_path in ctx.store_db.entity_db.entity_paths() {
@@ -499,37 +497,61 @@ pub fn identify_entities_per_system_per_class(
             continue;
         };
 
-        for component in &components {
-            if let Some(systems_per_class) = primary_component_per_system.get(component) {
-                for (class, systems) in systems_per_class {
-                    let Some((_, part_collection)) = system_collections_per_class.get(class) else {
-                        continue;
-                    };
+        let all_components: IntSet<_> = components.clone().into_iter().collect();
 
-                    for system in systems {
-                        // TODO(andreas/jleibs): This is only needed because of images.
-                        // The `queries_any_components_of` method should go away entirely after #3032 lands
-                        if let Ok(view_part_system) = part_collection.get_by_name(*system) {
-                            if !view_part_system.queries_any_components_of(
-                                store,
-                                ent_path,
-                                &components,
-                            ) {
-                                continue;
-                            }
+        for (required_components, systems_per_class) in &systems_per_required_components {
+            if !all_components.is_superset(&required_components.0) {
+                continue;
+            }
+
+            for (class, systems) in systems_per_class {
+                let Some((_, part_collection)) = system_collections_per_class.get(class) else {
+                    continue;
+                };
+
+                for system in systems {
+                    // TODO(andreas/jleibs): This is only needed because of images.
+                    // The `queries_any_components_of` method should go away entirely after #3032 lands
+                    if let Ok(view_part_system) = part_collection.get_by_name(*system) {
+                        if !view_part_system.queries_any_components_of(store, ent_path, &components)
+                        {
+                            continue;
                         }
-
-                        per_class_per_system_entities
-                            .entry(*class)
-                            .or_default()
-                            .entry(*system)
-                            .or_default()
-                            .insert(ent_path.clone());
                     }
+
+                    entities_per_system_per_class
+                        .entry(*class)
+                        .or_default()
+                        .entry(*system)
+                        .or_default()
+                        .insert(ent_path.clone());
                 }
             }
         }
     }
 
-    per_class_per_system_entities
+    entities_per_system_per_class
+}
+
+#[derive(Debug, Clone, Eq)]
+struct HashableIntSet<T: nohash_hasher::IsEnabled + std::hash::Hash>(IntSet<T>);
+
+impl<T: nohash_hasher::IsEnabled + std::hash::Hash + PartialEq> PartialEq for HashableIntSet<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len()
+            && self
+                .0
+                .iter()
+                .zip(other.0.iter())
+                .all(|(left, right)| left == right)
+    }
+}
+
+// TODO
+impl<T: nohash_hasher::IsEnabled + std::hash::Hash> std::hash::Hash for HashableIntSet<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for value in &self.0 {
+            value.hash(state);
+        }
+    }
 }

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -512,8 +512,6 @@ pub fn identify_entities_per_system_per_class(
                 };
 
                 for system in systems {
-                    // TODO(andreas/jleibs): This is only needed because of images.
-                    // The `heuristic_filter` method should go away entirely after #3032 lands
                     if let Ok(view_part_system) = part_collection.get_by_name(*system) {
                         if !view_part_system.heuristic_filter(store, ent_path, &all_components) {
                             continue;

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -534,6 +534,8 @@ pub fn identify_entities_per_system_per_class(
     entities_per_system_per_class
 }
 
+// ---
+
 #[derive(Debug, Clone, Eq)]
 struct HashableIntSet<T: nohash_hasher::IsEnabled + std::hash::Hash>(IntSet<T>);
 
@@ -548,7 +550,6 @@ impl<T: nohash_hasher::IsEnabled + std::hash::Hash + PartialEq> PartialEq for Ha
     }
 }
 
-// TODO
 impl<T: nohash_hasher::IsEnabled + std::hash::Hash> std::hash::Hash for HashableIntSet<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         for value in &self.0 {

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -513,7 +513,7 @@ pub fn identify_entities_per_system_per_class(
 
                 for system in systems {
                     // TODO(andreas/jleibs): This is only needed because of images.
-                    // The `queries_any_components_of` method should go away entirely after #3032 lands
+                    // The `heuristic_filter` method should go away entirely after #3032 lands
                     if let Ok(view_part_system) = part_collection.get_by_name(*system) {
                         if !view_part_system.heuristic_filter(store, ent_path, &all_components) {
                             continue;

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -1,10 +1,11 @@
 use re_viewer::external::{
     egui,
-    nohash_hasher::IntSet,
     re_log_types::EntityPath,
     re_query::query_archetype,
     re_renderer,
-    re_types::{self, components::InstanceKey, Archetype, ComponentName, Loggable as _},
+    re_types::{
+        self, components::InstanceKey, Archetype, ComponentName, ComponentNameSet, Loggable as _,
+    },
     re_viewer_context::{
         NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
         ViewQuery, ViewSystemName, ViewerContext,
@@ -43,7 +44,7 @@ impl NamedViewSystem for InstanceColorSystem {
 }
 
 impl ViewPartSystem for InstanceColorSystem {
-    fn required_components(&self) -> IntSet<ComponentName> {
+    fn required_components(&self) -> ComponentNameSet {
         ColorArchetype::required_components()
             .iter()
             .map(ToOwned::to_owned)

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -1,12 +1,13 @@
 use re_viewer::external::{
     egui,
+    nohash_hasher::IntSet,
     re_log_types::EntityPath,
     re_query::query_archetype,
     re_renderer,
     re_types::{self, components::InstanceKey, Archetype, ComponentName, Loggable as _},
     re_viewer_context::{
-        ArchetypeDefinition, NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-        ViewPartSystem, ViewQuery, ViewSystemName, ViewerContext,
+        NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
+        ViewQuery, ViewSystemName, ViewerContext,
     },
 };
 
@@ -42,12 +43,11 @@ impl NamedViewSystem for InstanceColorSystem {
 }
 
 impl ViewPartSystem for InstanceColorSystem {
-    /// The archetype this scene part is querying from the store.
-    ///
-    /// TODO(wumpf): In future versions there will be a hard restriction that limits the queries
-    ///              within the `populate` method to this archetype.
-    fn archetype(&self) -> ArchetypeDefinition {
-        ColorArchetype::all_components().try_into().unwrap()
+    fn required_components(&self) -> IntSet<ComponentName> {
+        ColorArchetype::required_components()
+            .iter()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     /// Populates the scene part with data from the store.


### PR DESCRIPTION
This refactors view selection & heuristic filtering based on the lengthy standup discussions we had regarding the difficulties met during the implementation of the mesh-related archetypes.

The most important changes are to the `ViewPartSystem` trait which now looks like this:
```rust
// [...]

    /// Returns the minimal set of components that the system _requires_ in order to be instantiated.
    fn required_components(&self) -> IntSet<ComponentName>;

    /// Implements a filter to heuristically determine whether or not to instantiate the system.
    ///
    /// If and when the system can be instantiated (i.e. because there is at least one entity that satisfies
    /// the minimal set of required components), this method applies an arbitrary filter to determine whether
    /// or not the system should be instantiated by default.
    ///
    /// The passed-in set of `components` corresponds to all the different component that have ever been logged
    /// on the entity path.
    ///
    /// By default, this always returns true.
    /// Override this method only if a more detailed condition is required to inform heuristics whether or not
    /// the given entity is relevant for this system.
    fn heuristic_filter(
        &self,
        _store: &re_arrow_store::DataStore,
        _ent_path: &EntityPath,
        _components: &IntSet<ComponentName>,
    ) -> bool {
        true
    }

// [...]
```
as well as the modification made to [the heuristic filtering logic](https://github.com/rerun-io/rerun/pull/3323/files#diff-3f3d4453e2c33e0cbe9e4d3be98acbeca9e8ae6425c7cfbc099cd40425e90698).


As a side-effect of these changes, our heuristics now support archetypes with multiple required components.

---

This also makes all space views opt-in based on indicator components, as opposed to the status quo where views are opt-out, even though there is no way to opt-out.

This prevents issues like the following:
![image](https://github.com/rerun-io/rerun/assets/2910679/971a7ded-3777-41ee-8e38-be13a8a7a2b1)
where multiple view systems render the same data because they all can, even though that wasn't the intention of the logger (which merely logged a `Mesh3D` archetype in this case).
Same data with this PR:
![image](https://github.com/rerun-io/rerun/assets/2910679/4571c84c-a532-4521-a9c8-6d0759725ddd)

In the future, we'll want to provide ways for users to easily opt-in into multiple views.
This is already possible today by extending existing archetypes, but could definitely be more friendly using blueprints.

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3323) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3323)
- [Docs preview](https://rerun.io/preview/bf0c154883d3135c06b8bb7cdeeef561f237d69b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bf0c154883d3135c06b8bb7cdeeef561f237d69b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)