### PR TITLE
Fix incorrect propagation of field's nullability into its inner list

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-8f5d0b67f16163c142d34d2af8153e2c531c6637600f0101865707f4fe0581dc
+bb3295936b69b2135ae471c9cbbf140f965d8e3a0b570a6d2dec3a2873a4924d

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for AffixFuzzer1 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -110,7 +110,7 @@ impl crate::Loggable for AffixFuzzer1 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -45,7 +45,7 @@ impl crate::Loggable for AffixFuzzer11 {
         DataType::List(Box::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Float32,
-            is_nullable: true,
+            is_nullable: false,
             metadata: [].into(),
         }))
     }
@@ -125,7 +125,7 @@ impl crate::Loggable for AffixFuzzer11 {
                         DataType::List(Box::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
-                            is_nullable: true,
+                            is_nullable: false,
                             metadata: [].into(),
                         })),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -45,7 +45,7 @@ impl crate::Loggable for AffixFuzzer13 {
         DataType::List(Box::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Utf8,
-            is_nullable: true,
+            is_nullable: false,
             metadata: [].into(),
         }))
     }
@@ -147,7 +147,7 @@ impl crate::Loggable for AffixFuzzer13 {
                         DataType::List(Box::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Utf8,
-                            is_nullable: true,
+                            is_nullable: false,
                             metadata: [].into(),
                         })),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -53,7 +53,7 @@ impl crate::Loggable for AffixFuzzer17 {
         DataType::List(Box::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-            is_nullable: true,
+            is_nullable: false,
             metadata: [].into(),
         }))
     }
@@ -134,7 +134,7 @@ impl crate::Loggable for AffixFuzzer17 {
                         DataType::List(Box::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                            is_nullable: true,
+                            is_nullable: false,
                             metadata: [].into(),
                         })),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -53,7 +53,7 @@ impl crate::Loggable for AffixFuzzer18 {
         DataType::List(Box::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
-            is_nullable: true,
+            is_nullable: false,
             metadata: [].into(),
         }))
     }
@@ -134,7 +134,7 @@ impl crate::Loggable for AffixFuzzer18 {
                         DataType::List(Box::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
-                            is_nullable: true,
+                            is_nullable: false,
                             metadata: [].into(),
                         })),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for AffixFuzzer2 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -110,7 +110,7 @@ impl crate::Loggable for AffixFuzzer2 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for AffixFuzzer3 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -110,7 +110,7 @@ impl crate::Loggable for AffixFuzzer3 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,

--- a/crates/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer4.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for AffixFuzzer4 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -110,7 +110,7 @@ impl crate::Loggable for AffixFuzzer4 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,

--- a/crates/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer5.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for AffixFuzzer5 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -110,7 +110,7 @@ impl crate::Loggable for AffixFuzzer5 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,

--- a/crates/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer6.rs
@@ -88,7 +88,7 @@ impl crate::Loggable for AffixFuzzer6 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -110,7 +110,7 @@ impl crate::Loggable for AffixFuzzer6 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -53,7 +53,7 @@ impl crate::Loggable for AffixFuzzer7 {
         DataType::List(Box::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
-            is_nullable: true,
+            is_nullable: false,
             metadata: [].into(),
         }))
     }
@@ -134,7 +134,7 @@ impl crate::Loggable for AffixFuzzer7 {
                         DataType::List(Box::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
-                            is_nullable: true,
+                            is_nullable: false,
                             metadata: [].into(),
                         })),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -76,7 +76,7 @@ impl crate::Loggable for AffixFuzzer1 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -98,7 +98,7 @@ impl crate::Loggable for AffixFuzzer1 {
                 data_type: DataType::List(Box::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
-                    is_nullable: true,
+                    is_nullable: false,
                     metadata: [].into(),
                 })),
                 is_nullable: true,
@@ -315,7 +315,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 DataType::List(Box::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
-                                    is_nullable: true,
+                                    is_nullable: false,
                                     metadata: [].into(),
                                 })),
                                 offsets,
@@ -452,7 +452,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 DataType::List(Box::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Utf8,
-                                    is_nullable: true,
+                                    is_nullable: false,
                                     metadata: [].into(),
                                 })),
                                 offsets,
@@ -615,7 +615,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 data_type: DataType::List(Box::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
-                                    is_nullable: true,
+                                    is_nullable: false,
                                     metadata: [].into(),
                                 })),
                                 is_nullable: true,
@@ -637,7 +637,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                 data_type: DataType::List(Box::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Utf8,
-                                    is_nullable: true,
+                                    is_nullable: false,
                                     metadata: [].into(),
                                 })),
                                 is_nullable: true,
