### PR TITLE
Fix `transform3d_simple` and reenable roundtrip test

### DIFF
--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-c1035773b907fbad5b925f086e0822586bb0c3e75a86465d955623de9f7c3ad3
+6f8f25bbe0900f90a47718d6993eaf116ba1e7ac8b59762162bbfe633b5a7e50

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -23,7 +23,7 @@
 /// use rerun::{
 ///     archetypes::{Arrows3D, Transform3D},
 ///     datatypes::{
-///         Angle, Mat3x3, RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D,
+///         Angle, RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D,
 ///     },
 ///     RecordingStreamBuilder,
 /// };
@@ -36,7 +36,7 @@
 ///
 ///     rec.log(
 ///         "base/translated",
-///         &Transform3D::new(TranslationAndMat3x3::new([1.0, 0.0, 0.0], Mat3x3::IDENTITY)),
+///         &Transform3D::new(TranslationAndMat3x3::translation([1.0, 0.0, 0.0])),
 ///     )?;
 ///
 ///     rec.log("base/translated", &Arrows3D::new([(0.0, 1.0, 0.0)]))?;

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -52,10 +52,6 @@ opt_out_compare = {
     "point3d_random": ["cpp", "py", "rust"], # TODO(#3206): need to align everything to use PCG64 in the same order etc... don't have time for that.
     "tensor_one_dim": ["cpp", "py", "rust"], # TODO(#3206): need to align everything to use PCG64 in the same order etc... don't have time for that.
     "tensor_simple": ["cpp", "py", "rust"], # TODO(#3206): need to align everything to use PCG64 in the same order etc... don't have time for that.
-    # TODO(#3207): two issues:
-    #   - cpp sends an identity transform for no reason
-    #   - python has a crazy indicator component out of nowhere
-    "transform3d_simple": ["cpp", "py", "rust"],
 }
 
 # fmt: on

--- a/docs/code-examples/transform3d_simple.py
+++ b/docs/code-examples/transform3d_simple.py
@@ -7,14 +7,10 @@ from rerun.experimental import dt as rrd
 
 rr.init("rerun_example_transform3d", spawn=True)
 
-origin = [0, 0, 0]
-base_vector = [0, 1, 0]
+rr2.log("base", rr2.Arrows3D([0, 1, 0]))
 
-rr.log_arrow("base", origin=origin, vector=base_vector)
-
-rr2.log("base/translated", rrd.TranslationRotationScale3D(translation=[1, 0, 0]))
-
-rr.log_arrow("base/translated", origin=origin, vector=base_vector)
+rr2.log("base/translated", rrd.TranslationAndMat3x3(translation=[1, 0, 0]))
+rr2.log("base/translated", rr2.Arrows3D([0, 1, 0]))
 
 rr2.log(
     "base/rotated_scaled",
@@ -23,5 +19,4 @@ rr2.log(
         scale=2,
     ),
 )
-
-rr.log_arrow("base/rotated_scaled", origin=origin, vector=base_vector)
+rr2.log("base/rotated_scaled", rr2.Arrows3D([0, 1, 0]))

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -3,7 +3,7 @@
 use rerun::{
     archetypes::{Arrows3D, Transform3D},
     datatypes::{
-        Angle, Mat3x3, RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D,
+        Angle, RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D,
     },
     RecordingStreamBuilder,
 };
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "base/translated",
-        &Transform3D::new(TranslationAndMat3x3::new([1.0, 0.0, 0.0], Mat3x3::IDENTITY)),
+        &Transform3D::new(TranslationAndMat3x3::translation([1.0, 0.0, 0.0])),
     )?;
 
     rec.log("base/translated", &Arrows3D::new([(0.0, 1.0, 0.0)]))?;

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -31,14 +31,10 @@ class Transform3D(Archetype):
 
     rr.init("rerun_example_transform3d", spawn=True)
 
-    origin = [0, 0, 0]
-    base_vector = [0, 1, 0]
+    rr2.log("base", rr2.Arrows3D([0, 1, 0]))
 
-    rr.log_arrow("base", origin=origin, vector=base_vector)
-
-    rr2.log("base/translated", rrd.TranslationRotationScale3D(translation=[1, 0, 0]))
-
-    rr.log_arrow("base/translated", origin=origin, vector=base_vector)
+    rr2.log("base/translated", rrd.TranslationAndMat3x3(translation=[1, 0, 0]))
+    rr2.log("base/translated", rr2.Arrows3D([0, 1, 0]))
 
     rr2.log(
         "base/rotated_scaled",
@@ -47,8 +43,7 @@ class Transform3D(Archetype):
             scale=2,
         ),
     )
-
-    rr.log_arrow("base/rotated_scaled", origin=origin, vector=base_vector)
+    rr2.log("base/rotated_scaled", rr2.Arrows3D([0, 1, 0]))
     ```
     """
 


### PR DESCRIPTION
Title.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3401) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3401)
- [Docs preview](https://rerun.io/preview/eddb08fa102356e42e815da2c006cf658b3ef7ca/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/eddb08fa102356e42e815da2c006cf658b3ef7ca/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)