### PR TITLE
Clarify matrix storage, improve Python API, add Python matrix array serializers

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
@@ -7,7 +7,26 @@ namespace rerun.datatypes;
 
 // ---
 
-/// A 3x3 column-major Matrix.
+/// A 3x3 Matrix.
+///
+/// Matrices in Rerun are stored as flat list of coefficients in column-major order:
+/// ```text
+///             column 0       column 1       column 2
+///        -------------------------------------------------
+/// row 0 | flat_columns[0] flat_columns[3] flat_columns[6]
+/// row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
+/// row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
+/// ```
+///
+/// \py However, construction is done from a list of rows, which follows NumPy's convention:
+/// \py ```python
+/// \py np.testing.assert_array_equal(
+/// \py     rrd.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
+/// \py )
+/// \py     np.testing.assert_array_equal(
+/// \py     rrd.Mat3x3([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
+/// \py )
+/// \py ```
 struct Mat3x3 (
   "attr.arrow.transparent",
   "attr.python.aliases": "Sequence[float], Sequence[Sequence[float]], npt.ArrayLike",
@@ -15,6 +34,7 @@ struct Mat3x3 (
   "attr.rust.tuple_struct",
   order: 500
 ) {
-  /// \py: matrix coefficients in column-major order
-  coeffs: [float32: 9] (order: 100);
+  /// \py Flat list of matrix coefficients in column-major order.
+  /// \cpp Flat list of matrix coefficients in column-major order.
+  flat_columns: [float32: 9] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
@@ -21,10 +21,22 @@ namespace rerun.datatypes;
 /// \py However, construction is done from a list of rows, which follows NumPy's convention:
 /// \py ```python
 /// \py np.testing.assert_array_equal(
-/// \py     rrd.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
+/// \py     rr.dt.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
 /// \py )
-/// \py     np.testing.assert_array_equal(
-/// \py     rrd.Mat3x3([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
+/// \py np.testing.assert_array_equal(
+/// \py     rr.dt.Mat3x3([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns,
+/// \py     np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32),
+/// \py )
+/// \py ```
+/// \py If you want to construct a matrix from a list of columns instead, use the named `columns` parameter:
+/// \py ```python
+/// \py np.testing.assert_array_equal(
+/// \py     rr.dt.Mat3x3(columns=[1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns,
+/// \py     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32),
+/// \py )
+/// \py np.testing.assert_array_equal(
+/// \py     rr.dt.Mat3x3(columns=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns,
+/// \py     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32),
 /// \py )
 /// \py ```
 struct Mat3x3 (

--- a/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
@@ -19,15 +19,26 @@ namespace rerun.datatypes;
 /// row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 /// ```
 ///
-/// \py However, construction is done by default from a list of rows, which follows NumPy's convention:
+/// \py However, construction is done from a list of rows, which follows NumPy's convention:
 /// \py ```python
 /// \py np.testing.assert_array_equal(
-/// \py     rrd.Mat4x4([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).flat_columns,
+/// \py     rr.dt.Mat4x4([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).flat_columns,
 /// \py     np.array([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16], dtype=np.float32),
 /// \py )
 /// \py np.testing.assert_array_equal(
-/// \py     rrd.Mat4x4(np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])).flat_columns,
+/// \py     rr.dt.Mat4x4([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]).flat_columns,
 /// \py     np.array([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16], dtype=np.float32),
+/// \py )
+/// \py ```
+/// \py If you want to construct a matrix from a list of columns instead, use the named `columns` parameter:
+/// \py ```python
+/// \py np.testing.assert_array_equal(
+/// \py     rr.dt.Mat4x4(columns=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).flat_columns,
+/// \py     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], dtype=np.float32),
+/// \py )
+/// \py np.testing.assert_array_equal(
+/// \py     rr.dt.Mat4x4(columns=[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]).flat_columns,
+/// \py     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], dtype=np.float32),
 /// \py )
 /// \py ```
 struct Mat4x4 (

--- a/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
@@ -7,7 +7,29 @@ namespace rerun.datatypes;
 
 // ---
 
-/// A 4x4 column-major Matrix.
+/// A 4x4 Matrix.
+///
+/// Matrices in Rerun are stored as flat list of coefficients in column-major order:
+/// ```text
+///            column 0         column 1         column 2         column 3
+///        --------------------------------------------------------------------
+/// row 0 | flat_columns[0]  flat_columns[4]  flat_columns[8]  flat_columns[12]
+/// row 1 | flat_columns[1]  flat_columns[5]  flat_columns[9]  flat_columns[13]
+/// row 2 | flat_columns[2]  flat_columns[6]  flat_columns[10] flat_columns[14]
+/// row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
+/// ```
+///
+/// \py However, construction is done by default from a list of rows, which follows NumPy's convention:
+/// \py ```python
+/// \py np.testing.assert_array_equal(
+/// \py     rrd.Mat4x4([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).flat_columns,
+/// \py     np.array([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16], dtype=np.float32),
+/// \py )
+/// \py np.testing.assert_array_equal(
+/// \py     rrd.Mat4x4(np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])).flat_columns,
+/// \py     np.array([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16], dtype=np.float32),
+/// \py )
+/// \py ```
 struct Mat4x4 (
   "attr.arrow.transparent",
   "attr.python.aliases": "Sequence[float], Sequence[Sequence[float]]",
@@ -15,6 +37,7 @@ struct Mat4x4 (
   "attr.rust.tuple_struct",
   order: 600
 ) {
-  /// \py: matrix coefficients in column-major order
-  coeffs: [float32: 16] (order: 100);
+  /// \py Flat list of matrix coefficients in column-major order.
+  /// \cpp Flat list of matrix coefficients in column-major order.
+  flat_columns: [float32: 16] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
@@ -43,7 +43,7 @@ namespace rerun.datatypes;
 /// \py ```
 struct Mat4x4 (
   "attr.arrow.transparent",
-  "attr.python.aliases": "Sequence[float], Sequence[Sequence[float]]",
+  "attr.python.aliases": "Sequence[float], Sequence[Sequence[float]], npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
   "attr.rust.tuple_struct",
   order: 600

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-b482772352fe6e0cdec474b99d3198f3479e4da3be9ee940b96ccf24d8b9b242
+0ef5db00435f5675f52c57605ca12cc8a89e4c9f4d5bba36ec355da57fd5da8d

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -13,7 +13,16 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// A 3x3 column-major Matrix.
+/// A 3x3 Matrix.
+///
+/// Matrices in Rerun are stored as flat list of coefficients in column-major order:
+/// ```text
+///             column 0       column 1       column 2
+///        -------------------------------------------------
+/// row 0 | flat_columns[0] flat_columns[3] flat_columns[6]
+/// row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
+/// row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
+/// ```
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Mat3x3(pub [f32; 9usize]);
 
@@ -142,7 +151,7 @@ impl crate::Loggable for Mat3x3 {
                         arrow_data.data_type().clone(),
                     )
                 })
-                .with_context("rerun.datatypes.Mat3x3#coeffs")?;
+                .with_context("rerun.datatypes.Mat3x3#flat_columns")?;
             if arrow_data.is_empty() {
                 Vec::new()
             } else {
@@ -160,7 +169,7 @@ impl crate::Loggable for Mat3x3 {
                                 arrow_data_inner.data_type().clone(),
                             )
                         })
-                        .with_context("rerun.datatypes.Mat3x3#coeffs")?
+                        .with_context("rerun.datatypes.Mat3x3#flat_columns")?
                         .into_iter()
                         .map(|opt| opt.copied())
                         .collect::<Vec<_>>()
@@ -195,7 +204,7 @@ impl crate::Loggable for Mat3x3 {
         .map(|v| v.ok_or_else(crate::DeserializationError::missing_data))
         .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.datatypes.Mat3x3#coeffs")
+        .with_context("rerun.datatypes.Mat3x3#flat_columns")
         .with_context("rerun.datatypes.Mat3x3")?)
     }
 }

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -13,7 +13,17 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// A 4x4 column-major Matrix.
+/// A 4x4 Matrix.
+///
+/// Matrices in Rerun are stored as flat list of coefficients in column-major order:
+/// ```text
+///            column 0         column 1         column 2         column 3
+///        --------------------------------------------------------------------
+/// row 0 | flat_columns[0]  flat_columns[4]  flat_columns[8]  flat_columns[12]
+/// row 1 | flat_columns[1]  flat_columns[5]  flat_columns[9]  flat_columns[13]
+/// row 2 | flat_columns[2]  flat_columns[6]  flat_columns[10] flat_columns[14]
+/// row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
+/// ```
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Mat4x4(pub [f32; 16usize]);
 
@@ -142,7 +152,7 @@ impl crate::Loggable for Mat4x4 {
                         arrow_data.data_type().clone(),
                     )
                 })