@@ -829,7 +829,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                     DataType::List(Box::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
-                                        is_nullable: true,
+                                        is_nullable: false,
                                         metadata: [].into(),
                                     })),
                                     arrow_data.data_type().clone(),
@@ -1026,7 +1026,7 @@ impl crate::Loggable for AffixFuzzer1 {
                                     DataType::List(Box::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Utf8,
-                                        is_nullable: true,
+                                        is_nullable: false,
                                         metadata: [].into(),
                                     })),
                                     arrow_data.data_type().clone(),

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -76,7 +76,7 @@ impl crate::Loggable for AffixFuzzer4 {
                     data_type: DataType::List(Box::new(Field {
                         name: "item".to_owned(),
                         data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                        is_nullable: true,
+                        is_nullable: false,
                         metadata: [].into(),
                     })),
                     is_nullable: false,
@@ -239,7 +239,7 @@ impl crate::Loggable for AffixFuzzer4 {
                                     name: "item".to_owned(),
                                     data_type:
                                         <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                                    is_nullable: true,
+                                    is_nullable: false,
                                     metadata: [].into(),
                                 })),
                                 offsets,
@@ -321,8 +321,8 @@ impl crate::Loggable for AffixFuzzer4 {
                             "many_optional".to_owned(), data_type :
                             DataType::List(Box::new(Field { name : "item".to_owned(),
                             data_type : < crate ::testing::datatypes::AffixFuzzer3 >
-                            ::arrow_datatype(), is_nullable : true, metadata : [].into(),
-                            })), is_nullable : false, metadata : [].into(), },
+                            ::arrow_datatype(), is_nullable : false, metadata : []
+                            .into(), })), is_nullable : false, metadata : [].into(), },
                         ],
                             Some(vec![0i32, 1i32, 2i32, 3i32]),
                             UnionMode::Dense,
@@ -451,7 +451,7 @@ impl crate::Loggable for AffixFuzzer4 {
                                     Box::new(Field {
                                         name: "item".to_owned(),
                                         data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                                        is_nullable: true,
+                                        is_nullable: false,
                                         metadata: [].into(),
                                     }),
                                 ),

--- a/crates/re_types_builder/src/arrow_registry.rs
+++ b/crates/re_types_builder/src/arrow_registry.rs
@@ -147,7 +147,11 @@ impl ArrowRegistry {
                 Box::new(LazyField {
                     name: "item".into(),
                     datatype: self.arrow_datatype_from_element_type(elem_type),
-                    is_nullable: field.is_nullable,
+                    // NOTE: Do _not_ confuse this with the nullability of the field itself!
+                    // This would be the nullability of the elements of the list itself, which our IDL
+                    // literally is unable to express at the moment, so you can be certain this is
+                    // always false.
+                    is_nullable: false,
                     metadata: Default::default(),
                 }),
                 length,
@@ -155,7 +159,11 @@ impl ArrowRegistry {
             Type::Vector { elem_type } => LazyDatatype::List(Box::new(LazyField {
                 name: "item".into(),
                 datatype: self.arrow_datatype_from_element_type(elem_type),
-                is_nullable: field.is_nullable,
+                // NOTE: Do _not_ confuse this with the nullability of the field itself!
+                // This would be the nullability of the elements of the list itself, which our IDL
+                // literally is unable to express at the moment, so you can be certain this is
+                // always false.
+                is_nullable: false,
                 metadata: Default::default(),
             })),
             Type::Object(fqname) => LazyDatatype::Unresolved(fqname),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer11.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer11.py
@@ -48,7 +48,7 @@ class AffixFuzzer11Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
             "rerun.testing.components.AffixFuzzer11",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer13.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer13.py
@@ -39,7 +39,7 @@ class AffixFuzzer13Type(BaseExtensionType):
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
-            pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
             "rerun.testing.components.AffixFuzzer13",
         )
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer16.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer16.py
@@ -67,7 +67,7 @@ class AffixFuzzer16Type(BaseExtensionType):
                                                 pa.field(
                                                     "many_floats_optional",
                                                     pa.list_(
-                                                        pa.field("item", pa.float32(), nullable=True, metadata={})
+                                                        pa.field("item", pa.float32(), nullable=False, metadata={})
                                                     ),
                                                     nullable=True,
                                                     metadata={},
@@ -80,7 +80,7 @@ class AffixFuzzer16Type(BaseExtensionType):
                                                 ),
                                                 pa.field(
                                                     "many_strings_optional",
-                                                    pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                                                     nullable=True,
                                                     metadata={},
                                                 ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer17.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer17.py
@@ -67,7 +67,7 @@ class AffixFuzzer17Type(BaseExtensionType):
                                                 pa.field(
                                                     "many_floats_optional",
                                                     pa.list_(
-                                                        pa.field("item", pa.float32(), nullable=True, metadata={})
+                                                        pa.field("item", pa.float32(), nullable=False, metadata={})
                                                     ),
                                                     nullable=True,
                                                     metadata={},
@@ -80,7 +80,7 @@ class AffixFuzzer17Type(BaseExtensionType):
                                                 ),
                                                 pa.field(
                                                     "many_strings_optional",
-                                                    pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                                                     nullable=True,
                                                     metadata={},
                                                 ),
@@ -111,7 +111,7 @@ class AffixFuzzer17Type(BaseExtensionType):
                             ),
                         ]
                     ),
