### PR TITLE
Onboarding screen: better margin, and shrink images to fit buttons

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/mod.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/mod.rs
@@ -74,9 +74,22 @@ impl WelcomeScreen {
         let response: WelcomeScreenResponse = egui::ScrollArea::vertical()
             .id_source(("welcome_screen_page", &self.current_page))
             .auto_shrink([false, false])
-            .show(ui, |ui| match self.current_page {
-                WelcomeScreenPage::Welcome => welcome_page_ui(ui, rx, command_sender),
-                WelcomeScreenPage::Examples => self.example_page.ui(ui, rx, command_sender),
+            .show(ui, |ui| {
+                let margin = egui::Margin {
+                    left: 40.0,
+                    right: 40.0,
+                    top: 16.0,
+                    bottom: 8.0,
+                };
+                egui::Frame {
+                    inner_margin: margin,
+                    ..Default::default()
+                }
+                .show(ui, |ui| match self.current_page {
+                    WelcomeScreenPage::Welcome => welcome_page_ui(ui, rx, command_sender),
+                    WelcomeScreenPage::Examples => self.example_page.ui(ui, rx, command_sender),
+                })
+                .inner
             })
             .inner;
 

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_page.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_page.rs
@@ -102,6 +102,12 @@ fn onboarding_content_ui(
         },
     ];
 
+    // Shrink images if needed so user can see all of the content buttons
+    let max_image_height = ui.available_height() - 300.0;
+
+    let centering_vspace = (ui.available_height() - 650.0) / 2.0;
+    ui.add_space(centering_vspace.at_least(0.0));
+
     let panel_count = panels.len();
 
     const MAX_COLUMN_WIDTH: f32 = 255.0;
@@ -124,18 +130,13 @@ fn onboarding_content_ui(
         .floor()
         .at_most(MAX_COLUMN_WIDTH);
 
-    // this space is added on the left so that the grid is centered
-    let centering_hspace = (ui.available_width()
-        - column_count as f32 * column_width
-        - (column_count - 1) as f32 * grid_spacing.x)
-        .at_least(0.0)
-        / 2.0;
-
-    // Shrink images if needed so user can see the buttons
-    let max_image_height = ui.available_height() - 300.0;
-
     ui.horizontal(|ui| {
-        ui.add_space(centering_hspace);
+        // this space is added on the left so that the grid is centered
+        let centering_hspace = (ui.available_width()
+            - column_count as f32 * column_width
+            - (column_count - 1) as f32 * grid_spacing.x)
+            / 2.0;
+        ui.add_space(centering_hspace.at_least(0.0));
 
         ui.vertical(|ui| {
             ui.horizontal_wrapped(|ui| {


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/3300

I shrink the images when vertical spacing is scant. The buttons will still be hidden if the view is made too narrow, but there are scrollbars.

![onboarding-screen-shrink-images](https://github.com/rerun-io/rerun/assets/1148717/ad34f0d3-2a1c-44b1-95ac-0b5d47086523)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3329) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3329)
- [Docs preview](https://rerun.io/preview/483d402ae38b8c82bb37d511bbfeff5d152f804e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/483d402ae38b8c82bb37d511bbfeff5d152f804e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)