### PR TITLE
Fix post-GC purging of streams view time histogram

### DIFF
--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -37,7 +37,7 @@ pub mod test_util;
 
 pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
-pub use self::store_gc::{GarbageCollectionOptions, GarbageCollectionTarget};
+pub use self::store_gc::{Deleted, GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats, EntityStats};
 pub use self::store_write::{WriteError, WriteResult};

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -986,12 +986,8 @@ impl IndexedBucketInner {
             re_tracing::profile_scope!("data");
             // shuffle component columns back into a sorted state
             for column in columns.values_mut() {
-                let mut source = {
-                    re_tracing::profile_scope!("clone");
-                    column.clone()
-                };
+                let mut source = column.clone();
                 {
-                    re_tracing::profile_scope!("rotate");
                     for (from, to) in swaps.iter().copied() {
                         column[to] = source[from].take();
                     }

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -657,10 +657,6 @@ impl IndexedTable {
         &mut self,
         time_range: impl RangeBounds<TimeInt>,
     ) -> impl Iterator<Item = (TimeInt, &mut IndexedBucket)> {
-        // Beware! This merely measures the time it takes to gather all the necessary metadata
-        // for building the returned iterator.
-        re_tracing::profile_function!();
-
         self.buckets
             .range_mut(time_range)
             .rev()

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -300,10 +300,10 @@ fn gc_correct() {
 
     let stats = DataStoreStats::from_store(&store);
 
-    let (row_ids, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
+    let (deleted, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
     let stats_diff = stats_diff + stats_empty; // account for fixed overhead
 
-    assert_eq!(row_ids.len() as u64, stats.total.num_rows);
+    assert_eq!(deleted.row_ids.len() as u64, stats.total.num_rows);
     assert_eq!(
         stats.metadata_registry.num_rows,
         stats_diff.metadata_registry.num_rows
@@ -316,12 +316,12 @@ fn gc_correct() {
 
     sanity_unwrap(&mut store);
     check_still_readable(&store);
-    for row_id in &row_ids {
+    for row_id in &deleted.row_ids {
         assert!(store.get_msg_metadata(row_id).is_none());
     }
 
-    let (row_ids, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
-    assert!(row_ids.is_empty());
+    let (deleted, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
+    assert!(deleted.row_ids.is_empty());
     assert_eq!(DataStoreStats::default(), stats_diff);
 
     sanity_unwrap(&mut store);

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -880,13 +880,13 @@ fn gc_impl(store: &mut DataStore) {
 
         let stats = DataStoreStats::from_store(store);
 
-        let (row_ids, stats_diff) = store.gc(GarbageCollectionOptions {
+        let (deleted, stats_diff) = store.gc(GarbageCollectionOptions {
             target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
             gc_timeless: false,
             protect_latest: 0,
             purge_empty_tables: false,
         });
-        for row_id in &row_ids {
+        for row_id in &deleted.row_ids {
             assert!(store.get_msg_metadata(row_id).is_none());
         }
 

--- a/crates/re_crash_handler/src/lib.rs
+++ b/crates/re_crash_handler/src/lib.rs
@@ -45,15 +45,11 @@ fn install_panic_hook(_build_info: BuildInfo) {
                 .name()
                 .map_or_else(|| format!("{:?}", thread.id()), |name| name.to_owned());
 
-            let file_line_suffix = if let Some(file_line) = &file_line {
-                format!(", {file_line}")
-            } else {
-                String::new()
-            };
-
-            eprintln!(
-                "\nthread '{thread_name}' panicked at '{msg}'{file_line_suffix}\n\n{callstack}"
-            );
+            eprintln!("\nthread '{thread_name}' panicked at '{msg}'");
+            if let Some(file_line) = &file_line {
+                eprintln!("{file_line}");
+            }
+            eprintln!("stack backtrace:\n{callstack}");
         } else {
             // This prints the panic message and callstack:
             (*previous_panic_hook)(panic_info);

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -185,11 +185,6 @@ impl EntityDb {
             data_store: _, // purged before this function is called
         } = self;
 
-        {
-            re_tracing::profile_scope!("times_per_timeline");
-            times_per_timeline.purge(deleted);
-        }
-
         let mut actually_deleted = Default::default();
 
         {

--- a/crates/re_int_histogram/src/tree.rs
+++ b/crates/re_int_histogram/src/tree.rs
@@ -1,6 +1,10 @@
-//! The histogram is implemented as a tree.
+//! The histogram is implemented as a trie.
 //!
-//! The branches are based on the next few bits of the key (also known as the "address").
+//! Each node in the trie stores a count of a key/address sharing a prefix up to `depth * LEVEL_STEP` bits.
+//! The key/address is always 64 bits.
+//!
+//! There are branch nodes, and two types of leaf nodes: dense, and sparse.
+//! Dense leaves are only found at the very bottom of the trie.
 
 use smallvec::{smallvec, SmallVec};
 

--- a/crates/re_log_types/src/time_point/timeline.rs
+++ b/crates/re_log_types/src/time_point/timeline.rs
@@ -126,6 +126,6 @@ impl SizeBytes for Timeline {
 impl std::hash::Hash for Timeline {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write_u64(self.name.hash() | self.typ.hash());
+        state.write_u64(self.name.hash() ^ self.typ.hash());
     }
 }

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -378,14 +378,30 @@ impl TimePanel {
                 if time_area_response.dragged_by(PointerButton::Primary) {
                     ui.scroll_with_delta(Vec2::Y * time_area_response.drag_delta().y);
                 }
-                self.show_children(
-                    ctx,
-                    time_area_response,
-                    time_area_painter,
-                    tree_max_y,
-                    &ctx.store_db.entity_db.tree,
-                    ui,
-                );
+
+                // Show "/" on top?
+                let show_root = false;
+
+                if show_root {
+                    self.show_tree(
+                        ctx,
+                        time_area_response,
+                        time_area_painter,
+                        tree_max_y,
+                        None,
+                        &ctx.store_db.entity_db.tree,
+                        ui,
+                    );
+                } else {
+                    self.show_children(
+                        ctx,
+                        time_area_response,
+                        time_area_painter,
+                        tree_max_y,
+                        &ctx.store_db.entity_db.tree,
+                        ui,
+                    );
+                }
             });
     }
 
@@ -396,7 +412,7 @@ impl TimePanel {
         time_area_response: &egui::Response,
         time_area_painter: &egui::Painter,
         tree_max_y: f32,
-        last_path_part: &EntityPathPart,
+        last_path_part: Option<&EntityPathPart>,
         tree: &EntityTree,
         ui: &mut egui::Ui,
     ) {
@@ -409,10 +425,14 @@ impl TimePanel {
         }
 
         // The last part of the the path component
-        let text = if tree.is_leaf() {
-            last_path_part.to_string()
+        let text = if let Some(last_path_part) = last_path_part {
+            if tree.is_leaf() {
+                last_path_part.to_string()
+            } else {
+                format!("{last_path_part}/") // show we have children with a /
+            }
         } else {
-            format!("{last_path_part}/") // show we have children with a /
+            "/".to_owned()
         };
 
         let collapsing_header_id = ui.make_persistent_id(&tree.path);
@@ -513,7 +533,7 @@ impl TimePanel {
                 time_area_response,
                 time_area_painter,
                 tree_max_y,
-                last_component,
+                Some(last_component),
                 child,
                 ui,
             );

--- a/examples/python/live_camera_edge_detection/main.py
+++ b/examples/python/live_camera_edge_detection/main.py
@@ -25,7 +25,10 @@ def run_canny(num_frames: int | None) -> None:
         # Read the frame
         ret, img = cap.read()
         if not ret:
-            print("Can't receive frame (stream end?). Exiting ...")
+            if frame_nr == 0:
+                print("Failed to capture any frame. No camera connected?")
+            else:
+                print("Can't receive frame (stream end?). Exiting…")
             break
 
         # Get the current frame time. On some platforms it always returns zero.

--- a/examples/python/notebook/blueprint.ipynb
+++ b/examples/python/notebook/blueprint.ipynb
@@ -33,7 +33,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "rr.init(\"Blueprint demo\")\n",
+                "rr.init(\"rerun_example_blueprint_demo\")\n",
                 "rr.start_web_viewer_server()\n",
                 "\n",
                 "rec = rr.memory_recording()"

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -22,7 +22,7 @@
     "import numpy as np\n",
     "import rerun as rr  # pip install rerun-sdk\n",
     "\n",
-    "rr.init(\"cube\")"
+    "rr.init(\"rerun_example_cube\")"
    ]
   },
   {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/2517

The datastore is not the only place we store data. For each node in the entity tree we store a _time histogram_ of where we have data. This was never properly purged post GC - a very rough heuristic was instead used (throw away everything up to the oldest time in the store - which will be an even worse heursistic after https://github.com/rerun-io/rerun/pull/3357).

With this PR, the store gc will book-keep exactly what was deleted, and it will be properly purged from all secondary indices.

The resulting code is a bit complicated, because the store has no idea about the hierarchical nature of the entity paths, but we store the time histograms (and other book-keeping) for each node. That is, logging to `/foo/bar` we will note the data on `/`, `/foo` and `/foo/bar`, but the data will only be registered in the store for `/foo/bar`.

I also fixed a bunch of other smaller things that came up.

Best reviewed commit-by-commit.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3364) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3364)
- [Docs preview](https://rerun.io/preview/18cbc53fe96798cbe45ab84ddeb66aa183253e12/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/18cbc53fe96798cbe45ab84ddeb66aa183253e12/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)