-                .with_context("rerun.datatypes.Mat4x4#coeffs")?;
+                .with_context("rerun.datatypes.Mat4x4#flat_columns")?;
             if arrow_data.is_empty() {
                 Vec::new()
             } else {
@@ -160,7 +170,7 @@ impl crate::Loggable for Mat4x4 {
                                 arrow_data_inner.data_type().clone(),
                             )
                         })
-                        .with_context("rerun.datatypes.Mat4x4#coeffs")?
+                        .with_context("rerun.datatypes.Mat4x4#flat_columns")?
                         .into_iter()
                         .map(|opt| opt.copied())
                         .collect::<Vec<_>>()
@@ -195,7 +205,7 @@ impl crate::Loggable for Mat4x4 {
         .map(|v| v.ok_or_else(crate::DeserializationError::missing_data))
         .map(|res| res.map(|v| Some(Self(v))))
         .collect::<crate::DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.datatypes.Mat4x4#coeffs")
+        .with_context("rerun.datatypes.Mat4x4#flat_columns")
         .with_context("rerun.datatypes.Mat4x4")?)
     }
 }

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -44,9 +44,9 @@ namespace rerun {
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
-            static_assert(sizeof(elements[0].coeffs) == sizeof(elements[0]));
+            static_assert(sizeof(elements[0].flat_columns) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                elements[0].coeffs,
+                elements[0].flat_columns,
                 static_cast<int64_t>(num_elements * 9),
                 nullptr
             ));

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -17,9 +17,19 @@ namespace arrow {
 
 namespace rerun {
     namespace datatypes {
-        /// A 3x3 column-major Matrix.
+        /// A 3x3 Matrix.
+        ///
+        /// Matrices in Rerun are stored as flat list of coefficients in column-major order:
+        /// ```text
+        ///             column 0       column 1       column 2
+        ///        -------------------------------------------------
+        /// row 0 | flat_columns[0] flat_columns[3] flat_columns[6]
+        /// row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
+        /// row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
+        /// ```
         struct Mat3x3 {
-            float coeffs[9];
+            /// Flat list of matrix coefficients in column-major order.
+            float flat_columns[9];
 
           public:
             // Extensions to generated type defined in 'mat3x3_ext.cpp'
@@ -28,7 +38,7 @@ namespace rerun {
 
             /// Creates a new 3x3 matrix from 3 *columns* of 3 elements each.
             Mat3x3(const Vec3D (&columns)[3])
-                : coeffs{
+                : flat_columns{
                       columns[0].x(),
                       columns[0].y(),
                       columns[0].z(),
@@ -43,17 +53,17 @@ namespace rerun {
           public:
             Mat3x3() = default;
 
-            Mat3x3(const float (&_coeffs)[9])
-                : coeffs{
-                      _coeffs[0],
-                      _coeffs[1],
-                      _coeffs[2],
-                      _coeffs[3],
-                      _coeffs[4],
-                      _coeffs[5],
-                      _coeffs[6],
-                      _coeffs[7],
-                      _coeffs[8]} {}
+            Mat3x3(const float (&_flat_columns)[9])
+                : flat_columns{
+                      _flat_columns[0],
+                      _flat_columns[1],
+                      _flat_columns[2],
+                      _flat_columns[3],
+                      _flat_columns[4],
+                      _flat_columns[5],
+                      _flat_columns[6],
+                      _flat_columns[7],
+                      _flat_columns[8]} {}
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/mat3x3_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3_ext.cpp
@@ -18,7 +18,7 @@ namespace rerun {
 
             /// Creates a new 3x3 matrix from 3 *columns* of 3 elements each.
             Mat3x3(const Vec3D (&columns)[3])
-                : coeffs{
+                : flat_columns{
                       columns[0].x(),
                       columns[0].y(),
                       columns[0].z(),

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -44,9 +44,9 @@ namespace rerun {
             auto value_builder = static_cast<arrow::FloatBuilder *>(builder->value_builder());
 
             ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements)));
-            static_assert(sizeof(elements[0].coeffs) == sizeof(elements[0]));
+            static_assert(sizeof(elements[0].flat_columns) == sizeof(elements[0]));
             ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                elements[0].coeffs,
+                elements[0].flat_columns,
                 static_cast<int64_t>(num_elements * 16),
                 nullptr
             ));

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -17,9 +17,20 @@ namespace arrow {
 
 namespace rerun {
     namespace datatypes {
-        /// A 4x4 column-major Matrix.
+        /// A 4x4 Matrix.
+        ///
+        /// Matrices in Rerun are stored as flat list of coefficients in column-major order:
+        /// ```text
+        ///            column 0         column 1         column 2         column 3
+        ///        --------------------------------------------------------------------
+        /// row 0 | flat_columns[0]  flat_columns[4]  flat_columns[8]  flat_columns[12]
+        /// row 1 | flat_columns[1]  flat_columns[5]  flat_columns[9]  flat_columns[13]
+        /// row 2 | flat_columns[2]  flat_columns[6]  flat_columns[10] flat_columns[14]
+        /// row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
+        /// ```
         struct Mat4x4 {
-            float coeffs[16];
+            /// Flat list of matrix coefficients in column-major order.
+            float flat_columns[16];
 
           public:
             // Extensions to generated type defined in 'mat4x4_ext.cpp'
@@ -27,47 +38,47 @@ namespace rerun {
             static const Mat4x4 IDENTITY;
 
             /// Creates a new 4x4 matrix from 3 *columns* of 4 elements each.
-            Mat4x4(const Vec4D (&_columns)[4])
-                : coeffs{
-                      _columns[0].x(),
-                      _columns[0].y(),
-                      _columns[0].z(),
-                      _columns[0].w(),
-                      _columns[1].x(),
-                      _columns[1].y(),
-                      _columns[1].z(),
-                      _columns[1].w(),
-                      _columns[2].x(),
-                      _columns[2].y(),
-                      _columns[2].z(),
-                      _columns[2].w(),
-                      _columns[3].x(),
-                      _columns[3].y(),
-                      _columns[3].z(),
-                      _columns[3].w(),
+            Mat4x4(const Vec4D (&columns)[4])
+                : flat_columns{
+                      columns[0].x(),
+                      columns[0].y(),
+                      columns[0].z(),
+                      columns[0].w(),
+                      columns[1].x(),
+                      columns[1].y(),
+                      columns[1].z(),
+                      columns[1].w(),
+                      columns[2].x(),
+                      columns[2].y(),
+                      columns[2].z(),
+                      columns[2].w(),
+                      columns[3].x(),
+                      columns[3].y(),
+                      columns[3].z(),
+                      columns[3].w(),
                   } {}
 
           public:
             Mat4x4() = default;
 
-            Mat4x4(const float (&_coeffs)[16])
-                : coeffs{
-                      _coeffs[0],
-                      _coeffs[1],
-                      _coeffs[2],
-                      _coeffs[3],
-                      _coeffs[4],
-                      _coeffs[5],
-                      _coeffs[6],
-                      _coeffs[7],
-                      _coeffs[8],
-                      _coeffs[9],
-                      _coeffs[10],
-                      _coeffs[11],
-                      _coeffs[12],
-                      _coeffs[13],
-                      _coeffs[14],
-                      _coeffs[15]} {}
+            Mat4x4(const float (&_flat_columns)[16])
+                : flat_columns{
+                      _flat_columns[0],
+                      _flat_columns[1],
+                      _flat_columns[2],
+                      _flat_columns[3],
+                      _flat_columns[4],
+                      _flat_columns[5],
+                      _flat_columns[6],
+                      _flat_columns[7],
+                      _flat_columns[8],
+                      _flat_columns[9],
+                      _flat_columns[10],
+                      _flat_columns[11],
+                      _flat_columns[12],
+                      _flat_columns[13],
+                      _flat_columns[14],
+                      _flat_columns[15]} {}
 
             /// Returns the arrow data type this type corresponds to.
             static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/mat4x4_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4_ext.cpp
@@ -17,24 +17,24 @@ namespace rerun {
             static const Mat4x4 IDENTITY;
 
             /// Creates a new 4x4 matrix from 3 *columns* of 4 elements each.
-            Mat4x4(const Vec4D (&_columns)[4])
-                : coeffs{
-                      _columns[0].x(),
-                      _columns[0].y(),
-                      _columns[0].z(),
-                      _columns[0].w(),
-                      _columns[1].x(),
-                      _columns[1].y(),
-                      _columns[1].z(),
-                      _columns[1].w(),
-                      _columns[2].x(),
-                      _columns[2].y(),
-                      _columns[2].z(),
-                      _columns[2].w(),
-                      _columns[3].x(),
-                      _columns[3].y(),
-                      _columns[3].z(),
-                      _columns[3].w(),
+            Mat4x4(const Vec4D (&columns)[4])
+                : flat_columns{
+                      columns[0].x(),
+                      columns[0].y(),
+                      columns[0].z(),
+                      columns[0].w(),
+                      columns[1].x(),
+                      columns[1].y(),
+                      columns[1].z(),
+                      columns[1].w(),
+                      columns[2].x(),
+                      columns[2].y(),
+                      columns[2].z(),
+                      columns[2].w(),
+                      columns[3].x(),
+                      columns[3].y(),
+                      columns[3].z(),
+                      columns[3].w(),
                   } {}
 
             // [CODEGEN COPY TO HEADER END]

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -16,24 +16,61 @@ from .._baseclasses import (
     BaseExtensionArray,
     BaseExtensionType,
 )
+from .._converters import (
+    to_np_float32,
+)
 from .mat3x3_ext import Mat3x3Ext
 
 __all__ = ["Mat3x3", "Mat3x3Array", "Mat3x3ArrayLike", "Mat3x3Like", "Mat3x3Type"]
 
 
-@define
+@define(init=False)
 class Mat3x3(Mat3x3Ext):
-    """A 3x3 column-major Matrix."""
+    """
+    A 3x3 Matrix.
 
-    # You can define your own __init__ function as a member of Mat3x3Ext in mat3x3_ext.py
+    Matrices in Rerun are stored as flat list of coefficients in column-major order:
+    ```text
+                column 0       column 1       column 2
+           -------------------------------------------------
+    row 0 | flat_columns[0] flat_columns[3] flat_columns[6]
+    row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
+    row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
+    ```
 
-    coeffs: npt.NDArray[np.float32] = field(
-        converter=Mat3x3Ext.coeffs__field_converter_override,  # type: ignore[misc]
+    However, construction is done from a list of rows, which follows NumPy's convention:
+    ```python
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
     )
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns,
+        np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32),
+    )
+    ```
+    If you want to construct a matrix from a list of columns instead, use the named `columns` parameter:
+    ```python
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3(columns=[1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns,
+        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3(columns=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns,
+        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32),
+    )
+    ```
+    """
+
+    # __init__ can be found in mat3x3_ext.py
+
+    flat_columns: npt.NDArray[np.float32] = field(converter=to_np_float32)
+    """
+    Flat list of matrix coefficients in column-major order.
+    """
 
     def __array__(self, dtype: npt.DTypeLike = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Mat3x3Ext in mat3x3_ext.py
-        return np.asarray(self.coeffs, dtype=dtype)
+        return np.asarray(self.flat_columns, dtype=dtype)
 
 
 if TYPE_CHECKING:
@@ -63,7 +100,7 @@ class Mat3x3Array(BaseExtensionArray[Mat3x3ArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in mat3x3_ext.py
+        return Mat3x3Ext.native_to_pa_array_override(data, data_type)
 
 
 Mat3x3Type._ARRAY_TYPE = Mat3x3Array

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import numpy as np
 import pyarrow as pa
@@ -33,13 +33,13 @@ class Mat3x3Ext:
 
     @staticmethod
     def native_to_pa_array_override(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Mat3x3
+        from . import Mat3x3, Mat3x3Like
 
         # Normalize into list of Mat3x3
         if isinstance(data, Sequence):
             # single matrix made up of flat float array.
             if isinstance(data[0], float | int):
-                matrices = [Mat3x3(data)]
+                matrices = [Mat3x3(cast(Mat3x3Like, data))]
             # if there's a sequence nested, either it's several matrices in various formats
             # where the first happens to be either a flat or nested sequence of floats,
             # or it's a single matrix with a nested sequence of floats.
@@ -49,7 +49,7 @@ class Mat3x3Ext:
                 and len(data[0]) == 3
                 and all(isinstance(elem, float | int) for elem in data[0])
             ):
-                matrices = [Mat3x3(data)]
+                matrices = [Mat3x3(cast(Mat3x3Like, data))]
             # several matrices otherwise!
             else:
                 matrices = [Mat3x3(m) for m in data]

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -25,8 +25,10 @@ class Mat3x3Ext:
                 arr = np.array(rows, dtype=np.float32).reshape(3, 3)
                 self.flat_columns = arr.flatten("F")
         elif columns is not None:
+            # Equalize the format of the columns to a 3x3 matrix.
+            # Numpy expects rows _and_ stores row-major. Therefore the flattened list will have flat columns.
             arr = np.array(columns, dtype=np.float32).reshape(3, 3)
-            self.flat_columns = arr.flatten()
+            self.flat_columns = arr.flatten("C")
         else:
             _send_warning("Need to specify either columns or columns of matrix.", 1, recording=None)
             self.flat_columns = np.identity(3, dtype=np.float32).flatten()

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 import numpy.typing as npt
+import pyarrow as pa
 
 if TYPE_CHECKING:
-    from . import Mat3x3Like
+    from . import Mat3x3ArrayLike, Mat3x3Like
 
 
 class Mat3x3Ext:
@@ -19,3 +20,31 @@ class Mat3x3Ext:
         else:
             arr = np.array(data, dtype=np.float32).reshape(3, 3)
             return arr.flatten("F")
+
+    @staticmethod
+    def native_to_pa_array_override(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
+        from . import Mat3x3
+
+        # Normalize into list of Mat3x3
+        if isinstance(data, Sequence):
+            # single matrix made up of flat float array.
+            if isinstance(data[0], float | int):
+                matrices = [Mat3x3(data)]
+            # if there's a sequence nested, either it's several matrices in various formats
+            # where the first happens to be either a flat or nested sequence of floats,
+            # or it's a single matrix with a nested sequence of floats.
+            # for that to be true, the nested sequence must be 3 floats.
+            elif (
+                isinstance(data[0], Sequence)
+                and len(data[0]) == 3
+                and all(isinstance(elem, float | int) for elem in data[0])
+            ):
+                matrices = [Mat3x3(data)]
+            # several matrices otherwise!
+            else:
+                matrices = [Mat3x3(m) for m in data]
+        else:
+            matrices = [Mat3x3(data)]
+
+        float_arrays = np.asarray([matrix.flat_columns for matrix in matrices], dtype=np.float32).reshape(-1)
+        return pa.FixedSizeListArray.from_arrays(float_arrays, type=data_type)

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -40,7 +40,7 @@ class Mat3x3Ext:
         # Normalize into list of Mat3x3
         if isinstance(data, Sequence):
             # single matrix made up of flat float array.
-            if len(data) > 0 and isinstance(data[0], float | int):
+            if len(data) > 0 and (isinstance(data[0], float) or isinstance(data[0], int)):
                 matrices = [Mat3x3(cast(Mat3x3Like, data))]
             # if there's a sequence nested, either it's several matrices in various formats
             # where the first happens to be either a flat or nested sequence of floats,
@@ -49,7 +49,7 @@ class Mat3x3Ext:
             elif (
                 isinstance(data[0], Sequence)
                 and len(data[0]) == 3
-                and all(isinstance(elem, float | int) for elem in data[0])
+                and all((isinstance(elem, float) or isinstance(elem, int)) for elem in data[0])
             ):
                 matrices = [Mat3x3(cast(Mat3x3Like, data))]
             # several matrices otherwise!

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
 
 class Mat3x3Ext:
     @staticmethod
-    def coeffs__field_converter_override(data: Mat3x3Like) -> npt.NDArray[np.float32]:
+    def flat_columns__field_converter_override(data: Mat3x3Like) -> npt.NDArray[np.float32]:
         from . import Mat3x3
 
         if isinstance(data, Mat3x3):
-            return data.coeffs
+            return data.flat_columns
         else:
             arr = np.array(data, dtype=np.float32).reshape(3, 3)
             return arr.flatten("F")

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -1,25 +1,35 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
-import numpy.typing as npt
 import pyarrow as pa
+
+from rerun.error_utils import _send_warning
 
 if TYPE_CHECKING:
     from . import Mat3x3ArrayLike, Mat3x3Like
 
 
 class Mat3x3Ext:
-    @staticmethod
-    def flat_columns__field_converter_override(data: Mat3x3Like) -> npt.NDArray[np.float32]:
+    def __init__(self: Any, rows: Mat3x3Like | None = None, *, columns: Mat3x3Like | None = None) -> None:
         from . import Mat3x3
 
-        if isinstance(data, Mat3x3):
-            return data.flat_columns
+        if rows is not None:
+            if columns is not None:
+                _send_warning("Can't specify both columns and rows of matrix.", 1, recording=None)
+
+            if isinstance(rows, Mat3x3):
+                self.flat_columns = rows.flat_columns
+            else:
+                arr = np.array(rows, dtype=np.float32).reshape(3, 3)
+                self.flat_columns = arr.flatten("F")
+        elif columns is not None:
+            arr = np.array(columns, dtype=np.float32).reshape(3, 3)
+            self.flat_columns = arr.flatten()
         else:
-            arr = np.array(data, dtype=np.float32).reshape(3, 3)
-            return arr.flatten("F")
+            _send_warning("Need to specify either columns or columns of matrix.", 1, recording=None)
+            self.flat_columns = np.identity(3, dtype=np.float32).flatten()
 
     @staticmethod
     def native_to_pa_array_override(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -40,7 +40,7 @@ class Mat3x3Ext:
         # Normalize into list of Mat3x3
         if isinstance(data, Sequence):
             # single matrix made up of flat float array.
-            if isinstance(data[0], float | int):
+            if len(data) > 0 and isinstance(data[0], float | int):
                 matrices = [Mat3x3(cast(Mat3x3Like, data))]
             # if there's a sequence nested, either it's several matrices in various formats
             # where the first happens to be either a flat or nested sequence of floats,

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -40,7 +40,7 @@ class Mat4x4Ext:
         # Normalize into list of Mat4x4
         if isinstance(data, Sequence):
             # single matrix made up of flat float array.
-            if isinstance(data[0], float | int):
+            if len(data) > 0 and isinstance(data[0], float | int):
                 matrices = [Mat4x4(cast(Mat4x4Like, data))]
             # if there's a sequence nested, either it's several matrices in various formats
             # where the first happens to be either a flat or nested sequence of floats,

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -1,25 +1,35 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
-import numpy.typing as npt
 import pyarrow as pa
+
+from rerun.error_utils import _send_warning
 
 if TYPE_CHECKING:
     from . import Mat4x4ArrayLike, Mat4x4Like
 
 
 class Mat4x4Ext:
-    @staticmethod
-    def flat_columns__field_converter_override(data: Mat4x4Like) -> npt.NDArray[np.float32]:
+    def __init__(self: Any, rows: Mat4x4Like | None = None, *, columns: Mat4x4Like | None = None) -> None:
         from . import Mat4x4
 
-        if isinstance(data, Mat4x4):
-            return data.flat_columns
+        if rows is not None:
+            if columns is not None:
+                _send_warning("Can't specify both columns and rows of matrix.", 1, recording=None)
+
+            if isinstance(rows, Mat4x4):
+                self.flat_columns = rows.flat_columns
+            else:
+                arr = np.array(rows, dtype=np.float32).reshape(4, 4)
+                self.flat_columns = arr.flatten("F")
+        elif columns is not None:
+            arr = np.array(columns, dtype=np.float32).reshape(4, 4)
+            self.flat_columns = arr.flatten()
         else:
-            arr = np.array(data, dtype=np.float32).reshape(4, 4)
-            return arr.flatten("F")
+            _send_warning("Need to specify either columns or columns of matrix.", 1, recording=None)
+            self.flat_columns = np.identity(4, dtype=np.float32).flatten()
 
     @staticmethod
     def native_to_pa_array_override(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -40,7 +40,7 @@ class Mat4x4Ext:
         # Normalize into list of Mat4x4
         if isinstance(data, Sequence):
             # single matrix made up of flat float array.
-            if len(data) > 0 and isinstance(data[0], float | int):
+            if len(data) > 0 and (isinstance(data[0], float) or isinstance(data[0], int)):
                 matrices = [Mat4x4(cast(Mat4x4Like, data))]
             # if there's a sequence nested, either it's several matrices in various formats
             # where the first happens to be either a flat or nested sequence of floats,
@@ -49,7 +49,7 @@ class Mat4x4Ext:
             elif (
                 isinstance(data[0], Sequence)
                 and len(data[0]) == 4
-                and all(isinstance(elem, float | int) for elem in data[0])
+                and all((isinstance(elem, float) or isinstance(elem, int)) for elem in data[0])
             ):
                 matrices = [Mat4x4(cast(Mat4x4Like, data))]
             # several matrices otherwise!

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import numpy as np
 import pyarrow as pa
@@ -33,13 +33,13 @@ class Mat4x4Ext:
 
     @staticmethod
     def native_to_pa_array_override(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Mat4x4
+        from . import Mat4x4, Mat4x4Like
 
         # Normalize into list of Mat4x4
         if isinstance(data, Sequence):
             # single matrix made up of flat float array.
             if isinstance(data[0], float | int):
-                matrices = [Mat4x4(data)]
+                matrices = [Mat4x4(cast(Mat4x4Like, data))]
             # if there's a sequence nested, either it's several matrices in various formats
             # where the first happens to be either a flat or nested sequence of floats,
             # or it's a single matrix with a nested sequence of floats.
@@ -49,7 +49,7 @@ class Mat4x4Ext:
                 and len(data[0]) == 4
                 and all(isinstance(elem, float | int) for elem in data[0])
             ):
-                matrices = [Mat4x4(data)]
+                matrices = [Mat4x4(cast(Mat4x4Like, data))]
             # several matrices otherwise!
             else:
                 matrices = [Mat4x4(m) for m in data]

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -25,6 +25,8 @@ class Mat4x4Ext:
                 arr = np.array(rows, dtype=np.float32).reshape(4, 4)
                 self.flat_columns = arr.flatten("F")
         elif columns is not None:
+            # Equalize the format of the columns to a 3x3 matrix.
+            # Numpy expects rows _and_ stores row-major. Therefore the flattened list will have flat columns.
             arr = np.array(columns, dtype=np.float32).reshape(4, 4)
             self.flat_columns = arr.flatten()
         else:

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
 
 class Mat4x4Ext:
     @staticmethod
-    def coeffs__field_converter_override(data: Mat4x4Like) -> npt.NDArray[np.float32]:
+    def flat_columns__field_converter_override(data: Mat4x4Like) -> npt.NDArray[np.float32]:
         from . import Mat4x4
 
         if isinstance(data, Mat4x4):
-            return data.coeffs
+            return data.flat_columns
         else:
             arr = np.array(data, dtype=np.float32).reshape(4, 4)
             return arr.flatten("F")

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 import numpy.typing as npt
+import pyarrow as pa
 
 if TYPE_CHECKING:
-    from . import Mat4x4Like
+    from . import Mat4x4ArrayLike, Mat4x4Like
 
 
 class Mat4x4Ext:
@@ -19,3 +20,31 @@ class Mat4x4Ext:
         else:
             arr = np.array(data, dtype=np.float32).reshape(4, 4)
             return arr.flatten("F")
+
+    @staticmethod
+    def native_to_pa_array_override(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:
+        from . import Mat4x4
+
+        # Normalize into list of Mat4x4
+        if isinstance(data, Sequence):
+            # single matrix made up of flat float array.
+            if isinstance(data[0], float | int):
+                matrices = [Mat4x4(data)]
+            # if there's a sequence nested, either it's several matrices in various formats
+            # where the first happens to be either a flat or nested sequence of floats,
+            # or it's a single matrix with a nested sequence of floats.
+            # for that to be true, the nested sequence must be 4 floats.
+            elif (
+                isinstance(data[0], Sequence)
+                and len(data[0]) == 4
+                and all(isinstance(elem, float | int) for elem in data[0])
+            ):
+                matrices = [Mat4x4(data)]
+            # several matrices otherwise!
+            else:
+                matrices = [Mat4x4(m) for m in data]
+        else:
+            matrices = [Mat4x4(data)]
+
+        float_arrays = np.asarray([matrix.flat_columns for matrix in matrices], dtype=np.float32).reshape(-1)
+        return pa.FixedSizeListArray.from_arrays(float_arrays, type=data_type)

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
@@ -89,12 +89,12 @@ def _build_union_array_from_scale(scale: Scale3D | None, type_: pa.DenseUnionTyp
 
 
 def _optional_mat3x3_to_arrow(mat: Mat3x3 | None) -> pa.Array:
-    from . import Mat3x3Type
+    from . import Mat3x3Array, Mat3x3Type
 
     if mat is None:
         return pa.nulls(1, Mat3x3Type().storage_type)
     else:
-        return pa.FixedSizeListArray.from_arrays(mat.coeffs, type=Mat3x3Type().storage_type)
+        return Mat3x3Array._native_to_pa_array(mat, Mat3x3Type().storage_type)
 
 
 def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.Array:

--- a/rerun_py/tests/unit/test_matnxn.py
+++ b/rerun_py/tests/unit/test_matnxn.py
@@ -11,6 +11,7 @@ MAT_3X3_INPUT = [
     [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    rr_dt.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]),
 ]
 
 
@@ -27,6 +28,7 @@ MAT_4X4_INPUT = [
     [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
     np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]),
     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+    rr_dt.Mat4x4([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
 ]
 
 
@@ -45,7 +47,19 @@ def test_mat3x3(data: rr_dt.Mat3x3Like) -> None:
     assert_correct_mat3x3(m)
 
 
+def test_mat3x3array() -> None:
+    assert rr_dt.Mat3x3Array.from_similar(MAT_3X3_INPUT) == rr_dt.Mat3x3Array.from_similar(
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9]] * len(MAT_3X3_INPUT)
+    )
+
+
 @pytest.mark.parametrize("data", MAT_4X4_INPUT)
 def test_mat4x4(data: rr_dt.Mat4x4Like) -> None:
     m = rr_dt.Mat4x4(data)
     assert_correct_mat4x4(m)
+
+
+def test_mat4x4array() -> None:
+    assert rr_dt.Mat4x4Array.from_similar(MAT_4X4_INPUT) == rr_dt.Mat4x4Array.from_similar(
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]] * len(MAT_4X4_INPUT)
+    )

--- a/rerun_py/tests/unit/test_matnxn.py
+++ b/rerun_py/tests/unit/test_matnxn.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 import pytest
 from rerun.experimental import dt as rr_dt
@@ -70,7 +72,7 @@ def test_mat3x3(data: rr_dt.Mat3x3Like) -> None:
 
 
 def test_mat3x3array() -> None:
-    assert rr_dt.Mat3x3Array.from_similar(MAT_3X3_INPUT) == rr_dt.Mat3x3Array.from_similar(
+    assert rr_dt.Mat3x3Array.from_similar(cast(rr_dt.Mat3x3ArrayLike, MAT_3X3_INPUT)) == rr_dt.Mat3x3Array.from_similar(
         [[1, 2, 3, 4, 5, 6, 7, 8, 9]] * len(MAT_3X3_INPUT)
     )
 
@@ -104,7 +106,7 @@ def test_mat4x4(data: rr_dt.Mat4x4Like) -> None:
 
 
 def test_mat4x4array() -> None:
-    assert rr_dt.Mat4x4Array.from_similar(MAT_4X4_INPUT) == rr_dt.Mat4x4Array.from_similar(
+    assert rr_dt.Mat4x4Array.from_similar(cast(rr_dt.Mat4x4ArrayLike, MAT_4X4_INPUT)) == rr_dt.Mat4x4Array.from_similar(
         [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]] * len(MAT_4X4_INPUT)
     )
 

--- a/rerun_py/tests/unit/test_matnxn.py
+++ b/rerun_py/tests/unit/test_matnxn.py
@@ -11,7 +11,18 @@ MAT_3X3_INPUT = [
     [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], order="F"),
     rr_dt.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    rr_dt.Mat3x3(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    rr_dt.Mat3x3(rows=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    rr_dt.Mat3x3(columns=[1, 4, 7, 2, 5, 8, 3, 6, 9]),
+    rr_dt.Mat3x3(columns=[[1, 4, 7], [2, 5, 8], [3, 6, 9]]),
+    rr_dt.Mat3x3(rr_dt.Mat3x3(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9])),
+    rr_dt.Mat3x3(rr_dt.Mat3x3(columns=[1, 4, 7, 2, 5, 8, 3, 6, 9])),
+    rr_dt.Mat3x3(rows=rr_dt.Mat3x3(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9])),
+    rr_dt.Mat3x3(rows=rr_dt.Mat3x3(columns=[1, 4, 7, 2, 5, 8, 3, 6, 9])),
+    rr_dt.Mat3x3(columns=rr_dt.Mat3x3(columns=[1, 4, 7, 2, 5, 8, 3, 6, 9])),
+    rr_dt.Mat3x3(columns=rr_dt.Mat3x3(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9])),
 ]
 
 
@@ -28,7 +39,18 @@ MAT_4X4_INPUT = [
     [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
     np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]),
     np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+    np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], order="F"),
     rr_dt.Mat4x4([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+    rr_dt.Mat4x4(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+    rr_dt.Mat4x4(rows=[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]),
+    rr_dt.Mat4x4(columns=[1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16]),
+    rr_dt.Mat4x4(columns=[[1, 5, 9, 13], [2, 6, 10, 14], [3, 7, 11, 15], [4, 8, 12, 16]]),
+    rr_dt.Mat4x4(rr_dt.Mat4x4(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])),
+    rr_dt.Mat4x4(rr_dt.Mat4x4(columns=[1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16])),
+    rr_dt.Mat4x4(rows=rr_dt.Mat4x4(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])),
+    rr_dt.Mat4x4(rows=rr_dt.Mat4x4(columns=[1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16])),
+    rr_dt.Mat4x4(columns=rr_dt.Mat4x4(columns=[1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16])),
+    rr_dt.Mat4x4(columns=rr_dt.Mat4x4(rows=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])),
 ]
 
 
@@ -53,6 +75,28 @@ def test_mat3x3array() -> None:
     )
 
 
+# Tests the snippet that are embedded in the docs.
+def test_mat3x3_doc_text() -> None:
+    import rerun.experimental as rr
+
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3([1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns, np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns,
+        np.array([1, 4, 7, 2, 5, 8, 3, 6, 9], dtype=np.float32),
+    )
+
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3(columns=[1, 2, 3, 4, 5, 6, 7, 8, 9]).flat_columns,
+        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        rr.dt.Mat3x3(columns=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]).flat_columns,
+        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32),
+    )
+
+
 @pytest.mark.parametrize("data", MAT_4X4_INPUT)
 def test_mat4x4(data: rr_dt.Mat4x4Like) -> None:
     m = rr_dt.Mat4x4(data)
@@ -62,4 +106,27 @@ def test_mat4x4(data: rr_dt.Mat4x4Like) -> None:
 def test_mat4x4array() -> None:
     assert rr_dt.Mat4x4Array.from_similar(MAT_4X4_INPUT) == rr_dt.Mat4x4Array.from_similar(
         [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]] * len(MAT_4X4_INPUT)
+    )
+
+
+# Tests the snippet that are embedded in the docs.
+def test_mat4x4_doc_text() -> None:
+    import rerun.experimental as rr
+
+    np.testing.assert_array_equal(
+        rr.dt.Mat4x4([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).flat_columns,
+        np.array([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        rr.dt.Mat4x4([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]).flat_columns,
+        np.array([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16], dtype=np.float32),
+    )
+
+    np.testing.assert_array_equal(
+        rr.dt.Mat4x4(columns=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).flat_columns,
+        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        rr.dt.Mat4x4(columns=[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]).flat_columns,
+        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], dtype=np.float32),
     )

--- a/rerun_py/tests/unit/test_matnxn.py
+++ b/rerun_py/tests/unit/test_matnxn.py
@@ -16,8 +16,8 @@ MAT_3X3_INPUT = [
 
 def assert_correct_mat3x3(m: rr_dt.Mat3x3 | None) -> None:
     assert m is not None
-    assert np.all(m.coeffs == np.array([1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0]))
-    assert m.coeffs.dtype == np.float32
+    assert np.all(m.flat_columns == np.array([1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0]))
+    assert m.flat_columns.dtype == np.float32
 
 
 MAT_4X4_INPUT = [
@@ -33,9 +33,10 @@ MAT_4X4_INPUT = [
 def assert_correct_mat4x4(m: rr_dt.Mat4x4 | None) -> None:
     assert m is not None
     assert np.all(
-        m.coeffs == np.array([1.0, 5.0, 9.0, 13.0, 2.0, 6.0, 10.0, 14.0, 3.0, 7.0, 11.0, 15.0, 4.0, 8.0, 12.0, 16.0])
+        m.flat_columns
+        == np.array([1.0, 5.0, 9.0, 13.0, 2.0, 6.0, 10.0, 14.0, 3.0, 7.0, 11.0, 15.0, 4.0, 8.0, 12.0, 16.0])
     )
-    assert m.coeffs.dtype == np.float32
+    assert m.flat_columns.dtype == np.float32
 
 
 @pytest.mark.parametrize("data", MAT_3X3_INPUT)


### PR DESCRIPTION
### What

* Fixes #2189
* Split out of and made pre-requisite for #3372

--

* rename `coeffs` -> `flat_columns` and add document matrix storage better
* add array serialization for mat3x3 & mat4x4
   * note that we don't yet actually need _arrays_ of matrices, but we better get this right while we're on it! This is also used in the upcoming Pinhole archetype 
* add ability to create matrices from colums to Python

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3385) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3385)
- [Docs preview](https://rerun.io/preview/f1b8617dcbce641c7683712f88f020769dfc6765/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f1b8617dcbce641c7683712f88f020769dfc6765/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)