### PR TITLE
Enforce TODO formatting

### DIFF
--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -272,7 +272,7 @@ impl<A: Archetype> ArchetypeView<A> {
     #[inline]
     pub fn iter_instance_keys(&self) -> impl Iterator<Item = InstanceKey> {
         re_tracing::profile_function!();
-        // TODO(https://github.com/rerun-io/rerun/issues/2750): Maybe make this an intersection instead
+        // TODO(#2750): Maybe make this an intersection instead
         self.required_comp().instance_keys().into_iter()
     }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1386,7 +1386,7 @@ mod tests {
                 assert_eq!(store_info.store_id, rid);
 
                 let mut got = DataTable::from_arrow_msg(&msg).unwrap();
-                // TODO(1760): we shouldn't have to (re)do this!
+                // TODO(#1760): we shouldn't have to (re)do this!
                 got.compute_all_size_bytes();
                 // NOTE: Override the resulting table's ID so they can be compared.
                 got.table_id = table.table_id;
@@ -1456,7 +1456,7 @@ mod tests {
                     assert_eq!(store_info.store_id, rid);
 
                     let mut got = DataTable::from_arrow_msg(&msg).unwrap();
-                    // TODO(1760): we shouldn't have to (re)do this!
+                    // TODO(#1760): we shouldn't have to (re)do this!
                     got.compute_all_size_bytes();
                     // NOTE: Override the resulting table's ID so they can be compared.
                     got.table_id = table.table_id;
@@ -1521,7 +1521,7 @@ mod tests {
                     assert_eq!(store_info.store_id, rid);
 
                     let mut got = DataTable::from_arrow_msg(&msg).unwrap();
-                    // TODO(1760): we shouldn't have to (re)do this!
+                    // TODO(#1760): we shouldn't have to (re)do this!
                     got.compute_all_size_bytes();
                     // NOTE: Override the resulting table's ID so they can be compared.
                     got.table_id = table.table_id;

--- a/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
+++ b/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
@@ -5,7 +5,7 @@ use re_viewer_context::{NamedViewSystem, ViewContextSystem};
 
 /// List of all non-interactive entities for lookup during picking evaluation.
 ///
-/// TODO(wumpf/jleibs): This is a temporary solution until the picking code can query propagated blueprint properties directly.
+/// TODO(wumpf, jleibs): This is a temporary solution until the picking code can query propagated blueprint properties directly.
 #[derive(Default)]
 pub struct NonInteractiveEntities(pub IntSet<EntityPathHash>);
 

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -153,7 +153,7 @@ impl Points2DPart {
             {
                 re_tracing::profile_scope!("marking additional highlight points");
                 for (highlighted_key, instance_mask_ids) in &ent_context.highlight.instances {
-                    // TODO(andreas/jeremy): We can do this much more efficiently
+                    // TODO(andreas, jeremy): We can do this much more efficiently
                     let highlighted_point_index = arch_view
                         .iter_instance_keys()
                         .position(|key| *highlighted_key == key);

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -158,7 +158,7 @@ impl Points3DPart {
             {
                 re_tracing::profile_scope!("marking additional highlight points");
                 for (highlighted_key, instance_mask_ids) in &ent_context.highlight.instances {
-                    // TODO(andreas/jeremy): We can do this much more efficiently
+                    // TODO(andreas, jeremy): We can do this much more efficiently
                     let highlighted_point_index = arch_view
                         .iter_instance_keys()
                         .position(|key| *highlighted_key == key);

--- a/crates/re_space_view_spatial/src/space_camera_3d.rs
+++ b/crates/re_space_view_spatial/src/space_camera_3d.rs
@@ -68,7 +68,7 @@ impl SpaceCamera3D {
         // we need to pre-transform the data from the user-defined `pinhole_view_coordinates` to the required
         // `image_view_coordinates`.
         //
-        // TODO(…): When Pinhole is an archetype instead of a component, `pinhole.project` should do this
+        // TODO(emilk): When Pinhole is an archetype instead of a component, `pinhole.project` should do this
         // internally.
         let point_in_image_unprojected =
             image_view_coordinates().from_other(&self.pinhole_view_coordinates) * point_in_cam;

--- a/crates/re_types/definitions/rerun/components/view_coordinates.fbs
+++ b/crates/re_types/definitions/rerun/components/view_coordinates.fbs
@@ -7,7 +7,7 @@ include "rerun/datatypes.fbs";
 
 namespace rerun.components;
 
-// TODO(https://github.com/rerun-io/rerun/issues/3384)
+// TODO(#3384)
 /*
 enum ViewDir: byte {
     Up = 1,

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-b736dbd729349210545e036dbbfb7c22c2b1fe097d54cbe6a2a57aceca9ee231
+6d78ea9bd1c6ae842768454e28bcd82a8c29b64512d05370d08c66aa4879bfb9

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-6d78ea9bd1c6ae842768454e28bcd82a8c29b64512d05370d08c66aa4879bfb9
+84b3bdce30e788a40972a3ec78fc8a639ae55f75317c2604a8c96045b4090e9a

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -595,7 +595,7 @@ fn quote_arrow_field_serializer(
                 }
             };
 
-            // TODO(https://github.com/rerun-io/rerun/issues/2993): The inner
+            // TODO(#2993): The inner
             // types of lists shouldn't be nullable, but both the python and C++
             // code-gen end up setting these to null when an outer fixed-sized
             // field does happen to be null. In order to keep everything aligned

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -805,7 +805,7 @@ impl ReUi {
                 image_size,
             );
 
-            // TODO(emilk/andreas): change color and size on hover
+            // TODO(emilk, andreas): change color and size on hover
             let tint = ui.visuals().widgets.inactive.fg_stroke.color;
             icon.as_image().tint(tint).paint_at(ui, image_rect);
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -164,7 +164,7 @@ impl App {
             storage
                 .and_then(|storage| {
                     // This re-implements: `eframe::get_value` so we can customize the warning message.
-                    // TODO(https://github.com/rerun-io/rerun/issues/2849): More thorough error-handling.
+                    // TODO(#2849): More thorough error-handling.
                     storage.get_string(eframe::APP_KEY).and_then(|value| {
                         match ron::from_str(&value) {
                             Ok(value) => Some(value),
@@ -948,7 +948,7 @@ impl eframe::App for App {
             eframe::set_value(storage, eframe::APP_KEY, &self.state);
 
             // Save the blueprints
-            // TODO(2579): implement web-storage for blueprints as well
+            // TODO(#2579): implement web-storage for blueprints as well
             if let Some(hub) = &mut self.store_hub {
                 match hub.gc_and_persist_app_blueprints() {
                     Ok(f) => f,

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -161,7 +161,7 @@ impl StoreHub {
     pub fn set_app_id(&mut self, app_id: ApplicationId) {
         // If we don't know of a blueprint for this `ApplicationId` yet,
         // try to load one from the persisted store
-        // TODO(2579): implement web-storage for blueprints as well
+        // TODO(#2579): implement web-storage for blueprints as well
         #[cfg(not(target_arch = "wasm32"))]
         if !self.blueprint_by_app_id.contains_key(&app_id) {
             if let Err(err) = self.try_to_load_persisted_blueprint(&app_id) {

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -23,7 +23,7 @@ pub struct ViewQuery<'s> {
     pub latest_at: TimeInt,
 
     /// The entity properties for all queried entities.
-    /// TODO(jleibs/wumpf): This will be replaced by blueprint queries.
+    /// TODO(jleibs, wumpf): This will be replaced by blueprint queries.
     pub entity_props_map: &'s EntityPropertyMap,
 
     /// Hover/select highlighting information for this space view.

--- a/docs/content/reference/viewer/viewport.md
+++ b/docs/content/reference/viewer/viewport.md
@@ -39,6 +39,6 @@ Rerun distinguishes various categories of Space Views:
 
 Which category is used is determined upon creation of a Space View.
 
-[TODO(@#1164)](https://github.com/rerun-io/rerun/issues/1164): Allow configuring the category of a space view after its creation.
+[TODO(#1164)](https://github.com/rerun-io/rerun/issues/1164): Allow configuring the category of a space view after its creation.
 
 The kind of Space View determines which Entities it can display, how it displays them and the way they can be interacted with.

--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -43,7 +43,7 @@ def log_annotated_bboxes(annotation: dict[str, Any]) -> tuple[npt.NDArray[np.flo
     Logs annotated oriented bounding boxes to Rerun.
 
     We currently calculate and return the 3D bounding boxes keypoints, labels, and colors for each object to log them in
-    each camera frame TODO(pablovela5620): Once #1581 is resolved this can be removed.
+    each camera frame TODO(#1581): once resolved this can be removed.
 
     annotation json file
     |  |-- label: object name of bounding box
@@ -55,7 +55,7 @@ def log_annotated_bboxes(annotation: dict[str, Any]) -> tuple[npt.NDArray[np.flo
     bbox_labels = []
     num_objects = len(annotation["data"])
     # Generate a color per object that can be reused across both 3D obb and their 2D projections
-    # TODO(pablovela5620): Once #1581 or #1728 is resolved this can be removed
+    # TODO(#1581, #1728): once resolved this can be removed
     color_positions = np.linspace(0, 1, num_objects)
     colormap = plt.colormaps["viridis"]
     colors = [colormap(pos) for pos in color_positions]
@@ -93,7 +93,7 @@ def compute_box_3d(
     """
     Given obb compute 3d keypoints of the box.
 
-    TODO(pablovela5620): Once #1581 is resolved this can be removed
+    TODO(#1581): once resolved this can be removed
     """
     length, height, width = half_size.tolist()
     center = np.reshape(transform, (-1, 3))
@@ -123,7 +123,7 @@ def log_line_segments(entity_path: str, bboxes_2d_filtered: npt.NDArray[np.float
     |/         |/
     1 -------- 0
 
-    TODO(pablovela5620): Once #1581 is resolved this can be removed
+    TODO(#1581): once resolved this can be removed
 
     :param bboxes_2d_filtered:
         A numpy array of shape (8, 2), representing the filtered 2D keypoints of the 3D bounding boxes.
@@ -175,7 +175,7 @@ def project_3d_bboxes_to_2d_keypoints(
     """
     Returns 2D keypoints of the 3D bounding box in the camera view.
 
-    TODO(pablovela5620): Once #1581 is resolved this can be removed
+    TODO(#1581): once resolved this can be removed
     Args:
         bboxes_3d: (nObjects, 8, 3) containing the 3D bounding box keypoints in world frame.
         camera_from_world: Tuple containing the camera translation and rotation_quaternion in world frame.
@@ -242,7 +242,7 @@ def log_camera(
     intrinsic = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
     camera_from_world = poses_from_traj[frame_id]
 
-    # TODO(pablovela5620): Once #1581 is resolved this can be removed
+    # TODO(#1581): once resolved this can be removed
     # Project 3D bounding boxes into 2D image
     bboxes_2d = project_3d_bboxes_to_2d_keypoints(bboxes, camera_from_world, intrinsic, img_width=w, img_height=h)
     # clear previous centroid labels

--- a/examples/python/depth_guided_stable_diffusion/huggingface_pipeline.py
+++ b/examples/python/depth_guided_stable_diffusion/huggingface_pipeline.py
@@ -570,7 +570,7 @@ class StableDiffusionDepth2ImgPipeline(DiffusionPipeline):
         )
         rr.log_tensor("diffusion/latents", latents, names=["b", "c", "h", "w"])
 
-        # 8. Prepare extra step kwargs. TODO(original author): Logic should ideally just be moved out of the pipeline
+        # 8. Prepare extra step kwargs. TODO(someone): Logic should ideally just be moved out of the pipeline
         extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)
 
         # 9. Denoising loop

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -46,7 +46,7 @@ impl std::fmt::Display for ColorCoordinatesMode {
 /// This state is preserved between frames, but not across Viewer sessions.
 #[derive(Default)]
 pub struct ColorCoordinatesSpaceViewState {
-    // TODO(wumpf/jleibs): This should be part of the Blueprint so that it is serialized out.
+    // TODO(wumpf, jleibs): This should be part of the Blueprint so that it is serialized out.
     //                      but right now there is no way of doing that.
     mode: ColorCoordinatesMode,
 }

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -57,7 +57,7 @@ class Archetype:
         for fld in fields(type(self)):
             if "component" in fld.metadata:
                 comp = getattr(self, fld.name)
-                # TODO(https://github.com/rerun-io/rerun/issues/3341): Depending on what we decide
+                # TODO(#3341): Depending on what we decide
                 # to do with optional components, we may need to make this instead call `_empty_pa_array`
                 if comp is not None:
                     yield comp

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -31,7 +31,7 @@ class TensorBuffer(TensorBufferExt):
 
     # You can define your own __init__ function as a member of TensorBufferExt in tensor_buffer_ext.py
 
-    inner: npt.NDArray[np.float16] | (npt.NDArray[np.float32] | (npt.NDArray[np.float64] | (npt.NDArray[np.int16] | (npt.NDArray[np.int32] | (npt.NDArray[np.int64] | (npt.NDArray[np.int8] | (npt.NDArray[np.uint16] | (npt.NDArray[np.uint32] | (npt.NDArray[np.uint64] | npt.NDArray[np.uint8]))))))))) = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
+    inner: npt.NDArray[np.float16] | npt.NDArray[np.float32] | npt.NDArray[np.float64] | npt.NDArray[np.int16] | npt.NDArray[np.int32] | npt.NDArray[np.int64] | npt.NDArray[np.int8] | npt.NDArray[np.uint16] | npt.NDArray[np.uint32] | npt.NDArray[np.uint64] | npt.NDArray[np.uint8] = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
     """
     U8 (npt.NDArray[np.uint8]):
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/scalar.py
@@ -77,7 +77,7 @@ def log_scalar(
 
         This won't show up on points at the moment, as our plots don't yet
         support displaying labels for individual points
-        TODO(https://github.com/rerun-io/rerun/issues/1289). If all points
+        TODO(#1289). If all points
         within a single entity path (i.e. a line) share the same label, then
         this label will be used as the label for the line itself. Otherwise, the
         line will be named after the entity path. The plot itself is named after

--- a/rerun_py/rerun_sdk/rerun_demo/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_demo/__main__.py
@@ -31,7 +31,7 @@ def run_structure_from_motion(args):
 
     serve_opts = []
 
-    # TODO(https://github.com/rerun-io/rerun/issues/1924): The need to special-case
+    # TODO(#1924): The need to special-case
     # this flag conversion is a bit awkward.
     if args.connect or args.addr:
         print("Connecting to external viewer is only supported with the --cube demo.", file=sys.stderr)

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -25,7 +25,7 @@ __all__ = ["AffixFuzzer3", "AffixFuzzer3Array", "AffixFuzzer3ArrayLike", "AffixF
 class AffixFuzzer3:
     # You can define your own __init__ function as a member of AffixFuzzer3Ext in affix_fuzzer3_ext.py
 
-    inner: float | (list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32]) = field()
+    inner: float | list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32] = field()
     """
     degrees (float):
 

--- a/scripts/generate_view_coordinate_defs.py
+++ b/scripts/generate_view_coordinate_defs.py
@@ -4,7 +4,7 @@ Generates the permutations of view coordinate name definitions.
 
 This will modify the different archetype extensions to include the appropriate constants.
 """
-# TODO(2388): This script can potentially go away or be significantly reduced.
+# TODO(#2388): This script can potentially go away or be significantly reduced.
 
 from __future__ import annotations
 

--- a/scripts/generate_view_coordinate_defs.py
+++ b/scripts/generate_view_coordinate_defs.py
@@ -4,7 +4,7 @@ Generates the permutations of view coordinate name definitions.
 
 This will modify the different archetype extensions to include the appropriate constants.
 """
-# TODO(https://github.com/rerun-io/rerun/issues/2388): This script can potentially go away or be significantly reduced.
+# TODO(2388): This script can potentially go away or be significantly reduced.
 
 from __future__ import annotations
 


### PR DESCRIPTION
A trivial PR to enforce the formatting of TODOs.

This is groundwork for an upcoming PR that checks for zombie TODOs on CI (TODOs that reference an issue that is already fixed).

TL;DR: these are legal, everything else is not (hopefully):
- `TODO(bob)`
- `TODO(bob, alice)`
- `TODO(#42)`
- `TODO(#42, #43)`
- `TODO(rust-lang/rust#42)`
- `TODO(rust-lang/rust#42, rust-lang/rust#43)`


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3404) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3404)
- [Docs preview](https://rerun.io/preview/45377186958fcb1722735389e8e8d12f13e071c4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/45377186958fcb1722735389e8e8d12f13e071c4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)