### PR TITLE
Click `recording://entity/path` links in markdown

### DIFF
--- a/crates/re_data_store/src/instance_path.rs
+++ b/crates/re_data_store/src/instance_path.rs
@@ -19,6 +19,13 @@ pub struct InstancePath {
     pub instance_key: InstanceKey,
 }
 
+impl From<EntityPath> for InstancePath {
+    #[inline]
+    fn from(entity_path: EntityPath) -> Self {
+        Self::entity_splat(entity_path)
+    }
+}
+
 impl InstancePath {
     /// Indicate the whole entity (all instances of it) - i.e. a splat.
     ///

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use crate::{
-    hash::Hash64, parse_entity_path, path::entity_path_impl::EntityPathImpl, EntityPathPart,
-    SizeBytes,
-};
+use crate::{hash::Hash64, path::entity_path_impl::EntityPathImpl, EntityPathPart, SizeBytes};
+
+use super::parse_path::parse_entity_path_components;
 
 // ----------------------------------------------------------------------------
 
@@ -212,7 +211,7 @@ impl From<&[EntityPathPart]> for EntityPath {
 impl From<&str> for EntityPath {
     #[inline]
     fn from(path: &str) -> Self {
-        Self::from(parse_entity_path(path).unwrap())
+        Self::from(parse_entity_path_components(path).unwrap())
     }
 }
 
@@ -345,5 +344,13 @@ impl std::fmt::Debug for EntityPath {
 impl std::fmt::Display for EntityPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.path.fmt(f)
+    }
+}
+
+impl std::str::FromStr for EntityPath {
+    type Err = crate::PathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_entity_path_components(s).map(Self::new)
     }
 }

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -14,7 +14,7 @@ mod parse_path;
 pub use component_path::ComponentPath;
 pub use entity_path::{EntityPath, EntityPathHash};
 pub use entity_path_impl::EntityPathImpl;
-pub use parse_path::{parse_entity_path, PathParseError};
+pub use parse_path::PathParseError;
 
 use re_string_interner::InternedString;
 

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -25,7 +25,7 @@ pub enum PathParseError {
 }
 
 /// Parses an entity path, e.g. `foo/bar/#1234/5678/"string index"/a6a5e96c-fd52-4d21-a394-ffbb6e5def1d`
