### PR TITLE
Fix forced sink race

### DIFF
--- a/crates/re_log_encoding/src/file_sink.rs
+++ b/crates/re_log_encoding/src/file_sink.rs
@@ -52,6 +52,10 @@ impl FileSink {
 
         re_log::debug!("Saving file to {path:?}…");
 
+        // TODO(andreas): Can we ensure that a single process doesn't
+        // have multiple file sinks for the same file live?
+        // This likely caused an instability in the past, see https://github.com/rerun-io/rerun/issues/3306
+
         let file = std::fs::File::create(&path)
             .map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
         let mut encoder = crate::encoder::Encoder::new(encoding_options, file)?;

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -554,7 +554,7 @@ impl RecordingStream {
     ) -> RecordingStreamResult<Self> {
         let sink = forced_sink_path().map_or(sink, |path| {
             re_log::info!("Forcing FileSink because of env-var {ENV_FORCE_SAVE}={path:?}");
-            // UInwrap is ok since this force sinks are only used in tests.
+            // `unwrap` is ok since this force sinks are only used in tests.
             Box::new(crate::sink::FileSink::new(path).unwrap()) as Box<dyn LogSink>
         });
         RecordingStreamInner::new(info, batcher_config, sink).map(|inner| Self {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -31,7 +31,7 @@ const ENV_FORCE_SAVE: &str = "_RERUN_TEST_FORCE_SAVE";
 /// Newly created created [`RecordingStream`]s should use a [`crate::sink::FileSink`] pointing to this path.
 /// Furthermore, [`RecordingStream::set_sink`] calls after this should not swap out to a new sink but re-use the existing one.
 /// Note that creating a new [`crate::sink::FileSink`] to the same file path (even temporarily) can cause
-/// a race between file cration (and thus clearing) and pending file writes.
+/// a race between file creation (and thus clearing) and pending file writes.
 fn forced_sink_path() -> Option<String> {
     std::env::var(ENV_FORCE_SAVE).ok()
 }


### PR DESCRIPTION
### What

* Fixes #3306
... until proven otherwise.

C++ created the forced file sink three times during code sample roundtrip tests:

* 2x during RecordingStreamBuilder::buffered() (one flat in the that function and one again in RecordingStream::new )
* 1x during RecordingStream::connect, I think this is the problematic one, other languages don’t do that in their demos!

The problem is that each one is created while the previous one still exist. Upon creation we call File::create which is supposed to clear out the file. Meanwhile, the previous sink is still alive! It now gets closed, flushing out remaining data in a separate thread which may race with creation of a new file sink.

I am not entirely sure if this is the issue that causes #3306, but it seems quite likely given that this problem was only observed in the example roundtrip tests which in turn is the only problem that uses the forced file sink.


In the future we should have some precaution against having several file sinks to the same file alive.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3346) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3346)
- [Docs preview](https://rerun.io/preview/0829bd32c0147188fd9e6a27b96c65eaba5d1911/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0829bd32c0147188fd9e6a27b96c65eaba5d1911/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)