### PR TITLE
Python rotation3d array serialization

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-f1fffafcb5c451716a6a74d369fee53886e3d8fce049eecc2f3bfbad2522f7cd
+9877ee060c77e686d315f2d1f8e05dee6f92d4bab4e64f98957fc4b19fb53cba

--- a/rerun_py/rerun_sdk/rerun/_rerun2/_unions.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/_unions.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+
+def union_discriminant_type(data_type: pa.DenseUnionType, discriminant: str) -> pa.DataType:
+    """Return the data type of the given discriminant."""
+    return next(f.type for f in list(data_type) if f.name == discriminant)
+
+
+def build_dense_union(data_type: pa.DenseUnionType, discriminant: str, child: pa.Array) -> pa.Array:
+    """
+    Build a dense UnionArray given the `data_type`, a discriminant, and the child value array for a single child.
+
+    If the discriminant string doesn't match any possible value, a `ValueError` is raised.
+    """
+    try:
+        idx = [f.name for f in list(data_type)].index(discriminant)
+        type_ids = pa.array([idx] * len(child), type=pa.int8())
+        value_offsets = pa.array(range(len(child)), type=pa.int32())
+
+        children = [pa.nulls(0, type=f.type) for f in list(data_type)]
+        try:
+            children[idx] = child.cast(data_type[idx].type, safe=False)
+        except pa.ArrowInvalid:
+            # Since we're having issues with nullability in union types,
+            # the cast sometimes fails but can be skipped.
+            children[idx] = child
+
+        return pa.Array.from_buffers(
+            type=data_type,
+            length=len(child),
+            buffers=[None, type_ids.buffers()[1], value_offsets.buffers()[1]],
+            children=children,
+        )
+
+    except ValueError as e:
+        raise ValueError(e.args)

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/angle.py
@@ -75,7 +75,7 @@ class AngleArray(BaseExtensionArray[AngleArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: AngleArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in angle_ext.py
+        return AngleExt.native_to_pa_array_override(data, data_type)
 
 
 AngleType._ARRAY_TYPE = AngleArray

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/angle_ext.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/angle_ext.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+
+if TYPE_CHECKING:
+    from . import AngleArrayLike
 
 
 class AngleExt:
@@ -11,3 +16,57 @@ class AngleExt:
             self.__attrs_init__(inner=deg, kind="degrees")  # pyright: ignore[reportGeneralTypeIssues]
         else:
             raise ValueError("Either `rad` or `deg` must be provided.")
+
+    @staticmethod
+    def native_to_pa_array_override(data: AngleArrayLike, data_type: pa.DataType) -> pa.Array:
+        from . import Angle
+
+        if isinstance(data, Angle) or isinstance(data, float):
+            data = [data]
+
+        types: list[int] = []
+        value_offsets: list[int] = []
+
+        num_nulls = 0
+        radians: list[float] = []
+        degrees: list[float] = []
+
+        null_type_idx = 0
+        radian_type_idx = 1
+        degree_type_idx = 2
+
+        for angle in data:
+            if angle is None:
+                value_offsets.append(num_nulls)
+                num_nulls += 1
+                types.append(null_type_idx)
+            else:
+                if isinstance(angle, float):
+                    angle = Angle(angle)
+
+                if angle.kind == "radians":
+                    value_offsets.append(len(radians))
+                    radians.append(angle.inner)
+                    types.append(radian_type_idx)
+                elif angle.kind == "degrees":
+                    value_offsets.append(len(degrees))
+                    degrees.append(angle.inner)
+                    types.append(degree_type_idx)
+                else:
+                    raise ValueError(f"Unknown angle kind: {angle.kind} (expected `radians` or `degrees`)")
+
+        # don't use pa.UnionArray.from_dense because it makes all fields nullable.
+        return pa.UnionArray.from_buffers(
+            type=data_type,
+            length=len(data),
+            buffers=[
+                None,
+                pa.array(types, type=pa.int8()).buffers()[1],
+                pa.array(value_offsets, type=pa.int32()).buffers()[1],
+            ],
+            children=[
+                pa.nulls(num_nulls, pa.null()),
+                pa.array(radians, type=pa.float32()),
+                pa.array(degrees, type=pa.float32()),
+            ],
+        )

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion.py
@@ -65,7 +65,7 @@ class QuaternionArray(BaseExtensionArray[QuaternionArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: QuaternionArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in quaternion_ext.py
+        return QuaternionExt.native_to_pa_array_override(data, data_type)
 
 
 QuaternionType._ARRAY_TYPE = QuaternionArray

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion_ext.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/quaternion_ext.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import numpy.typing as npt
+import pyarrow as pa
+
+if TYPE_CHECKING:
+    from . import QuaternionArrayLike
+
+NUMPY_VERSION = tuple(map(int, np.version.version.split(".")[:2]))
 
 
 class QuaternionExt:
     def __init__(self: Any, *, xyzw: npt.ArrayLike) -> None:
         self.__attrs_init__(xyzw=xyzw)
+
+    @staticmethod
+    def native_to_pa_array_override(data: QuaternionArrayLike, data_type: pa.DataType) -> pa.Array:
+        from . import Quaternion
+
+        if isinstance(data, Quaternion):
+            data = [data]
+
+        quaternions = np.asarray([q.xyzw for q in data], dtype=np.float32).reshape((-1,))
+        return pa.FixedSizeListArray.from_arrays(quaternions, type=data_type)

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation3d.py
@@ -103,7 +103,7 @@ class Rotation3DArray(BaseExtensionArray[Rotation3DArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: Rotation3DArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in rotation3d_ext.py
+        return Rotation3DExt.native_to_pa_array_override(data, data_type)
 
 
 Rotation3DType._ARRAY_TYPE = Rotation3DArray

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation3d_ext.py
@@ -8,6 +8,8 @@ import pyarrow as pa
 if TYPE_CHECKING:
     from . import Quaternion, Rotation3DArrayLike, Rotation3DLike, RotationAxisAngle
 
+from .._unions import union_discriminant_type
+
 
 class Rotation3DExt:
     @staticmethod
@@ -73,9 +75,9 @@ class Rotation3DExt:
             ],
             children=[
                 pa.nulls(num_nulls, pa.null()),
-                QuaternionArray._native_to_pa_array(quaternions, _union_discriminant_type(data_type, "Quaternion")),
+                QuaternionArray._native_to_pa_array(quaternions, union_discriminant_type(data_type, "Quaternion")),
                 RotationAxisAngleArray._native_to_pa_array(
-                    rotation_axis_angles, _union_discriminant_type(data_type, "AxisAngle")
+                    rotation_axis_angles, union_discriminant_type(data_type, "AxisAngle")
                 ),
             ],
         )
@@ -84,9 +86,3 @@ class Rotation3DExt:
 def is_sequence(obj: Any) -> bool:
     t = type(obj)
     return hasattr(t, "__len__") and hasattr(t, "__getitem__")
-
-
-# TODO: move
-def _union_discriminant_type(data_type: pa.DenseUnionType, discriminant: str) -> pa.DataType:
-    """Return the data type of the given discriminant."""
-    return next(f.type for f in list(data_type) if f.name == discriminant)

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation_axis_angle.py
@@ -102,7 +102,7 @@ class RotationAxisAngleArray(BaseExtensionArray[RotationAxisAngleArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: RotationAxisAngleArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in rotation_axis_angle_ext.py
+        return RotationAxisAngleExt.native_to_pa_array_override(data, data_type)
 
 
 RotationAxisAngleType._ARRAY_TYPE = RotationAxisAngleArray

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation_axis_angle_ext.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/rotation_axis_angle_ext.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pyarrow as pa
+
 if TYPE_CHECKING:
-    from . import Angle, AngleLike
+    from . import Angle, AngleLike, RotationAxisAngleArrayLike
 
 
 class RotationAxisAngleExt:
@@ -16,3 +18,21 @@ class RotationAxisAngleExt:
             return x
         else:
             return Angle(rad=x)
+
+    @staticmethod
+    def native_to_pa_array_override(data: RotationAxisAngleArrayLike, data_type: pa.DataType) -> pa.Array:
+        from . import AngleArray, RotationAxisAngle, Vec3DArray
+
+        if isinstance(data, RotationAxisAngle):
+            data = [data]
+
+        axis_pa_array = Vec3DArray._native_to_pa_array([rotation.axis for rotation in data], data_type["axis"].type)
+        angle_pa_arr = AngleArray._native_to_pa_array([rotation.angle for rotation in data], data_type["angle"].type)
+
+        return pa.StructArray.from_arrays(
+            [
+                axis_pa_array,
+                angle_pa_arr,
+            ],
+            fields=list(data_type),
+        )

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/tensor_data_ext.py
@@ -12,6 +12,8 @@ from PIL import Image
 
 from rerun.log.error_utils import _send_warning
 
+from .._unions import build_dense_union
+
 
 class TorchTensorLike(Protocol):
     """Describes what is need from a Torch Tensor to be loggable to Rerun."""
@@ -212,37 +214,6 @@ class TensorDataExt:
 ################################################################################
 
 
-# TODO(jleibs): Move this somewhere common
-def _build_dense_union(data_type: pa.DenseUnionType, discriminant: str, child: pa.Array) -> pa.Array:
-    """
-    Build a dense UnionArray given the `data_type`, a discriminant, and the child value array.
-
-    If the discriminant string doesn't match any possible value, a `ValueError` is raised.
-    """
-    try:
-        idx = [f.name for f in list(data_type)].index(discriminant)
-        type_ids = pa.array([idx] * len(child), type=pa.int8())
-        value_offsets = pa.array(range(len(child)), type=pa.int32())
-
-        children = [pa.nulls(0, type=f.type) for f in list(data_type)]
-        try:
-            children[idx] = child.cast(data_type[idx].type, safe=False)
-        except pa.ArrowInvalid:
-            # Since we're having issues with nullability in union types (see below),
-            # the cast sometimes fails but can be skipped.
-            children[idx] = child
-
-        return pa.Array.from_buffers(
-            type=data_type,
-            length=len(child),
-            buffers=[None, type_ids.buffers()[1], value_offsets.buffers()[1]],
-            children=children,
-        )
-
-    except ValueError as e:
-        raise ValueError(e.args)
-
-
 def _build_shape_array(dims: list[TensorDimension]) -> pa.Array:
     from . import TensorDimensionType
 
@@ -298,7 +269,7 @@ def _build_buffer_array(buffer: TensorBufferLike) -> pa.Array:
         assert buffer.dtype.type in DTYPE_MAP, f"Failed to find {buffer.dtype.type} in f{DTYPE_MAP}"
         discriminant = DTYPE_MAP[buffer.dtype.type]
 
-    return _build_dense_union(
+    return build_dense_union(
         data_type,
         discriminant=discriminant,
         child=data_inner,

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/transform3d_ext.py
@@ -89,29 +89,6 @@ def _build_dense_union(data_type: pa.DenseUnionType, discriminant: str, child: p
         raise ValueError(e.args)
 
 
-def _build_struct_array_from_axis_angle_rotation(
-    rotation: RotationAxisAngle, axis_angle_type: pa.StructType
-) -> pa.StructArray:
-    axis = pa.FixedSizeListArray.from_arrays(
-        np.array(rotation.axis.xyz, dtype=np.float32).flatten(), type=axis_angle_type["axis"].type
-    )
-
-    angle = pa.array([rotation.angle.inner], type=pa.float32())
-    if rotation.angle.kind == "degrees":
-        angle_variant = "Degrees"
-    else:
-        angle_variant = "Radians"
-    angle_pa_arr = _build_dense_union(axis_angle_type["angle"].type, angle_variant, angle)
-
-    return pa.StructArray.from_arrays(
-        [
-            axis,
-            angle_pa_arr,
-        ],
-        fields=list(axis_angle_type),
-    )
-
-
 def _build_union_array_from_scale(scale: Scale3D | None, type_: pa.DenseUnionType) -> pa.Array:
     from . import Vec3D
 
@@ -134,37 +111,6 @@ def _build_union_array_from_scale(scale: Scale3D | None, type_: pa.DenseUnionTyp
     return _build_dense_union(type_, scale_discriminant, scale_pa_arr)
 
 
-def _build_union_array_from_rotation(rotation: Rotation3D | None, type_: pa.DenseUnionType) -> pa.Array:
-    from . import Quaternion, RotationAxisAngle
-
-    if rotation is None:
-        rotation_discriminant = "_null_markers"
-        rotation_pa_arr = pa.nulls(1, pa.null())
-        return _build_dense_union(type_, rotation_discriminant, rotation_pa_arr)
-
-    rotation_arm = rotation.inner
-
-    if isinstance(rotation_arm, RotationAxisAngle):
-        rotation_discriminant = "AxisAngle"
-        axis_angle_type = _union_discriminant_type(type_, rotation_discriminant)
-        stored_rotation = _build_struct_array_from_axis_angle_rotation(
-            rotation_arm, cast(pa.StructType, axis_angle_type)
-        )
-    elif isinstance(rotation_arm, Quaternion):
-        rotation_discriminant = "Quaternion"
-        np_rotation = np.array(rotation_arm.xyzw, dtype=np.float32).flatten()
-        stored_rotation = pa.FixedSizeListArray.from_arrays(
-            np_rotation, type=_union_discriminant_type(type_, rotation_discriminant)
-        )
-    else:
-        raise ValueError(
-            f"Unknown 3d rotation representation: {rotation_arm} (expected `Rotation3D`, `RotationAxisAngle`, "
-            "`Quaternion`, or `None`."
-        )
-
-    return _build_dense_union(type_, rotation_discriminant, stored_rotation)
-
-
 def _optional_mat3x3_to_arrow(mat: Mat3x3 | None) -> pa.Array:
     from . import Mat3x3Type
 
@@ -181,6 +127,15 @@ def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.Array:
         return pa.nulls(1, Vec3DType().storage_type)
     else:
         return pa.FixedSizeListArray.from_arrays(translation.xyz, type=Vec3DType().storage_type)
+
+
+def _optional_rotation_to_arrow(rotation: Rotation3D | None, storage_type: pa.DataType) -> pa.Array:
+    from . import Rotation3DArray
+
+    if rotation is None:
+        return pa.nulls(1, storage_type)
+    else:
+        return Rotation3DArray._native_to_pa_array(rotation, storage_type)
 
 
 def _build_struct_array_from_translation_mat3x3(
@@ -203,7 +158,7 @@ def _build_struct_array_from_translation_rotation_scale(
     transform: TranslationRotationScale3D, type_: pa.StructType
 ) -> pa.StructArray:
     translation = _optional_translation_to_arrow(transform.translation)
-    rotation = _build_union_array_from_rotation(transform.rotation, type_["rotation"].type)
+    rotation = _optional_rotation_to_arrow(transform.rotation, type_["rotation"].type)
     scale = _build_union_array_from_scale(transform.scale, type_["scale"].type)
 
     return pa.StructArray.from_arrays(

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -79,7 +79,6 @@ def vec3ds_expected(empty: bool, type_: Any | None) -> Any:
 
 rotations_arrays: list[rrd.Rotation3DArrayLike] = [
     [],
-    np.array([]),
     # Rotation3D
     rrd.Rotation3D(rrd.Quaternion(xyzw=[1, 2, 3, 4])),
     rrd.Rotation3D(rrd.RotationAxisAngle([1.0, 2.0, 3.0], rrd.Angle(4))),
@@ -96,7 +95,6 @@ rotations_arrays: list[rrd.Rotation3DArrayLike] = [
     [
         rrd.Rotation3D(rrd.Quaternion(xyzw=[1, 2, 3, 4])),
         [1, 2, 3, 4],
-        None,
         rrd.Quaternion(xyzw=[1, 2, 3, 4]),
         rrd.RotationAxisAngle([1, 2, 3], 4),
     ],
@@ -113,10 +111,7 @@ def expected_rotations(rotations: rrd.Rotation3DArrayLike, type_: Any) -> Any:
     elif isinstance(rotations, rrd.Quaternion):
         return type_.from_similar(rrd.Quaternion(xyzw=[1, 2, 3, 4]))
     else:  # sequence of Rotation3DLike
-        return type_.from_similar(
-            [rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 2
-            + [None, rrd.Quaternion(xyzw=[1, 2, 3, 4]), rrd.RotationAxisAngle([1, 2, 3], 4)]
-        )
+        return type_.from_similar([rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 3 + [rrd.RotationAxisAngle([1, 2, 3], 4)])
 
 
 radii_arrays: list[rrc.RadiusArrayLike | None] = [

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -113,8 +113,10 @@ def expected_rotations(rotations: rrd.Rotation3DArrayLike, type_: Any) -> Any:
     elif isinstance(rotations, rrd.Quaternion):
         return type_.from_similar(rrd.Quaternion(xyzw=[1, 2, 3, 4]))
     else:  # sequence of Rotation3DLike
-        return type_.from_similar([rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 2 + [None, rrd.Quaternion(xyzw=[1, 2, 3, 4]), rrd.RotationAxisAngle([1, 2, 3], 4)])
-
+        return type_.from_similar(
+            [rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 2
+            + [None, rrd.Quaternion(xyzw=[1, 2, 3, 4]), rrd.RotationAxisAngle([1, 2, 3], 4)]
+        )
 
 
 radii_arrays: list[rrc.RadiusArrayLike | None] = [

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -77,6 +77,46 @@ def vec3ds_expected(empty: bool, type_: Any | None) -> Any:
         return rrd.Vec3DArray.from_similar([] if empty else [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
 
+rotations_arrays: list[rrd.Rotation3DArrayLike] = [
+    [],
+    np.array([]),
+    # Rotation3D
+    rrd.Rotation3D(rrd.Quaternion(xyzw=[1, 2, 3, 4])),
+    rrd.Rotation3D(rrd.RotationAxisAngle([1.0, 2.0, 3.0], rrd.Angle(4))),
+    # Quaternion
+    rrd.Quaternion(xyzw=[1, 2, 3, 4]),
+    rrd.Quaternion(xyzw=[1.0, 2.0, 3.0, 4.0]),
+    rrd.Quaternion(xyzw=np.array([1, 2, 3, 4])),
+    # RotationAxisAngle
+    rrd.RotationAxisAngle([1, 2, 3], 4),
+    rrd.RotationAxisAngle([1.0, 2.0, 3.0], rrd.Angle(4)),
+    rrd.RotationAxisAngle(rrd.Vec3D([1, 2, 3]), rrd.Angle(4)),
+    rrd.RotationAxisAngle(np.array([1, 2, 3], dtype=np.uint8), rrd.Angle(rad=4)),
+    # Sequence[Rotation3DArray]
+    [
+        rrd.Rotation3D(rrd.Quaternion(xyzw=[1, 2, 3, 4])),
+        [1, 2, 3, 4],
+        None,
+        rrd.Quaternion(xyzw=[1, 2, 3, 4]),
+        rrd.RotationAxisAngle([1, 2, 3], 4),
+    ],
+]
+
+
+def expected_rotations(rotations: rrd.Rotation3DArrayLike, type_: Any) -> Any:
+    if is_empty(rotations):
+        return type_.from_similar([])
+    elif isinstance(rotations, rrd.Rotation3D):
+        return type_.from_similar(rotations)
+    elif isinstance(rotations, rrd.RotationAxisAngle):
+        return type_.from_similar(rrd.RotationAxisAngle([1, 2, 3], 4))
+    elif isinstance(rotations, rrd.Quaternion):
+        return type_.from_similar(rrd.Quaternion(xyzw=[1, 2, 3, 4]))
+    else:  # sequence of Rotation3DLike
+        return type_.from_similar([rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 2 + [None, rrd.Quaternion(xyzw=[1, 2, 3, 4]), rrd.RotationAxisAngle([1, 2, 3], 4)])
+
+
+
 radii_arrays: list[rrc.RadiusArrayLike | None] = [
     None,
     [],

--- a/rerun_py/tests/unit/test_rotation3d.py
+++ b/rerun_py/tests/unit/test_rotation3d.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from rerun.experimental import dt as rrd
+
+from .common_arrays import (
+    expected_rotations,
+    rotations_arrays,
+)
+
+
+def test_rotation3d() -> None:
+    for rotations in rotations_arrays:
+        print(f"rrd.Rotation3DArray.from_similar({rotations})")
+        datatype = rrd.Rotation3DArray.from_similar(rotations)
+        print(f"{datatype}\n")
+
+        assert datatype == expected_rotations(rotations, rrd.Rotation3DArray)
+
+
+if __name__ == "__main__":
+    test_rotation3d()


### PR DESCRIPTION
### What

Implements `native_to_pa_array_override` for `Rotation3D`. This is a prerequisite to Box3D using a `Rotation3D` component.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3326) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3326)
- [Docs preview](https://rerun.io/preview/25519393279f07c70d0ba925074c209fa061fd9b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/25519393279f07c70d0ba925074c209fa061fd9b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)