### PR TITLE
Generate `impl From` for trivial tuple types

### DIFF
--- a/crates/re_query/src/dataframe_util.rs
+++ b/crates/re_query/src/dataframe_util.rs
@@ -216,10 +216,10 @@ fn test_df_builder() {
     use re_types::components::{Color, Radius};
 
     let radii = vec![
-        Some(Radius::new(1.0)),
-        Some(Radius::new(3.0)),
-        Some(Radius::new(5.0)),
-        Some(Radius::new(7.0)),
+        Some(Radius(1.0)),
+        Some(Radius(3.0)),
+        Some(Radius(5.0)),
+        Some(Radius(7.0)),
     ];
 
     let colors = vec![

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-3a1aa4a904e3c6dacf556e535767b8e1ac58a48a8d7e6f731e2525994e96a8da
+b736dbd729349210545e036dbbfb7c22c2b1fe097d54cbe6a2a57aceca9ee231

--- a/crates/re_types/src/components/clear_settings.rs
+++ b/crates/re_types/src/components/clear_settings.rs
@@ -20,6 +20,20 @@ pub struct ClearSettings(
     pub bool,
 );
 
+impl From<bool> for ClearSettings {
+    #[inline]
+    fn from(recursive: bool) -> Self {
+        Self(recursive)
+    }
+}
+
+impl From<ClearSettings> for bool {
+    #[inline]
+    fn from(value: ClearSettings) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<ClearSettings> for ::std::borrow::Cow<'a, ClearSettings> {
     #[inline]
     fn from(value: ClearSettings) -> Self {

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -17,6 +17,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct DepthMeter(pub f32);
 
+impl From<f32> for DepthMeter {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DepthMeter> for f32 {
+    #[inline]
+    fn from(value: DepthMeter) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<DepthMeter> for ::std::borrow::Cow<'a, DepthMeter> {
     #[inline]
     fn from(value: DepthMeter) -> Self {

--- a/crates/re_types/src/components/depth_meter_ext.rs
+++ b/crates/re_types/src/components/depth_meter_ext.rs
@@ -1,19 +1,5 @@
 use super::DepthMeter;
 
-impl DepthMeter {
-    #[inline]
-    pub const fn new(r: f32) -> Self {
-        Self(r)
-    }
-}
-
-impl From<f32> for DepthMeter {
-    #[inline]
-    fn from(r: f32) -> Self {
-        Self::new(r)
-    }
-}
-
 impl std::fmt::Display for DepthMeter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:.prec$}", self.0, prec = crate::DISPLAY_PRECISION)

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -21,6 +21,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct DisconnectedSpace(pub bool);
 
+impl From<bool> for DisconnectedSpace {
+    #[inline]
+    fn from(is_disconnected: bool) -> Self {
+        Self(is_disconnected)
+    }
+}
+
+impl From<DisconnectedSpace> for bool {
+    #[inline]
+    fn from(value: DisconnectedSpace) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<DisconnectedSpace> for ::std::borrow::Cow<'a, DisconnectedSpace> {
     #[inline]
     fn from(value: DisconnectedSpace) -> Self {

--- a/crates/re_types/src/components/disconnected_space_ext.rs
+++ b/crates/re_types/src/components/disconnected_space_ext.rs
@@ -1,11 +1,5 @@
 use super::DisconnectedSpace;
 
-impl From<bool> for DisconnectedSpace {
-    fn from(b: bool) -> Self {
-        Self(b)
-    }
-}
-
 impl Default for DisconnectedSpace {
     fn default() -> Self {
         Self(true)

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -24,6 +24,20 @@
 #[repr(transparent)]
 pub struct DrawOrder(pub f32);
 
+impl From<f32> for DrawOrder {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DrawOrder> for f32 {
+    #[inline]
+    fn from(value: DrawOrder) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<DrawOrder> for ::std::borrow::Cow<'a, DrawOrder> {
     #[inline]
     fn from(value: DrawOrder) -> Self {

--- a/crates/re_types/src/components/draw_order_ext.rs
+++ b/crates/re_types/src/components/draw_order_ext.rs
@@ -44,17 +44,3 @@ impl std::cmp::Ord for DrawOrder {
         self.partial_cmp(other).unwrap()
     }
 }
-
-impl From<f32> for DrawOrder {
-    #[inline]
-    fn from(value: f32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<DrawOrder> for f32 {
-    #[inline]
-    fn from(value: DrawOrder) -> Self {
-        value.0
-    }
-}

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -18,6 +18,20 @@
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct InstanceKey(pub u64);
 
+impl From<u64> for InstanceKey {
+    #[inline]
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<InstanceKey> for u64 {
+    #[inline]
+    fn from(value: InstanceKey) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<InstanceKey> for ::std::borrow::Cow<'a, InstanceKey> {
     #[inline]
     fn from(value: InstanceKey) -> Self {

--- a/crates/re_types/src/components/instance_key_ext.rs
+++ b/crates/re_types/src/components/instance_key_ext.rs
@@ -7,20 +7,6 @@ impl InstanceKey {
     pub const SPLAT: Self = Self(u64::MAX);
 }
 
-impl From<u64> for InstanceKey {
-    #[inline]
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<InstanceKey> for u64 {
-    #[inline]
-    fn from(value: InstanceKey) -> Self {
-        value.0
-    }
-}
-
 impl InstanceKey {
     #[allow(clippy::should_implement_trait)]
     #[inline]

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -17,6 +17,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Radius(pub f32);
 
+impl From<f32> for Radius {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Radius> for f32 {
+    #[inline]
+    fn from(value: Radius) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Radius> for ::std::borrow::Cow<'a, Radius> {
     #[inline]
     fn from(value: Radius) -> Self {

--- a/crates/re_types/src/components/radius_ext.rs
+++ b/crates/re_types/src/components/radius_ext.rs
@@ -1,20 +1,8 @@
 use super::Radius;
 
 impl Radius {
-    pub const ZERO: Self = Self::new(0.0);
-    pub const ONE: Self = Self::new(1.0);
-
-    #[inline]
-    pub const fn new(r: f32) -> Self {
-        Self(r)
-    }
-}
-
-impl From<f32> for Radius {
-    #[inline]
-    fn from(r: f32) -> Self {
-        Self::new(r)
-    }
+    pub const ZERO: Self = Self(0.0);
+    pub const ONE: Self = Self(1.0);
 }
 
 impl std::fmt::Display for Radius {

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -35,6 +35,20 @@ pub struct ViewCoordinates(
     pub [u8; 3usize],
 );
 
+impl From<[u8; 3usize]> for ViewCoordinates {
+    #[inline]
+    fn from(coordinates: [u8; 3usize]) -> Self {
+        Self(coordinates)
+    }
+}
+
+impl From<ViewCoordinates> for [u8; 3usize] {
+    #[inline]
+    fn from(value: ViewCoordinates) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<ViewCoordinates> for ::std::borrow::Cow<'a, ViewCoordinates> {
     #[inline]
     fn from(value: ViewCoordinates) -> Self {

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -21,6 +21,20 @@
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ClassId(pub u16);
 
+impl From<u16> for ClassId {
+    #[inline]
+    fn from(id: u16) -> Self {
+        Self(id)
+    }
+}
+
+impl From<ClassId> for u16 {
+    #[inline]
+    fn from(value: ClassId) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<ClassId> for ::std::borrow::Cow<'a, ClassId> {
     #[inline]
     fn from(value: ClassId) -> Self {

--- a/crates/re_types/src/datatypes/class_id_ext.rs
+++ b/crates/re_types/src/datatypes/class_id_ext.rs
@@ -1,12 +1,5 @@
 use super::ClassId;
 
-impl From<u16> for ClassId {
-    #[inline]
-    fn from(value: u16) -> Self {
-        Self(value)
-    }
-}
-
 impl std::fmt::Display for ClassId {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/re_types/src/datatypes/color.rs
+++ b/crates/re_types/src/datatypes/color.rs
@@ -23,6 +23,20 @@
 #[repr(transparent)]
 pub struct Color(pub u32);
 
+impl From<u32> for Color {
+    #[inline]
+    fn from(rgba: u32) -> Self {
+        Self(rgba)
+    }
+}
+
+impl From<Color> for u32 {
+    #[inline]
+    fn from(value: Color) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Color> for ::std::borrow::Cow<'a, Color> {
     #[inline]
     fn from(value: Color) -> Self {

--- a/crates/re_types/src/datatypes/color_ext.rs
+++ b/crates/re_types/src/datatypes/color_ext.rs
@@ -36,13 +36,6 @@ impl Color {
     }
 }
 
-impl From<u32> for Color {
-    #[inline]
-    fn from(rgba: u32) -> Self {
-        Self::from_u32(rgba)
-    }
-}
-
 impl From<(u8, u8, u8)> for Color {
     #[inline]
     fn from((r, g, b): (u8, u8, u8)) -> Self {

--- a/crates/re_types/src/datatypes/float32.rs
+++ b/crates/re_types/src/datatypes/float32.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Float32(pub f32);
 
+impl From<f32> for Float32 {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Float32> for f32 {
+    #[inline]
+    fn from(value: Float32) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Float32> for ::std::borrow::Cow<'a, Float32> {
     #[inline]
     fn from(value: Float32) -> Self {

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -23,6 +23,20 @@
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct KeypointId(pub u16);
 
+impl From<u16> for KeypointId {
+    #[inline]
+    fn from(id: u16) -> Self {
+        Self(id)
+    }
+}
+
+impl From<KeypointId> for u16 {
+    #[inline]
+    fn from(value: KeypointId) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<KeypointId> for ::std::borrow::Cow<'a, KeypointId> {
     #[inline]
     fn from(value: KeypointId) -> Self {

--- a/crates/re_types/src/datatypes/keypoint_id_ext.rs
+++ b/crates/re_types/src/datatypes/keypoint_id_ext.rs
@@ -1,12 +1,5 @@
 use super::KeypointId;
 
-impl From<u16> for KeypointId {
-    #[inline]
-    fn from(value: u16) -> Self {
-        Self(value)
-    }
-}
-
 impl std::fmt::Display for KeypointId {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -26,6 +26,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Mat3x3(pub [f32; 9usize]);
 
+impl From<[f32; 9usize]> for Mat3x3 {
+    #[inline]
+    fn from(flat_columns: [f32; 9usize]) -> Self {
+        Self(flat_columns)
+    }
+}
+
+impl From<Mat3x3> for [f32; 9usize] {
+    #[inline]
+    fn from(value: Mat3x3) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Mat3x3> for ::std::borrow::Cow<'a, Mat3x3> {
     #[inline]
     fn from(value: Mat3x3) -> Self {

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -27,6 +27,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Mat4x4(pub [f32; 16usize]);
 
+impl From<[f32; 16usize]> for Mat4x4 {
+    #[inline]
+    fn from(flat_columns: [f32; 16usize]) -> Self {
+        Self(flat_columns)
+    }
+}
+
+impl From<Mat4x4> for [f32; 16usize] {
+    #[inline]
+    fn from(value: Mat4x4) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Mat4x4> for ::std::borrow::Cow<'a, Mat4x4> {
     #[inline]
     fn from(value: Mat4x4) -> Self {

--- a/crates/re_types/src/datatypes/mesh_properties.rs
+++ b/crates/re_types/src/datatypes/mesh_properties.rs
@@ -20,6 +20,20 @@ pub struct MeshProperties {
     pub vertex_indices: Option<crate::ArrowBuffer<u32>>,
 }
 
+impl From<Option<crate::ArrowBuffer<u32>>> for MeshProperties {
+    #[inline]
+    fn from(vertex_indices: Option<crate::ArrowBuffer<u32>>) -> Self {
+        Self { vertex_indices }
+    }
+}
+
+impl From<MeshProperties> for Option<crate::ArrowBuffer<u32>> {
+    #[inline]
+    fn from(value: MeshProperties) -> Self {
+        value.vertex_indices
+    }
+}
+
 impl<'a> From<MeshProperties> for ::std::borrow::Cow<'a, MeshProperties> {
     #[inline]
     fn from(value: MeshProperties) -> Self {

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -20,6 +20,20 @@
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Quaternion(pub [f32; 4usize]);
 
+impl From<[f32; 4usize]> for Quaternion {
+    #[inline]
+    fn from(xyzw: [f32; 4usize]) -> Self {
+        Self(xyzw)
+    }
+}
+
+impl From<Quaternion> for [f32; 4usize] {
+    #[inline]
+    fn from(value: Quaternion) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Quaternion> for ::std::borrow::Cow<'a, Quaternion> {
     #[inline]
     fn from(value: Quaternion) -> Self {

--- a/crates/re_types/src/datatypes/utf8.rs
+++ b/crates/re_types/src/datatypes/utf8.rs
@@ -18,6 +18,20 @@
 #[repr(transparent)]
 pub struct Utf8(pub crate::ArrowString);
 
+impl From<crate::ArrowString> for Utf8 {
+    #[inline]
+    fn from(value: crate::ArrowString) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Utf8> for crate::ArrowString {
+    #[inline]
+    fn from(value: Utf8) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Utf8> for ::std::borrow::Cow<'a, Utf8> {
     #[inline]
     fn from(value: Utf8) -> Self {

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -18,6 +18,20 @@
 #[repr(C)]
 pub struct UVec2D(pub [u32; 2usize]);
 
+impl From<[u32; 2usize]> for UVec2D {
+    #[inline]
+    fn from(xy: [u32; 2usize]) -> Self {
+        Self(xy)
+    }
+}
+
+impl From<UVec2D> for [u32; 2usize] {
+    #[inline]
+    fn from(value: UVec2D) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<UVec2D> for ::std::borrow::Cow<'a, UVec2D> {
     #[inline]
     fn from(value: UVec2D) -> Self {

--- a/crates/re_types/src/datatypes/uvec2d_ext.rs
+++ b/crates/re_types/src/datatypes/uvec2d_ext.rs
@@ -27,13 +27,6 @@ impl From<(u32, u32)> for UVec2D {
     }
 }
 
-impl From<[u32; 2]> for UVec2D {
-    #[inline]
-    fn from(v: [u32; 2]) -> Self {
-        Self(v)
-    }
-}
-
 // NOTE: All these by-ref impls make the lives of end-users much easier when juggling around with
 // slices, because Rust cannot keep track of the inherent `Copy` capability of it all across all the
 // layers of `Into`/`IntoIterator`.

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -18,6 +18,20 @@
 #[repr(C)]
 pub struct UVec3D(pub [u32; 3usize]);
 
+impl From<[u32; 3usize]> for UVec3D {
+    #[inline]
+    fn from(xyz: [u32; 3usize]) -> Self {
+        Self(xyz)
+    }
+}
+
+impl From<UVec3D> for [u32; 3usize] {
+    #[inline]
+    fn from(value: UVec3D) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<UVec3D> for ::std::borrow::Cow<'a, UVec3D> {
     #[inline]
     fn from(value: UVec3D) -> Self {

--- a/crates/re_types/src/datatypes/uvec3d_ext.rs
+++ b/crates/re_types/src/datatypes/uvec3d_ext.rs
@@ -25,13 +25,6 @@ impl UVec3D {
     }
 }
 
-impl From<[u32; 3]> for UVec3D {
-    #[inline]
-    fn from(v: [u32; 3]) -> Self {
-        Self(v)
-    }
-}
-
 impl From<(u32, u32, u32)> for UVec3D {
     #[inline]
     fn from((x, y, z): (u32, u32, u32)) -> Self {

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -18,6 +18,20 @@
 #[repr(C)]
 pub struct UVec4D(pub [u32; 4usize]);
 
+impl From<[u32; 4usize]> for UVec4D {
+    #[inline]
+    fn from(xyzw: [u32; 4usize]) -> Self {
+        Self(xyzw)
+    }
+}
+
+impl From<UVec4D> for [u32; 4usize] {
+    #[inline]
+    fn from(value: UVec4D) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<UVec4D> for ::std::borrow::Cow<'a, UVec4D> {
     #[inline]
     fn from(value: UVec4D) -> Self {

--- a/crates/re_types/src/datatypes/uvec4d_ext.rs
+++ b/crates/re_types/src/datatypes/uvec4d_ext.rs
@@ -30,13 +30,6 @@ impl UVec4D {
     }
 }
 
-impl From<[u32; 4]> for UVec4D {
-    #[inline]
-    fn from(v: [u32; 4]) -> Self {
-        Self(v)
-    }
-}
-
 impl From<(u32, u32, u32, u32)> for UVec4D {
     #[inline]
     fn from((x, y, z, w): (u32, u32, u32, u32)) -> Self {

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -18,6 +18,20 @@
 #[repr(C)]
 pub struct Vec2D(pub [f32; 2usize]);
 
+impl From<[f32; 2usize]> for Vec2D {
+    #[inline]
+    fn from(xy: [f32; 2usize]) -> Self {
+        Self(xy)
+    }
+}
+
+impl From<Vec2D> for [f32; 2usize] {
+    #[inline]
+    fn from(value: Vec2D) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Vec2D> for ::std::borrow::Cow<'a, Vec2D> {
     #[inline]
     fn from(value: Vec2D) -> Self {

--- a/crates/re_types/src/datatypes/vec2d_ext.rs
+++ b/crates/re_types/src/datatypes/vec2d_ext.rs
@@ -27,13 +27,6 @@ impl From<(f32, f32)> for Vec2D {
     }
 }
 
-impl From<[f32; 2]> for Vec2D {
-    #[inline]
-    fn from(v: [f32; 2]) -> Self {
-        Self(v)
-    }
-}
-
 // NOTE: All these by-ref impls make the lives of end-users much easier when juggling around with
 // slices, because Rust cannot keep track of the inherent `Copy` capability of it all across all the
 // layers of `Into`/`IntoIterator`.

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -18,6 +18,20 @@
 #[repr(C)]
 pub struct Vec3D(pub [f32; 3usize]);
 
+impl From<[f32; 3usize]> for Vec3D {
+    #[inline]
+    fn from(xyz: [f32; 3usize]) -> Self {
+        Self(xyz)
+    }
+}
+
+impl From<Vec3D> for [f32; 3usize] {
+    #[inline]
+    fn from(value: Vec3D) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Vec3D> for ::std::borrow::Cow<'a, Vec3D> {
     #[inline]
     fn from(value: Vec3D) -> Self {

--- a/crates/re_types/src/datatypes/vec3d_ext.rs
+++ b/crates/re_types/src/datatypes/vec3d_ext.rs
@@ -25,13 +25,6 @@ impl Vec3D {
     }
 }
 
-impl From<[f32; 3]> for Vec3D {
-    #[inline]
-    fn from(v: [f32; 3]) -> Self {
-        Self(v)
-    }
-}
-
 impl From<(f32, f32, f32)> for Vec3D {
     #[inline]
     fn from((x, y, z): (f32, f32, f32)) -> Self {

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -18,6 +18,20 @@
 #[repr(C)]
 pub struct Vec4D(pub [f32; 4usize]);
 
+impl From<[f32; 4usize]> for Vec4D {
+    #[inline]
+    fn from(xyzw: [f32; 4usize]) -> Self {
+        Self(xyzw)
+    }
+}
+
+impl From<Vec4D> for [f32; 4usize] {
+    #[inline]
+    fn from(value: Vec4D) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<Vec4D> for ::std::borrow::Cow<'a, Vec4D> {
     #[inline]
     fn from(value: Vec4D) -> Self {

--- a/crates/re_types/src/datatypes/vec4d_ext.rs
+++ b/crates/re_types/src/datatypes/vec4d_ext.rs
@@ -29,13 +29,6 @@ impl Vec4D {
     }
 }
 
-impl From<[f32; 4]> for Vec4D {
-    #[inline]
-    fn from(v: [f32; 4]) -> Self {
-        Self(v)
-    }
-}
-
 impl From<(f32, f32, f32, f32)> for Vec4D {
     #[inline]
     fn from((x, y, z, w): (f32, f32, f32, f32)) -> Self {

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer10(pub Option<crate::ArrowString>);
 
+impl From<Option<crate::ArrowString>> for AffixFuzzer10 {
+    #[inline]
+    fn from(single_string_optional: Option<crate::ArrowString>) -> Self {
+        Self(single_string_optional)
+    }
+}
+
+impl From<AffixFuzzer10> for Option<crate::ArrowString> {
+    #[inline]
+    fn from(value: AffixFuzzer10) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer10> for ::std::borrow::Cow<'a, AffixFuzzer10> {
     #[inline]
     fn from(value: AffixFuzzer10) -> Self {

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer11(pub Option<crate::ArrowBuffer<f32>>);
 
+impl From<Option<crate::ArrowBuffer<f32>>> for AffixFuzzer11 {
+    #[inline]
+    fn from(many_floats_optional: Option<crate::ArrowBuffer<f32>>) -> Self {
+        Self(many_floats_optional)
+    }
+}
+
+impl From<AffixFuzzer11> for Option<crate::ArrowBuffer<f32>> {
+    #[inline]
+    fn from(value: AffixFuzzer11) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer11> for ::std::borrow::Cow<'a, AffixFuzzer11> {
     #[inline]
     fn from(value: AffixFuzzer11) -> Self {

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer12(pub Vec<crate::ArrowString>);
 
+impl From<Vec<crate::ArrowString>> for AffixFuzzer12 {
+    #[inline]
+    fn from(many_strings_required: Vec<crate::ArrowString>) -> Self {
+        Self(many_strings_required)
+    }
+}
+
+impl From<AffixFuzzer12> for Vec<crate::ArrowString> {
+    #[inline]
+    fn from(value: AffixFuzzer12) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer12> for ::std::borrow::Cow<'a, AffixFuzzer12> {
     #[inline]
     fn from(value: AffixFuzzer12) -> Self {

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer13(pub Option<Vec<crate::ArrowString>>);
 
+impl From<Option<Vec<crate::ArrowString>>> for AffixFuzzer13 {
+    #[inline]
+    fn from(many_strings_optional: Option<Vec<crate::ArrowString>>) -> Self {
+        Self(many_strings_optional)
+    }
+}
+
+impl From<AffixFuzzer13> for Option<Vec<crate::ArrowString>> {
+    #[inline]
+    fn from(value: AffixFuzzer13) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer13> for ::std::borrow::Cow<'a, AffixFuzzer13> {
     #[inline]
     fn from(value: AffixFuzzer13) -> Self {

--- a/crates/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer8.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer8(pub Option<f32>);
 
+impl From<Option<f32>> for AffixFuzzer8 {
+    #[inline]
+    fn from(single_float_optional: Option<f32>) -> Self {
+        Self(single_float_optional)
+    }
+}
+
+impl From<AffixFuzzer8> for Option<f32> {
+    #[inline]
+    fn from(value: AffixFuzzer8) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer8> for ::std::borrow::Cow<'a, AffixFuzzer8> {
     #[inline]
     fn from(value: AffixFuzzer8) -> Self {

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer9(pub crate::ArrowString);
 
+impl From<crate::ArrowString> for AffixFuzzer9 {
+    #[inline]
+    fn from(single_string_required: crate::ArrowString) -> Self {
+        Self(single_string_required)
+    }
+}
+
+impl From<AffixFuzzer9> for crate::ArrowString {
+    #[inline]
+    fn from(value: AffixFuzzer9) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer9> for ::std::borrow::Cow<'a, AffixFuzzer9> {
     #[inline]
     fn from(value: AffixFuzzer9) -> Self {

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -16,6 +16,20 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer2(pub Option<f32>);
 
+impl From<Option<f32>> for AffixFuzzer2 {
+    #[inline]
+    fn from(single_float_optional: Option<f32>) -> Self {
+        Self(single_float_optional)
+    }
+}
+
+impl From<AffixFuzzer2> for Option<f32> {
+    #[inline]
+    fn from(value: AffixFuzzer2) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<AffixFuzzer2> for ::std::borrow::Cow<'a, AffixFuzzer2> {
     #[inline]
     fn from(value: AffixFuzzer2) -> Self {

--- a/crates/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -18,6 +18,20 @@ pub struct FlattenedScalar {
     pub value: f32,
 }
 
+impl From<f32> for FlattenedScalar {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self { value }
+    }
+}
+
+impl From<FlattenedScalar> for f32 {
+    #[inline]
+    fn from(value: FlattenedScalar) -> Self {
+        value.value
+    }
+}
+
 impl<'a> From<FlattenedScalar> for ::std::borrow::Cow<'a, FlattenedScalar> {
     #[inline]
     fn from(value: FlattenedScalar) -> Self {

--- a/crates/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/re_types/src/testing/datatypes/primitive_component.rs
@@ -17,6 +17,20 @@
 #[repr(transparent)]
 pub struct PrimitiveComponent(pub u32);
 
+impl From<u32> for PrimitiveComponent {
+    #[inline]
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PrimitiveComponent> for u32 {
+    #[inline]
+    fn from(value: PrimitiveComponent) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<PrimitiveComponent> for ::std::borrow::Cow<'a, PrimitiveComponent> {
     #[inline]
     fn from(value: PrimitiveComponent) -> Self {

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -17,6 +17,20 @@
 #[repr(transparent)]
 pub struct StringComponent(pub crate::ArrowString);
 
+impl From<crate::ArrowString> for StringComponent {
+    #[inline]
+    fn from(value: crate::ArrowString) -> Self {
+        Self(value)
+    }
+}
+
+impl From<StringComponent> for crate::ArrowString {
+    #[inline]
+    fn from(value: StringComponent) -> Self {
+        value.0
+    }
+}
+
 impl<'a> From<StringComponent> for ::std::borrow::Cow<'a, StringComponent> {
     #[inline]
     fn from(value: StringComponent) -> Self {


### PR DESCRIPTION
### What

... and remove a handful of unnecessary trivial `new` methods.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3396) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3396)
- [Docs preview](https://rerun.io/preview/8f8bd179acba010e8cb16d074addc8ce41691339/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8f8bd179acba010e8cb16d074addc8ce41691339/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)