### PR TITLE
Fix color greyscale colormap not being even

### DIFF
--- a/crates/re_renderer/shader/colormap.wgsl
+++ b/crates/re_renderer/shader/colormap.wgsl
@@ -15,7 +15,9 @@ const COLORMAP_VIRIDIS:   u32 = 6u;
 fn colormap_srgb(which: u32, t_unsaturated: f32) -> Vec3 {
     let t = saturate(t_unsaturated);
     if which == COLORMAP_GRAYSCALE {
-        return srgb_from_linear(Vec3(t));
+        // A linear gray gradient in sRGB gamma space is supposed to be perceptually even as-is!
+        // Easy to get confused: A linear gradient in sRGB linear space is *not* perceptually even.
+        return Vec3(t);
     } else if which == COLORMAP_INFERNO {
         return colormap_inferno_srgb(t);
     } else if which == COLORMAP_MAGMA {


### PR DESCRIPTION
### What

Pointed out in #3373 that our grey colormap looked broken in the preview. When diving into it I got at first a scare about our color space pipeline being broken, but eventually I concluded that it was only the gray colormap which was broken.

Grey before/after with reference gradient from gimp:
![fix](https://github.com/rerun-io/rerun/assets/1220815/d293d4a1-7aa4-4307-b66e-f0b6ad6ec7de)

(unchanged) turbo colormap gradient compared with the render from Matplot webpage (a bit sloppy but shows that we're definitely not some wild gamma converstion away from it!):
<img width="1248" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/1440e775-7b7c-4327-a6b0-dadbf8e78a6f">



This affects all usages of the greyscale colormap.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
