### PR TITLE
Hide stream view and selection view in welcome app

### DIFF
--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -79,6 +79,28 @@ impl<'a> AppBlueprint<'a> {
     }
 }
 
+pub fn setup_welcome_screen_blueprint(welcome_screen_blueprint: &mut StoreDb) {
+    for (panel_name, expanded) in [
+        (PanelState::BLUEPRINT_VIEW_PATH, true),
+        (PanelState::SELECTION_VIEW_PATH, false),
+        (PanelState::TIMELINE_VIEW_PATH, false),
+    ] {
+        let entity_path = EntityPath::from(panel_name);
+        // TODO(jleibs): Seq instead of timeless?
+        let timepoint = TimePoint::timeless();
+
+        let component = PanelState { expanded };
+
+        let row =
+            DataRow::from_cells1_sized(RowId::random(), entity_path, timepoint, 1, [component]);
+
+        welcome_screen_blueprint
+            .entity_db
+            .try_add_data_row(&row)
+            .unwrap();
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 impl<'a> AppBlueprint<'a> {

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -58,20 +58,26 @@ impl StoreHub {
     /// screen.
     pub fn new() -> Self {
         re_tracing::profile_function!();
-        let mut blueprints = HashMap::new();
-        blueprints.insert(
-            Self::welcome_screen_app_id(),
-            StoreId::from_string(
-                StoreKind::Blueprint,
-                Self::welcome_screen_app_id().to_string(),
-            ),
+        let mut blueprint_by_app_id = HashMap::new();
+        let mut store_dbs = StoreBundle::default();
+
+        let welcome_screen_store_id = StoreId::from_string(
+            StoreKind::Blueprint,
+            Self::welcome_screen_app_id().to_string(),
         );
+        blueprint_by_app_id.insert(
+            Self::welcome_screen_app_id(),
+            welcome_screen_store_id.clone(),
+        );
+
+        let welcome_screen_blueprint = store_dbs.blueprint_entry(&welcome_screen_store_id);
+        crate::app_blueprint::setup_welcome_screen_blueprint(welcome_screen_blueprint);
 
         Self {
             selected_rec_id: None,
             selected_application_id: None,
-            blueprint_by_app_id: blueprints,
-            store_dbs: Default::default(),
+            blueprint_by_app_id,
+            store_dbs,
 
             was_recording_active: false,
 


### PR DESCRIPTION
### What
In the welcome screen blueprint, hide the selection view and streams/time view:

`cargo rerun reset && cargo rerun` ->

<img width="1712" alt="Screenshot 2023-09-15 at 13 10 17" src="https://github.com/rerun-io/rerun/assets/1148717/fc1743dc-74ac-4056-8c99-a7b44e493985">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3333) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3333)
- [Docs preview](https://rerun.io/preview/eb2d7e5d9c012b5090cf4bfb5c36674c594f097d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/eb2d7e5d9c012b5090cf4bfb5c36674c594f097d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)