-                    nullable=True,
+                    nullable=False,
                     metadata={},
                 )
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer18.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer18.py
@@ -82,7 +82,10 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                                 "many_floats_optional",
                                                                 pa.list_(
                                                                     pa.field(
-                                                                        "item", pa.float32(), nullable=True, metadata={}
+                                                                        "item",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     )
                                                                 ),
                                                                 nullable=True,
@@ -102,7 +105,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                                 "many_strings_optional",
                                                                 pa.list_(
                                                                     pa.field(
-                                                                        "item", pa.utf8(), nullable=True, metadata={}
+                                                                        "item", pa.utf8(), nullable=False, metadata={}
                                                                     )
                                                                 ),
                                                                 nullable=True,
@@ -193,7 +196,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                                             pa.field(
                                                                                 "item",
                                                                                 pa.float32(),
-                                                                                nullable=True,
+                                                                                nullable=False,
                                                                                 metadata={},
                                                                             )
                                                                         ),
@@ -219,7 +222,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                                             pa.field(
                                                                                 "item",
                                                                                 pa.utf8(),
-                                                                                nullable=True,
+                                                                                nullable=False,
                                                                                 metadata={},
                                                                             )
                                                                         ),
@@ -320,7 +323,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                                             pa.field(
                                                                                 "item",
                                                                                 pa.float32(),
-                                                                                nullable=True,
+                                                                                nullable=False,
                                                                                 metadata={},
                                                                             )
                                                                         ),
@@ -346,7 +349,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                                             pa.field(
                                                                                 "item",
                                                                                 pa.utf8(),
-                                                                                nullable=True,
+                                                                                nullable=False,
                                                                                 metadata={},
                                                                             )
                                                                         ),
@@ -399,7 +402,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                                                 ),
                                             ]
                                         ),
-                                        nullable=True,
+                                        nullable=False,
                                         metadata={},
                                     )
                                 ),
@@ -408,7 +411,7 @@ class AffixFuzzer18Type(BaseExtensionType):
                             ),
                         ]
                     ),
-                    nullable=True,
+                    nullable=False,
                     metadata={},
                 )
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer7.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/components/affix_fuzzer7.py
@@ -50,7 +50,7 @@ class AffixFuzzer7Type(BaseExtensionType):
                             pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                             pa.field(
                                 "many_floats_optional",
-                                pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+                                pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
                                 nullable=True,
                                 metadata={},
                             ),
@@ -62,7 +62,7 @@ class AffixFuzzer7Type(BaseExtensionType):
                             ),
                             pa.field(
                                 "many_strings_optional",
-                                pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                                 nullable=True,
                                 metadata={},
                             ),
@@ -76,7 +76,7 @@ class AffixFuzzer7Type(BaseExtensionType):
                             pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                         ]
                     ),
-                    nullable=True,
+                    nullable=False,
                     metadata={},
                 )
             ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer1.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer1.py
@@ -74,7 +74,7 @@ class AffixFuzzer1Type(BaseExtensionType):
                     pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                     pa.field(
                         "many_floats_optional",
-                        pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+                        pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
                         nullable=True,
                         metadata={},
                     ),
@@ -86,7 +86,7 @@ class AffixFuzzer1Type(BaseExtensionType):
                     ),
                     pa.field(
                         "many_strings_optional",
-                        pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                        pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                         nullable=True,
                         metadata={},
                     ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer3.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer3.py
@@ -81,7 +81,7 @@ class AffixFuzzer3Type(BaseExtensionType):
                                         pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                                         pa.field(
                                             "many_floats_optional",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=True, metadata={})),
+                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
                                             nullable=True,
                                             metadata={},
                                         ),