-pub fn parse_entity_path(path: &str) -> Result<Vec<EntityPathPart>, PathParseError> {
+pub fn parse_entity_path_components(path: &str) -> Result<Vec<EntityPathPart>, PathParseError> {
     if path.is_empty() {
         return Err(PathParseError::EmptyString);
     }
@@ -146,20 +146,31 @@ fn test_unescape_string() {
 fn test_parse_path() {
     use crate::entity_path_vec;
 
-    assert_eq!(parse_entity_path(""), Err(PathParseError::EmptyString));
-    assert_eq!(parse_entity_path("/"), Ok(entity_path_vec!()));
-    assert_eq!(parse_entity_path("foo"), Ok(entity_path_vec!("foo")));
-    assert_eq!(parse_entity_path("/foo"), Err(PathParseError::LeadingSlash));
     assert_eq!(
-        parse_entity_path("foo/bar"),
+        parse_entity_path_components(""),
+        Err(PathParseError::EmptyString)
+    );
+    assert_eq!(parse_entity_path_components("/"), Ok(entity_path_vec!()));
+    assert_eq!(
+        parse_entity_path_components("foo"),
+        Ok(entity_path_vec!("foo"))
+    );
+    assert_eq!(
+        parse_entity_path_components("/foo"),
+        Err(PathParseError::LeadingSlash)
+    );
+    assert_eq!(
+        parse_entity_path_components("foo/bar"),
         Ok(entity_path_vec!("foo", "bar"))
     );
     assert_eq!(
-        parse_entity_path("foo//bar"),
+        parse_entity_path_components("foo//bar"),
         Err(PathParseError::DoubleSlash)
     );
     assert_eq!(
-        parse_entity_path(r#"foo/"bar"/#123/-1234/6d046bf4-e5d3-4599-9153-85dd97218cb3"#),
+        parse_entity_path_components(
+            r#"foo/"bar"/#123/-1234/6d046bf4-e5d3-4599-9153-85dd97218cb3"#
+        ),
         Ok(entity_path_vec!(
             "foo",
             Index::String("bar".into()),
@@ -169,7 +180,7 @@ fn test_parse_path() {
         ))
     );
     assert_eq!(
-        parse_entity_path(r#"foo/"bar""baz""#),
+        parse_entity_path_components(r#"foo/"bar""baz""#),
         Err(PathParseError::MissingSlash)
     );
 }

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -5,7 +5,7 @@ use re_log_types::{LogMsg, StoreId, TimeRangeF};
 use re_smart_channel::ReceiveSet;
 use re_viewer_context::{
     AppOptions, Caches, CommandSender, ComponentUiRegistry, PlayState, RecordingConfig,
-    SpaceViewClassRegistry, StoreContext, ViewerContext,
+    SelectionState, SpaceViewClassRegistry, StoreContext, ViewerContext,
 };
 use re_viewport::{SpaceInfoCollection, Viewport, ViewportState};
 
@@ -232,6 +232,9 @@ impl AppState {
         if WATERMARK {
             re_ui.paint_watermark();
         }
+
+        // This must run after any ui code, or other code that tells egui to open an url:
+        check_for_clicked_hyperlinks(&re_ui.egui_ctx, &mut rec_cfg.selection_state);
     }
 
     pub fn recording_config_mut(&mut self, rec_id: &StoreId) -> Option<&mut RecordingConfig> {
@@ -281,4 +284,36 @@ fn recording_config_entry<'cfgs>(
     configs
         .entry(id)
         .or_insert_with(|| new_recording_config(store_db))
+}
+
+/// We allow linking to entities and components via hyperlinks,
+/// e.g. in embedded markdown.
+///
+/// Detect and handle that here.
+///
+/// Must run after any ui code, or other code that tells egui to open an url.
+fn check_for_clicked_hyperlinks(egui_ctx: &egui::Context, selection_state: &mut SelectionState) {
+    let recording_scheme = "recording://";
+
+    let mut path = None;
+
+    egui_ctx.output_mut(|o| {
+        if let Some(open_url) = &o.open_url {
+            if let Some(path_str) = open_url.url.strip_prefix(recording_scheme) {
+                path = Some(path_str.to_owned());
+                o.open_url = None;
+            }
+        }
+    });
+
+    if let Some(path) = path {
+        match path.parse() {
+            Ok(item) => {
+                selection_state.set_single_selection(item);
+            }
+            Err(err) => {
+                re_log::warn!("Failed to parse entity path {path:?}: {err}");
+            }
+        }
+    }
 }

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use re_data_store::InstancePath;
-use re_log_types::ComponentPath;
+use re_log_types::{ComponentPath, EntityPath};
 
 use super::{DataBlueprintGroupHandle, SpaceViewId};
 
@@ -15,6 +15,44 @@ pub enum Item {
     SpaceView(SpaceViewId),
     InstancePath(Option<SpaceViewId>, InstancePath),
     DataBlueprintGroup(SpaceViewId, DataBlueprintGroupHandle),
+}
+
+impl From<SpaceViewId> for Item {
+    #[inline]
+    fn from(space_view_id: SpaceViewId) -> Self {
+        Self::SpaceView(space_view_id)
+    }
+}
+
+impl From<ComponentPath> for Item {
+    #[inline]
+    fn from(component_path: ComponentPath) -> Self {
+        Self::ComponentPath(component_path)
+    }
+}
+
+impl From<InstancePath> for Item {
+    #[inline]
+    fn from(instance_path: InstancePath) -> Self {
+        Self::InstancePath(None, instance_path)
+    }
+}
+
+impl From<EntityPath> for Item {
+    #[inline]
+    fn from(entity_path: EntityPath) -> Self {
+        Self::InstancePath(None, InstancePath::from(entity_path))
+    }
+}
+
+impl std::str::FromStr for Item {
+    type Err = re_log_types::PathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO(emilk): support component paths and instance paths
+        let entity_path = EntityPath::from_str(s)?;
+        Ok(Self::from(entity_path))
+    }
 }
 
 impl std::fmt::Debug for Item {

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1365,7 +1365,6 @@ fn slice_from_np_array<'a, T: numpy::Element, D: numpy::ndarray::Dimension>(
 }
 
 fn parse_entity_path(entity_path: &str) -> PyResult<EntityPath> {
-    let components = re_log_types::parse_entity_path(entity_path)
-        .map_err(|err| PyTypeError::new_err(err.to_string()))?;
-    Ok(EntityPath::from(components))
+    use std::str::FromStr as _;
+    EntityPath::from_str(entity_path).map_err(|err| PyTypeError::new_err(err.to_string()))
 }


### PR DESCRIPTION
### What
You can now embed links to entities in markdown documents using `recording://entity/path`.

Support for linking to components and instances coming later.

Linking to a non-existing entity results in a bit confusing UI at the moment.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3388) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3388)
- [Docs preview](https://rerun.io/preview/1932b73990c8d3f1520505fbe9db7964a6dab4a0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1932b73990c8d3f1520505fbe9db7964a6dab4a0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)