### PR TITLE
Force each PR to opt-in to or opt-out of the changelog

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -24,6 +24,14 @@ jobs:
           count: 0
           labels: "do-not-merge"
 
+      - name: Require label "include in changelog" or "exclude from changelog"
+        uses: mheap/github-action-required-labels@v3
+        with:
+          mode: minimum
+          count: 1
+          labels: "exclude from changelog, include in changelog"
+
+
       - name: Require at least one label
         uses: mheap/github-action-required-labels@v3
         with:


### PR DESCRIPTION
### What
I've noticed a lot of small PRs that are not opting out of the changelog, but probably should.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3403) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3403)
- [Docs preview](https://rerun.io/preview/ff139f89fab837806ca136f566004b3f2a3e6ece/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ff139f89fab837806ca136f566004b3f2a3e6ece/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)