### PR TITLE
Keep track of how files where sources for analytics and UI

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -988,6 +988,7 @@ impl eframe::App for App {
                 for file in files {
                     self.command_sender
                         .send_system(SystemCommand::LoadDataSource(DataSource::FileContents(
+                            FileSource::FileDialog,
                             file.clone(),
                         )));
                 }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -2,7 +2,7 @@ use web_time::Instant;
 
 use re_data_source::{DataSource, FileContents};
 use re_data_store::store_db::StoreDb;
-use re_log_types::{LogMsg, StoreKind};
+use re_log_types::{FileSource, LogMsg, StoreKind};
 use re_renderer::WgpuResourcePoolStatistics;
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
 use re_ui::{toasts, UICommand, UICommandSender};
@@ -390,6 +390,7 @@ impl App {
                 for file_path in open_file_dialog_native() {
                     self.command_sender
                         .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
+                            FileSource::FileDialog,
                             file_path,
                         )));
                 }
@@ -861,6 +862,7 @@ impl App {
                 // This is what we get on Web.
                 self.command_sender
                     .send_system(SystemCommand::LoadDataSource(DataSource::FileContents(
+                        FileSource::DragAndDrop,
                         FileContents {
                             name: file.name.clone(),
                             bytes: bytes.clone(),
@@ -872,7 +874,10 @@ impl App {
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(path) = file.path {
                 self.command_sender
-                    .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(path)));
+                    .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
+                        FileSource::DragAndDrop,
+                        path,
+                    )));
             }
         }
     }

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -92,7 +92,9 @@ impl AppEnvironment {
         use re_log_types::StoreSource;
         match source {
             StoreSource::CSdk => Self::CSdk,
+
             StoreSource::PythonSdk(python_version) => Self::PythonSdk(python_version.clone()),
+
             StoreSource::RustSdk {
                 rustc_version,
                 llvm_version,
@@ -100,17 +102,18 @@ impl AppEnvironment {
                 rustc_version: rustc_version.clone(),
                 llvm_version: llvm_version.clone(),
             },
-            StoreSource::FileFromCli {
-                rustc_version,
-                llvm_version,
-            } => Self::RerunCli {
-                rustc_version: rustc_version.clone(),
-                llvm_version: llvm_version.clone(),
-            },
-            StoreSource::Unknown | StoreSource::Other(_) => Self::RustSdk {
-                rustc_version: "unknown".into(),
-                llvm_version: "unknown".into(),
-            },
+
+            StoreSource::File { .. } | StoreSource::Unknown | StoreSource::Other(_) => {
+                // We should not really get here
+
+                #[cfg(debug_assertions)]
+                re_log::warn_once!("Asked to create an AppEnvironment from {source:?}");
+
+                Self::RustSdk {
+                    rustc_version: "unknown".into(),
+                    llvm_version: "unknown".into(),
+                }
+            }
         }
     }
 }

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -176,7 +176,11 @@ impl ViewerAnalytics {
                 StoreSource::CSdk => "c_sdk".to_owned(),
                 StoreSource::PythonSdk(_version) => "python_sdk".to_owned(),
                 StoreSource::RustSdk { .. } => "rust_sdk".to_owned(),
-                StoreSource::FileFromCli { .. } => "file_cli".to_owned(),
+                StoreSource::File { file_source } => match file_source {
+                    re_log_types::FileSource::Cli => "file_cli".to_owned(),
+                    re_log_types::FileSource::DragAndDrop => "file_drag_and_drop".to_owned(),
+                    re_log_types::FileSource::FileDialog => "file_dialog".to_owned(),
+                },
                 StoreSource::Other(other) => other.clone(),
             };
 
@@ -187,16 +191,17 @@ impl ViewerAnalytics {
             // environment, _not_ the environment in which the viewer is running!
             #[allow(clippy::match_same_arms)]
             match &store_info.store_source {
-                StoreSource::FileFromCli {
-                    rustc_version,
-                    llvm_version,
+                StoreSource::File { .. } => {
+                    self.register("rust_version", env!("RE_BUILD_RUSTC_VERSION")); // Rust/LLVM version used to compile the viewer
+                    self.register("llvm_version", env!("RE_BUILD_LLVM_VERSION")); // Rust/LLVM version used to compile the viewer
+                    self.deregister("python_version"); // can't be both!
                 }
-                | StoreSource::RustSdk {
+                StoreSource::RustSdk {
                     rustc_version,
                     llvm_version,
                 } => {
-                    self.register("rust_version", rustc_version.to_string());
-                    self.register("llvm_version", llvm_version.to_string());
+                    self.register("rust_version", rustc_version.to_string()); // Rust/LLVM version of the the code compiling the Rust SDK
+                    self.register("llvm_version", llvm_version.to_string()); // Rust/LLVM version of the the code compiling the Rust SDK
                     self.deregister("python_version"); // can't be both!
                 }
                 StoreSource::PythonSdk(version) => {

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -455,7 +455,7 @@ async fn run_impl(
             .url_or_paths
             .iter()
             .cloned()
-            .map(DataSource::from_uri)
+            .map(|uri| DataSource::from_uri(re_log_types::FileSource::Cli, uri))
             .collect_vec();
 
         #[cfg(feature = "web_viewer")]


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/3272

```
pub enum FileSource {
    Cli,
    DragAndDrop,
    FileDialog,
}
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3371) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3371)
- [Docs preview](https://rerun.io/preview/460a3460e72914df330f4e3b0c2c517f740bd9fe/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/460a3460e72914df330f4e3b0c2c517f740bd9fe/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)