@@ -93,7 +93,7 @@ class AffixFuzzer3Type(BaseExtensionType):
                                         ),
                                         pa.field(
                                             "many_strings_optional",
-                                            pa.list_(pa.field("item", pa.utf8(), nullable=True, metadata={})),
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                                             nullable=True,
                                             metadata={},
                                         ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer4.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer4.py
@@ -90,7 +90,7 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                     pa.field(
                                                         "many_floats_optional",
                                                         pa.list_(
-                                                            pa.field("item", pa.float32(), nullable=True, metadata={})
+                                                            pa.field("item", pa.float32(), nullable=False, metadata={})
                                                         ),
                                                         nullable=True,
                                                         metadata={},
@@ -106,7 +106,7 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                     pa.field(
                                                         "many_strings_optional",
                                                         pa.list_(
-                                                            pa.field("item", pa.utf8(), nullable=True, metadata={})
+                                                            pa.field("item", pa.utf8(), nullable=False, metadata={})
                                                         ),
                                                         nullable=True,
                                                         metadata={},
@@ -186,7 +186,10 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                                 "many_floats_optional",
                                                                 pa.list_(
                                                                     pa.field(
-                                                                        "item", pa.float32(), nullable=True, metadata={}
+                                                                        "item",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     )
                                                                 ),
                                                                 nullable=True,
@@ -206,7 +209,7 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                                 "many_strings_optional",
                                                                 pa.list_(
                                                                     pa.field(
-                                                                        "item", pa.utf8(), nullable=True, metadata={}
+                                                                        "item", pa.utf8(), nullable=False, metadata={}
                                                                     )
                                                                 ),
                                                                 nullable=True,
@@ -299,7 +302,10 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                                 "many_floats_optional",
                                                                 pa.list_(
                                                                     pa.field(
-                                                                        "item", pa.float32(), nullable=True, metadata={}
+                                                                        "item",
+                                                                        pa.float32(),
+                                                                        nullable=False,
+                                                                        metadata={},
                                                                     )
                                                                 ),
                                                                 nullable=True,
@@ -319,7 +325,7 @@ class AffixFuzzer4Type(BaseExtensionType):
                                                                 "many_strings_optional",
                                                                 pa.list_(
                                                                     pa.field(
-                                                                        "item", pa.utf8(), nullable=True, metadata={}
+                                                                        "item", pa.utf8(), nullable=False, metadata={}
                                                                     )
                                                                 ),
                                                                 nullable=True,
@@ -366,7 +372,7 @@ class AffixFuzzer4Type(BaseExtensionType):
                                         ),
                                     ]
                                 ),
-                                nullable=True,
+                                nullable=False,
                                 metadata={},
                             )
                         ),

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer5.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer5.py
@@ -98,7 +98,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                         pa.field(
                                                                             "item",
                                                                             pa.float32(),
-                                                                            nullable=True,
+                                                                            nullable=False,
                                                                             metadata={},
                                                                         )
                                                                     ),
@@ -124,7 +124,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                         pa.field(
                                                                             "item",
                                                                             pa.utf8(),
-                                                                            nullable=True,
+                                                                            nullable=False,
                                                                             metadata={},
                                                                         )
                                                                     ),
@@ -221,7 +221,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                                 pa.field(
                                                                                     "item",
                                                                                     pa.float32(),
-                                                                                    nullable=True,
+                                                                                    nullable=False,
                                                                                     metadata={},
                                                                                 )
                                                                             ),
@@ -247,7 +247,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                                 pa.field(
                                                                                     "item",
                                                                                     pa.utf8(),
-                                                                                    nullable=True,
+                                                                                    nullable=False,
                                                                                     metadata={},
                                                                                 )
                                                                             ),
@@ -349,7 +349,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                                 pa.field(
                                                                                     "item",
                                                                                     pa.float32(),
-                                                                                    nullable=True,
+                                                                                    nullable=False,
                                                                                     metadata={},
                                                                                 )
                                                                             ),
@@ -375,7 +375,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                                                 pa.field(
                                                                                     "item",
                                                                                     pa.utf8(),
-                                                                                    nullable=True,
+                                                                                    nullable=False,
                                                                                     metadata={},
                                                                                 )
                                                                             ),
@@ -429,7 +429,7 @@ class AffixFuzzer5Type(BaseExtensionType):
                                                     ),
                                                 ]
                                             ),
-                                            nullable=True,
+                                            nullable=False,
                                             metadata={},
                                         )
                                     ),


### PR DESCRIPTION
The arrow pass of the codegen wrongly attributes the nullability of a field to its inner entity (whether it's a list or fixed-size list), which leads to corrupt datatypes being generated.

This generally doesn't cause any issues in practice because one cannot trust what the datatype says anyway, and nullability is instead checked by directly looking at the bitmap itself at runtime.

_But_, it turns out that the C++ backend completely ignore this piece of metadata at the moment, and therefore ends up generating datatypes that don't match what the Rust & Python backends generate, leading to broken roundtrips.

Fix the semantic pass so everyone agrees once again.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3352) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3352)
- [Docs preview](https://rerun.io/preview/e6f5534150ec72da6d22e6893b337873c7b607b5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e6f5534150ec72da6d22e6893b337873c7b607b5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)