### PR TITLE
Speed up Python codegen by running black/ruff on a directory of files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4700,10 +4700,12 @@ dependencies = [
  "quote",
  "rayon",
  "re_build_tools",
+ "re_error",
  "re_log",
  "re_tracing",
  "rust-format",
  "syn 2.0.28",
+ "tempfile",
  "unindent",
  "xshell",
 ]

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-b1949ed82aea1611946dd789274a6c2fe52fc0cc605f73f0e4b4ac82767b2e28
+2c0a3a5cdc48f78281ef68fab6a3f90c3899d85ed85e2d8907bed4913e8bfdc8

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-6261cec0db8e1eae1c9c7748a465989ae1864c669ba433d83ce3e3673a5505d7
+894098f046e84eb108da7933223ce4a6450a1a7c365ebbd9db11f211062e17aa

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-894098f046e84eb108da7933223ce4a6450a1a7c365ebbd9db11f211062e17aa
+b1949ed82aea1611946dd789274a6c2fe52fc0cc605f73f0e4b4ac82767b2e28

--- a/crates/re_types_builder/Cargo.toml
+++ b/crates/re_types_builder/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 
 
 [dependencies]
+re_error.workspace = true
 re_log.workspace = true
 re_tracing = { workspace = true, features = ["server"] }
 
@@ -36,6 +37,7 @@ quote = "1.0"
 rayon.workspace = true
 rust-format = "0.3"
 syn = "2.0"
+tempfile = "3.0"
 unindent.workspace = true
 xshell = "0.2"
 

--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -111,7 +111,7 @@ pub fn remove_old_files_from_folder(folder_path: Utf8PathBuf, filepaths: &BTreeS
 }
 
 /// Write file if any changes were made and ensure folder hierarchy exists.
-pub fn write_file(filepath: &Utf8PathBuf, source: String) {
+pub fn write_file(filepath: &Utf8PathBuf, source: &str) {
     if let Ok(existing) = std::fs::read_to_string(filepath) {
         if existing == source {
             // Don't touch the timestamp unnecessarily

--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -67,7 +67,7 @@ impl StringExt for String {
 /// Remove all files in the given folder that are not in the given set.
 pub fn remove_old_files_from_folder(folder_path: Utf8PathBuf, filepaths: &BTreeSet<Utf8PathBuf>) {
     re_tracing::profile_function!();
-    re_log::info!("Checking for old files in {folder_path}");
+    re_log::debug!("Checking for old files in {folder_path}");
     for entry in std::fs::read_dir(folder_path).unwrap().flatten() {
         if entry.file_type().unwrap().is_dir() {
             continue;

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -160,7 +160,7 @@ impl CppCodeGenerator {
                     &folder_path_sdk
                 };
                 let filepath = folder_path.join(format!("{filename_stem}.{extension}"));
-                write_file(&filepath, string);
+                write_file(&filepath, &string);
                 let inserted = filepaths.insert(filepath);
                 assert!(
                     inserted,
@@ -193,7 +193,7 @@ impl CppCodeGenerator {
                 .join(format!("{folder_name}.hpp"));
             let string = string_from_token_stream(&tokens, None);
             let string = format_code(&string);
-            write_file(&filepath, string);
+            write_file(&filepath, &string);
             filepaths.insert(filepath);
         }
 

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -252,7 +252,7 @@ fn write_file(filepath: &Utf8PathBuf, mut code: String) {
         }
     }
 
-    crate::codegen::common::write_file(filepath, code);
+    crate::codegen::common::write_file(filepath, &code);
 }
 
 /// Replace `#[doc = "…"]` attributes with `/// …` doc comments,

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -281,7 +281,7 @@ pub fn generate_gitattributes_for_generated_files(
         generated_files.join("")
     );
 
-    codegen::write_file(&path, content);
+    codegen::write_file(&path, &content);
 }
 
 /// Generates C++ code.

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer3.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/affix_fuzzer3.py
@@ -25,7 +25,7 @@ __all__ = ["AffixFuzzer3", "AffixFuzzer3Array", "AffixFuzzer3ArrayLike", "AffixF
 class AffixFuzzer3:
     # You can define your own __init__ function as a member of AffixFuzzer3Ext in affix_fuzzer3_ext.py
 
-    inner: float | list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32] = field()
+    inner: float | (list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32]) = field()
     """
     degrees (float):
 

--- a/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/_rerun2/datatypes/tensor_buffer.py
@@ -31,7 +31,7 @@ class TensorBuffer(TensorBufferExt):
 
     # You can define your own __init__ function as a member of TensorBufferExt in tensor_buffer_ext.py
 
-    inner: npt.NDArray[np.float32] | npt.NDArray[np.float64] | npt.NDArray[np.int16] | npt.NDArray[np.int32] | npt.NDArray[np.int64] | npt.NDArray[np.int8] | npt.NDArray[np.uint16] | npt.NDArray[np.uint32] | npt.NDArray[np.uint64] | npt.NDArray[np.uint8] = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
+    inner: npt.NDArray[np.float32] | (npt.NDArray[np.float64] | (npt.NDArray[np.int16] | (npt.NDArray[np.int32] | (npt.NDArray[np.int64] | (npt.NDArray[np.int8] | (npt.NDArray[np.uint16] | (npt.NDArray[np.uint32] | (npt.NDArray[np.uint64] | npt.NDArray[np.uint8])))))))) = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
     """
     U8 (npt.NDArray[np.uint8]):
 


### PR DESCRIPTION
### What
It makes the codegen run almost twice as fast - from ~5s to ~2.7s

The output is… almost the same 😠 

![image](https://github.com/rerun-io/rerun/assets/1148717/e01ad64f-6ab2-414a-8d8f-9d472e012735)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3368) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3368)
- [Docs preview](https://rerun.io/preview/7f051795b61da45e8c7c99b6ffcb1e5fe9dfd5e0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7f051795b61da45e8c7c99b6ffcb1e5fe9dfd5e0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)