### PR TITLE
Fix cargo doc race condition

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -167,17 +167,32 @@ jobs:
           command: test
           args: --doc --all-features
 
-      - name: cargo doc
+      # run `cargo doc` in two steps, one without `rerun-cli`, then only `rerun-cli`
+      # this fixes the race condition caused by having two crates with the same
+      # name in the workspace (`rerun`, `rerun-cli` bin)
+      - name: cargo doc --exclude rerun-cli
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --no-deps --all-features
+          args: --no-deps --all-features --workspace --exclude rerun-cli
 
-      - name: cargo doc --document-private-items
+      - name: cargo doc -p rerun-cli
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --document-private-items --no-deps --all-features
+          args: --no-deps --all-features --workspace -p rerun-cli
+
+      - name: cargo doc --document-private-items --exclude rerun-cli
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --document-private-items --no-deps --all-features --workspace --exclude rerun-cli
+
+      - name: cargo doc --document-private-items -p rerun-cli
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --document-private-items --no-deps --all-features -p rerun-cli
 
       # Just a normal `cargo test` should always work:
       - name: cargo test --all-targets


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

We have two crates named `rerun` in the workspace (`rerun-cli` binary, and `rerun` top-level crate). This creates a race condition in `cargo doc`, which would sometimes fail on CI.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3407) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3407)
- [Docs preview](https://rerun.io/preview/e021080ca26ebadb54714b1ff146d0d1c11148a0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e021080ca26ebadb54714b1ff146d0d1c11148a0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)