### PR TITLE
Clean up python generated classes and allow `ComponentBatch(...)` style constructors

### DIFF
--- a/crates/re_types/definitions/rerun/components/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/components/annotation_context.fbs
@@ -17,7 +17,7 @@ namespace rerun.components;
 /// path-hierarchy when searching up through the ancestors of a given entity
 /// path.
 table AnnotationContext (
-  "attr.python.array_aliases": "datatypes.ClassDescription, Sequence[datatypes.ClassDescriptionMapElemLike]",
+  "attr.python.array_aliases": "datatypes.ClassDescriptionLike, datatypes.ClassDescriptionArrayLike, Sequence[datatypes.ClassDescriptionMapElemLike]",
   "attr.rust.derive": "Default, Eq, PartialEq",
   order: 100
 ) {

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-5f4333d099d85ab11ba56a94a087721c51dd78a32c5ae464bde5c3cd1cf7184a
+6f3c0c3da6b1c9994f20aef69d2b20b9bd0da016b926e5f8095228f44aa45e76

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-6f3c0c3da6b1c9994f20aef69d2b20b9bd0da016b926e5f8095228f44aa45e76
+879d33df3fbb99178624e96a6ac1c6f05ee14b4683be2cb6c9b48b7469efb257

--- a/docs/code-examples/asset3d_out_of_tree.py
+++ b/docs/code-examples/asset3d_out_of_tree.py
@@ -26,4 +26,4 @@ for i in range(1, 20):
     rr.set_time_sequence("frame", i)
 
     translation = rr2.dt.TranslationRotationScale3D(translation=[0, 0, i - 10.0])
-    rr2.log_components("asset", [rr2.cmp.OutOfTreeTransform3DArray.from_similar(translation)])
+    rr2.log_components("asset", [rr2.cmp.OutOfTreeTransform3DBatch(translation)])

--- a/docs/code-examples/custom_data.py
+++ b/docs/code-examples/custom_data.py
@@ -22,7 +22,7 @@ class ConfidenceBatch(rr2.ComponentBatchLike):
         """The name of the custom component."""
         return "user.Confidence"
 
-    def as_arrow_batch(self) -> pa.Array:
+    def as_arrow_array(self) -> pa.Array:
         """The arrow batch representing the custom component."""
         return pa.array(self.confidence, type=pa.float32())
 

--- a/docs/code-examples/mesh3d_partial_updates.py
+++ b/docs/code-examples/mesh3d_partial_updates.py
@@ -22,4 +22,4 @@ rr2.log(
 factors = np.abs(np.sin(np.arange(1, 300, dtype=np.float32) * 0.04))
 for i, factor in enumerate(factors):
     rr.set_time_sequence("frame", i)
-    rr2.log_components("triangle", [rr2.cmp.Position3DArray.from_similar(vertex_positions * factor)])
+    rr2.log_components("triangle", [rr2.cmp.Position3DBatch(vertex_positions * factor)])

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -185,7 +185,7 @@ class BaseBatch(Generic[T]):
 
         For optional components, the default value of None is preserved in the field to indicate that the optional
         field was not specified.
-        If any value other than None is provided, it is passed through to `from_similar`.
+        If any value other than None is provided, it is passed through to `__init__`.
 
         Parameters
         ----------

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["AnnotationContext"]
 
@@ -47,9 +45,9 @@ class AnnotationContext(Archetype):
 
     # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py
 
-    context: components.AnnotationContextArray = field(
+    context: components.AnnotationContextBatch = field(
         metadata={"component": "required"},
-        converter=components.AnnotationContextArray.from_similar,  # type: ignore[misc]
+        converter=components.AnnotationContextBatch,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .arrows3d_ext import Arrows3DExt
 
 __all__ = ["Arrows3D"]
@@ -44,18 +42,18 @@ class Arrows3D(Arrows3DExt, Archetype):
 
     # __init__ can be found in arrows3d_ext.py
 
-    vectors: components.Vector3DArray = field(
+    vectors: components.Vector3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Vector3DArray.from_similar,  # type: ignore[misc]
+        converter=components.Vector3DBatch,  # type: ignore[misc]
     )
     """
     All the vectors for each arrow in the batch.
     """
 
-    origins: components.Origin3DArray | None = field(
+    origins: components.Origin3DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.Origin3DArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.Origin3DBatch._optional,  # type: ignore[misc]
     )
     """
     All the origin points for each arrow in the batch.
@@ -63,10 +61,10 @@ class Arrows3D(Arrows3DExt, Archetype):
     If no origins are set, (0, 0, 0) is used as the origin for each arrow.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the arrows.
@@ -75,28 +73,28 @@ class Arrows3D(Arrows3DExt, Archetype):
     The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
     """
 
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the points.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the arrows.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional class Ids for the points.
@@ -104,10 +102,10 @@ class Arrows3D(Arrows3DExt, Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual point in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -67,7 +67,7 @@ class Asset3D(Asset3DExt, Archetype):
         rr.set_time_sequence("frame", i)
 
         translation = rr2.dt.TranslationRotationScale3D(translation=[0, 0, i - 10.0])
-        rr2.log_components("asset", [rr2.cmp.OutOfTreeTransform3DArray.from_similar(translation)])
+        rr2.log_components("asset", [rr2.cmp.OutOfTreeTransform3DBatch(translation)])
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .asset3d_ext import Asset3DExt
 
 __all__ = ["Asset3D"]
@@ -75,18 +73,18 @@ class Asset3D(Asset3DExt, Archetype):
 
     # You can define your own __init__ function as a member of Asset3DExt in asset3d_ext.py
 
-    data: components.BlobArray = field(
+    data: components.BlobBatch = field(
         metadata={"component": "required"},
-        converter=components.BlobArray.from_similar,  # type: ignore[misc]
+        converter=components.BlobBatch,  # type: ignore[misc]
     )
     """
     The asset's bytes.
     """
 
-    media_type: components.MediaTypeArray | None = field(
+    media_type: components.MediaTypeBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.MediaTypeArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.MediaTypeBatch._optional,  # type: ignore[misc]
     )
     """
     The Media Type of the asset.
@@ -99,10 +97,10 @@ class Asset3D(Asset3DExt, Archetype):
     If it cannot guess, it won't be able to render the asset.
     """
 
-    transform: components.OutOfTreeTransform3DArray | None = field(
+    transform: components.OutOfTreeTransform3DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.OutOfTreeTransform3DArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.OutOfTreeTransform3DBatch._optional,  # type: ignore[misc]
     )
     """
     An out-of-tree transform.

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .bar_chart_ext import BarChartExt
 
 __all__ = ["BarChart"]
@@ -37,7 +35,7 @@ class BarChart(BarChartExt, Archetype):
 
     # You can define your own __init__ function as a member of BarChartExt in bar_chart_ext.py
 
-    values: components.TensorDataArray = field(
+    values: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=BarChartExt.values__field_converter_override,  # type: ignore[misc]
     )

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
@@ -5,20 +5,20 @@ from typing import TYPE_CHECKING
 from rerun.error_utils import _send_warning
 
 if TYPE_CHECKING:
-    from ..components import TensorDataArray
+    from ..components import TensorDataBatch
     from ..datatypes import TensorDataArrayLike
 
 
 class BarChartExt:
     @staticmethod
-    def values__field_converter_override(data: TensorDataArrayLike) -> TensorDataArray:
-        from ..components import TensorDataArray
+    def values__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
+        from ..components import TensorDataBatch
 
-        tensor_data = TensorDataArray.from_similar(data)
+        tensor_data = TensorDataBatch(data)
 
         # TODO(jleibs): Doing this on raw arrow data is not great. Clean this up
         # once we coerce to a canonical non-arrow type.
-        shape_dims = tensor_data[0].value["shape"].values.field(0).to_numpy()
+        shape_dims = tensor_data.as_arrow_array()[0].value["shape"].values.field(0).to_numpy()
 
         if len(shape_dims) != 1:
             _send_warning(

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .boxes2d_ext import Boxes2DExt
 
 __all__ = ["Boxes2D"]
@@ -39,54 +37,54 @@ class Boxes2D(Boxes2DExt, Archetype):
 
     # __init__ can be found in boxes2d_ext.py
 
-    half_sizes: components.HalfSizes2DArray = field(
+    half_sizes: components.HalfSizes2DBatch = field(
         metadata={"component": "required"},
-        converter=components.HalfSizes2DArray.from_similar,  # type: ignore[misc]
+        converter=components.HalfSizes2DBatch,  # type: ignore[misc]
     )
     """
     All half-extents that make up the batch of boxes.
     """
 
-    centers: components.Position2DArray | None = field(
+    centers: components.Position2DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.Position2DArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.Position2DBatch._optional,  # type: ignore[misc]
     )
     """
     Optional center positions of the boxes.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the lines that make up the boxes.
     """
 
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the boxes.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the boxes.
     """
 
-    draw_order: components.DrawOrderArray | None = field(
+    draw_order: components.DrawOrderBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DrawOrderArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies the 2D drawing order.
@@ -95,10 +93,10 @@ class Boxes2D(Boxes2DExt, Archetype):
     The default for 2D boxes is 10.0.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional `ClassId`s for the boxes.
@@ -106,10 +104,10 @@ class Boxes2D(Boxes2DExt, Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual boxes in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .boxes3d_ext import Boxes3DExt
 
 __all__ = ["Boxes3D"]
@@ -60,59 +58,59 @@ class Boxes3D(Boxes3DExt, Archetype):
 
     # __init__ can be found in boxes3d_ext.py
 
-    half_sizes: components.HalfSizes3DArray = field(
+    half_sizes: components.HalfSizes3DBatch = field(
         metadata={"component": "required"},
-        converter=components.HalfSizes3DArray.from_similar,  # type: ignore[misc]
+        converter=components.HalfSizes3DBatch,  # type: ignore[misc]
     )
     """
     All half-extents that make up the batch of boxes.
     """
 
-    centers: components.Position3DArray | None = field(
+    centers: components.Position3DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.Position3DArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.Position3DBatch._optional,  # type: ignore[misc]
     )
     """
     Optional center positions of the boxes.
     """
 
-    rotations: components.Rotation3DArray | None = field(
+    rotations: components.Rotation3DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.Rotation3DArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.Rotation3DBatch._optional,  # type: ignore[misc]
     )
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the boxes.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the lines that make up the boxes.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the boxes.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional `ClassId`s for the boxes.
@@ -120,10 +118,10 @@ class Boxes3D(Boxes3DExt, Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual boxes in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["Clear"]
 
@@ -68,9 +66,9 @@ class Clear(Archetype):
 
     # You can define your own __init__ function as a member of ClearExt in clear_ext.py
 
-    settings: components.ClearSettingsArray = field(
+    settings: components.ClearSettingsBatch = field(
         metadata={"component": "required"},
-        converter=components.ClearSettingsArray.from_similar,  # type: ignore[misc]
+        converter=components.ClearSettingsBatch,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .depth_image_ext import DepthImageExt
 
 __all__ = ["DepthImage"]
@@ -47,7 +45,7 @@ class DepthImage(DepthImageExt, Archetype):
 
     # You can define your own __init__ function as a member of DepthImageExt in depth_image_ext.py
 
-    data: components.TensorDataArray = field(
+    data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=DepthImageExt.data__field_converter_override,  # type: ignore[misc]
     )
@@ -55,10 +53,10 @@ class DepthImage(DepthImageExt, Archetype):
     The depth-image data. Should always be a rank-2 tensor.
     """
 
-    meter: components.DepthMeterArray | None = field(
+    meter: components.DepthMeterBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DepthMeterArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DepthMeterBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies how long a meter is in the native depth units.
@@ -67,10 +65,10 @@ class DepthImage(DepthImageExt, Archetype):
     and a range of up to ~65 meters (2^16 / 1000).
     """
 
-    draw_order: components.DrawOrderArray | None = field(
+    draw_order: components.DrawOrderBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DrawOrderArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies the 2D drawing order.

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyarrow as pa
@@ -10,22 +10,23 @@ from rerun.error_utils import _send_warning
 from .._validators import find_non_empty_dim_indices
 
 if TYPE_CHECKING:
-    from ..components import TensorDataArray
+    from ..components import TensorDataBatch
     from ..datatypes import TensorDataArrayLike
 
 
 class DepthImageExt:
     @staticmethod
-    def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataArray:
-        from ..components import TensorDataArray
+    def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
+        from ..components import TensorDataBatch
         from ..datatypes import TensorDataType, TensorDimensionType
 
-        tensor_data = TensorDataArray.from_similar(data)
+        tensor_data = TensorDataBatch(data)
+        tensor_data_arrow = tensor_data.as_arrow_array()
 
         # TODO(jleibs): Doing this on raw arrow data is not great. Clean this up
         # once we coerce to a canonical non-arrow type.
-        shape_dims = tensor_data[0].value["shape"].values.field(0).to_numpy()
-        shape_names = tensor_data[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
+        shape_dims = tensor_data_arrow[0].value["shape"].values.field(0).to_numpy()
+        shape_names = tensor_data_arrow[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
 
         non_empty_dims = find_non_empty_dim_indices(shape_dims)
 
@@ -52,29 +53,25 @@ class DepthImageExt:
                 offsets=[0, len(shape_dims)],
                 values=pa.StructArray.from_arrays(
                     [
-                        tensor_data[0].value["shape"].values.field(0),
+                        tensor_data_arrow[0].value["shape"].values.field(0),
                         shape_names,
                     ],
                     fields=[shape_data_type.field("size"), shape_data_type.field("name")],
                 ),
             ).cast(tensor_data_type.field("shape").type)
 
-            return cast(
-                TensorDataArray,
-                TensorDataArray._EXTENSION_TYPE().wrap_array(
-                    pa.StructArray.from_arrays(
-                        [
-                            new_shape,
-                            tensor_data.storage.field(1),
-                        ],
-                        fields=[
-                            tensor_data_type.field("shape"),
-                            tensor_data_type.field("buffer"),
-                        ],
-                    ).cast(tensor_data.storage.type)
-                ),
+            return TensorDataBatch(
+                pa.StructArray.from_arrays(
+                    [
+                        new_shape,
+                        tensor_data_arrow.storage.field(1),
+                    ],
+                    fields=[
+                        tensor_data_type.field("shape"),
+                        tensor_data_type.field("buffer"),
+                    ],
+                ).cast(tensor_data_arrow.storage.type)
             )
 
         # TODO(jleibs): Should we enforce specific names on images? Specifically, what if the existing names are wrong.
-
         return tensor_data

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["DisconnectedSpace"]
 
@@ -45,9 +43,9 @@ class DisconnectedSpace(Archetype):
 
     # You can define your own __init__ function as a member of DisconnectedSpaceExt in disconnected_space_ext.py
 
-    disconnected_space: components.DisconnectedSpaceArray = field(
+    disconnected_space: components.DisconnectedSpaceBatch = field(
         metadata={"component": "required"},
-        converter=components.DisconnectedSpaceArray.from_similar,  # type: ignore[misc]
+        converter=components.DisconnectedSpaceBatch,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .image_ext import ImageExt
 
 __all__ = ["Image"]
@@ -50,7 +48,7 @@ class Image(ImageExt, Archetype):
 
     # You can define your own __init__ function as a member of ImageExt in image_ext.py
 
-    data: components.TensorDataArray = field(
+    data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=ImageExt.data__field_converter_override,  # type: ignore[misc]
     )
@@ -58,10 +56,10 @@ class Image(ImageExt, Archetype):
     The image data. Should always be a rank-2 or rank-3 tensor.
     """
 
-    draw_order: components.DrawOrderArray | None = field(
+    draw_order: components.DrawOrderBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DrawOrderArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies the 2D drawing order.

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyarrow as pa
@@ -10,22 +10,26 @@ from rerun.error_utils import _send_warning
 from .._validators import find_non_empty_dim_indices
 
 if TYPE_CHECKING:
-    from ..components import TensorDataArray
+    from ..components import TensorDataBatch
     from ..datatypes import TensorDataArrayLike
 
 
 class ImageExt:
     @staticmethod
-    def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataArray:
-        from ..components import TensorDataArray
+    def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
+        from ..components import TensorDataBatch
         from ..datatypes import TensorDataType, TensorDimensionType
 
-        tensor_data = TensorDataArray.from_similar(data)
+        tensor_data = TensorDataBatch(data)
+        tensor_data_arrow = tensor_data.as_arrow_array()
+
+        tensor_data_type = TensorDataType().storage_type
+        shape_data_type = TensorDimensionType().storage_type
 
         # TODO(jleibs): Doing this on raw arrow data is not great. Clean this up
         # once we coerce to a canonical non-arrow type.
-        shape_dims = tensor_data[0].value["shape"].values.field(0).to_numpy()
-        shape_names = tensor_data[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
+        shape_dims = tensor_data_arrow[0].value["shape"].values.field(0).to_numpy()
+        shape_names = tensor_data_arrow[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
 
         non_empty_dims = find_non_empty_dim_indices(shape_dims)
 
@@ -61,29 +65,24 @@ class ImageExt:
                 offsets=[0, len(shape_dims)],
                 values=pa.StructArray.from_arrays(
                     [
-                        tensor_data[0].value["shape"].values.field(0),
+                        tensor_data_arrow[0].value["shape"].values.field(0),
                         shape_names,
                     ],
                     fields=[shape_data_type.field("size"), shape_data_type.field("name")],
                 ),
             ).cast(tensor_data_type.field("shape").type)
 
-            return cast(
-                TensorDataArray,
-                TensorDataArray._EXTENSION_TYPE().wrap_array(
-                    pa.StructArray.from_arrays(
-                        [
-                            new_shape,
-                            tensor_data.storage.field(1),
-                        ],
-                        fields=[
-                            tensor_data_type.field("shape"),
-                            tensor_data_type.field("buffer"),
-                        ],
-                    ).cast(tensor_data.storage.type)
-                ),
+            return TensorDataBatch(
+                pa.StructArray.from_arrays(
+                    [
+                        new_shape,
+                        tensor_data_arrow.storage.field(1),
+                    ],
+                    fields=[
+                        tensor_data_type.field("shape"),
+                        tensor_data_type.field("buffer"),
+                    ],
+                ).cast(tensor_data_arrow.storage.type)
             )
-
         # TODO(jleibs): Should we enforce specific names on images? Specifically, what if the existing names are wrong.
-
         return tensor_data

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["LineStrips2D"]
 
@@ -66,55 +64,55 @@ class LineStrips2D(Archetype):
 
     # You can define your own __init__ function as a member of LineStrips2DExt in line_strips2d_ext.py
 
-    strips: components.LineStrip2DArray = field(
+    strips: components.LineStrip2DBatch = field(
         metadata={"component": "required"},
-        converter=components.LineStrip2DArray.from_similar,  # type: ignore[misc]
+        converter=components.LineStrip2DBatch,  # type: ignore[misc]
     )
     """
     All the actual 2D line strips that make up the batch.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the line strips.
     """
 
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the line strips.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the line strips.
     """
 
-    draw_order: components.DrawOrderArray | None = field(
+    draw_order: components.DrawOrderBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DrawOrderArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies the 2D drawing order of each line strip.
     Objects with higher values are drawn on top of those with lower values.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional `ClassId`s for the lines.
@@ -122,10 +120,10 @@ class LineStrips2D(Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual line strip in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["LineStrips3D"]
 
@@ -84,45 +82,45 @@ class LineStrips3D(Archetype):
 
     # You can define your own __init__ function as a member of LineStrips3DExt in line_strips3d_ext.py
 
-    strips: components.LineStrip3DArray = field(
+    strips: components.LineStrip3DBatch = field(
         metadata={"component": "required"},
-        converter=components.LineStrip3DArray.from_similar,  # type: ignore[misc]
+        converter=components.LineStrip3DBatch,  # type: ignore[misc]
     )
     """
     All the actual 3D line strips that make up the batch.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the line strips.
     """
 
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the line strips.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the line strips.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional `ClassId`s for the lines.
@@ -130,10 +128,10 @@ class LineStrips3D(Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual line strip in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["Mesh3D"]
 
@@ -72,9 +70,9 @@ class Mesh3D(Archetype):
 
     # You can define your own __init__ function as a member of Mesh3DExt in mesh3d_ext.py
 
-    vertex_positions: components.Position3DArray = field(
+    vertex_positions: components.Position3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Position3DArray.from_similar,  # type: ignore[misc]
+        converter=components.Position3DBatch,  # type: ignore[misc]
     )
     """
     The positions of each vertex.
@@ -82,19 +80,19 @@ class Mesh3D(Archetype):
     If no `indices` are specified, then each triplet of positions is interpreted as a triangle.
     """
 
-    mesh_properties: components.MeshPropertiesArray | None = field(
+    mesh_properties: components.MeshPropertiesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.MeshPropertiesArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.MeshPropertiesBatch._optional,  # type: ignore[misc]
     )
     """
     Optional properties for the mesh as a whole (including indexed drawing).
     """
 
-    vertex_normals: components.Vector3DArray | None = field(
+    vertex_normals: components.Vector3DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.Vector3DArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.Vector3DBatch._optional,  # type: ignore[misc]
     )
     """
     An optional normal for each vertex.
@@ -102,28 +100,28 @@ class Mesh3D(Archetype):
     If specified, this must have as many elements as `vertex_positions`.
     """
 
-    vertex_colors: components.ColorArray | None = field(
+    vertex_colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     An optional color for each vertex.
     """
 
-    mesh_material: components.MaterialArray | None = field(
+    mesh_material: components.MaterialBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.MaterialArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.MaterialBatch._optional,  # type: ignore[misc]
     )
     """
     Optional material properties for the mesh as a whole.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional class Ids for the vertices.
@@ -131,10 +129,10 @@ class Mesh3D(Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual vertex in the mesh.

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -64,7 +64,7 @@ class Mesh3D(Archetype):
     factors = np.abs(np.sin(np.arange(1, 300, dtype=np.float32) * 0.04))
     for i, factor in enumerate(factors):
         rr.set_time_sequence("frame", i)
-        rr2.log_components("triangle", [rr2.cmp.Position3DArray.from_similar(vertex_positions * factor)])
+        rr2.log_components("triangle", [rr2.cmp.Position3DBatch(vertex_positions * factor)])
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .pinhole_ext import PinholeExt
 
 __all__ = ["Pinhole"]
@@ -39,18 +37,18 @@ class Pinhole(PinholeExt, Archetype):
 
     # __init__ can be found in pinhole_ext.py
 
-    image_from_camera: components.PinholeProjectionArray = field(
+    image_from_camera: components.PinholeProjectionBatch = field(
         metadata={"component": "required"},
-        converter=components.PinholeProjectionArray.from_similar,  # type: ignore[misc]
+        converter=components.PinholeProjectionBatch,  # type: ignore[misc]
     )
     """
     Camera projection, from image coordinates to view coordinates.
     """
 
-    resolution: components.ResolutionArray | None = field(
+    resolution: components.ResolutionBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ResolutionArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ResolutionBatch._optional,  # type: ignore[misc]
     )
     """
     Pixel resolution (usually integers) of child image space. Width and height.
@@ -63,10 +61,10 @@ class Pinhole(PinholeExt, Archetype):
     `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
     """
 
-    camera_xyz: components.ViewCoordinatesArray | None = field(
+    camera_xyz: components.ViewCoordinatesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ViewCoordinatesArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ViewCoordinatesBatch._optional,  # type: ignore[misc]
     )
     """
     Sets the view coordinates for the camera.

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["Points2D"]
 
@@ -37,27 +35,27 @@ class Points2D(Archetype):
 
     # You can define your own __init__ function as a member of Points2DExt in points2d_ext.py
 
-    positions: components.Position2DArray = field(
+    positions: components.Position2DBatch = field(
         metadata={"component": "required"},
-        converter=components.Position2DArray.from_similar,  # type: ignore[misc]
+        converter=components.Position2DBatch,  # type: ignore[misc]
     )
     """
     All the 2D positions at which the point cloud shows points.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the points, effectively turning them into circles.
     """
 
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the points.
@@ -66,29 +64,29 @@ class Points2D(Archetype):
     As either 0-1 floats or 0-255 integers, with separate alpha.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the points.
     """
 
-    draw_order: components.DrawOrderArray | None = field(
+    draw_order: components.DrawOrderBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DrawOrderArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies the 2D drawing order.
     Objects with higher values are drawn on top of those with lower values.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional class Ids for the points.
@@ -96,10 +94,10 @@ class Points2D(Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    keypoint_ids: components.KeypointIdArray | None = field(
+    keypoint_ids: components.KeypointIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.KeypointIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.KeypointIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional keypoint IDs for the points, identifying them within a class.
@@ -112,10 +110,10 @@ class Points2D(Archetype):
     detected skeleton.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual point in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["Points3D"]
 
@@ -34,27 +32,27 @@ class Points3D(Archetype):
 
     # You can define your own __init__ function as a member of Points3DExt in points3d_ext.py
 
-    positions: components.Position3DArray = field(
+    positions: components.Position3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Position3DArray.from_similar,  # type: ignore[misc]
+        converter=components.Position3DBatch,  # type: ignore[misc]
     )
     """
     All the 3D positions at which the point cloud shows points.
     """
 
-    radii: components.RadiusArray | None = field(
+    radii: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     Optional radii for the points, effectively turning them into circles.
     """
 
-    colors: components.ColorArray | None = field(
+    colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional colors for the points.
@@ -63,19 +61,19 @@ class Points3D(Archetype):
     As either 0-1 floats or 0-255 integers, with separate alpha.
     """
 
-    labels: components.TextArray | None = field(
+    labels: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     Optional text labels for the points.
     """
 
-    class_ids: components.ClassIdArray | None = field(
+    class_ids: components.ClassIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ClassIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ClassIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional class Ids for the points.
@@ -83,10 +81,10 @@ class Points3D(Archetype):
     The class ID provides colors and labels if not specified explicitly.
     """
 
-    keypoint_ids: components.KeypointIdArray | None = field(
+    keypoint_ids: components.KeypointIdBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.KeypointIdArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.KeypointIdBatch._optional,  # type: ignore[misc]
     )
     """
     Optional keypoint IDs for the points, identifying them within a class.
@@ -99,10 +97,10 @@ class Points3D(Archetype):
     detected skeleton.
     """
 
-    instance_keys: components.InstanceKeyArray | None = field(
+    instance_keys: components.InstanceKeyBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.InstanceKeyArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
     )
     """
     Unique identifiers for each individual point in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .segmentation_image_ext import SegmentationImageExt
 
 __all__ = ["SegmentationImage"]
@@ -51,7 +49,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
 
     # You can define your own __init__ function as a member of SegmentationImageExt in segmentation_image_ext.py
 
-    data: components.TensorDataArray = field(
+    data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=SegmentationImageExt.data__field_converter_override,  # type: ignore[misc]
     )
@@ -59,10 +57,10 @@ class SegmentationImage(SegmentationImageExt, Archetype):
     The image data. Should always be a rank-2 tensor.
     """
 
-    draw_order: components.DrawOrderArray | None = field(
+    draw_order: components.DrawOrderBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.DrawOrderArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
     )
     """
     An optional floating point value that specifies the 2D drawing order.

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyarrow as pa
@@ -10,22 +10,23 @@ from rerun.error_utils import _send_warning
 from .._validators import find_non_empty_dim_indices
 
 if TYPE_CHECKING:
-    from ..components import TensorDataArray
+    from ..components import TensorDataBatch
     from ..datatypes import TensorDataArrayLike
 
 
 class SegmentationImageExt:
     @staticmethod
-    def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataArray:
-        from ..components import TensorDataArray
+    def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
+        from ..components import TensorDataBatch
         from ..datatypes import TensorDataType, TensorDimensionType
 
-        tensor_data = TensorDataArray.from_similar(data)
+        tensor_data = TensorDataBatch(data)
+        tensor_data_arrow = tensor_data.as_arrow_array()
 
         # TODO(jleibs): Doing this on raw arrow data is not great. Clean this up
         # once we coerce to a canonical non-arrow type.
-        shape_dims = tensor_data[0].value["shape"].values.field(0).to_numpy()
-        shape_names = tensor_data[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
+        shape_dims = tensor_data_arrow[0].value["shape"].values.field(0).to_numpy()
+        shape_names = tensor_data_arrow[0].value["shape"].values.field(1).to_numpy(zero_copy_only=False)
 
         non_empty_dims = find_non_empty_dim_indices(shape_dims)
 
@@ -52,27 +53,24 @@ class SegmentationImageExt:
                 offsets=[0, len(shape_dims)],
                 values=pa.StructArray.from_arrays(
                     [
-                        tensor_data[0].value["shape"].values.field(0),
+                        tensor_data_arrow[0].value["shape"].values.field(0),
                         shape_names,
                     ],
                     fields=[shape_data_type.field("size"), shape_data_type.field("name")],
                 ),
             ).cast(tensor_data_type.field("shape").type)
 
-            return cast(
-                TensorDataArray,
-                TensorDataArray._EXTENSION_TYPE().wrap_array(
-                    pa.StructArray.from_arrays(
-                        [
-                            new_shape,
-                            tensor_data.storage.field(1),
-                        ],
-                        fields=[
-                            tensor_data_type.field("shape"),
-                            tensor_data_type.field("buffer"),
-                        ],
-                    ).cast(tensor_data.storage.type)
-                ),
+            return TensorDataBatch(
+                pa.StructArray.from_arrays(
+                    [
+                        new_shape,
+                        tensor_data_arrow.storage.field(1),
+                    ],
+                    fields=[
+                        tensor_data_type.field("shape"),
+                        tensor_data_type.field("buffer"),
+                    ],
+                ).cast(tensor_data_arrow.storage.type)
             )
 
         # TODO(jleibs): Should we enforce specific names on images? Specifically, what if the existing names are wrong.

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["Tensor"]
 
@@ -41,9 +39,9 @@ class Tensor(Archetype):
 
     # You can define your own __init__ function as a member of TensorExt in tensor_ext.py
 
-    data: components.TensorDataArray = field(
+    data: components.TensorDataBatch = field(
         metadata={"component": "required"},
-        converter=components.TensorDataArray.from_similar,  # type: ignore[misc]
+        converter=components.TensorDataBatch,  # type: ignore[misc]
     )
     """
     The tensor data

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["TextDocument"]
 
@@ -21,14 +19,14 @@ class TextDocument(Archetype):
 
     # You can define your own __init__ function as a member of TextDocumentExt in text_document_ext.py
 
-    body: components.TextArray = field(
+    body: components.TextBatch = field(
         metadata={"component": "required"},
-        converter=components.TextArray.from_similar,  # type: ignore[misc]
+        converter=components.TextBatch,  # type: ignore[misc]
     )
-    media_type: components.MediaTypeArray | None = field(
+    media_type: components.MediaTypeBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.MediaTypeArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.MediaTypeBatch._optional,  # type: ignore[misc]
     )
     """
     The Media Type of the text.

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["TextLog"]
 
@@ -21,19 +19,19 @@ class TextLog(Archetype):
 
     # You can define your own __init__ function as a member of TextLogExt in text_log_ext.py
 
-    body: components.TextArray = field(
+    body: components.TextBatch = field(
         metadata={"component": "required"},
-        converter=components.TextArray.from_similar,  # type: ignore[misc]
+        converter=components.TextBatch,  # type: ignore[misc]
     )
-    level: components.TextLogLevelArray | None = field(
+    level: components.TextLogLevelBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextLogLevelArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextLogLevelBatch._optional,  # type: ignore[misc]
     )
-    color: components.ColorArray | None = field(
+    color: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["TimeSeriesScalar"]
 
@@ -64,18 +62,18 @@ class TimeSeriesScalar(Archetype):
 
     # You can define your own __init__ function as a member of TimeSeriesScalarExt in time_series_scalar_ext.py
 
-    scalar: components.ScalarArray = field(
+    scalar: components.ScalarBatch = field(
         metadata={"component": "required"},
-        converter=components.ScalarArray.from_similar,  # type: ignore[misc]
+        converter=components.ScalarBatch,  # type: ignore[misc]
     )
     """
     The scalar value to log.
     """
 
-    radius: components.RadiusArray | None = field(
+    radius: components.RadiusBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RadiusArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
     )
     """
     An optional radius for the point.
@@ -88,10 +86,10 @@ class TimeSeriesScalar(Archetype):
     line will use the default width of `1.0`.
     """
 
-    color: components.ColorArray | None = field(
+    color: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColorArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
     )
     """
     Optional color for the scalar entry.
@@ -107,10 +105,10 @@ class TimeSeriesScalar(Archetype):
     Otherwise, the line will appear gray in the legend.
     """
 
-    label: components.TextArray | None = field(
+    label: components.TextBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TextArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     """
     An optional label for the point.
@@ -123,10 +121,10 @@ class TimeSeriesScalar(Archetype):
     the space it's in.
     """
 
-    scattered: components.ScalarScatteringArray | None = field(
+    scattered: components.ScalarScatteringBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ScalarScatteringArray.optional_from_similar,  # type: ignore[misc]
+        converter=components.ScalarScatteringBatch._optional,  # type: ignore[misc]
     )
     """
     Specifies whether a point in a scatter plot should form a continuous line.

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 
 __all__ = ["Transform3D"]
 
@@ -49,9 +47,9 @@ class Transform3D(Archetype):
 
     # You can define your own __init__ function as a member of Transform3DExt in transform3d_ext.py
 
-    transform: components.Transform3DArray = field(
+    transform: components.Transform3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Transform3DArray.from_similar,  # type: ignore[misc]
+        converter=components.Transform3DBatch,  # type: ignore[misc]
     )
     """
     The transform

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import (
-    Archetype,
-)
+from .._baseclasses import Archetype
 from .view_coordinates_ext import ViewCoordinatesExt
 
 __all__ = ["ViewCoordinates"]
@@ -50,9 +48,9 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
 
     # You can define your own __init__ function as a member of ViewCoordinatesExt in view_coordinates_ext.py
 
-    xyz: components.ViewCoordinatesArray = field(
+    xyz: components.ViewCoordinatesBatch = field(
         metadata={"component": "required"},
-        converter=components.ViewCoordinatesArray.from_similar,  # type: ignore[misc]
+        converter=components.ViewCoordinatesBatch,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/components/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/components/__init__.py
@@ -4,196 +4,196 @@ from __future__ import annotations
 
 from .annotation_context import (
     AnnotationContext,
-    AnnotationContextArray,
     AnnotationContextArrayLike,
+    AnnotationContextBatch,
     AnnotationContextLike,
     AnnotationContextType,
 )
-from .blob import Blob, BlobArray, BlobArrayLike, BlobLike, BlobType
-from .class_id import ClassId, ClassIdArray, ClassIdType
+from .blob import Blob, BlobArrayLike, BlobBatch, BlobLike, BlobType
+from .class_id import ClassId, ClassIdBatch, ClassIdType
 from .clear_settings import (
     ClearSettings,
-    ClearSettingsArray,
     ClearSettingsArrayLike,
+    ClearSettingsBatch,
     ClearSettingsLike,
     ClearSettingsType,
 )
-from .color import Color, ColorArray, ColorType
-from .depth_meter import DepthMeter, DepthMeterArray, DepthMeterArrayLike, DepthMeterLike, DepthMeterType
+from .color import Color, ColorBatch, ColorType
+from .depth_meter import DepthMeter, DepthMeterArrayLike, DepthMeterBatch, DepthMeterLike, DepthMeterType
 from .disconnected_space import (
     DisconnectedSpace,
-    DisconnectedSpaceArray,
     DisconnectedSpaceArrayLike,
+    DisconnectedSpaceBatch,
     DisconnectedSpaceLike,
     DisconnectedSpaceType,
 )
-from .draw_order import DrawOrder, DrawOrderArray, DrawOrderArrayLike, DrawOrderLike, DrawOrderType
-from .half_sizes2d import HalfSizes2D, HalfSizes2DArray, HalfSizes2DType
-from .half_sizes3d import HalfSizes3D, HalfSizes3DArray, HalfSizes3DType
-from .instance_key import InstanceKey, InstanceKeyArray, InstanceKeyArrayLike, InstanceKeyLike, InstanceKeyType
-from .keypoint_id import KeypointId, KeypointIdArray, KeypointIdType
-from .line_strip2d import LineStrip2D, LineStrip2DArray, LineStrip2DArrayLike, LineStrip2DLike, LineStrip2DType
-from .line_strip3d import LineStrip3D, LineStrip3DArray, LineStrip3DArrayLike, LineStrip3DLike, LineStrip3DType
-from .material import Material, MaterialArray, MaterialType
-from .media_type import MediaType, MediaTypeArray, MediaTypeType
-from .mesh_properties import MeshProperties, MeshPropertiesArray, MeshPropertiesType
-from .origin2d import Origin2D, Origin2DArray, Origin2DType
-from .origin3d import Origin3D, Origin3DArray, Origin3DType
-from .out_of_tree_transform3d import OutOfTreeTransform3D, OutOfTreeTransform3DArray, OutOfTreeTransform3DType
-from .pinhole_projection import PinholeProjection, PinholeProjectionArray, PinholeProjectionType
-from .position2d import Position2D, Position2DArray, Position2DType
-from .position3d import Position3D, Position3DArray, Position3DType
-from .radius import Radius, RadiusArray, RadiusArrayLike, RadiusLike, RadiusType
-from .resolution import Resolution, ResolutionArray, ResolutionType
-from .rotation3d import Rotation3D, Rotation3DArray, Rotation3DType
-from .scalar import Scalar, ScalarArray, ScalarArrayLike, ScalarLike, ScalarType
+from .draw_order import DrawOrder, DrawOrderArrayLike, DrawOrderBatch, DrawOrderLike, DrawOrderType
+from .half_sizes2d import HalfSizes2D, HalfSizes2DBatch, HalfSizes2DType
+from .half_sizes3d import HalfSizes3D, HalfSizes3DBatch, HalfSizes3DType
+from .instance_key import InstanceKey, InstanceKeyArrayLike, InstanceKeyBatch, InstanceKeyLike, InstanceKeyType
+from .keypoint_id import KeypointId, KeypointIdBatch, KeypointIdType
+from .line_strip2d import LineStrip2D, LineStrip2DArrayLike, LineStrip2DBatch, LineStrip2DLike, LineStrip2DType
+from .line_strip3d import LineStrip3D, LineStrip3DArrayLike, LineStrip3DBatch, LineStrip3DLike, LineStrip3DType
+from .material import Material, MaterialBatch, MaterialType
+from .media_type import MediaType, MediaTypeBatch, MediaTypeType
+from .mesh_properties import MeshProperties, MeshPropertiesBatch, MeshPropertiesType
+from .origin2d import Origin2D, Origin2DBatch, Origin2DType
+from .origin3d import Origin3D, Origin3DBatch, Origin3DType
+from .out_of_tree_transform3d import OutOfTreeTransform3D, OutOfTreeTransform3DBatch, OutOfTreeTransform3DType
+from .pinhole_projection import PinholeProjection, PinholeProjectionBatch, PinholeProjectionType
+from .position2d import Position2D, Position2DBatch, Position2DType
+from .position3d import Position3D, Position3DBatch, Position3DType
+from .radius import Radius, RadiusArrayLike, RadiusBatch, RadiusLike, RadiusType
+from .resolution import Resolution, ResolutionBatch, ResolutionType
+from .rotation3d import Rotation3D, Rotation3DBatch, Rotation3DType
+from .scalar import Scalar, ScalarArrayLike, ScalarBatch, ScalarLike, ScalarType
 from .scalar_scattering import (
     ScalarScattering,
-    ScalarScatteringArray,
     ScalarScatteringArrayLike,
+    ScalarScatteringBatch,
     ScalarScatteringLike,
     ScalarScatteringType,
 )
-from .tensor_data import TensorData, TensorDataArray, TensorDataType
-from .text import Text, TextArray, TextType
-from .text_log_level import TextLogLevel, TextLogLevelArray, TextLogLevelType
-from .transform3d import Transform3D, Transform3DArray, Transform3DType
-from .vector3d import Vector3D, Vector3DArray, Vector3DType
+from .tensor_data import TensorData, TensorDataBatch, TensorDataType
+from .text import Text, TextBatch, TextType
+from .text_log_level import TextLogLevel, TextLogLevelBatch, TextLogLevelType
+from .transform3d import Transform3D, Transform3DBatch, Transform3DType
+from .vector3d import Vector3D, Vector3DBatch, Vector3DType
 from .view_coordinates import (
     ViewCoordinates,
-    ViewCoordinatesArray,
     ViewCoordinatesArrayLike,
+    ViewCoordinatesBatch,
     ViewCoordinatesLike,
     ViewCoordinatesType,
 )
 
 __all__ = [
     "AnnotationContext",
-    "AnnotationContextArray",
     "AnnotationContextArrayLike",
+    "AnnotationContextBatch",
     "AnnotationContextLike",
     "AnnotationContextType",
     "Blob",
-    "BlobArray",
     "BlobArrayLike",
+    "BlobBatch",
     "BlobLike",
     "BlobType",
     "ClassId",
-    "ClassIdArray",
+    "ClassIdBatch",
     "ClassIdType",
     "ClearSettings",
-    "ClearSettingsArray",
     "ClearSettingsArrayLike",
+    "ClearSettingsBatch",
     "ClearSettingsLike",
     "ClearSettingsType",
     "Color",
-    "ColorArray",
+    "ColorBatch",
     "ColorType",
     "DepthMeter",
-    "DepthMeterArray",
     "DepthMeterArrayLike",
+    "DepthMeterBatch",
     "DepthMeterLike",
     "DepthMeterType",
     "DisconnectedSpace",
-    "DisconnectedSpaceArray",
     "DisconnectedSpaceArrayLike",
+    "DisconnectedSpaceBatch",
     "DisconnectedSpaceLike",
     "DisconnectedSpaceType",
     "DrawOrder",
-    "DrawOrderArray",
     "DrawOrderArrayLike",
+    "DrawOrderBatch",
     "DrawOrderLike",
     "DrawOrderType",
     "HalfSizes2D",
-    "HalfSizes2DArray",
+    "HalfSizes2DBatch",
     "HalfSizes2DType",
     "HalfSizes3D",
-    "HalfSizes3DArray",
+    "HalfSizes3DBatch",
     "HalfSizes3DType",
     "InstanceKey",
-    "InstanceKeyArray",
     "InstanceKeyArrayLike",
+    "InstanceKeyBatch",
     "InstanceKeyLike",
     "InstanceKeyType",
     "KeypointId",
-    "KeypointIdArray",
+    "KeypointIdBatch",
     "KeypointIdType",
     "LineStrip2D",
-    "LineStrip2DArray",
     "LineStrip2DArrayLike",
+    "LineStrip2DBatch",
     "LineStrip2DLike",
     "LineStrip2DType",
     "LineStrip3D",
-    "LineStrip3DArray",
     "LineStrip3DArrayLike",
+    "LineStrip3DBatch",
     "LineStrip3DLike",
     "LineStrip3DType",
     "Material",
-    "MaterialArray",
+    "MaterialBatch",
     "MaterialType",
     "MediaType",
-    "MediaTypeArray",
+    "MediaTypeBatch",
     "MediaTypeType",
     "MeshProperties",
-    "MeshPropertiesArray",
+    "MeshPropertiesBatch",
     "MeshPropertiesType",
     "Origin2D",
-    "Origin2DArray",
+    "Origin2DBatch",
     "Origin2DType",
     "Origin3D",
-    "Origin3DArray",
+    "Origin3DBatch",
     "Origin3DType",
     "OutOfTreeTransform3D",
-    "OutOfTreeTransform3DArray",
+    "OutOfTreeTransform3DBatch",
     "OutOfTreeTransform3DType",
     "PinholeProjection",
-    "PinholeProjectionArray",
+    "PinholeProjectionBatch",
     "PinholeProjectionType",
     "Position2D",
-    "Position2DArray",
+    "Position2DBatch",
     "Position2DType",
     "Position3D",
-    "Position3DArray",
+    "Position3DBatch",
     "Position3DType",
     "Radius",
-    "RadiusArray",
     "RadiusArrayLike",
+    "RadiusBatch",
     "RadiusLike",
     "RadiusType",
     "Resolution",
-    "ResolutionArray",
+    "ResolutionBatch",
     "ResolutionType",
     "Rotation3D",
-    "Rotation3DArray",
+    "Rotation3DBatch",
     "Rotation3DType",
     "Scalar",
-    "ScalarArray",
     "ScalarArrayLike",
+    "ScalarBatch",
     "ScalarLike",
     "ScalarScattering",
-    "ScalarScatteringArray",
     "ScalarScatteringArrayLike",
+    "ScalarScatteringBatch",
     "ScalarScatteringLike",
     "ScalarScatteringType",
     "ScalarType",
     "TensorData",
-    "TensorDataArray",
+    "TensorDataBatch",
     "TensorDataType",
     "Text",
-    "TextArray",
+    "TextBatch",
     "TextLogLevel",
-    "TextLogLevelArray",
+    "TextLogLevelBatch",
     "TextLogLevelType",
     "TextType",
     "Transform3D",
-    "Transform3DArray",
+    "Transform3DBatch",
     "Transform3DType",
     "Vector3D",
-    "Vector3DArray",
+    "Vector3DBatch",
     "Vector3DType",
     "ViewCoordinates",
-    "ViewCoordinatesArray",
     "ViewCoordinatesArrayLike",
+    "ViewCoordinatesBatch",
     "ViewCoordinatesLike",
     "ViewCoordinatesType",
 ]

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -46,7 +46,8 @@ AnnotationContextLike = AnnotationContext
 AnnotationContextArrayLike = Union[
     AnnotationContext,
     Sequence[AnnotationContextLike],
-    datatypes.ClassDescription,
+    datatypes.ClassDescriptionLike,
+    datatypes.ClassDescriptionArrayLike,
     Sequence[datatypes.ClassDescriptionMapElemLike],
 ]
 

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .annotation_context_ext import AnnotationContextExt
 
 __all__ = [
     "AnnotationContext",
-    "AnnotationContextArray",
     "AnnotationContextArrayLike",
+    "AnnotationContextBatch",
     "AnnotationContextLike",
     "AnnotationContextType",
 ]
@@ -54,10 +51,9 @@ AnnotationContextArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AnnotationContextType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.AnnotationContext"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -135,20 +131,17 @@ class AnnotationContextType(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.components.AnnotationContext",
+            self._TYPE_NAME,
         )
 
 
-class AnnotationContextArray(BaseExtensionArray[AnnotationContextArrayLike]):
-    _EXTENSION_NAME = "rerun.components.AnnotationContext"
-    _EXTENSION_TYPE = AnnotationContextType
+class AnnotationContextBatch(BaseBatch[AnnotationContextArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AnnotationContextType()
 
     @staticmethod
     def _native_to_pa_array(data: AnnotationContextArrayLike, data_type: pa.DataType) -> pa.Array:
         return AnnotationContextExt.native_to_pa_array_override(data, data_type)
 
-
-AnnotationContextType._ARRAY_TYPE = AnnotationContextArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AnnotationContextType())

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context_ext.py
@@ -23,7 +23,7 @@ class AnnotationContextExt:
 
     @staticmethod
     def native_to_pa_array_override(data: AnnotationContextArrayLike, data_type: pa.DataType) -> pa.Array:
-        from ..datatypes import ClassDescription, ClassDescriptionMapElemArray
+        from ..datatypes import ClassDescription, ClassDescriptionMapElemBatch
         from . import AnnotationContext
 
         if isinstance(data, ClassDescription):
@@ -36,6 +36,6 @@ class AnnotationContextExt:
         if not isinstance(data, AnnotationContext):
             data = AnnotationContext(class_map=data)  # type: ignore[arg-type]
 
-        internal_array = ClassDescriptionMapElemArray.from_similar(data.class_map).storage
+        internal_array = ClassDescriptionMapElemBatch(data.class_map).as_arrow_array().storage
 
         return pa.ListArray.from_arrays(offsets=[0, len(internal_array)], values=internal_array).cast(data_type)

--- a/rerun_py/rerun_sdk/rerun/components/blob_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob_ext.py
@@ -17,11 +17,11 @@ def next_offset(acc: int, arr: Sized) -> int:
 class BlobExt:
     @staticmethod
     def native_to_pa_array_override(data: BlobArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Blob, BlobArray
+        from . import Blob, BlobBatch
 
         # someone or something is building things manually, let them!
-        if isinstance(data, BlobArray):
-            return data.storage
+        if isinstance(data, BlobBatch):
+            return data.as_arrow_array().storage
 
         # pure-numpy fast path
         elif isinstance(data, np.ndarray):

--- a/rerun_py/rerun_sdk/rerun/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/class_id.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["ClassId", "ClassIdArray", "ClassIdType"]
+__all__ = ["ClassId", "ClassIdBatch", "ClassIdType"]
 
 
 class ClassId(datatypes.ClassId):
@@ -23,18 +20,13 @@ class ClassId(datatypes.ClassId):
     pass
 
 
-class ClassIdType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.ClassId"
-    _DELEGATED_EXTENSION_TYPE = datatypes.ClassIdType
+class ClassIdType(datatypes.ClassIdType):
+    _TYPE_NAME: str = "rerun.components.ClassId"
 
 
-class ClassIdArray(BaseDelegatingExtensionArray[datatypes.ClassIdArrayLike]):
-    _EXTENSION_NAME = "rerun.components.ClassId"
-    _EXTENSION_TYPE = ClassIdType
-    _DELEGATED_ARRAY_TYPE = datatypes.ClassIdArray
+class ClassIdBatch(datatypes.ClassIdBatch, ComponentBatchMixin):
+    _ARROW_TYPE = ClassIdType()
 
-
-ClassIdType._ARRAY_TYPE = ClassIdArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ClassIdType())

--- a/rerun_py/rerun_sdk/rerun/components/clear_settings.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_settings.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .clear_settings_ext import ClearSettingsExt
 
-__all__ = ["ClearSettings", "ClearSettingsArray", "ClearSettingsArrayLike", "ClearSettingsLike", "ClearSettingsType"]
+__all__ = ["ClearSettings", "ClearSettingsArrayLike", "ClearSettingsBatch", "ClearSettingsLike", "ClearSettingsType"]
 
 
 @define
@@ -41,24 +38,20 @@ else:
 ClearSettingsArrayLike = Union[ClearSettings, Sequence[ClearSettingsLike], bool, npt.NDArray[np.bool_]]
 
 
-# --- Arrow support ---
-
-
 class ClearSettingsType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.ClearSettings"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.bool_(), "rerun.components.ClearSettings")
+        pa.ExtensionType.__init__(self, pa.bool_(), self._TYPE_NAME)
 
 
-class ClearSettingsArray(BaseExtensionArray[ClearSettingsArrayLike]):
-    _EXTENSION_NAME = "rerun.components.ClearSettings"
-    _EXTENSION_TYPE = ClearSettingsType
+class ClearSettingsBatch(BaseBatch[ClearSettingsArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = ClearSettingsType()
 
     @staticmethod
     def _native_to_pa_array(data: ClearSettingsArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClearSettingsExt.native_to_pa_array_override(data, data_type)
 
-
-ClearSettingsType._ARRAY_TYPE = ClearSettingsArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ClearSettingsType())

--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Color", "ColorArray", "ColorType"]
+__all__ = ["Color", "ColorBatch", "ColorType"]
 
 
 class Color(datatypes.Color):
@@ -32,18 +29,13 @@ class Color(datatypes.Color):
     pass
 
 
-class ColorType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Color"
-    _DELEGATED_EXTENSION_TYPE = datatypes.ColorType
+class ColorType(datatypes.ColorType):
+    _TYPE_NAME: str = "rerun.components.Color"
 
 
-class ColorArray(BaseDelegatingExtensionArray[datatypes.ColorArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Color"
-    _EXTENSION_TYPE = ColorType
-    _DELEGATED_ARRAY_TYPE = datatypes.ColorArray
+class ColorBatch(datatypes.ColorBatch, ComponentBatchMixin):
+    _ARROW_TYPE = ColorType()
 
-
-ColorType._ARRAY_TYPE = ColorArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ColorType())

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .depth_meter_ext import DepthMeterExt
 
-__all__ = ["DepthMeter", "DepthMeterArray", "DepthMeterArrayLike", "DepthMeterLike", "DepthMeterType"]
+__all__ = ["DepthMeter", "DepthMeterArrayLike", "DepthMeterBatch", "DepthMeterLike", "DepthMeterType"]
 
 
 @define
@@ -45,24 +42,20 @@ else:
 DepthMeterArrayLike = Union[DepthMeter, Sequence[DepthMeterLike], float, npt.NDArray[np.float32]]
 
 
-# --- Arrow support ---
-
-
 class DepthMeterType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.DepthMeter"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), "rerun.components.DepthMeter")
+        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
 
 
-class DepthMeterArray(BaseExtensionArray[DepthMeterArrayLike]):
-    _EXTENSION_NAME = "rerun.components.DepthMeter"
-    _EXTENSION_TYPE = DepthMeterType
+class DepthMeterBatch(BaseBatch[DepthMeterArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = DepthMeterType()
 
     @staticmethod
     def _native_to_pa_array(data: DepthMeterArrayLike, data_type: pa.DataType) -> pa.Array:
         return DepthMeterExt.native_to_pa_array_override(data, data_type)
 
-
-DepthMeterType._ARRAY_TYPE = DepthMeterArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(DepthMeterType())

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .disconnected_space_ext import DisconnectedSpaceExt
 
 __all__ = [
     "DisconnectedSpace",
-    "DisconnectedSpaceArray",
     "DisconnectedSpaceArrayLike",
+    "DisconnectedSpaceBatch",
     "DisconnectedSpaceLike",
     "DisconnectedSpaceType",
 ]
@@ -50,24 +47,20 @@ else:
 DisconnectedSpaceArrayLike = Union[DisconnectedSpace, Sequence[DisconnectedSpaceLike], bool, npt.NDArray[np.bool_]]
 
 
-# --- Arrow support ---
-
-
 class DisconnectedSpaceType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.DisconnectedSpace"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.bool_(), "rerun.components.DisconnectedSpace")
+        pa.ExtensionType.__init__(self, pa.bool_(), self._TYPE_NAME)
 
 
-class DisconnectedSpaceArray(BaseExtensionArray[DisconnectedSpaceArrayLike]):
-    _EXTENSION_NAME = "rerun.components.DisconnectedSpace"
-    _EXTENSION_TYPE = DisconnectedSpaceType
+class DisconnectedSpaceBatch(BaseBatch[DisconnectedSpaceArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = DisconnectedSpaceType()
 
     @staticmethod
     def _native_to_pa_array(data: DisconnectedSpaceArrayLike, data_type: pa.DataType) -> pa.Array:
         return DisconnectedSpaceExt.native_to_pa_array_override(data, data_type)
 
-
-DisconnectedSpaceType._ARRAY_TYPE = DisconnectedSpaceArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(DisconnectedSpaceType())

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .draw_order_ext import DrawOrderExt
 
-__all__ = ["DrawOrder", "DrawOrderArray", "DrawOrderArrayLike", "DrawOrderLike", "DrawOrderType"]
+__all__ = ["DrawOrder", "DrawOrderArrayLike", "DrawOrderBatch", "DrawOrderLike", "DrawOrderType"]
 
 
 @define
@@ -53,24 +50,20 @@ else:
 DrawOrderArrayLike = Union[DrawOrder, Sequence[DrawOrderLike], float, npt.NDArray[np.float32]]
 
 
-# --- Arrow support ---
-
-
 class DrawOrderType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.DrawOrder"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), "rerun.components.DrawOrder")
+        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
 
 
-class DrawOrderArray(BaseExtensionArray[DrawOrderArrayLike]):
-    _EXTENSION_NAME = "rerun.components.DrawOrder"
-    _EXTENSION_TYPE = DrawOrderType
+class DrawOrderBatch(BaseBatch[DrawOrderArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = DrawOrderType()
 
     @staticmethod
     def _native_to_pa_array(data: DrawOrderArrayLike, data_type: pa.DataType) -> pa.Array:
         return DrawOrderExt.native_to_pa_array_override(data, data_type)
 
-
-DrawOrderType._ARRAY_TYPE = DrawOrderArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(DrawOrderType())

--- a/rerun_py/rerun_sdk/rerun/components/half_sizes2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_sizes2d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["HalfSizes2D", "HalfSizes2DArray", "HalfSizes2DType"]
+__all__ = ["HalfSizes2D", "HalfSizes2DBatch", "HalfSizes2DType"]
 
 
 class HalfSizes2D(datatypes.Vec2D):
@@ -28,18 +25,13 @@ class HalfSizes2D(datatypes.Vec2D):
     pass
 
 
-class HalfSizes2DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.HalfSizes2D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec2DType
+class HalfSizes2DType(datatypes.Vec2DType):
+    _TYPE_NAME: str = "rerun.components.HalfSizes2D"
 
 
-class HalfSizes2DArray(BaseDelegatingExtensionArray[datatypes.Vec2DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.HalfSizes2D"
-    _EXTENSION_TYPE = HalfSizes2DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec2DArray
+class HalfSizes2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = HalfSizes2DType()
 
-
-HalfSizes2DType._ARRAY_TYPE = HalfSizes2DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(HalfSizes2DType())

--- a/rerun_py/rerun_sdk/rerun/components/half_sizes3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_sizes3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["HalfSizes3D", "HalfSizes3DArray", "HalfSizes3DType"]
+__all__ = ["HalfSizes3D", "HalfSizes3DBatch", "HalfSizes3DType"]
 
 
 class HalfSizes3D(datatypes.Vec3D):
@@ -28,18 +25,13 @@ class HalfSizes3D(datatypes.Vec3D):
     pass
 
 
-class HalfSizes3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.HalfSizes3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec3DType
+class HalfSizes3DType(datatypes.Vec3DType):
+    _TYPE_NAME: str = "rerun.components.HalfSizes3D"
 
 
-class HalfSizes3DArray(BaseDelegatingExtensionArray[datatypes.Vec3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.HalfSizes3D"
-    _EXTENSION_TYPE = HalfSizes3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec3DArray
+class HalfSizes3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = HalfSizes3DType()
 
-
-HalfSizes3DType._ARRAY_TYPE = HalfSizes3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(HalfSizes3DType())

--- a/rerun_py/rerun_sdk/rerun/components/instance_key.py
+++ b/rerun_py/rerun_sdk/rerun/components/instance_key.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .instance_key_ext import InstanceKeyExt
 
-__all__ = ["InstanceKey", "InstanceKeyArray", "InstanceKeyArrayLike", "InstanceKeyLike", "InstanceKeyType"]
+__all__ = ["InstanceKey", "InstanceKeyArrayLike", "InstanceKeyBatch", "InstanceKeyLike", "InstanceKeyType"]
 
 
 @define
@@ -45,24 +42,20 @@ else:
 InstanceKeyArrayLike = Union[InstanceKey, Sequence[InstanceKeyLike], int, npt.NDArray[np.uint64]]
 
 
-# --- Arrow support ---
-
-
 class InstanceKeyType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.InstanceKey"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint64(), "rerun.components.InstanceKey")
+        pa.ExtensionType.__init__(self, pa.uint64(), self._TYPE_NAME)
 
 
-class InstanceKeyArray(BaseExtensionArray[InstanceKeyArrayLike]):
-    _EXTENSION_NAME = "rerun.components.InstanceKey"
-    _EXTENSION_TYPE = InstanceKeyType
+class InstanceKeyBatch(BaseBatch[InstanceKeyArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = InstanceKeyType()
 
     @staticmethod
     def _native_to_pa_array(data: InstanceKeyArrayLike, data_type: pa.DataType) -> pa.Array:
         return InstanceKeyExt.native_to_pa_array_override(data, data_type)
 
-
-InstanceKeyType._ARRAY_TYPE = InstanceKeyArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(InstanceKeyType())

--- a/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["KeypointId", "KeypointIdArray", "KeypointIdType"]
+__all__ = ["KeypointId", "KeypointIdBatch", "KeypointIdType"]
 
 
 class KeypointId(datatypes.KeypointId):
@@ -30,18 +27,13 @@ class KeypointId(datatypes.KeypointId):
     pass
 
 
-class KeypointIdType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.KeypointId"
-    _DELEGATED_EXTENSION_TYPE = datatypes.KeypointIdType
+class KeypointIdType(datatypes.KeypointIdType):
+    _TYPE_NAME: str = "rerun.components.KeypointId"
 
 
-class KeypointIdArray(BaseDelegatingExtensionArray[datatypes.KeypointIdArrayLike]):
-    _EXTENSION_NAME = "rerun.components.KeypointId"
-    _EXTENSION_TYPE = KeypointIdType
-    _DELEGATED_ARRAY_TYPE = datatypes.KeypointIdArray
+class KeypointIdBatch(datatypes.KeypointIdBatch, ComponentBatchMixin):
+    _ARROW_TYPE = KeypointIdType()
 
-
-KeypointIdType._ARRAY_TYPE = KeypointIdArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(KeypointIdType())

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -13,13 +13,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .line_strip2d_ext import LineStrip2DExt
 
-__all__ = ["LineStrip2D", "LineStrip2DArray", "LineStrip2DArrayLike", "LineStrip2DLike", "LineStrip2DType"]
+__all__ = ["LineStrip2D", "LineStrip2DArrayLike", "LineStrip2DBatch", "LineStrip2DLike", "LineStrip2DType"]
 
 
 @define
@@ -52,10 +49,9 @@ else:
 LineStrip2DArrayLike = Union[LineStrip2D, Sequence[LineStrip2DLike], npt.NDArray[np.float32]]
 
 
-# --- Arrow support ---
-
-
 class LineStrip2DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.LineStrip2D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -67,20 +63,17 @@ class LineStrip2DType(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.components.LineStrip2D",
+            self._TYPE_NAME,
         )
 
 
-class LineStrip2DArray(BaseExtensionArray[LineStrip2DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.LineStrip2D"
-    _EXTENSION_TYPE = LineStrip2DType
+class LineStrip2DBatch(BaseBatch[LineStrip2DArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = LineStrip2DType()
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip2DArrayLike, data_type: pa.DataType) -> pa.Array:
         return LineStrip2DExt.native_to_pa_array_override(data, data_type)
 
-
-LineStrip2DType._ARRAY_TYPE = LineStrip2DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(LineStrip2DType())

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -13,13 +13,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .line_strip3d_ext import LineStrip3DExt
 
-__all__ = ["LineStrip3D", "LineStrip3DArray", "LineStrip3DArrayLike", "LineStrip3DLike", "LineStrip3DType"]
+__all__ = ["LineStrip3D", "LineStrip3DArrayLike", "LineStrip3DBatch", "LineStrip3DLike", "LineStrip3DType"]
 
 
 @define
@@ -52,10 +49,9 @@ else:
 LineStrip3DArrayLike = Union[LineStrip3D, Sequence[LineStrip3DLike], npt.NDArray[np.float32]]
 
 
-# --- Arrow support ---
-
-
 class LineStrip3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.LineStrip3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -67,20 +63,17 @@ class LineStrip3DType(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.components.LineStrip3D",
+            self._TYPE_NAME,
         )
 
 
-class LineStrip3DArray(BaseExtensionArray[LineStrip3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.LineStrip3D"
-    _EXTENSION_TYPE = LineStrip3DType
+class LineStrip3DBatch(BaseBatch[LineStrip3DArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = LineStrip3DType()
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return LineStrip3DExt.native_to_pa_array_override(data, data_type)
 
-
-LineStrip3DType._ARRAY_TYPE = LineStrip3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(LineStrip3DType())

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d_ext.py
@@ -17,7 +17,7 @@ def next_offset(acc: int, arr: Sized) -> int:
 class LineStrip3DExt:
     @staticmethod
     def native_to_pa_array_override(data: LineStrip3DArrayLike, data_type: pa.DataType) -> pa.Array:
-        from ..datatypes import Vec3DArray
+        from ..datatypes import Vec3DBatch
         from . import LineStrip3D
 
         # pure-numpy fast path
@@ -25,34 +25,34 @@ class LineStrip3DExt:
             if len(data) == 0:
                 inners = []
             elif data.ndim == 2:
-                inners = [Vec3DArray.from_similar(data).storage]
+                inners = [Vec3DBatch(data).as_arrow_array().as_arrow_array().storage]
             else:
                 o = 0
                 offsets = [o] + [o := next_offset(o, arr) for arr in data]
-                inner = Vec3DArray.from_similar(data.reshape(-1)).storage
+                inner = Vec3DBatch(data.reshape(-1)).as_arrow_array().storage
                 return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         # pure-object
         elif isinstance(data, LineStrip3D):
-            inners = [Vec3DArray.from_similar(data.points).storage]
+            inners = [Vec3DBatch(data.points).as_arrow_array().storage]
 
         # sequences
         elif isinstance(data, Sequence):
             if len(data) == 0:
                 inners = []
-            elif isinstance(data, np.ndarray):
-                inners = [Vec3DArray.from_similar(datum).storage for datum in data]
+            elif isinstance(data[0], np.ndarray):
+                inners = [Vec3DBatch(datum).as_arrow_array().storage for datum in data]  # type: ignore[arg-type]
             elif isinstance(data[0], LineStrip3D):
-                inners = [Vec3DArray.from_similar(datum.points).storage for datum in data]  # type: ignore[union-attr]
+                inners = [Vec3DBatch(datum.points).as_arrow_array().storage for datum in data]  # type: ignore[union-attr]
             else:
-                inners = [Vec3DArray.from_similar(datum).storage for datum in data]  # type: ignore[arg-type]
+                inners = [Vec3DBatch(datum).as_arrow_array().storage for datum in data]  # type: ignore[arg-type]
 
         else:
-            inners = [Vec3DArray.from_similar(data).storage]
+            inners = [Vec3DBatch(data).as_arrow_array().storage]
 
         if len(inners) == 0:
             offsets = pa.array([0], type=pa.int32())
-            inner = Vec3DArray.from_similar([]).storage
+            inner = Vec3DBatch([]).as_arrow_array().storage
             return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         o = 0

--- a/rerun_py/rerun_sdk/rerun/components/material.py
+++ b/rerun_py/rerun_sdk/rerun/components/material.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Material", "MaterialArray", "MaterialType"]
+__all__ = ["Material", "MaterialBatch", "MaterialType"]
 
 
 class Material(datatypes.Material):
@@ -21,18 +18,13 @@ class Material(datatypes.Material):
     pass
 
 
-class MaterialType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Material"
-    _DELEGATED_EXTENSION_TYPE = datatypes.MaterialType
+class MaterialType(datatypes.MaterialType):
+    _TYPE_NAME: str = "rerun.components.Material"
 
 
-class MaterialArray(BaseDelegatingExtensionArray[datatypes.MaterialArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Material"
-    _EXTENSION_TYPE = MaterialType
-    _DELEGATED_ARRAY_TYPE = datatypes.MaterialArray
+class MaterialBatch(datatypes.MaterialBatch, ComponentBatchMixin):
+    _ARROW_TYPE = MaterialType()
 
-
-MaterialType._ARRAY_TYPE = MaterialArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(MaterialType())

--- a/rerun_py/rerun_sdk/rerun/components/media_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type.py
@@ -6,13 +6,10 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 from .media_type_ext import MediaTypeExt
 
-__all__ = ["MediaType", "MediaTypeArray", "MediaTypeType"]
+__all__ = ["MediaType", "MediaTypeBatch", "MediaTypeType"]
 
 
 class MediaType(MediaTypeExt, datatypes.Utf8):
@@ -29,18 +26,13 @@ class MediaType(MediaTypeExt, datatypes.Utf8):
     pass
 
 
-class MediaTypeType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.MediaType"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Utf8Type
+class MediaTypeType(datatypes.Utf8Type):
+    _TYPE_NAME: str = "rerun.components.MediaType"
 
 
-class MediaTypeArray(BaseDelegatingExtensionArray[datatypes.Utf8ArrayLike]):
-    _EXTENSION_NAME = "rerun.components.MediaType"
-    _EXTENSION_TYPE = MediaTypeType
-    _DELEGATED_ARRAY_TYPE = datatypes.Utf8Array
+class MediaTypeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
+    _ARROW_TYPE = MediaTypeType()
 
-
-MediaTypeType._ARRAY_TYPE = MediaTypeArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(MediaTypeType())

--- a/rerun_py/rerun_sdk/rerun/components/mesh_properties.py
+++ b/rerun_py/rerun_sdk/rerun/components/mesh_properties.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["MeshProperties", "MeshPropertiesArray", "MeshPropertiesType"]
+__all__ = ["MeshProperties", "MeshPropertiesBatch", "MeshPropertiesType"]
 
 
 class MeshProperties(datatypes.MeshProperties):
@@ -21,18 +18,13 @@ class MeshProperties(datatypes.MeshProperties):
     pass
 
 
-class MeshPropertiesType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.MeshProperties"
-    _DELEGATED_EXTENSION_TYPE = datatypes.MeshPropertiesType
+class MeshPropertiesType(datatypes.MeshPropertiesType):
+    _TYPE_NAME: str = "rerun.components.MeshProperties"
 
 
-class MeshPropertiesArray(BaseDelegatingExtensionArray[datatypes.MeshPropertiesArrayLike]):
-    _EXTENSION_NAME = "rerun.components.MeshProperties"
-    _EXTENSION_TYPE = MeshPropertiesType
-    _DELEGATED_ARRAY_TYPE = datatypes.MeshPropertiesArray
+class MeshPropertiesBatch(datatypes.MeshPropertiesBatch, ComponentBatchMixin):
+    _ARROW_TYPE = MeshPropertiesType()
 
-
-MeshPropertiesType._ARRAY_TYPE = MeshPropertiesArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(MeshPropertiesType())

--- a/rerun_py/rerun_sdk/rerun/components/origin2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/origin2d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Origin2D", "Origin2DArray", "Origin2DType"]
+__all__ = ["Origin2D", "Origin2DBatch", "Origin2DType"]
 
 
 class Origin2D(datatypes.Vec2D):
@@ -23,18 +20,13 @@ class Origin2D(datatypes.Vec2D):
     pass
 
 
-class Origin2DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Origin2D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec2DType
+class Origin2DType(datatypes.Vec2DType):
+    _TYPE_NAME: str = "rerun.components.Origin2D"
 
 
-class Origin2DArray(BaseDelegatingExtensionArray[datatypes.Vec2DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Origin2D"
-    _EXTENSION_TYPE = Origin2DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec2DArray
+class Origin2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Origin2DType()
 
-
-Origin2DType._ARRAY_TYPE = Origin2DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Origin2DType())

--- a/rerun_py/rerun_sdk/rerun/components/origin3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/origin3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Origin3D", "Origin3DArray", "Origin3DType"]
+__all__ = ["Origin3D", "Origin3DBatch", "Origin3DType"]
 
 
 class Origin3D(datatypes.Vec3D):
@@ -23,18 +20,13 @@ class Origin3D(datatypes.Vec3D):
     pass
 
 
-class Origin3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Origin3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec3DType
+class Origin3DType(datatypes.Vec3DType):
+    _TYPE_NAME: str = "rerun.components.Origin3D"
 
 
-class Origin3DArray(BaseDelegatingExtensionArray[datatypes.Vec3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Origin3D"
-    _EXTENSION_TYPE = Origin3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec3DArray
+class Origin3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Origin3DType()
 
-
-Origin3DType._ARRAY_TYPE = Origin3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Origin3DType())

--- a/rerun_py/rerun_sdk/rerun/components/out_of_tree_transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/out_of_tree_transform3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["OutOfTreeTransform3D", "OutOfTreeTransform3DArray", "OutOfTreeTransform3DType"]
+__all__ = ["OutOfTreeTransform3D", "OutOfTreeTransform3DBatch", "OutOfTreeTransform3DType"]
 
 
 class OutOfTreeTransform3D(datatypes.Transform3D):
@@ -27,18 +24,13 @@ class OutOfTreeTransform3D(datatypes.Transform3D):
     pass
 
 
-class OutOfTreeTransform3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.OutOfTreeTransform3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Transform3DType
+class OutOfTreeTransform3DType(datatypes.Transform3DType):
+    _TYPE_NAME: str = "rerun.components.OutOfTreeTransform3D"
 
 
-class OutOfTreeTransform3DArray(BaseDelegatingExtensionArray[datatypes.Transform3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.OutOfTreeTransform3D"
-    _EXTENSION_TYPE = OutOfTreeTransform3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Transform3DArray
+class OutOfTreeTransform3DBatch(datatypes.Transform3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = OutOfTreeTransform3DType()
 
-
-OutOfTreeTransform3DType._ARRAY_TYPE = OutOfTreeTransform3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(OutOfTreeTransform3DType())

--- a/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
+++ b/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["PinholeProjection", "PinholeProjectionArray", "PinholeProjectionType"]
+__all__ = ["PinholeProjection", "PinholeProjectionBatch", "PinholeProjectionType"]
 
 
 class PinholeProjection(datatypes.Mat3x3):
@@ -36,18 +33,13 @@ class PinholeProjection(datatypes.Mat3x3):
     pass
 
 
-class PinholeProjectionType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.PinholeProjection"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Mat3x3Type
+class PinholeProjectionType(datatypes.Mat3x3Type):
+    _TYPE_NAME: str = "rerun.components.PinholeProjection"
 
 
-class PinholeProjectionArray(BaseDelegatingExtensionArray[datatypes.Mat3x3ArrayLike]):
-    _EXTENSION_NAME = "rerun.components.PinholeProjection"
-    _EXTENSION_TYPE = PinholeProjectionType
-    _DELEGATED_ARRAY_TYPE = datatypes.Mat3x3Array
+class PinholeProjectionBatch(datatypes.Mat3x3Batch, ComponentBatchMixin):
+    _ARROW_TYPE = PinholeProjectionType()
 
-
-PinholeProjectionType._ARRAY_TYPE = PinholeProjectionArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(PinholeProjectionType())

--- a/rerun_py/rerun_sdk/rerun/components/position2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position2d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Position2D", "Position2DArray", "Position2DType"]
+__all__ = ["Position2D", "Position2DBatch", "Position2DType"]
 
 
 class Position2D(datatypes.Vec2D):
@@ -23,18 +20,13 @@ class Position2D(datatypes.Vec2D):
     pass
 
 
-class Position2DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Position2D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec2DType
+class Position2DType(datatypes.Vec2DType):
+    _TYPE_NAME: str = "rerun.components.Position2D"
 
 
-class Position2DArray(BaseDelegatingExtensionArray[datatypes.Vec2DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Position2D"
-    _EXTENSION_TYPE = Position2DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec2DArray
+class Position2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Position2DType()
 
-
-Position2DType._ARRAY_TYPE = Position2DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Position2DType())

--- a/rerun_py/rerun_sdk/rerun/components/position3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Position3D", "Position3DArray", "Position3DType"]
+__all__ = ["Position3D", "Position3DBatch", "Position3DType"]
 
 
 class Position3D(datatypes.Vec3D):
@@ -23,18 +20,13 @@ class Position3D(datatypes.Vec3D):
     pass
 
 
-class Position3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Position3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec3DType
+class Position3DType(datatypes.Vec3DType):
+    _TYPE_NAME: str = "rerun.components.Position3D"
 
 
-class Position3DArray(BaseDelegatingExtensionArray[datatypes.Vec3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Position3D"
-    _EXTENSION_TYPE = Position3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec3DArray
+class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Position3DType()
 
-
-Position3DType._ARRAY_TYPE = Position3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Position3DType())

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .radius_ext import RadiusExt
 
-__all__ = ["Radius", "RadiusArray", "RadiusArrayLike", "RadiusLike", "RadiusType"]
+__all__ = ["Radius", "RadiusArrayLike", "RadiusBatch", "RadiusLike", "RadiusType"]
 
 
 @define
@@ -45,24 +42,20 @@ else:
 RadiusArrayLike = Union[Radius, Sequence[RadiusLike], float, npt.NDArray[np.float32]]
 
 
-# --- Arrow support ---
-
-
 class RadiusType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.Radius"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), "rerun.components.Radius")
+        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
 
 
-class RadiusArray(BaseExtensionArray[RadiusArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Radius"
-    _EXTENSION_TYPE = RadiusType
+class RadiusBatch(BaseBatch[RadiusArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = RadiusType()
 
     @staticmethod
     def _native_to_pa_array(data: RadiusArrayLike, data_type: pa.DataType) -> pa.Array:
         return RadiusExt.native_to_pa_array_override(data, data_type)
 
-
-RadiusType._ARRAY_TYPE = RadiusArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(RadiusType())

--- a/rerun_py/rerun_sdk/rerun/components/resolution.py
+++ b/rerun_py/rerun_sdk/rerun/components/resolution.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Resolution", "ResolutionArray", "ResolutionType"]
+__all__ = ["Resolution", "ResolutionBatch", "ResolutionType"]
 
 
 class Resolution(datatypes.Vec2D):
@@ -27,18 +24,13 @@ class Resolution(datatypes.Vec2D):
     pass
 
 
-class ResolutionType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Resolution"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec2DType
+class ResolutionType(datatypes.Vec2DType):
+    _TYPE_NAME: str = "rerun.components.Resolution"
 
 
-class ResolutionArray(BaseDelegatingExtensionArray[datatypes.Vec2DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Resolution"
-    _EXTENSION_TYPE = ResolutionType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec2DArray
+class ResolutionBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = ResolutionType()
 
-
-ResolutionType._ARRAY_TYPE = ResolutionArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ResolutionType())

--- a/rerun_py/rerun_sdk/rerun/components/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Rotation3D", "Rotation3DArray", "Rotation3DType"]
+__all__ = ["Rotation3D", "Rotation3DBatch", "Rotation3DType"]
 
 
 class Rotation3D(datatypes.Rotation3D):
@@ -23,18 +20,13 @@ class Rotation3D(datatypes.Rotation3D):
     pass
 
 
-class Rotation3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Rotation3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Rotation3DType
+class Rotation3DType(datatypes.Rotation3DType):
+    _TYPE_NAME: str = "rerun.components.Rotation3D"
 
 
-class Rotation3DArray(BaseDelegatingExtensionArray[datatypes.Rotation3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Rotation3D"
-    _EXTENSION_TYPE = Rotation3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Rotation3DArray
+class Rotation3DBatch(datatypes.Rotation3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Rotation3DType()
 
-
-Rotation3DType._ARRAY_TYPE = Rotation3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Rotation3DType())

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .scalar_ext import ScalarExt
 
-__all__ = ["Scalar", "ScalarArray", "ScalarArrayLike", "ScalarLike", "ScalarType"]
+__all__ = ["Scalar", "ScalarArrayLike", "ScalarBatch", "ScalarLike", "ScalarType"]
 
 
 @define
@@ -49,24 +46,20 @@ else:
 ScalarArrayLike = Union[Scalar, Sequence[ScalarLike], float, npt.NDArray[np.float64]]
 
 
-# --- Arrow support ---
-
-
 class ScalarType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.Scalar"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float64(), "rerun.components.Scalar")
+        pa.ExtensionType.__init__(self, pa.float64(), self._TYPE_NAME)
 
 
-class ScalarArray(BaseExtensionArray[ScalarArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Scalar"
-    _EXTENSION_TYPE = ScalarType
+class ScalarBatch(BaseBatch[ScalarArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = ScalarType()
 
     @staticmethod
     def _native_to_pa_array(data: ScalarArrayLike, data_type: pa.DataType) -> pa.Array:
         return ScalarExt.native_to_pa_array_override(data, data_type)
 
-
-ScalarType._ARRAY_TYPE = ScalarArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ScalarType())

--- a/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .scalar_scattering_ext import ScalarScatteringExt
 
 __all__ = [
     "ScalarScattering",
-    "ScalarScatteringArray",
     "ScalarScatteringArrayLike",
+    "ScalarScatteringBatch",
     "ScalarScatteringLike",
     "ScalarScatteringType",
 ]
@@ -44,24 +41,20 @@ else:
 ScalarScatteringArrayLike = Union[ScalarScattering, Sequence[ScalarScatteringLike], bool, npt.NDArray[np.bool_]]
 
 
-# --- Arrow support ---
-
-
 class ScalarScatteringType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.ScalarScattering"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.bool_(), "rerun.components.ScalarScattering")
+        pa.ExtensionType.__init__(self, pa.bool_(), self._TYPE_NAME)
 
 
-class ScalarScatteringArray(BaseExtensionArray[ScalarScatteringArrayLike]):
-    _EXTENSION_NAME = "rerun.components.ScalarScattering"
-    _EXTENSION_TYPE = ScalarScatteringType
+class ScalarScatteringBatch(BaseBatch[ScalarScatteringArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = ScalarScatteringType()
 
     @staticmethod
     def _native_to_pa_array(data: ScalarScatteringArrayLike, data_type: pa.DataType) -> pa.Array:
         return ScalarScatteringExt.native_to_pa_array_override(data, data_type)
 
-
-ScalarScatteringType._ARRAY_TYPE = ScalarScatteringArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ScalarScatteringType())

--- a/rerun_py/rerun_sdk/rerun/components/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_data.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["TensorData", "TensorDataArray", "TensorDataType"]
+__all__ = ["TensorData", "TensorDataBatch", "TensorDataType"]
 
 
 class TensorData(datatypes.TensorData):
@@ -21,18 +18,13 @@ class TensorData(datatypes.TensorData):
     pass
 
 
-class TensorDataType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.TensorData"
-    _DELEGATED_EXTENSION_TYPE = datatypes.TensorDataType
+class TensorDataType(datatypes.TensorDataType):
+    _TYPE_NAME: str = "rerun.components.TensorData"
 
 
-class TensorDataArray(BaseDelegatingExtensionArray[datatypes.TensorDataArrayLike]):
-    _EXTENSION_NAME = "rerun.components.TensorData"
-    _EXTENSION_TYPE = TensorDataType
-    _DELEGATED_ARRAY_TYPE = datatypes.TensorDataArray
+class TensorDataBatch(datatypes.TensorDataBatch, ComponentBatchMixin):
+    _ARROW_TYPE = TensorDataType()
 
-
-TensorDataType._ARRAY_TYPE = TensorDataArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TensorDataType())

--- a/rerun_py/rerun_sdk/rerun/components/text.py
+++ b/rerun_py/rerun_sdk/rerun/components/text.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Text", "TextArray", "TextType"]
+__all__ = ["Text", "TextBatch", "TextType"]
 
 
 class Text(datatypes.Utf8):
@@ -23,18 +20,13 @@ class Text(datatypes.Utf8):
     pass
 
 
-class TextType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Text"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Utf8Type
+class TextType(datatypes.Utf8Type):
+    _TYPE_NAME: str = "rerun.components.Text"
 
 
-class TextArray(BaseDelegatingExtensionArray[datatypes.Utf8ArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Text"
-    _EXTENSION_TYPE = TextType
-    _DELEGATED_ARRAY_TYPE = datatypes.Utf8Array
+class TextBatch(datatypes.Utf8Batch, ComponentBatchMixin):
+    _ARROW_TYPE = TextType()
 
-
-TextType._ARRAY_TYPE = TextArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TextType())

--- a/rerun_py/rerun_sdk/rerun/components/text_log_level.py
+++ b/rerun_py/rerun_sdk/rerun/components/text_log_level.py
@@ -6,13 +6,10 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 from .text_log_level_ext import TextLogLevelExt
 
-__all__ = ["TextLogLevel", "TextLogLevelArray", "TextLogLevelType"]
+__all__ = ["TextLogLevel", "TextLogLevelBatch", "TextLogLevelType"]
 
 
 class TextLogLevel(TextLogLevelExt, datatypes.Utf8):
@@ -34,18 +31,13 @@ class TextLogLevel(TextLogLevelExt, datatypes.Utf8):
     pass
 
 
-class TextLogLevelType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.TextLogLevel"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Utf8Type
+class TextLogLevelType(datatypes.Utf8Type):
+    _TYPE_NAME: str = "rerun.components.TextLogLevel"
 
 
-class TextLogLevelArray(BaseDelegatingExtensionArray[datatypes.Utf8ArrayLike]):
-    _EXTENSION_NAME = "rerun.components.TextLogLevel"
-    _EXTENSION_TYPE = TextLogLevelType
-    _DELEGATED_ARRAY_TYPE = datatypes.Utf8Array
+class TextLogLevelBatch(datatypes.Utf8Batch, ComponentBatchMixin):
+    _ARROW_TYPE = TextLogLevelType()
 
-
-TextLogLevelType._ARRAY_TYPE = TextLogLevelArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TextLogLevelType())

--- a/rerun_py/rerun_sdk/rerun/components/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Transform3D", "Transform3DArray", "Transform3DType"]
+__all__ = ["Transform3D", "Transform3DBatch", "Transform3DType"]
 
 
 class Transform3D(datatypes.Transform3D):
@@ -23,18 +20,13 @@ class Transform3D(datatypes.Transform3D):
     pass
 
 
-class Transform3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Transform3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Transform3DType
+class Transform3DType(datatypes.Transform3DType):
+    _TYPE_NAME: str = "rerun.components.Transform3D"
 
 
-class Transform3DArray(BaseDelegatingExtensionArray[datatypes.Transform3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Transform3D"
-    _EXTENSION_TYPE = Transform3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Transform3DArray
+class Transform3DBatch(datatypes.Transform3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Transform3DType()
 
-
-Transform3DType._ARRAY_TYPE = Transform3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Transform3DType())

--- a/rerun_py/rerun_sdk/rerun/components/vector3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector3d.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from .._baseclasses import ComponentBatchMixin
 
-__all__ = ["Vector3D", "Vector3DArray", "Vector3DType"]
+__all__ = ["Vector3D", "Vector3DBatch", "Vector3DType"]
 
 
 class Vector3D(datatypes.Vec3D):
@@ -23,18 +20,13 @@ class Vector3D(datatypes.Vec3D):
     pass
 
 
-class Vector3DType(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.components.Vector3D"
-    _DELEGATED_EXTENSION_TYPE = datatypes.Vec3DType
+class Vector3DType(datatypes.Vec3DType):
+    _TYPE_NAME: str = "rerun.components.Vector3D"
 
 
-class Vector3DArray(BaseDelegatingExtensionArray[datatypes.Vec3DArrayLike]):
-    _EXTENSION_NAME = "rerun.components.Vector3D"
-    _EXTENSION_TYPE = Vector3DType
-    _DELEGATED_ARRAY_TYPE = datatypes.Vec3DArray
+class Vector3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
+    _ARROW_TYPE = Vector3DType()
 
-
-Vector3DType._ARRAY_TYPE = Vector3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Vector3DType())

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from .view_coordinates_ext import ViewCoordinatesExt
 
 __all__ = [
     "ViewCoordinates",
-    "ViewCoordinatesArray",
     "ViewCoordinatesArrayLike",
+    "ViewCoordinatesBatch",
     "ViewCoordinatesLike",
     "ViewCoordinatesType",
 ]
@@ -70,28 +67,22 @@ else:
 ViewCoordinatesArrayLike = Union[ViewCoordinates, Sequence[ViewCoordinatesLike], npt.ArrayLike]
 
 
-# --- Arrow support ---
-
-
 class ViewCoordinatesType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.components.ViewCoordinates"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self,
-            pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 3),
-            "rerun.components.ViewCoordinates",
+            self, pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 3), self._TYPE_NAME
         )
 
 
-class ViewCoordinatesArray(BaseExtensionArray[ViewCoordinatesArrayLike]):
-    _EXTENSION_NAME = "rerun.components.ViewCoordinates"
-    _EXTENSION_TYPE = ViewCoordinatesType
+class ViewCoordinatesBatch(BaseBatch[ViewCoordinatesArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = ViewCoordinatesType()
 
     @staticmethod
     def _native_to_pa_array(data: ViewCoordinatesArrayLike, data_type: pa.DataType) -> pa.Array:
         return ViewCoordinatesExt.native_to_pa_array_override(data, data_type)
 
-
-ViewCoordinatesType._ARRAY_TYPE = ViewCoordinatesArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ViewCoordinatesType())

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates_ext.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 import numpy as np
+import numpy.typing as npt
 import pyarrow as pa
 
 if TYPE_CHECKING:
     from ..log import ComponentBatchLike
-    from . import ViewCoordinates, ViewCoordinatesArrayLike, ViewCoordinatesLike
+    from . import ViewCoordinates, ViewCoordinatesArrayLike
 
 
 class ViewCoordinatesExt:
@@ -21,7 +22,7 @@ class ViewCoordinatesExt:
         Back = 6
 
     @staticmethod
-    def coordinates__field_converter_override(data: ViewCoordinatesLike) -> pa.Array:
+    def coordinates__field_converter_override(data: npt.ArrayLike) -> npt.NDArray[np.uint8]:
         coordinates = np.asarray(data, dtype=np.uint8)
         if coordinates.shape != (3,):
             raise ValueError(f"ViewCoordinates must be a 3-element array. Got: {coordinates.shape}")
@@ -62,8 +63,9 @@ class ViewCoordinatesExt:
     # Implement the ArchetypeLike protocol
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:
         from ..archetypes import ViewCoordinates
+        from ..components import ViewCoordinates as ViewCoordinatesComponent
 
-        return ViewCoordinates(self).as_component_batches()
+        return ViewCoordinates(cast(ViewCoordinatesComponent, self)).as_component_batches()
 
     def num_instances(self) -> int:
         # Always a mono-component

--- a/rerun_py/rerun_sdk/rerun/datatypes/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/__init__.py
@@ -2,234 +2,234 @@
 
 from __future__ import annotations
 
-from .angle import Angle, AngleArray, AngleArrayLike, AngleLike, AngleType
+from .angle import Angle, AngleArrayLike, AngleBatch, AngleLike, AngleType
 from .annotation_info import (
     AnnotationInfo,
-    AnnotationInfoArray,
     AnnotationInfoArrayLike,
+    AnnotationInfoBatch,
     AnnotationInfoLike,
     AnnotationInfoType,
 )
 from .class_description import (
     ClassDescription,
-    ClassDescriptionArray,
     ClassDescriptionArrayLike,
+    ClassDescriptionBatch,
     ClassDescriptionLike,
     ClassDescriptionType,
 )
 from .class_description_map_elem import (
     ClassDescriptionMapElem,
-    ClassDescriptionMapElemArray,
     ClassDescriptionMapElemArrayLike,
+    ClassDescriptionMapElemBatch,
     ClassDescriptionMapElemLike,
     ClassDescriptionMapElemType,
 )
-from .class_id import ClassId, ClassIdArray, ClassIdArrayLike, ClassIdLike, ClassIdType
-from .color import Color, ColorArray, ColorArrayLike, ColorLike, ColorType
-from .float32 import Float32, Float32Array, Float32ArrayLike, Float32Like, Float32Type
-from .keypoint_id import KeypointId, KeypointIdArray, KeypointIdArrayLike, KeypointIdLike, KeypointIdType
-from .keypoint_pair import KeypointPair, KeypointPairArray, KeypointPairArrayLike, KeypointPairLike, KeypointPairType
-from .mat3x3 import Mat3x3, Mat3x3Array, Mat3x3ArrayLike, Mat3x3Like, Mat3x3Type
-from .mat4x4 import Mat4x4, Mat4x4Array, Mat4x4ArrayLike, Mat4x4Like, Mat4x4Type
-from .material import Material, MaterialArray, MaterialArrayLike, MaterialLike, MaterialType
+from .class_id import ClassId, ClassIdArrayLike, ClassIdBatch, ClassIdLike, ClassIdType
+from .color import Color, ColorArrayLike, ColorBatch, ColorLike, ColorType
+from .float32 import Float32, Float32ArrayLike, Float32Batch, Float32Like, Float32Type
+from .keypoint_id import KeypointId, KeypointIdArrayLike, KeypointIdBatch, KeypointIdLike, KeypointIdType
+from .keypoint_pair import KeypointPair, KeypointPairArrayLike, KeypointPairBatch, KeypointPairLike, KeypointPairType
+from .mat3x3 import Mat3x3, Mat3x3ArrayLike, Mat3x3Batch, Mat3x3Like, Mat3x3Type
+from .mat4x4 import Mat4x4, Mat4x4ArrayLike, Mat4x4Batch, Mat4x4Like, Mat4x4Type
+from .material import Material, MaterialArrayLike, MaterialBatch, MaterialLike, MaterialType
 from .mesh_properties import (
     MeshProperties,
-    MeshPropertiesArray,
     MeshPropertiesArrayLike,
+    MeshPropertiesBatch,
     MeshPropertiesLike,
     MeshPropertiesType,
 )
-from .quaternion import Quaternion, QuaternionArray, QuaternionArrayLike, QuaternionLike, QuaternionType
-from .rotation3d import Rotation3D, Rotation3DArray, Rotation3DArrayLike, Rotation3DLike, Rotation3DType
+from .quaternion import Quaternion, QuaternionArrayLike, QuaternionBatch, QuaternionLike, QuaternionType
+from .rotation3d import Rotation3D, Rotation3DArrayLike, Rotation3DBatch, Rotation3DLike, Rotation3DType
 from .rotation_axis_angle import (
     RotationAxisAngle,
-    RotationAxisAngleArray,
     RotationAxisAngleArrayLike,
+    RotationAxisAngleBatch,
     RotationAxisAngleLike,
     RotationAxisAngleType,
 )
-from .scale3d import Scale3D, Scale3DArray, Scale3DArrayLike, Scale3DLike, Scale3DType
-from .tensor_buffer import TensorBuffer, TensorBufferArray, TensorBufferArrayLike, TensorBufferLike, TensorBufferType
-from .tensor_data import TensorData, TensorDataArray, TensorDataArrayLike, TensorDataLike, TensorDataType
+from .scale3d import Scale3D, Scale3DArrayLike, Scale3DBatch, Scale3DLike, Scale3DType
+from .tensor_buffer import TensorBuffer, TensorBufferArrayLike, TensorBufferBatch, TensorBufferLike, TensorBufferType
+from .tensor_data import TensorData, TensorDataArrayLike, TensorDataBatch, TensorDataLike, TensorDataType
 from .tensor_dimension import (
     TensorDimension,
-    TensorDimensionArray,
     TensorDimensionArrayLike,
+    TensorDimensionBatch,
     TensorDimensionLike,
     TensorDimensionType,
 )
-from .transform3d import Transform3D, Transform3DArray, Transform3DArrayLike, Transform3DLike, Transform3DType
+from .transform3d import Transform3D, Transform3DArrayLike, Transform3DBatch, Transform3DLike, Transform3DType
 from .translation_and_mat3x3 import (
     TranslationAndMat3x3,
-    TranslationAndMat3x3Array,
     TranslationAndMat3x3ArrayLike,
+    TranslationAndMat3x3Batch,
     TranslationAndMat3x3Like,
     TranslationAndMat3x3Type,
 )
 from .translation_rotation_scale3d import (
     TranslationRotationScale3D,
-    TranslationRotationScale3DArray,
     TranslationRotationScale3DArrayLike,
+    TranslationRotationScale3DBatch,
     TranslationRotationScale3DLike,
     TranslationRotationScale3DType,
 )
-from .utf8 import Utf8, Utf8Array, Utf8ArrayLike, Utf8Like, Utf8Type
-from .uvec2d import UVec2D, UVec2DArray, UVec2DArrayLike, UVec2DLike, UVec2DType
-from .uvec3d import UVec3D, UVec3DArray, UVec3DArrayLike, UVec3DLike, UVec3DType
-from .uvec4d import UVec4D, UVec4DArray, UVec4DArrayLike, UVec4DLike, UVec4DType
-from .vec2d import Vec2D, Vec2DArray, Vec2DArrayLike, Vec2DLike, Vec2DType
-from .vec3d import Vec3D, Vec3DArray, Vec3DArrayLike, Vec3DLike, Vec3DType
-from .vec4d import Vec4D, Vec4DArray, Vec4DArrayLike, Vec4DLike, Vec4DType
+from .utf8 import Utf8, Utf8ArrayLike, Utf8Batch, Utf8Like, Utf8Type
+from .uvec2d import UVec2D, UVec2DArrayLike, UVec2DBatch, UVec2DLike, UVec2DType
+from .uvec3d import UVec3D, UVec3DArrayLike, UVec3DBatch, UVec3DLike, UVec3DType
+from .uvec4d import UVec4D, UVec4DArrayLike, UVec4DBatch, UVec4DLike, UVec4DType
+from .vec2d import Vec2D, Vec2DArrayLike, Vec2DBatch, Vec2DLike, Vec2DType
+from .vec3d import Vec3D, Vec3DArrayLike, Vec3DBatch, Vec3DLike, Vec3DType
+from .vec4d import Vec4D, Vec4DArrayLike, Vec4DBatch, Vec4DLike, Vec4DType
 
 __all__ = [
     "Angle",
-    "AngleArray",
     "AngleArrayLike",
+    "AngleBatch",
     "AngleLike",
     "AngleType",
     "AnnotationInfo",
-    "AnnotationInfoArray",
     "AnnotationInfoArrayLike",
+    "AnnotationInfoBatch",
     "AnnotationInfoLike",
     "AnnotationInfoType",
     "ClassDescription",
-    "ClassDescriptionArray",
     "ClassDescriptionArrayLike",
+    "ClassDescriptionBatch",
     "ClassDescriptionLike",
     "ClassDescriptionMapElem",
-    "ClassDescriptionMapElemArray",
     "ClassDescriptionMapElemArrayLike",
+    "ClassDescriptionMapElemBatch",
     "ClassDescriptionMapElemLike",
     "ClassDescriptionMapElemType",
     "ClassDescriptionType",
     "ClassId",
-    "ClassIdArray",
     "ClassIdArrayLike",
+    "ClassIdBatch",
     "ClassIdLike",
     "ClassIdType",
     "Color",
-    "ColorArray",
     "ColorArrayLike",
+    "ColorBatch",
     "ColorLike",
     "ColorType",
     "Float32",
-    "Float32Array",
     "Float32ArrayLike",
+    "Float32Batch",
     "Float32Like",
     "Float32Type",
     "KeypointId",
-    "KeypointIdArray",
     "KeypointIdArrayLike",
+    "KeypointIdBatch",
     "KeypointIdLike",
     "KeypointIdType",
     "KeypointPair",
-    "KeypointPairArray",
     "KeypointPairArrayLike",
+    "KeypointPairBatch",
     "KeypointPairLike",
     "KeypointPairType",
     "Mat3x3",
-    "Mat3x3Array",
     "Mat3x3ArrayLike",
+    "Mat3x3Batch",
     "Mat3x3Like",
     "Mat3x3Type",
     "Mat4x4",
-    "Mat4x4Array",
     "Mat4x4ArrayLike",
+    "Mat4x4Batch",
     "Mat4x4Like",
     "Mat4x4Type",
     "Material",
-    "MaterialArray",
     "MaterialArrayLike",
+    "MaterialBatch",
     "MaterialLike",
     "MaterialType",
     "MeshProperties",
-    "MeshPropertiesArray",
     "MeshPropertiesArrayLike",
+    "MeshPropertiesBatch",
     "MeshPropertiesLike",
     "MeshPropertiesType",
     "Quaternion",
-    "QuaternionArray",
     "QuaternionArrayLike",
+    "QuaternionBatch",
     "QuaternionLike",
     "QuaternionType",
     "Rotation3D",
-    "Rotation3DArray",
     "Rotation3DArrayLike",
+    "Rotation3DBatch",
     "Rotation3DLike",
     "Rotation3DType",
     "RotationAxisAngle",
-    "RotationAxisAngleArray",
     "RotationAxisAngleArrayLike",
+    "RotationAxisAngleBatch",
     "RotationAxisAngleLike",
     "RotationAxisAngleType",
     "Scale3D",
-    "Scale3DArray",
     "Scale3DArrayLike",
+    "Scale3DBatch",
     "Scale3DLike",
     "Scale3DType",
     "TensorBuffer",
-    "TensorBufferArray",
     "TensorBufferArrayLike",
+    "TensorBufferBatch",
     "TensorBufferLike",
     "TensorBufferType",
     "TensorData",
-    "TensorDataArray",
     "TensorDataArrayLike",
+    "TensorDataBatch",
     "TensorDataLike",
     "TensorDataType",
     "TensorDimension",
-    "TensorDimensionArray",
     "TensorDimensionArrayLike",
+    "TensorDimensionBatch",
     "TensorDimensionLike",
     "TensorDimensionType",
     "Transform3D",
-    "Transform3DArray",
     "Transform3DArrayLike",
+    "Transform3DBatch",
     "Transform3DLike",
     "Transform3DType",
     "TranslationAndMat3x3",
-    "TranslationAndMat3x3Array",
     "TranslationAndMat3x3ArrayLike",
+    "TranslationAndMat3x3Batch",
     "TranslationAndMat3x3Like",
     "TranslationAndMat3x3Type",
     "TranslationRotationScale3D",
-    "TranslationRotationScale3DArray",
     "TranslationRotationScale3DArrayLike",
+    "TranslationRotationScale3DBatch",
     "TranslationRotationScale3DLike",
     "TranslationRotationScale3DType",
     "UVec2D",
-    "UVec2DArray",
     "UVec2DArrayLike",
+    "UVec2DBatch",
     "UVec2DLike",
     "UVec2DType",
     "UVec3D",
-    "UVec3DArray",
     "UVec3DArrayLike",
+    "UVec3DBatch",
     "UVec3DLike",
     "UVec3DType",
     "UVec4D",
-    "UVec4DArray",
     "UVec4DArrayLike",
+    "UVec4DBatch",
     "UVec4DLike",
     "UVec4DType",
     "Utf8",
-    "Utf8Array",
     "Utf8ArrayLike",
+    "Utf8Batch",
     "Utf8Like",
     "Utf8Type",
     "Vec2D",
-    "Vec2DArray",
     "Vec2DArrayLike",
+    "Vec2DBatch",
     "Vec2DLike",
     "Vec2DType",
     "Vec3D",
-    "Vec3DArray",
     "Vec3DArrayLike",
+    "Vec3DBatch",
     "Vec3DLike",
     "Vec3DType",
     "Vec4D",
-    "Vec4DArray",
     "Vec4DArrayLike",
+    "Vec4DBatch",
     "Vec4DLike",
     "Vec4DType",
 ]

--- a/rerun_py/rerun_sdk/rerun/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/angle.py
@@ -10,13 +10,10 @@ from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .angle_ext import AngleExt
 
-__all__ = ["Angle", "AngleArray", "AngleArrayLike", "AngleLike", "AngleType"]
+__all__ = ["Angle", "AngleArrayLike", "AngleBatch", "AngleLike", "AngleType"]
 
 
 @define(init=False)
@@ -51,10 +48,10 @@ else:
     AngleLike = Any
     AngleArrayLike = Any
 
-# --- Arrow support ---
-
 
 class AngleType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Angle"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -65,20 +62,17 @@ class AngleType(BaseExtensionType):
                     pa.field("Degrees", pa.float32(), nullable=False, metadata={}),
                 ]
             ),
-            "rerun.datatypes.Angle",
+            self._TYPE_NAME,
         )
 
 
-class AngleArray(BaseExtensionArray[AngleArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Angle"
-    _EXTENSION_TYPE = AngleType
+class AngleBatch(BaseBatch[AngleArrayLike]):
+    _ARROW_TYPE = AngleType()
 
     @staticmethod
     def _native_to_pa_array(data: AngleArrayLike, data_type: pa.DataType) -> pa.Array:
         return AngleExt.native_to_pa_array_override(data, data_type)
 
-
-AngleType._ARRAY_TYPE = AngleArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AngleType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .annotation_info_ext import AnnotationInfoExt
 
 __all__ = [
     "AnnotationInfo",
-    "AnnotationInfoArray",
     "AnnotationInfoArrayLike",
+    "AnnotationInfoBatch",
     "AnnotationInfoLike",
     "AnnotationInfoType",
 ]
@@ -86,10 +83,9 @@ AnnotationInfoArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AnnotationInfoType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.AnnotationInfo"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -100,20 +96,17 @@ class AnnotationInfoType(BaseExtensionType):
                     pa.field("color", pa.uint32(), nullable=True, metadata={}),
                 ]
             ),
-            "rerun.datatypes.AnnotationInfo",
+            self._TYPE_NAME,
         )
 
 
-class AnnotationInfoArray(BaseExtensionArray[AnnotationInfoArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.AnnotationInfo"
-    _EXTENSION_TYPE = AnnotationInfoType
+class AnnotationInfoBatch(BaseBatch[AnnotationInfoArrayLike]):
+    _ARROW_TYPE = AnnotationInfoType()
 
     @staticmethod
     def _native_to_pa_array(data: AnnotationInfoArrayLike, data_type: pa.DataType) -> pa.Array:
         return AnnotationInfoExt.native_to_pa_array_override(data, data_type)
 
-
-AnnotationInfoType._ARRAY_TYPE = AnnotationInfoArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AnnotationInfoType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .class_description_ext import ClassDescriptionExt
 
 __all__ = [
     "ClassDescription",
-    "ClassDescriptionArray",
     "ClassDescriptionArrayLike",
+    "ClassDescriptionBatch",
     "ClassDescriptionLike",
     "ClassDescriptionType",
 ]
@@ -80,10 +77,9 @@ ClassDescriptionArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class ClassDescriptionType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.ClassDescription"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -140,20 +136,17 @@ class ClassDescriptionType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.ClassDescription",
+            self._TYPE_NAME,
         )
 
 
-class ClassDescriptionArray(BaseExtensionArray[ClassDescriptionArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.ClassDescription"
-    _EXTENSION_TYPE = ClassDescriptionType
+class ClassDescriptionBatch(BaseBatch[ClassDescriptionArrayLike]):
+    _ARROW_TYPE = ClassDescriptionType()
 
     @staticmethod
     def _native_to_pa_array(data: ClassDescriptionArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClassDescriptionExt.native_to_pa_array_override(data, data_type)
 
-
-ClassDescriptionType._ARRAY_TYPE = ClassDescriptionArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ClassDescriptionType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
@@ -80,7 +80,7 @@ class ClassDescriptionExt:
 
     @staticmethod
     def native_to_pa_array_override(data: ClassDescriptionArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import AnnotationInfoArray, ClassDescription, KeypointPairArray
+        from . import AnnotationInfoBatch, ClassDescription, KeypointPairBatch
 
         if isinstance(data, ClassDescription):
             data = [data]
@@ -91,7 +91,7 @@ class ClassDescriptionExt:
         annotations = [item.keypoint_annotations for item in descs]
         connections = [item.keypoint_connections for item in descs]
 
-        infos_array = AnnotationInfoArray.from_similar(infos).storage
+        infos_array = AnnotationInfoBatch(infos).as_arrow_array().storage
 
         annotation_offsets = list(
             itertools.chain([0], itertools.accumulate(len(ann) if ann else 0 for ann in annotations))
@@ -100,7 +100,7 @@ class ClassDescriptionExt:
         # annotation_null_map = pa.array([ann is None for ann in annotations], type=pa.bool_())
         # concat_annotations = list(itertools.chain.from_iterable(ann for ann in annotations if ann is not None))
         concat_annotations = list(itertools.chain.from_iterable(annotations))
-        annotation_values_array = AnnotationInfoArray.from_similar(concat_annotations).storage
+        annotation_values_array = AnnotationInfoBatch(concat_annotations).as_arrow_array().storage
         # annotations_array = pa.ListArray.from_arrays(annotation_offsets,
         #                                              annotation_values_array,
         #                                              mask=annotation_null_map)
@@ -115,7 +115,7 @@ class ClassDescriptionExt:
         # connection_null_map = pa.array([con is None for con in connections], type=pa.bool_())
         # concat_connections = list(itertools.chain.from_iterable(con for con in connections if con is not None))
         concat_connections = list(itertools.chain.from_iterable(connections))
-        connection_values_array = KeypointPairArray.from_similar(concat_connections).storage
+        connection_values_array = KeypointPairBatch(concat_connections).as_arrow_array().storage
         # connection_array = pa.ListArray.from_arrays(connections_offsets,
         #                                             connection_values_array,
         #                                             mask=connection_null_map)

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .class_description_map_elem_ext import ClassDescriptionMapElemExt
 
 __all__ = [
     "ClassDescriptionMapElem",
-    "ClassDescriptionMapElemArray",
     "ClassDescriptionMapElemArrayLike",
+    "ClassDescriptionMapElemBatch",
     "ClassDescriptionMapElemLike",
     "ClassDescriptionMapElemType",
 ]
@@ -62,10 +59,9 @@ ClassDescriptionMapElemArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class ClassDescriptionMapElemType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.ClassDescriptionMapElem"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -132,20 +128,17 @@ class ClassDescriptionMapElemType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.ClassDescriptionMapElem",
+            self._TYPE_NAME,
         )
 
 
-class ClassDescriptionMapElemArray(BaseExtensionArray[ClassDescriptionMapElemArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.ClassDescriptionMapElem"
-    _EXTENSION_TYPE = ClassDescriptionMapElemType
+class ClassDescriptionMapElemBatch(BaseBatch[ClassDescriptionMapElemArrayLike]):
+    _ARROW_TYPE = ClassDescriptionMapElemType()
 
     @staticmethod
     def _native_to_pa_array(data: ClassDescriptionMapElemArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClassDescriptionMapElemExt.native_to_pa_array_override(data, data_type)
 
-
-ClassDescriptionMapElemType._ARRAY_TYPE = ClassDescriptionMapElemArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ClassDescriptionMapElemType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem_ext.py
@@ -29,7 +29,7 @@ def _class_description_map_elem_converter(
 class ClassDescriptionMapElemExt:
     @staticmethod
     def native_to_pa_array_override(data: ClassDescriptionMapElemArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import ClassDescriptionArray, ClassDescriptionMapElem, ClassIdArray
+        from . import ClassDescriptionBatch, ClassDescriptionMapElem, ClassIdBatch
 
         if isinstance(data, ClassDescriptionMapElem):
             data = [data]
@@ -39,8 +39,8 @@ class ClassDescriptionMapElemExt:
         ids = [item.class_id for item in map_items]
         class_descriptions = [item.class_description for item in map_items]
 
-        id_array = ClassIdArray.from_similar(ids).storage
-        desc_array = ClassDescriptionArray.from_similar(class_descriptions).storage
+        id_array = ClassIdBatch(ids).as_arrow_array().storage
+        desc_array = ClassDescriptionBatch(class_descriptions).as_arrow_array().storage
 
         return pa.StructArray.from_arrays(
             arrays=[id_array, desc_array],

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .class_id_ext import ClassIdExt
 
-__all__ = ["ClassId", "ClassIdArray", "ClassIdArrayLike", "ClassIdLike", "ClassIdType"]
+__all__ = ["ClassId", "ClassIdArrayLike", "ClassIdBatch", "ClassIdLike", "ClassIdType"]
 
 
 @define
@@ -53,24 +50,20 @@ ClassIdArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class ClassIdType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.ClassId"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint16(), "rerun.datatypes.ClassId")
+        pa.ExtensionType.__init__(self, pa.uint16(), self._TYPE_NAME)
 
 
-class ClassIdArray(BaseExtensionArray[ClassIdArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.ClassId"
-    _EXTENSION_TYPE = ClassIdType
+class ClassIdBatch(BaseBatch[ClassIdArrayLike]):
+    _ARROW_TYPE = ClassIdType()
 
     @staticmethod
     def _native_to_pa_array(data: ClassIdArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClassIdExt.native_to_pa_array_override(data, data_type)
 
-
-ClassIdType._ARRAY_TYPE = ClassIdArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ClassIdType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/color.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/color.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .color_ext import ColorExt
 
-__all__ = ["Color", "ColorArray", "ColorArrayLike", "ColorLike", "ColorType"]
+__all__ = ["Color", "ColorArrayLike", "ColorBatch", "ColorLike", "ColorType"]
 
 
 @define
@@ -62,24 +59,20 @@ ColorArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class ColorType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Color"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint32(), "rerun.datatypes.Color")
+        pa.ExtensionType.__init__(self, pa.uint32(), self._TYPE_NAME)
 
 
-class ColorArray(BaseExtensionArray[ColorArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Color"
-    _EXTENSION_TYPE = ColorType
+class ColorBatch(BaseBatch[ColorArrayLike]):
+    _ARROW_TYPE = ColorType()
 
     @staticmethod
     def _native_to_pa_array(data: ColorArrayLike, data_type: pa.DataType) -> pa.Array:
         return ColorExt.native_to_pa_array_override(data, data_type)
 
-
-ColorType._ARRAY_TYPE = ColorArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(ColorType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/color_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/color_ext.py
@@ -34,7 +34,7 @@ class ColorExt:
     - numpy array: interpreted as rgb or rgba values, range depending on dtype
     - anything else (int or convertible to int): interpreted as a 32-bit packed rgba value
 
-    Possible inputs for `ColorArray.from_similar()`:
+    Possible inputs for `ColorBatch()`:
     - a single `Color` instance
     - a sequence of `Color` instances
     - Nx3 or Nx4 numpy array, range depending on dtype

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -12,12 +12,9 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 
-__all__ = ["Float32", "Float32Array", "Float32ArrayLike", "Float32Like", "Float32Type"]
+__all__ = ["Float32", "Float32ArrayLike", "Float32Batch", "Float32Like", "Float32Type"]
 
 
 @define
@@ -41,24 +38,20 @@ Float32ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class Float32Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Float32"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), "rerun.datatypes.Float32")
+        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
 
 
-class Float32Array(BaseExtensionArray[Float32ArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Float32"
-    _EXTENSION_TYPE = Float32Type
+class Float32Batch(BaseBatch[Float32ArrayLike]):
+    _ARROW_TYPE = Float32Type()
 
     @staticmethod
     def _native_to_pa_array(data: Float32ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in float32_ext.py
 
-
-Float32Type._ARRAY_TYPE = Float32Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Float32Type())

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .keypoint_id_ext import KeypointIdExt
 
-__all__ = ["KeypointId", "KeypointIdArray", "KeypointIdArrayLike", "KeypointIdLike", "KeypointIdType"]
+__all__ = ["KeypointId", "KeypointIdArrayLike", "KeypointIdBatch", "KeypointIdLike", "KeypointIdType"]
 
 
 @define
@@ -60,24 +57,20 @@ KeypointIdArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class KeypointIdType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.KeypointId"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint16(), "rerun.datatypes.KeypointId")
+        pa.ExtensionType.__init__(self, pa.uint16(), self._TYPE_NAME)
 
 
-class KeypointIdArray(BaseExtensionArray[KeypointIdArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.KeypointId"
-    _EXTENSION_TYPE = KeypointIdType
+class KeypointIdBatch(BaseBatch[KeypointIdArrayLike]):
+    _ARROW_TYPE = KeypointIdType()
 
     @staticmethod
     def _native_to_pa_array(data: KeypointIdArrayLike, data_type: pa.DataType) -> pa.Array:
         return KeypointIdExt.native_to_pa_array_override(data, data_type)
 
-
-KeypointIdType._ARRAY_TYPE = KeypointIdArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(KeypointIdType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
@@ -11,13 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .keypoint_pair_ext import KeypointPairExt
 
-__all__ = ["KeypointPair", "KeypointPairArray", "KeypointPairArrayLike", "KeypointPairLike", "KeypointPairType"]
+__all__ = ["KeypointPair", "KeypointPairArrayLike", "KeypointPairBatch", "KeypointPairLike", "KeypointPairType"]
 
 
 def _keypoint_pair__keypoint0__special_field_converter_override(x: datatypes.KeypointIdLike) -> datatypes.KeypointId:
@@ -55,10 +52,9 @@ KeypointPairArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class KeypointPairType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.KeypointPair"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -68,20 +64,17 @@ class KeypointPairType(BaseExtensionType):
                     pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
                 ]
             ),
-            "rerun.datatypes.KeypointPair",
+            self._TYPE_NAME,
         )
 
 
-class KeypointPairArray(BaseExtensionArray[KeypointPairArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.KeypointPair"
-    _EXTENSION_TYPE = KeypointPairType
+class KeypointPairBatch(BaseBatch[KeypointPairArrayLike]):
+    _ARROW_TYPE = KeypointPairType()
 
     @staticmethod
     def _native_to_pa_array(data: KeypointPairArrayLike, data_type: pa.DataType) -> pa.Array:
         return KeypointPairExt.native_to_pa_array_override(data, data_type)
 
-
-KeypointPairType._ARRAY_TYPE = KeypointPairArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(KeypointPairType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair_ext.py
@@ -26,7 +26,7 @@ def _keypoint_pair_converter(
 class KeypointPairExt:
     @staticmethod
     def native_to_pa_array_override(data: KeypointPairArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import KeypointIdArray, KeypointPair
+        from . import KeypointIdBatch, KeypointPair
 
         if isinstance(data, KeypointPair):
             data = [data]
@@ -36,8 +36,8 @@ class KeypointPairExt:
         keypoint0 = [pair.keypoint0 for pair in keypoints]
         keypoint1 = [pair.keypoint1 for pair in keypoints]
 
-        keypoint0_array = KeypointIdArray.from_similar(keypoint0).storage
-        keypoint1_array = KeypointIdArray.from_similar(keypoint1).storage
+        keypoint0_array = KeypointIdBatch(keypoint0).as_arrow_array().storage
+        keypoint1_array = KeypointIdBatch(keypoint1).as_arrow_array().storage
 
         return pa.StructArray.from_arrays(
             arrays=[keypoint0_array, keypoint1_array],

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_float32,
 )
 from .mat3x3_ext import Mat3x3Ext
 
-__all__ = ["Mat3x3", "Mat3x3Array", "Mat3x3ArrayLike", "Mat3x3Like", "Mat3x3Type"]
+__all__ = ["Mat3x3", "Mat3x3ArrayLike", "Mat3x3Batch", "Mat3x3Like", "Mat3x3Type"]
 
 
 @define(init=False)
@@ -84,26 +81,22 @@ Mat3x3ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class Mat3x3Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Mat3x3"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9), "rerun.datatypes.Mat3x3"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9), self._TYPE_NAME
         )
 
 
-class Mat3x3Array(BaseExtensionArray[Mat3x3ArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Mat3x3"
-    _EXTENSION_TYPE = Mat3x3Type
+class Mat3x3Batch(BaseBatch[Mat3x3ArrayLike]):
+    _ARROW_TYPE = Mat3x3Type()
 
     @staticmethod
     def _native_to_pa_array(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Mat3x3Ext.native_to_pa_array_override(data, data_type)
 
-
-Mat3x3Type._ARRAY_TYPE = Mat3x3Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Mat3x3Type())

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_float32,
 )
 from .mat4x4_ext import Mat4x4Ext
 
-__all__ = ["Mat4x4", "Mat4x4Array", "Mat4x4ArrayLike", "Mat4x4Like", "Mat4x4Type"]
+__all__ = ["Mat4x4", "Mat4x4ArrayLike", "Mat4x4Batch", "Mat4x4Like", "Mat4x4Type"]
 
 
 @define(init=False)
@@ -86,26 +83,22 @@ Mat4x4ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class Mat4x4Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Mat4x4"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 16), "rerun.datatypes.Mat4x4"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 16), self._TYPE_NAME
         )
 
 
-class Mat4x4Array(BaseExtensionArray[Mat4x4ArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Mat4x4"
-    _EXTENSION_TYPE = Mat4x4Type
+class Mat4x4Batch(BaseBatch[Mat4x4ArrayLike]):
+    _ARROW_TYPE = Mat4x4Type()
 
     @staticmethod
     def _native_to_pa_array(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Mat4x4Ext.native_to_pa_array_override(data, data_type)
 
-
-Mat4x4Type._ARRAY_TYPE = Mat4x4Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Mat4x4Type())

--- a/rerun_py/rerun_sdk/rerun/datatypes/material.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/material.py
@@ -11,13 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .material_ext import MaterialExt
 
-__all__ = ["Material", "MaterialArray", "MaterialArrayLike", "MaterialLike", "MaterialType"]
+__all__ = ["Material", "MaterialArrayLike", "MaterialBatch", "MaterialLike", "MaterialType"]
 
 
 def _material__albedo_factor__special_field_converter_override(x: datatypes.ColorLike | None) -> datatypes.Color | None:
@@ -48,28 +45,22 @@ MaterialArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class MaterialType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Material"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self,
-            pa.struct([pa.field("albedo_factor", pa.uint32(), nullable=True, metadata={})]),
-            "rerun.datatypes.Material",
+            self, pa.struct([pa.field("albedo_factor", pa.uint32(), nullable=True, metadata={})]), self._TYPE_NAME
         )
 
 
-class MaterialArray(BaseExtensionArray[MaterialArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Material"
-    _EXTENSION_TYPE = MaterialType
+class MaterialBatch(BaseBatch[MaterialArrayLike]):
+    _ARROW_TYPE = MaterialType()
 
     @staticmethod
     def _native_to_pa_array(data: MaterialArrayLike, data_type: pa.DataType) -> pa.Array:
         return MaterialExt.native_to_pa_array_override(data, data_type)
 
-
-MaterialType._ARRAY_TYPE = MaterialArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(MaterialType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
@@ -12,10 +12,7 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_uint32,
 )
@@ -23,8 +20,8 @@ from .mesh_properties_ext import MeshPropertiesExt
 
 __all__ = [
     "MeshProperties",
-    "MeshPropertiesArray",
     "MeshPropertiesArrayLike",
+    "MeshPropertiesBatch",
     "MeshPropertiesLike",
     "MeshPropertiesType",
 ]
@@ -52,10 +49,9 @@ MeshPropertiesArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class MeshPropertiesType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.MeshProperties"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -69,20 +65,17 @@ class MeshPropertiesType(BaseExtensionType):
                     )
                 ]
             ),
-            "rerun.datatypes.MeshProperties",
+            self._TYPE_NAME,
         )
 
 
-class MeshPropertiesArray(BaseExtensionArray[MeshPropertiesArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.MeshProperties"
-    _EXTENSION_TYPE = MeshPropertiesType
+class MeshPropertiesBatch(BaseBatch[MeshPropertiesArrayLike]):
+    _ARROW_TYPE = MeshPropertiesType()
 
     @staticmethod
     def _native_to_pa_array(data: MeshPropertiesArrayLike, data_type: pa.DataType) -> pa.Array:
         return MeshPropertiesExt.native_to_pa_array_override(data, data_type)
 
-
-MeshPropertiesType._ARRAY_TYPE = MeshPropertiesArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(MeshPropertiesType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_float32,
 )
 from .quaternion_ext import QuaternionExt
 
-__all__ = ["Quaternion", "QuaternionArray", "QuaternionArrayLike", "QuaternionLike", "QuaternionType"]
+__all__ = ["Quaternion", "QuaternionArrayLike", "QuaternionBatch", "QuaternionLike", "QuaternionType"]
 
 
 @define(init=False)
@@ -49,26 +46,22 @@ QuaternionArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class QuaternionType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Quaternion"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), "rerun.datatypes.Quaternion"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), self._TYPE_NAME
         )
 
 
-class QuaternionArray(BaseExtensionArray[QuaternionArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Quaternion"
-    _EXTENSION_TYPE = QuaternionType
+class QuaternionBatch(BaseBatch[QuaternionArrayLike]):
+    _ARROW_TYPE = QuaternionType()
 
     @staticmethod
     def _native_to_pa_array(data: QuaternionArrayLike, data_type: pa.DataType) -> pa.Array:
         return QuaternionExt.native_to_pa_array_override(data, data_type)
 
-
-QuaternionType._ARRAY_TYPE = QuaternionArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(QuaternionType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
@@ -11,13 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .rotation3d_ext import Rotation3DExt
 
-__all__ = ["Rotation3D", "Rotation3DArray", "Rotation3DArrayLike", "Rotation3DLike", "Rotation3DType"]
+__all__ = ["Rotation3D", "Rotation3DArrayLike", "Rotation3DBatch", "Rotation3DLike", "Rotation3DType"]
 
 
 @define
@@ -48,10 +45,10 @@ else:
     Rotation3DLike = Any
     Rotation3DArrayLike = Any
 
-# --- Arrow support ---
-
 
 class Rotation3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Rotation3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -93,20 +90,17 @@ class Rotation3DType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.Rotation3D",
+            self._TYPE_NAME,
         )
 
 
-class Rotation3DArray(BaseExtensionArray[Rotation3DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Rotation3D"
-    _EXTENSION_TYPE = Rotation3DType
+class Rotation3DBatch(BaseBatch[Rotation3DArrayLike]):
+    _ARROW_TYPE = Rotation3DType()
 
     @staticmethod
     def _native_to_pa_array(data: Rotation3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Rotation3DExt.native_to_pa_array_override(data, data_type)
 
-
-Rotation3DType._ARRAY_TYPE = Rotation3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Rotation3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation3d_ext.py
@@ -33,7 +33,7 @@ class Rotation3DExt:
 
     @staticmethod
     def native_to_pa_array_override(data: Rotation3DArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Quaternion, QuaternionArray, Rotation3D, RotationAxisAngle, RotationAxisAngleArray
+        from . import Quaternion, QuaternionBatch, Rotation3D, RotationAxisAngle, RotationAxisAngleBatch
 
         if isinstance(data, Rotation3D) or isinstance(data, RotationAxisAngle) or isinstance(data, Quaternion):
             data = [data]
@@ -81,8 +81,8 @@ class Rotation3DExt:
             ],
             children=[
                 pa.nulls(num_nulls, pa.null()),
-                QuaternionArray._native_to_pa_array(quaternions, union_discriminant_type(data_type, "Quaternion")),
-                RotationAxisAngleArray._native_to_pa_array(
+                QuaternionBatch._native_to_pa_array(quaternions, union_discriminant_type(data_type, "Quaternion")),
+                RotationAxisAngleBatch._native_to_pa_array(
                     rotation_axis_angles, union_discriminant_type(data_type, "AxisAngle")
                 ),
             ],

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .rotation_axis_angle_ext import RotationAxisAngleExt
 
 __all__ = [
     "RotationAxisAngle",
-    "RotationAxisAngleArray",
     "RotationAxisAngleArrayLike",
+    "RotationAxisAngleBatch",
     "RotationAxisAngleLike",
     "RotationAxisAngleType",
 ]
@@ -63,10 +60,9 @@ RotationAxisAngleArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class RotationAxisAngleType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.RotationAxisAngle"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -92,20 +88,17 @@ class RotationAxisAngleType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.RotationAxisAngle",
+            self._TYPE_NAME,
         )
 
 
-class RotationAxisAngleArray(BaseExtensionArray[RotationAxisAngleArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.RotationAxisAngle"
-    _EXTENSION_TYPE = RotationAxisAngleType
+class RotationAxisAngleBatch(BaseBatch[RotationAxisAngleArrayLike]):
+    _ARROW_TYPE = RotationAxisAngleType()
 
     @staticmethod
     def _native_to_pa_array(data: RotationAxisAngleArrayLike, data_type: pa.DataType) -> pa.Array:
         return RotationAxisAngleExt.native_to_pa_array_override(data, data_type)
 
-
-RotationAxisAngleType._ARRAY_TYPE = RotationAxisAngleArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(RotationAxisAngleType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle_ext.py
@@ -21,13 +21,13 @@ class RotationAxisAngleExt:
 
     @staticmethod
     def native_to_pa_array_override(data: RotationAxisAngleArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import AngleArray, RotationAxisAngle, Vec3DArray
+        from . import AngleBatch, RotationAxisAngle, Vec3DBatch
 
         if isinstance(data, RotationAxisAngle):
             data = [data]
 
-        axis_pa_array = Vec3DArray._native_to_pa_array([rotation.axis for rotation in data], data_type["axis"].type)
-        angle_pa_arr = AngleArray._native_to_pa_array([rotation.angle for rotation in data], data_type["angle"].type)
+        axis_pa_array = Vec3DBatch._native_to_pa_array([rotation.axis for rotation in data], data_type["axis"].type)
+        angle_pa_arr = AngleBatch._native_to_pa_array([rotation.angle for rotation in data], data_type["angle"].type)
 
         return pa.StructArray.from_arrays(
             [

--- a/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
@@ -11,13 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .scale3d_ext import Scale3DExt
 
-__all__ = ["Scale3D", "Scale3DArray", "Scale3DArrayLike", "Scale3DLike", "Scale3DType"]
+__all__ = ["Scale3D", "Scale3DArrayLike", "Scale3DBatch", "Scale3DLike", "Scale3DType"]
 
 
 @define
@@ -61,10 +58,10 @@ else:
     Scale3DLike = Any
     Scale3DArrayLike = Any
 
-# --- Arrow support ---
-
 
 class Scale3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Scale3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -80,20 +77,17 @@ class Scale3DType(BaseExtensionType):
                     pa.field("Uniform", pa.float32(), nullable=False, metadata={}),
                 ]
             ),
-            "rerun.datatypes.Scale3D",
+            self._TYPE_NAME,
         )
 
 
-class Scale3DArray(BaseExtensionArray[Scale3DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Scale3D"
-    _EXTENSION_TYPE = Scale3DType
+class Scale3DBatch(BaseBatch[Scale3DArrayLike]):
+    _ARROW_TYPE = Scale3DType()
 
     @staticmethod
     def _native_to_pa_array(data: Scale3DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in scale3d_ext.py
 
-
-Scale3DType._ARRAY_TYPE = Scale3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Scale3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -12,13 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .tensor_buffer_ext import TensorBufferExt
 
-__all__ = ["TensorBuffer", "TensorBufferArray", "TensorBufferArrayLike", "TensorBufferLike", "TensorBufferType"]
+__all__ = ["TensorBuffer", "TensorBufferArrayLike", "TensorBufferBatch", "TensorBufferLike", "TensorBufferType"]
 
 
 @define
@@ -97,10 +94,10 @@ else:
     TensorBufferLike = Any
     TensorBufferArrayLike = Any
 
-# --- Arrow support ---
-
 
 class TensorBufferType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.TensorBuffer"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -181,20 +178,17 @@ class TensorBufferType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.TensorBuffer",
+            self._TYPE_NAME,
         )
 
 
-class TensorBufferArray(BaseExtensionArray[TensorBufferArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.TensorBuffer"
-    _EXTENSION_TYPE = TensorBufferType
+class TensorBufferBatch(BaseBatch[TensorBufferArrayLike]):
+    _ARROW_TYPE = TensorBufferType()
 
     @staticmethod
     def _native_to_pa_array(data: TensorBufferArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in tensor_buffer_ext.py
 
-
-TensorBufferType._ARRAY_TYPE = TensorBufferArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TensorBufferType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
@@ -12,13 +12,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .tensor_data_ext import TensorDataExt
 
-__all__ = ["TensorData", "TensorDataArray", "TensorDataArrayLike", "TensorDataLike", "TensorDataType"]
+__all__ = ["TensorData", "TensorDataArrayLike", "TensorDataBatch", "TensorDataLike", "TensorDataType"]
 
 
 def _tensor_data__buffer__special_field_converter_override(x: datatypes.TensorBufferLike) -> datatypes.TensorBuffer:
@@ -55,10 +52,9 @@ else:
 TensorDataArrayLike = Union[TensorData, Sequence[TensorDataLike], npt.ArrayLike]
 
 
-# --- Arrow support ---
-
-
 class TensorDataType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.TensorData"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -166,20 +162,17 @@ class TensorDataType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.TensorData",
+            self._TYPE_NAME,
         )
 
 
-class TensorDataArray(BaseExtensionArray[TensorDataArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.TensorData"
-    _EXTENSION_TYPE = TensorDataType
+class TensorDataBatch(BaseBatch[TensorDataArrayLike]):
+    _ARROW_TYPE = TensorDataType()
 
     @staticmethod
     def _native_to_pa_array(data: TensorDataArrayLike, data_type: pa.DataType) -> pa.Array:
         return TensorDataExt.native_to_pa_array_override(data, data_type)
 
-
-TensorDataType._ARRAY_TYPE = TensorDataArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TensorDataType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
@@ -10,18 +10,15 @@ from typing import Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     str_or_none,
 )
 
 __all__ = [
     "TensorDimension",
-    "TensorDimensionArray",
     "TensorDimensionArrayLike",
+    "TensorDimensionBatch",
     "TensorDimensionLike",
     "TensorDimensionType",
 ]
@@ -44,10 +41,9 @@ TensorDimensionArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class TensorDimensionType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.TensorDimension"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -57,20 +53,17 @@ class TensorDimensionType(BaseExtensionType):
                     pa.field("name", pa.utf8(), nullable=True, metadata={}),
                 ]
             ),
-            "rerun.datatypes.TensorDimension",
+            self._TYPE_NAME,
         )
 
 
-class TensorDimensionArray(BaseExtensionArray[TensorDimensionArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.TensorDimension"
-    _EXTENSION_TYPE = TensorDimensionType
+class TensorDimensionBatch(BaseBatch[TensorDimensionArrayLike]):
+    _ARROW_TYPE = TensorDimensionType()
 
     @staticmethod
     def _native_to_pa_array(data: TensorDimensionArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in tensor_dimension_ext.py
 
-
-TensorDimensionType._ARRAY_TYPE = TensorDimensionArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TensorDimensionType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
@@ -11,13 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .transform3d_ext import Transform3DExt
 
-__all__ = ["Transform3D", "Transform3DArray", "Transform3DArrayLike", "Transform3DLike", "Transform3DType"]
+__all__ = ["Transform3D", "Transform3DArrayLike", "Transform3DBatch", "Transform3DLike", "Transform3DType"]
 
 
 @define
@@ -50,10 +47,10 @@ else:
     Transform3DLike = Any
     Transform3DArrayLike = Any
 
-# --- Arrow support ---
-
 
 class Transform3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Transform3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -184,20 +181,17 @@ class Transform3DType(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.datatypes.Transform3D",
+            self._TYPE_NAME,
         )
 
 
-class Transform3DArray(BaseExtensionArray[Transform3DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Transform3D"
-    _EXTENSION_TYPE = Transform3DType
+class Transform3DBatch(BaseBatch[Transform3DArrayLike]):
+    _ARROW_TYPE = Transform3DType()
 
     @staticmethod
     def _native_to_pa_array(data: Transform3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Transform3DExt.native_to_pa_array_override(data, data_type)
 
-
-Transform3DType._ARRAY_TYPE = Transform3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Transform3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
@@ -23,11 +23,11 @@ if TYPE_CHECKING:
 class Transform3DExt:
     @staticmethod
     def native_to_pa_array_override(data: Transform3DArrayLike, data_type: pa.DataType) -> pa.Array:
-        from ..datatypes import Transform3DArray
+        from ..datatypes import Transform3DBatch
         from . import Transform3D, TranslationAndMat3x3, TranslationRotationScale3D
 
-        if isinstance(data, Transform3DArray):
-            return data.storage
+        if isinstance(data, Transform3DBatch):
+            return data.pa_array.storage
 
         if isinstance(data, Transform3D):
             data = data.inner
@@ -55,8 +55,9 @@ class Transform3DExt:
     # Implement the ArchetypeLike
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:
         from ..archetypes import Transform3D
+        from ..datatypes import Transform3D as Transform3DDataType
 
-        return Transform3D(self).as_component_batches()
+        return Transform3D(cast(Transform3DDataType, self)).as_component_batches()
 
     def num_instances(self) -> int:
         # Always a mono-component
@@ -66,7 +67,7 @@ class Transform3DExt:
 # TODO(#2623): lots of boilerplate here that could be auto-generated
 # To address that:
 # 1) rewrite everything in the form of `xxx__native_to_pa_array_override()`
-# 2) higher level `xxx__native_to_pa_array_override()` should call into lower level `xxx::from_similar()`
+# 2) higher level `xxx__native_to_pa_array_override()` should call into lower level `xxx::__init__()`
 # 3) identify regularities and auto-gen them
 
 
@@ -93,12 +94,12 @@ def _build_union_array_from_scale(scale: Scale3D | None, type_: pa.DenseUnionTyp
 
 
 def _optional_mat3x3_to_arrow(mat: Mat3x3 | None) -> pa.Array:
-    from . import Mat3x3Array, Mat3x3Type
+    from . import Mat3x3Batch, Mat3x3Type
 
     if mat is None:
         return pa.nulls(1, Mat3x3Type().storage_type)
     else:
-        return Mat3x3Array._native_to_pa_array(mat, Mat3x3Type().storage_type)
+        return Mat3x3Batch._native_to_pa_array(mat, Mat3x3Type().storage_type)
 
 
 def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.Array:
@@ -111,12 +112,12 @@ def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.Array:
 
 
 def _optional_rotation_to_arrow(rotation: Rotation3D | None, storage_type: pa.DataType) -> pa.Array:
-    from . import Rotation3DArray
+    from . import Rotation3DBatch
 
     if rotation is None:
         return pa.nulls(1, storage_type)
     else:
-        return Rotation3DArray._native_to_pa_array(rotation, storage_type)
+        return Rotation3DBatch._native_to_pa_array(rotation, storage_type)
 
 
 def _build_struct_array_from_translation_mat3x3(

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .translation_and_mat3x3_ext import TranslationAndMat3x3Ext
 
 __all__ = [
     "TranslationAndMat3x3",
-    "TranslationAndMat3x3Array",
     "TranslationAndMat3x3ArrayLike",
+    "TranslationAndMat3x3Batch",
     "TranslationAndMat3x3Like",
     "TranslationAndMat3x3Type",
 ]
@@ -86,10 +83,9 @@ TranslationAndMat3x3ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class TranslationAndMat3x3Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.TranslationAndMat3x3"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -110,20 +106,17 @@ class TranslationAndMat3x3Type(BaseExtensionType):
                     pa.field("from_parent", pa.bool_(), nullable=False, metadata={}),
                 ]
             ),
-            "rerun.datatypes.TranslationAndMat3x3",
+            self._TYPE_NAME,
         )
 
 
-class TranslationAndMat3x3Array(BaseExtensionArray[TranslationAndMat3x3ArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.TranslationAndMat3x3"
-    _EXTENSION_TYPE = TranslationAndMat3x3Type
+class TranslationAndMat3x3Batch(BaseBatch[TranslationAndMat3x3ArrayLike]):
+    _ARROW_TYPE = TranslationAndMat3x3Type()
 
     @staticmethod
     def _native_to_pa_array(data: TranslationAndMat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in translation_and_mat3x3_ext.py
 
-
-TranslationAndMat3x3Type._ARRAY_TYPE = TranslationAndMat3x3Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TranslationAndMat3x3Type())

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 if TYPE_CHECKING:
     from ..log import ComponentBatchLike
@@ -22,8 +22,9 @@ class TranslationAndMat3x3Ext:
     # Implement the ArchetypeLike
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:
         from ..archetypes import Transform3D
+        from ..datatypes import TranslationAndMat3x3
 
-        return Transform3D(self).as_component_batches()
+        return Transform3D(cast(TranslationAndMat3x3, self)).as_component_batches()
 
     def num_instances(self) -> int:
         # Always a mono-component

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
@@ -11,16 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .translation_rotation_scale3d_ext import TranslationRotationScale3DExt
 
 __all__ = [
     "TranslationRotationScale3D",
-    "TranslationRotationScale3DArray",
     "TranslationRotationScale3DArrayLike",
+    "TranslationRotationScale3DBatch",
     "TranslationRotationScale3DLike",
     "TranslationRotationScale3DType",
 ]
@@ -90,10 +87,9 @@ TranslationRotationScale3DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class TranslationRotationScale3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.TranslationRotationScale3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -172,20 +168,17 @@ class TranslationRotationScale3DType(BaseExtensionType):
                     pa.field("from_parent", pa.bool_(), nullable=False, metadata={}),
                 ]
             ),
-            "rerun.datatypes.TranslationRotationScale3D",
+            self._TYPE_NAME,
         )
 
 
-class TranslationRotationScale3DArray(BaseExtensionArray[TranslationRotationScale3DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.TranslationRotationScale3D"
-    _EXTENSION_TYPE = TranslationRotationScale3DType
+class TranslationRotationScale3DBatch(BaseBatch[TranslationRotationScale3DArrayLike]):
+    _ARROW_TYPE = TranslationRotationScale3DType()
 
     @staticmethod
     def _native_to_pa_array(data: TranslationRotationScale3DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in translation_rotation_scale3d_ext.py
 
-
-TranslationRotationScale3DType._ARRAY_TYPE = TranslationRotationScale3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(TranslationRotationScale3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 if TYPE_CHECKING:
     from ..log import ComponentBatchLike
@@ -32,8 +32,9 @@ class TranslationRotationScale3DExt:
     # Implement the ArchetypeLike protocol
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:
         from ..archetypes import Transform3D
+        from ..datatypes import TranslationRotationScale3D
 
-        return Transform3D(self).as_component_batches()
+        return Transform3D(cast(TranslationRotationScale3D, self)).as_component_batches()
 
     def num_instances(self) -> int:
         # Always a mono-component

--- a/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
@@ -10,13 +10,10 @@ from typing import TYPE_CHECKING, Any, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .utf8_ext import Utf8Ext
 
-__all__ = ["Utf8", "Utf8Array", "Utf8ArrayLike", "Utf8Like", "Utf8Type"]
+__all__ = ["Utf8", "Utf8ArrayLike", "Utf8Batch", "Utf8Like", "Utf8Type"]
 
 
 @define
@@ -39,24 +36,20 @@ else:
 Utf8ArrayLike = Union[Utf8, Sequence[Utf8Like], str, Sequence[str]]
 
 
-# --- Arrow support ---
-
-
 class Utf8Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Utf8"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), "rerun.datatypes.Utf8")
+        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
 
 
-class Utf8Array(BaseExtensionArray[Utf8ArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Utf8"
-    _EXTENSION_TYPE = Utf8Type
+class Utf8Batch(BaseBatch[Utf8ArrayLike]):
+    _ARROW_TYPE = Utf8Type()
 
     @staticmethod
     def _native_to_pa_array(data: Utf8ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Utf8Ext.native_to_pa_array_override(data, data_type)
 
-
-Utf8Type._ARRAY_TYPE = Utf8Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Utf8Type())

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -12,15 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_uint32,
 )
 
-__all__ = ["UVec2D", "UVec2DArray", "UVec2DArrayLike", "UVec2DLike", "UVec2DType"]
+__all__ = ["UVec2D", "UVec2DArrayLike", "UVec2DBatch", "UVec2DLike", "UVec2DType"]
 
 
 @define
@@ -46,26 +43,22 @@ UVec2DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class UVec2DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.UVec2D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 2), "rerun.datatypes.UVec2D"
+            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 2), self._TYPE_NAME
         )
 
 
-class UVec2DArray(BaseExtensionArray[UVec2DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.UVec2D"
-    _EXTENSION_TYPE = UVec2DType
+class UVec2DBatch(BaseBatch[UVec2DArrayLike]):
+    _ARROW_TYPE = UVec2DType()
 
     @staticmethod
     def _native_to_pa_array(data: UVec2DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in uvec2d_ext.py
 
-
-UVec2DType._ARRAY_TYPE = UVec2DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(UVec2DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -12,15 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_uint32,
 )
 
-__all__ = ["UVec3D", "UVec3DArray", "UVec3DArrayLike", "UVec3DLike", "UVec3DType"]
+__all__ = ["UVec3D", "UVec3DArrayLike", "UVec3DBatch", "UVec3DLike", "UVec3DType"]
 
 
 @define
@@ -46,26 +43,22 @@ UVec3DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class UVec3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.UVec3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 3), "rerun.datatypes.UVec3D"
+            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 3), self._TYPE_NAME
         )
 
 
-class UVec3DArray(BaseExtensionArray[UVec3DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.UVec3D"
-    _EXTENSION_TYPE = UVec3DType
+class UVec3DBatch(BaseBatch[UVec3DArrayLike]):
+    _ARROW_TYPE = UVec3DType()
 
     @staticmethod
     def _native_to_pa_array(data: UVec3DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in uvec3d_ext.py
 
-
-UVec3DType._ARRAY_TYPE = UVec3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(UVec3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -12,15 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_uint32,
 )
 
-__all__ = ["UVec4D", "UVec4DArray", "UVec4DArrayLike", "UVec4DLike", "UVec4DType"]
+__all__ = ["UVec4D", "UVec4DArrayLike", "UVec4DBatch", "UVec4DLike", "UVec4DType"]
 
 
 @define
@@ -46,26 +43,22 @@ UVec4DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class UVec4DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.UVec4D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 4), "rerun.datatypes.UVec4D"
+            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 4), self._TYPE_NAME
         )
 
 
-class UVec4DArray(BaseExtensionArray[UVec4DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.UVec4D"
-    _EXTENSION_TYPE = UVec4DType
+class UVec4DBatch(BaseBatch[UVec4DArrayLike]):
+    _ARROW_TYPE = UVec4DType()
 
     @staticmethod
     def _native_to_pa_array(data: UVec4DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in uvec4d_ext.py
 
-
-UVec4DType._ARRAY_TYPE = UVec4DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(UVec4DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_float32,
 )
 from .vec2d_ext import Vec2DExt
 
-__all__ = ["Vec2D", "Vec2DArray", "Vec2DArrayLike", "Vec2DLike", "Vec2DType"]
+__all__ = ["Vec2D", "Vec2DArrayLike", "Vec2DBatch", "Vec2DLike", "Vec2DType"]
 
 
 @define
@@ -47,26 +44,22 @@ Vec2DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class Vec2DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Vec2D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2), "rerun.datatypes.Vec2D"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2), self._TYPE_NAME
         )
 
 
-class Vec2DArray(BaseExtensionArray[Vec2DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Vec2D"
-    _EXTENSION_TYPE = Vec2DType
+class Vec2DBatch(BaseBatch[Vec2DArrayLike]):
+    _ARROW_TYPE = Vec2DType()
 
     @staticmethod
     def _native_to_pa_array(data: Vec2DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Vec2DExt.native_to_pa_array_override(data, data_type)
 
-
-Vec2DType._ARRAY_TYPE = Vec2DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Vec2DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_float32,
 )
 from .vec3d_ext import Vec3DExt
 
-__all__ = ["Vec3D", "Vec3DArray", "Vec3DArrayLike", "Vec3DLike", "Vec3DType"]
+__all__ = ["Vec3D", "Vec3DArrayLike", "Vec3DBatch", "Vec3DLike", "Vec3DType"]
 
 
 @define
@@ -47,26 +44,22 @@ Vec3DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class Vec3DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Vec3D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3), "rerun.datatypes.Vec3D"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3), self._TYPE_NAME
         )
 
 
-class Vec3DArray(BaseExtensionArray[Vec3DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Vec3D"
-    _EXTENSION_TYPE = Vec3DType
+class Vec3DBatch(BaseBatch[Vec3DArrayLike]):
+    _ARROW_TYPE = Vec3DType()
 
     @staticmethod
     def _native_to_pa_array(data: Vec3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Vec3DExt.native_to_pa_array_override(data, data_type)
 
-
-Vec3DType._ARRAY_TYPE = Vec3DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Vec3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -12,16 +12,13 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from .._baseclasses import BaseBatch, BaseExtensionType
 from .._converters import (
     to_np_float32,
 )
 from .vec4d_ext import Vec4DExt
 
-__all__ = ["Vec4D", "Vec4DArray", "Vec4DArrayLike", "Vec4DLike", "Vec4DType"]
+__all__ = ["Vec4D", "Vec4DArrayLike", "Vec4DBatch", "Vec4DLike", "Vec4DType"]
 
 
 @define
@@ -47,26 +44,22 @@ Vec4DArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class Vec4DType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.datatypes.Vec4D"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), "rerun.datatypes.Vec4D"
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), self._TYPE_NAME
         )
 
 
-class Vec4DArray(BaseExtensionArray[Vec4DArrayLike]):
-    _EXTENSION_NAME = "rerun.datatypes.Vec4D"
-    _EXTENSION_TYPE = Vec4DType
+class Vec4DBatch(BaseBatch[Vec4DArrayLike]):
+    _ARROW_TYPE = Vec4DType()
 
     @staticmethod
     def _native_to_pa_array(data: Vec4DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Vec4DExt.native_to_pa_array_override(data, data_type)
 
-
-Vec4DType._ARRAY_TYPE = Vec4DArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(Vec4DType())

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/annotation.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/annotation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Sequence
 
 from rerun.datatypes import AnnotationInfo, ClassDescription, ClassDescriptionLike
 from rerun.log_deprecated.log_decorator import log_decorator
@@ -12,7 +12,7 @@ __all__ = ["log_annotation_context", "AnnotationInfo", "ClassDescription", "Clas
 @log_decorator
 def log_annotation_context(
     entity_path: str,
-    class_descriptions: ClassDescriptionLike | Iterable[ClassDescriptionLike],
+    class_descriptions: ClassDescriptionLike | Sequence[ClassDescriptionLike],
     *,
     timeless: bool = True,
     recording: RecordingStream | None = None,

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/extension_components.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/extension_components.py
@@ -133,7 +133,7 @@ def log_extension_components(
     splats: dict[str, Any] = {}
 
     if len(identifiers_np):
-        instanced["rerun.components.InstanceKey"] = rrc.InstanceKeyArray.from_similar(identifiers_np).storage
+        instanced["rerun.components.InstanceKey"] = rrc.InstanceKeyBatch(identifiers_np).as_arrow_array().storage
 
     _add_extension_components(instanced, splats, ext, identifiers_np)
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
@@ -112,7 +112,7 @@ def log_mesh_file(
         transform = np.require(transform, dtype="float32")
         translation = transform[..., -1]
         mat = [transform[..., 0], transform[..., 1], transform[..., 2]]
-        asset3d.transform = rr2.dt.Transform3DArray.from_similar(
+        asset3d.transform = rr2.cmp.OutOfTreeTransform3DBatch(
             rr2.dt.TranslationAndMat3x3(translation=translation, matrix=mat)
         )
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -166,6 +166,10 @@ def log_line_strips_2d(
         except ValueError:
             _send_warning("Only integer identifiers supported", 1)
 
+    # New types use Sequence, not Iterable
+    if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
+        line_strips = list(line_strips)
+
     stroke_widths = _normalize_radii(stroke_widths)
     radii = stroke_widths / 2.0
 
@@ -242,6 +246,10 @@ def log_line_strips_3d(
             identifiers_np = np.require(identifiers, dtype="uint64")
         except ValueError:
             _send_warning("Only integer identifiers supported", 1)
+
+    # New types use Sequence, not Iterable
+    if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
+        line_strips = list(line_strips)
 
     stroke_widths = _normalize_radii(stroke_widths)
     radii = stroke_widths / 2.0

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -6,9 +6,7 @@
 from __future__ import annotations
 
 from attrs import define, field
-from rerun._baseclasses import (
-    Archetype,
-)
+from rerun._baseclasses import Archetype
 
 from .. import components
 
@@ -19,341 +17,341 @@ __all__ = ["AffixFuzzer1"]
 class AffixFuzzer1(Archetype):
     # You can define your own __init__ function as a member of AffixFuzzer1Ext in affix_fuzzer1_ext.py
 
-    fuzz1001: components.AffixFuzzer1Array = field(
+    fuzz1001: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer1Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer1Batch,  # type: ignore[misc]
     )
-    fuzz1002: components.AffixFuzzer2Array = field(
+    fuzz1002: components.AffixFuzzer2Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer2Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer2Batch,  # type: ignore[misc]
     )
-    fuzz1003: components.AffixFuzzer3Array = field(
+    fuzz1003: components.AffixFuzzer3Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer3Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer3Batch,  # type: ignore[misc]
     )
-    fuzz1004: components.AffixFuzzer4Array = field(
+    fuzz1004: components.AffixFuzzer4Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer4Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer4Batch,  # type: ignore[misc]
     )
-    fuzz1005: components.AffixFuzzer5Array = field(
+    fuzz1005: components.AffixFuzzer5Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer5Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer5Batch,  # type: ignore[misc]
     )
-    fuzz1006: components.AffixFuzzer6Array = field(
+    fuzz1006: components.AffixFuzzer6Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer6Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer6Batch,  # type: ignore[misc]
     )
-    fuzz1007: components.AffixFuzzer7Array = field(
+    fuzz1007: components.AffixFuzzer7Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer7Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer7Batch,  # type: ignore[misc]
     )
-    fuzz1008: components.AffixFuzzer8Array = field(
+    fuzz1008: components.AffixFuzzer8Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer8Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer8Batch,  # type: ignore[misc]
     )
-    fuzz1009: components.AffixFuzzer9Array = field(
+    fuzz1009: components.AffixFuzzer9Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer9Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer9Batch,  # type: ignore[misc]
     )
-    fuzz1010: components.AffixFuzzer10Array = field(
+    fuzz1010: components.AffixFuzzer10Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer10Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer10Batch,  # type: ignore[misc]
     )
-    fuzz1011: components.AffixFuzzer11Array = field(
+    fuzz1011: components.AffixFuzzer11Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer11Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer11Batch,  # type: ignore[misc]
     )
-    fuzz1012: components.AffixFuzzer12Array = field(
+    fuzz1012: components.AffixFuzzer12Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer12Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer12Batch,  # type: ignore[misc]
     )
-    fuzz1013: components.AffixFuzzer13Array = field(
+    fuzz1013: components.AffixFuzzer13Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer13Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer13Batch,  # type: ignore[misc]
     )
-    fuzz1014: components.AffixFuzzer14Array = field(
+    fuzz1014: components.AffixFuzzer14Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer14Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer14Batch,  # type: ignore[misc]
     )
-    fuzz1015: components.AffixFuzzer15Array = field(
+    fuzz1015: components.AffixFuzzer15Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer15Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer15Batch,  # type: ignore[misc]
     )
-    fuzz1016: components.AffixFuzzer16Array = field(
+    fuzz1016: components.AffixFuzzer16Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer16Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer16Batch,  # type: ignore[misc]
     )
-    fuzz1017: components.AffixFuzzer17Array = field(
+    fuzz1017: components.AffixFuzzer17Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer17Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer17Batch,  # type: ignore[misc]
     )
-    fuzz1018: components.AffixFuzzer18Array = field(
+    fuzz1018: components.AffixFuzzer18Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer18Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer18Batch,  # type: ignore[misc]
     )
-    fuzz1019: components.AffixFuzzer19Array = field(
+    fuzz1019: components.AffixFuzzer19Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer19Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer19Batch,  # type: ignore[misc]
     )
-    fuzz1020: components.AffixFuzzer20Array = field(
+    fuzz1020: components.AffixFuzzer20Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer20Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer20Batch,  # type: ignore[misc]
     )
-    fuzz1021: components.AffixFuzzer21Array = field(
+    fuzz1021: components.AffixFuzzer21Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer21Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer21Batch,  # type: ignore[misc]
     )
-    fuzz1101: components.AffixFuzzer1Array = field(
+    fuzz1101: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer1Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer1Batch,  # type: ignore[misc]
     )
-    fuzz1102: components.AffixFuzzer2Array = field(
+    fuzz1102: components.AffixFuzzer2Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer2Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer2Batch,  # type: ignore[misc]
     )
-    fuzz1103: components.AffixFuzzer3Array = field(
+    fuzz1103: components.AffixFuzzer3Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer3Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer3Batch,  # type: ignore[misc]
     )
-    fuzz1104: components.AffixFuzzer4Array = field(
+    fuzz1104: components.AffixFuzzer4Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer4Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer4Batch,  # type: ignore[misc]
     )
-    fuzz1105: components.AffixFuzzer5Array = field(
+    fuzz1105: components.AffixFuzzer5Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer5Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer5Batch,  # type: ignore[misc]
     )
-    fuzz1106: components.AffixFuzzer6Array = field(
+    fuzz1106: components.AffixFuzzer6Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer6Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer6Batch,  # type: ignore[misc]
     )
-    fuzz1107: components.AffixFuzzer7Array = field(
+    fuzz1107: components.AffixFuzzer7Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer7Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer7Batch,  # type: ignore[misc]
     )
-    fuzz1108: components.AffixFuzzer8Array = field(
+    fuzz1108: components.AffixFuzzer8Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer8Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer8Batch,  # type: ignore[misc]
     )
-    fuzz1109: components.AffixFuzzer9Array = field(
+    fuzz1109: components.AffixFuzzer9Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer9Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer9Batch,  # type: ignore[misc]
     )
-    fuzz1110: components.AffixFuzzer10Array = field(
+    fuzz1110: components.AffixFuzzer10Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer10Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer10Batch,  # type: ignore[misc]
     )
-    fuzz1111: components.AffixFuzzer11Array = field(
+    fuzz1111: components.AffixFuzzer11Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer11Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer11Batch,  # type: ignore[misc]
     )
-    fuzz1112: components.AffixFuzzer12Array = field(
+    fuzz1112: components.AffixFuzzer12Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer12Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer12Batch,  # type: ignore[misc]
     )
-    fuzz1113: components.AffixFuzzer13Array = field(
+    fuzz1113: components.AffixFuzzer13Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer13Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer13Batch,  # type: ignore[misc]
     )
-    fuzz1114: components.AffixFuzzer14Array = field(
+    fuzz1114: components.AffixFuzzer14Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer14Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer14Batch,  # type: ignore[misc]
     )
-    fuzz1115: components.AffixFuzzer15Array = field(
+    fuzz1115: components.AffixFuzzer15Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer15Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer15Batch,  # type: ignore[misc]
     )
-    fuzz1116: components.AffixFuzzer16Array = field(
+    fuzz1116: components.AffixFuzzer16Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer16Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer16Batch,  # type: ignore[misc]
     )
-    fuzz1117: components.AffixFuzzer17Array = field(
+    fuzz1117: components.AffixFuzzer17Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer17Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer17Batch,  # type: ignore[misc]
     )
-    fuzz1118: components.AffixFuzzer18Array = field(
+    fuzz1118: components.AffixFuzzer18Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer18Array.from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer18Batch,  # type: ignore[misc]
     )
-    fuzz2001: components.AffixFuzzer1Array | None = field(
+    fuzz2001: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer1Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer1Batch._optional,  # type: ignore[misc]
     )
-    fuzz2002: components.AffixFuzzer2Array | None = field(
+    fuzz2002: components.AffixFuzzer2Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer2Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer2Batch._optional,  # type: ignore[misc]
     )
-    fuzz2003: components.AffixFuzzer3Array | None = field(
+    fuzz2003: components.AffixFuzzer3Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer3Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer3Batch._optional,  # type: ignore[misc]
     )
-    fuzz2004: components.AffixFuzzer4Array | None = field(
+    fuzz2004: components.AffixFuzzer4Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer4Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer4Batch._optional,  # type: ignore[misc]
     )
-    fuzz2005: components.AffixFuzzer5Array | None = field(
+    fuzz2005: components.AffixFuzzer5Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer5Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer5Batch._optional,  # type: ignore[misc]
     )
-    fuzz2006: components.AffixFuzzer6Array | None = field(
+    fuzz2006: components.AffixFuzzer6Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer6Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer6Batch._optional,  # type: ignore[misc]
     )
-    fuzz2007: components.AffixFuzzer7Array | None = field(
+    fuzz2007: components.AffixFuzzer7Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer7Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer7Batch._optional,  # type: ignore[misc]
     )
-    fuzz2008: components.AffixFuzzer8Array | None = field(
+    fuzz2008: components.AffixFuzzer8Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer8Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer8Batch._optional,  # type: ignore[misc]
     )
-    fuzz2009: components.AffixFuzzer9Array | None = field(
+    fuzz2009: components.AffixFuzzer9Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer9Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer9Batch._optional,  # type: ignore[misc]
     )
-    fuzz2010: components.AffixFuzzer10Array | None = field(
+    fuzz2010: components.AffixFuzzer10Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer10Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer10Batch._optional,  # type: ignore[misc]
     )
-    fuzz2011: components.AffixFuzzer11Array | None = field(
+    fuzz2011: components.AffixFuzzer11Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer11Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer11Batch._optional,  # type: ignore[misc]
     )
-    fuzz2012: components.AffixFuzzer12Array | None = field(
+    fuzz2012: components.AffixFuzzer12Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer12Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer12Batch._optional,  # type: ignore[misc]
     )
-    fuzz2013: components.AffixFuzzer13Array | None = field(
+    fuzz2013: components.AffixFuzzer13Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer13Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer13Batch._optional,  # type: ignore[misc]
     )
-    fuzz2014: components.AffixFuzzer14Array | None = field(
+    fuzz2014: components.AffixFuzzer14Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer14Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer14Batch._optional,  # type: ignore[misc]
     )
-    fuzz2015: components.AffixFuzzer15Array | None = field(
+    fuzz2015: components.AffixFuzzer15Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer15Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer15Batch._optional,  # type: ignore[misc]
     )
-    fuzz2016: components.AffixFuzzer16Array | None = field(
+    fuzz2016: components.AffixFuzzer16Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer16Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer16Batch._optional,  # type: ignore[misc]
     )
-    fuzz2017: components.AffixFuzzer17Array | None = field(
+    fuzz2017: components.AffixFuzzer17Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer17Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer17Batch._optional,  # type: ignore[misc]
     )
-    fuzz2018: components.AffixFuzzer18Array | None = field(
+    fuzz2018: components.AffixFuzzer18Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer18Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer18Batch._optional,  # type: ignore[misc]
     )
-    fuzz2101: components.AffixFuzzer1Array | None = field(
+    fuzz2101: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer1Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer1Batch._optional,  # type: ignore[misc]
     )
-    fuzz2102: components.AffixFuzzer2Array | None = field(
+    fuzz2102: components.AffixFuzzer2Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer2Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer2Batch._optional,  # type: ignore[misc]
     )
-    fuzz2103: components.AffixFuzzer3Array | None = field(
+    fuzz2103: components.AffixFuzzer3Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer3Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer3Batch._optional,  # type: ignore[misc]
     )
-    fuzz2104: components.AffixFuzzer4Array | None = field(
+    fuzz2104: components.AffixFuzzer4Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer4Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer4Batch._optional,  # type: ignore[misc]
     )
-    fuzz2105: components.AffixFuzzer5Array | None = field(
+    fuzz2105: components.AffixFuzzer5Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer5Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer5Batch._optional,  # type: ignore[misc]
     )
-    fuzz2106: components.AffixFuzzer6Array | None = field(
+    fuzz2106: components.AffixFuzzer6Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer6Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer6Batch._optional,  # type: ignore[misc]
     )
-    fuzz2107: components.AffixFuzzer7Array | None = field(
+    fuzz2107: components.AffixFuzzer7Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer7Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer7Batch._optional,  # type: ignore[misc]
     )
-    fuzz2108: components.AffixFuzzer8Array | None = field(
+    fuzz2108: components.AffixFuzzer8Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer8Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer8Batch._optional,  # type: ignore[misc]
     )
-    fuzz2109: components.AffixFuzzer9Array | None = field(
+    fuzz2109: components.AffixFuzzer9Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer9Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer9Batch._optional,  # type: ignore[misc]
     )
-    fuzz2110: components.AffixFuzzer10Array | None = field(
+    fuzz2110: components.AffixFuzzer10Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer10Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer10Batch._optional,  # type: ignore[misc]
     )
-    fuzz2111: components.AffixFuzzer11Array | None = field(
+    fuzz2111: components.AffixFuzzer11Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer11Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer11Batch._optional,  # type: ignore[misc]
     )
-    fuzz2112: components.AffixFuzzer12Array | None = field(
+    fuzz2112: components.AffixFuzzer12Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer12Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer12Batch._optional,  # type: ignore[misc]
     )
-    fuzz2113: components.AffixFuzzer13Array | None = field(
+    fuzz2113: components.AffixFuzzer13Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer13Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer13Batch._optional,  # type: ignore[misc]
     )
-    fuzz2114: components.AffixFuzzer14Array | None = field(
+    fuzz2114: components.AffixFuzzer14Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer14Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer14Batch._optional,  # type: ignore[misc]
     )
-    fuzz2115: components.AffixFuzzer15Array | None = field(
+    fuzz2115: components.AffixFuzzer15Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer15Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer15Batch._optional,  # type: ignore[misc]
     )
-    fuzz2116: components.AffixFuzzer16Array | None = field(
+    fuzz2116: components.AffixFuzzer16Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer16Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer16Batch._optional,  # type: ignore[misc]
     )
-    fuzz2117: components.AffixFuzzer17Array | None = field(
+    fuzz2117: components.AffixFuzzer17Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer17Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer17Batch._optional,  # type: ignore[misc]
     )
-    fuzz2118: components.AffixFuzzer18Array | None = field(
+    fuzz2118: components.AffixFuzzer18Batch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AffixFuzzer18Array.optional_from_similar,  # type: ignore[misc]
+        converter=components.AffixFuzzer18Batch._optional,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/tests/test_types/components/__init__.py
+++ b/rerun_py/tests/test_types/components/__init__.py
@@ -2,152 +2,152 @@
 
 from __future__ import annotations
 
-from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1Array, AffixFuzzer1Type
-from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2Array, AffixFuzzer2Type
-from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3Array, AffixFuzzer3Type
-from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4Array, AffixFuzzer4Type
-from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5Array, AffixFuzzer5Type
-from .affix_fuzzer6 import AffixFuzzer6, AffixFuzzer6Array, AffixFuzzer6Type
-from .affix_fuzzer7 import AffixFuzzer7, AffixFuzzer7Array, AffixFuzzer7ArrayLike, AffixFuzzer7Like, AffixFuzzer7Type
-from .affix_fuzzer8 import AffixFuzzer8, AffixFuzzer8Array, AffixFuzzer8ArrayLike, AffixFuzzer8Like, AffixFuzzer8Type
-from .affix_fuzzer9 import AffixFuzzer9, AffixFuzzer9Array, AffixFuzzer9ArrayLike, AffixFuzzer9Like, AffixFuzzer9Type
+from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1Batch, AffixFuzzer1Type
+from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2Batch, AffixFuzzer2Type
+from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3Batch, AffixFuzzer3Type
+from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4Batch, AffixFuzzer4Type
+from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5Batch, AffixFuzzer5Type
+from .affix_fuzzer6 import AffixFuzzer6, AffixFuzzer6Batch, AffixFuzzer6Type
+from .affix_fuzzer7 import AffixFuzzer7, AffixFuzzer7ArrayLike, AffixFuzzer7Batch, AffixFuzzer7Like, AffixFuzzer7Type
+from .affix_fuzzer8 import AffixFuzzer8, AffixFuzzer8ArrayLike, AffixFuzzer8Batch, AffixFuzzer8Like, AffixFuzzer8Type
+from .affix_fuzzer9 import AffixFuzzer9, AffixFuzzer9ArrayLike, AffixFuzzer9Batch, AffixFuzzer9Like, AffixFuzzer9Type
 from .affix_fuzzer10 import (
     AffixFuzzer10,
-    AffixFuzzer10Array,
     AffixFuzzer10ArrayLike,
+    AffixFuzzer10Batch,
     AffixFuzzer10Like,
     AffixFuzzer10Type,
 )
 from .affix_fuzzer11 import (
     AffixFuzzer11,
-    AffixFuzzer11Array,
     AffixFuzzer11ArrayLike,
+    AffixFuzzer11Batch,
     AffixFuzzer11Like,
     AffixFuzzer11Type,
 )
 from .affix_fuzzer12 import (
     AffixFuzzer12,
-    AffixFuzzer12Array,
     AffixFuzzer12ArrayLike,
+    AffixFuzzer12Batch,
     AffixFuzzer12Like,
     AffixFuzzer12Type,
 )
 from .affix_fuzzer13 import (
     AffixFuzzer13,
-    AffixFuzzer13Array,
     AffixFuzzer13ArrayLike,
+    AffixFuzzer13Batch,
     AffixFuzzer13Like,
     AffixFuzzer13Type,
 )
-from .affix_fuzzer14 import AffixFuzzer14, AffixFuzzer14Array, AffixFuzzer14Type
-from .affix_fuzzer15 import AffixFuzzer15, AffixFuzzer15Array, AffixFuzzer15Type
+from .affix_fuzzer14 import AffixFuzzer14, AffixFuzzer14Batch, AffixFuzzer14Type
+from .affix_fuzzer15 import AffixFuzzer15, AffixFuzzer15Batch, AffixFuzzer15Type
 from .affix_fuzzer16 import (
     AffixFuzzer16,
-    AffixFuzzer16Array,
     AffixFuzzer16ArrayLike,
+    AffixFuzzer16Batch,
     AffixFuzzer16Like,
     AffixFuzzer16Type,
 )
 from .affix_fuzzer17 import (
     AffixFuzzer17,
-    AffixFuzzer17Array,
     AffixFuzzer17ArrayLike,
+    AffixFuzzer17Batch,
     AffixFuzzer17Like,
     AffixFuzzer17Type,
 )
 from .affix_fuzzer18 import (
     AffixFuzzer18,
-    AffixFuzzer18Array,
     AffixFuzzer18ArrayLike,
+    AffixFuzzer18Batch,
     AffixFuzzer18Like,
     AffixFuzzer18Type,
 )
-from .affix_fuzzer19 import AffixFuzzer19, AffixFuzzer19Array, AffixFuzzer19Type
-from .affix_fuzzer20 import AffixFuzzer20, AffixFuzzer20Array, AffixFuzzer20Type
-from .affix_fuzzer21 import AffixFuzzer21, AffixFuzzer21Array, AffixFuzzer21Type
+from .affix_fuzzer19 import AffixFuzzer19, AffixFuzzer19Batch, AffixFuzzer19Type
+from .affix_fuzzer20 import AffixFuzzer20, AffixFuzzer20Batch, AffixFuzzer20Type
+from .affix_fuzzer21 import AffixFuzzer21, AffixFuzzer21Batch, AffixFuzzer21Type
 
 __all__ = [
     "AffixFuzzer1",
     "AffixFuzzer10",
-    "AffixFuzzer10Array",
     "AffixFuzzer10ArrayLike",
+    "AffixFuzzer10Batch",
     "AffixFuzzer10Like",
     "AffixFuzzer10Type",
     "AffixFuzzer11",
-    "AffixFuzzer11Array",
     "AffixFuzzer11ArrayLike",
+    "AffixFuzzer11Batch",
     "AffixFuzzer11Like",
     "AffixFuzzer11Type",
     "AffixFuzzer12",
-    "AffixFuzzer12Array",
     "AffixFuzzer12ArrayLike",
+    "AffixFuzzer12Batch",
     "AffixFuzzer12Like",
     "AffixFuzzer12Type",
     "AffixFuzzer13",
-    "AffixFuzzer13Array",
     "AffixFuzzer13ArrayLike",
+    "AffixFuzzer13Batch",
     "AffixFuzzer13Like",
     "AffixFuzzer13Type",
     "AffixFuzzer14",
-    "AffixFuzzer14Array",
+    "AffixFuzzer14Batch",
     "AffixFuzzer14Type",
     "AffixFuzzer15",
-    "AffixFuzzer15Array",
+    "AffixFuzzer15Batch",
     "AffixFuzzer15Type",
     "AffixFuzzer16",
-    "AffixFuzzer16Array",
     "AffixFuzzer16ArrayLike",
+    "AffixFuzzer16Batch",
     "AffixFuzzer16Like",
     "AffixFuzzer16Type",
     "AffixFuzzer17",
-    "AffixFuzzer17Array",
     "AffixFuzzer17ArrayLike",
+    "AffixFuzzer17Batch",
     "AffixFuzzer17Like",
     "AffixFuzzer17Type",
     "AffixFuzzer18",
-    "AffixFuzzer18Array",
     "AffixFuzzer18ArrayLike",
+    "AffixFuzzer18Batch",
     "AffixFuzzer18Like",
     "AffixFuzzer18Type",
     "AffixFuzzer19",
-    "AffixFuzzer19Array",
+    "AffixFuzzer19Batch",
     "AffixFuzzer19Type",
-    "AffixFuzzer1Array",
+    "AffixFuzzer1Batch",
     "AffixFuzzer1Type",
     "AffixFuzzer2",
     "AffixFuzzer20",
-    "AffixFuzzer20Array",
+    "AffixFuzzer20Batch",
     "AffixFuzzer20Type",
     "AffixFuzzer21",
-    "AffixFuzzer21Array",
+    "AffixFuzzer21Batch",
     "AffixFuzzer21Type",
-    "AffixFuzzer2Array",
+    "AffixFuzzer2Batch",
     "AffixFuzzer2Type",
     "AffixFuzzer3",
-    "AffixFuzzer3Array",
+    "AffixFuzzer3Batch",
     "AffixFuzzer3Type",
     "AffixFuzzer4",
-    "AffixFuzzer4Array",
+    "AffixFuzzer4Batch",
     "AffixFuzzer4Type",
     "AffixFuzzer5",
-    "AffixFuzzer5Array",
+    "AffixFuzzer5Batch",
     "AffixFuzzer5Type",
     "AffixFuzzer6",
-    "AffixFuzzer6Array",
+    "AffixFuzzer6Batch",
     "AffixFuzzer6Type",
     "AffixFuzzer7",
-    "AffixFuzzer7Array",
     "AffixFuzzer7ArrayLike",
+    "AffixFuzzer7Batch",
     "AffixFuzzer7Like",
     "AffixFuzzer7Type",
     "AffixFuzzer8",
-    "AffixFuzzer8Array",
     "AffixFuzzer8ArrayLike",
+    "AffixFuzzer8Batch",
     "AffixFuzzer8Like",
     "AffixFuzzer8Type",
     "AffixFuzzer9",
-    "AffixFuzzer9Array",
     "AffixFuzzer9ArrayLike",
+    "AffixFuzzer9Batch",
     "AffixFuzzer9Like",
     "AffixFuzzer9Type",
 ]

--- a/rerun_py/tests/test_types/components/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer1.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer1", "AffixFuzzer1Array", "AffixFuzzer1Type"]
+__all__ = ["AffixFuzzer1", "AffixFuzzer1Batch", "AffixFuzzer1Type"]
 
 
 class AffixFuzzer1(datatypes.AffixFuzzer1):
@@ -22,18 +19,13 @@ class AffixFuzzer1(datatypes.AffixFuzzer1):
     pass
 
 
-class AffixFuzzer1Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer1"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer1Type
+class AffixFuzzer1Type(datatypes.AffixFuzzer1Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer1"
 
 
-class AffixFuzzer1Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer1"
-    _EXTENSION_TYPE = AffixFuzzer1Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer1Array
+class AffixFuzzer1Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer1Type()
 
-
-AffixFuzzer1Type._ARRAY_TYPE = AffixFuzzer1Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer1Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -9,15 +9,12 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from rerun._converters import (
     str_or_none,
 )
 
-__all__ = ["AffixFuzzer10", "AffixFuzzer10Array", "AffixFuzzer10ArrayLike", "AffixFuzzer10Like", "AffixFuzzer10Type"]
+__all__ = ["AffixFuzzer10", "AffixFuzzer10ArrayLike", "AffixFuzzer10Batch", "AffixFuzzer10Like", "AffixFuzzer10Type"]
 
 
 @define
@@ -34,24 +31,20 @@ AffixFuzzer10ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer10Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer10"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), "rerun.testing.components.AffixFuzzer10")
+        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
 
 
-class AffixFuzzer10Array(BaseExtensionArray[AffixFuzzer10ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer10"
-    _EXTENSION_TYPE = AffixFuzzer10Type
+class AffixFuzzer10Batch(BaseBatch[AffixFuzzer10ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer10Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer10ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer10_ext.py
 
-
-AffixFuzzer10Type._ARRAY_TYPE = AffixFuzzer10Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer10Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -11,15 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from rerun._converters import (
     to_np_float32,
 )
 
-__all__ = ["AffixFuzzer11", "AffixFuzzer11Array", "AffixFuzzer11ArrayLike", "AffixFuzzer11Like", "AffixFuzzer11Type"]
+__all__ = ["AffixFuzzer11", "AffixFuzzer11ArrayLike", "AffixFuzzer11Batch", "AffixFuzzer11Like", "AffixFuzzer11Type"]
 
 
 @define
@@ -40,28 +37,22 @@ AffixFuzzer11ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer11Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer11"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self,
-            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-            "rerun.testing.components.AffixFuzzer11",
+            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})), self._TYPE_NAME
         )
 
 
-class AffixFuzzer11Array(BaseExtensionArray[AffixFuzzer11ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer11"
-    _EXTENSION_TYPE = AffixFuzzer11Type
+class AffixFuzzer11Batch(BaseBatch[AffixFuzzer11ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer11Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer11ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer11_ext.py
 
-
-AffixFuzzer11Type._ARRAY_TYPE = AffixFuzzer11Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer11Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -9,12 +9,9 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
-__all__ = ["AffixFuzzer12", "AffixFuzzer12Array", "AffixFuzzer12ArrayLike", "AffixFuzzer12Like", "AffixFuzzer12Type"]
+__all__ = ["AffixFuzzer12", "AffixFuzzer12ArrayLike", "AffixFuzzer12Batch", "AffixFuzzer12Like", "AffixFuzzer12Type"]
 
 
 @define
@@ -31,28 +28,22 @@ AffixFuzzer12ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer12Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer12"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self,
-            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-            "rerun.testing.components.AffixFuzzer12",
+            self, pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})), self._TYPE_NAME
         )
 
 
-class AffixFuzzer12Array(BaseExtensionArray[AffixFuzzer12ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer12"
-    _EXTENSION_TYPE = AffixFuzzer12Type
+class AffixFuzzer12Batch(BaseBatch[AffixFuzzer12ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer12Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer12ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer12_ext.py
 
-
-AffixFuzzer12Type._ARRAY_TYPE = AffixFuzzer12Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer12Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -9,12 +9,9 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
-__all__ = ["AffixFuzzer13", "AffixFuzzer13Array", "AffixFuzzer13ArrayLike", "AffixFuzzer13Like", "AffixFuzzer13Type"]
+__all__ = ["AffixFuzzer13", "AffixFuzzer13ArrayLike", "AffixFuzzer13Batch", "AffixFuzzer13Like", "AffixFuzzer13Type"]
 
 
 @define
@@ -31,28 +28,22 @@ AffixFuzzer13ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer13Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer13"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self,
-            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-            "rerun.testing.components.AffixFuzzer13",
+            self, pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})), self._TYPE_NAME
         )
 
 
-class AffixFuzzer13Array(BaseExtensionArray[AffixFuzzer13ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer13"
-    _EXTENSION_TYPE = AffixFuzzer13Type
+class AffixFuzzer13Batch(BaseBatch[AffixFuzzer13ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer13Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer13ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer13_ext.py
 
-
-AffixFuzzer13Type._ARRAY_TYPE = AffixFuzzer13Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer13Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer14.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer14.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer14", "AffixFuzzer14Array", "AffixFuzzer14Type"]
+__all__ = ["AffixFuzzer14", "AffixFuzzer14Batch", "AffixFuzzer14Type"]
 
 
 class AffixFuzzer14(datatypes.AffixFuzzer3):
@@ -22,18 +19,13 @@ class AffixFuzzer14(datatypes.AffixFuzzer3):
     pass
 
 
-class AffixFuzzer14Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer14"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer3Type
+class AffixFuzzer14Type(datatypes.AffixFuzzer3Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer14"
 
 
-class AffixFuzzer14Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer3ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer14"
-    _EXTENSION_TYPE = AffixFuzzer14Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer3Array
+class AffixFuzzer14Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer14Type()
 
-
-AffixFuzzer14Type._ARRAY_TYPE = AffixFuzzer14Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer14Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer15.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer15.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer15", "AffixFuzzer15Array", "AffixFuzzer15Type"]
+__all__ = ["AffixFuzzer15", "AffixFuzzer15Batch", "AffixFuzzer15Type"]
 
 
 class AffixFuzzer15(datatypes.AffixFuzzer3):
@@ -22,18 +19,13 @@ class AffixFuzzer15(datatypes.AffixFuzzer3):
     pass
 
 
-class AffixFuzzer15Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer15"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer3Type
+class AffixFuzzer15Type(datatypes.AffixFuzzer3Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer15"
 
 
-class AffixFuzzer15Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer3ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer15"
-    _EXTENSION_TYPE = AffixFuzzer15Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer3Array
+class AffixFuzzer15Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer15Type()
 
-
-AffixFuzzer15Type._ARRAY_TYPE = AffixFuzzer15Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer15Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -9,14 +9,11 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer16", "AffixFuzzer16Array", "AffixFuzzer16ArrayLike", "AffixFuzzer16Like", "AffixFuzzer16Type"]
+__all__ = ["AffixFuzzer16", "AffixFuzzer16ArrayLike", "AffixFuzzer16Batch", "AffixFuzzer16Like", "AffixFuzzer16Type"]
 
 
 @define
@@ -33,10 +30,9 @@ AffixFuzzer16ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer16Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer16"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -115,20 +111,17 @@ class AffixFuzzer16Type(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.testing.components.AffixFuzzer16",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer16Array(BaseExtensionArray[AffixFuzzer16ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer16"
-    _EXTENSION_TYPE = AffixFuzzer16Type
+class AffixFuzzer16Batch(BaseBatch[AffixFuzzer16ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer16Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer16ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer16_ext.py
 
-
-AffixFuzzer16Type._ARRAY_TYPE = AffixFuzzer16Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer16Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -9,14 +9,11 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer17", "AffixFuzzer17Array", "AffixFuzzer17ArrayLike", "AffixFuzzer17Like", "AffixFuzzer17Type"]
+__all__ = ["AffixFuzzer17", "AffixFuzzer17ArrayLike", "AffixFuzzer17Batch", "AffixFuzzer17Like", "AffixFuzzer17Type"]
 
 
 @define
@@ -33,10 +30,9 @@ AffixFuzzer17ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer17Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer17"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -115,20 +111,17 @@ class AffixFuzzer17Type(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.testing.components.AffixFuzzer17",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer17Array(BaseExtensionArray[AffixFuzzer17ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer17"
-    _EXTENSION_TYPE = AffixFuzzer17Type
+class AffixFuzzer17Batch(BaseBatch[AffixFuzzer17ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer17Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer17ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer17_ext.py
 
-
-AffixFuzzer17Type._ARRAY_TYPE = AffixFuzzer17Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer17Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -9,14 +9,11 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer18", "AffixFuzzer18Array", "AffixFuzzer18ArrayLike", "AffixFuzzer18Like", "AffixFuzzer18Type"]
+__all__ = ["AffixFuzzer18", "AffixFuzzer18ArrayLike", "AffixFuzzer18Batch", "AffixFuzzer18Like", "AffixFuzzer18Type"]
 
 
 @define
@@ -33,10 +30,9 @@ AffixFuzzer18ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer18Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer18"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -415,20 +411,17 @@ class AffixFuzzer18Type(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.testing.components.AffixFuzzer18",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer18Array(BaseExtensionArray[AffixFuzzer18ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer18"
-    _EXTENSION_TYPE = AffixFuzzer18Type
+class AffixFuzzer18Batch(BaseBatch[AffixFuzzer18ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer18Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer18ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer18_ext.py
 
-
-AffixFuzzer18Type._ARRAY_TYPE = AffixFuzzer18Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer18Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer19.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer19.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer19", "AffixFuzzer19Array", "AffixFuzzer19Type"]
+__all__ = ["AffixFuzzer19", "AffixFuzzer19Batch", "AffixFuzzer19Type"]
 
 
 class AffixFuzzer19(datatypes.AffixFuzzer5):
@@ -22,18 +19,13 @@ class AffixFuzzer19(datatypes.AffixFuzzer5):
     pass
 
 
-class AffixFuzzer19Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer19"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer5Type
+class AffixFuzzer19Type(datatypes.AffixFuzzer5Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer19"
 
 
-class AffixFuzzer19Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer5ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer19"
-    _EXTENSION_TYPE = AffixFuzzer19Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer5Array
+class AffixFuzzer19Batch(datatypes.AffixFuzzer5Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer19Type()
 
-
-AffixFuzzer19Type._ARRAY_TYPE = AffixFuzzer19Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer19Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer2.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer2", "AffixFuzzer2Array", "AffixFuzzer2Type"]
+__all__ = ["AffixFuzzer2", "AffixFuzzer2Batch", "AffixFuzzer2Type"]
 
 
 class AffixFuzzer2(datatypes.AffixFuzzer1):
@@ -22,18 +19,13 @@ class AffixFuzzer2(datatypes.AffixFuzzer1):
     pass
 
 
-class AffixFuzzer2Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer2"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer1Type
+class AffixFuzzer2Type(datatypes.AffixFuzzer1Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer2"
 
 
-class AffixFuzzer2Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer2"
-    _EXTENSION_TYPE = AffixFuzzer2Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer1Array
+class AffixFuzzer2Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer2Type()
 
-
-AffixFuzzer2Type._ARRAY_TYPE = AffixFuzzer2Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer2Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer20.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer20", "AffixFuzzer20Array", "AffixFuzzer20Type"]
+__all__ = ["AffixFuzzer20", "AffixFuzzer20Batch", "AffixFuzzer20Type"]
 
 
 class AffixFuzzer20(datatypes.AffixFuzzer20):
@@ -22,18 +19,13 @@ class AffixFuzzer20(datatypes.AffixFuzzer20):
     pass
 
 
-class AffixFuzzer20Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer20"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer20Type
+class AffixFuzzer20Type(datatypes.AffixFuzzer20Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer20"
 
 
-class AffixFuzzer20Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer20ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer20"
-    _EXTENSION_TYPE = AffixFuzzer20Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer20Array
+class AffixFuzzer20Batch(datatypes.AffixFuzzer20Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer20Type()
 
-
-AffixFuzzer20Type._ARRAY_TYPE = AffixFuzzer20Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer20Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer21.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer21", "AffixFuzzer21Array", "AffixFuzzer21Type"]
+__all__ = ["AffixFuzzer21", "AffixFuzzer21Batch", "AffixFuzzer21Type"]
 
 
 class AffixFuzzer21(datatypes.AffixFuzzer21):
@@ -22,18 +19,13 @@ class AffixFuzzer21(datatypes.AffixFuzzer21):
     pass
 
 
-class AffixFuzzer21Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer21"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer21Type
+class AffixFuzzer21Type(datatypes.AffixFuzzer21Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer21"
 
 
-class AffixFuzzer21Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer21ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer21"
-    _EXTENSION_TYPE = AffixFuzzer21Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer21Array
+class AffixFuzzer21Batch(datatypes.AffixFuzzer21Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer21Type()
 
-
-AffixFuzzer21Type._ARRAY_TYPE = AffixFuzzer21Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer21Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer3.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer3", "AffixFuzzer3Array", "AffixFuzzer3Type"]
+__all__ = ["AffixFuzzer3", "AffixFuzzer3Batch", "AffixFuzzer3Type"]
 
 
 class AffixFuzzer3(datatypes.AffixFuzzer1):
@@ -22,18 +19,13 @@ class AffixFuzzer3(datatypes.AffixFuzzer1):
     pass
 
 
-class AffixFuzzer3Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer3"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer1Type
+class AffixFuzzer3Type(datatypes.AffixFuzzer1Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer3"
 
 
-class AffixFuzzer3Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer3"
-    _EXTENSION_TYPE = AffixFuzzer3Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer1Array
+class AffixFuzzer3Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer3Type()
 
-
-AffixFuzzer3Type._ARRAY_TYPE = AffixFuzzer3Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer3Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer4.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer4", "AffixFuzzer4Array", "AffixFuzzer4Type"]
+__all__ = ["AffixFuzzer4", "AffixFuzzer4Batch", "AffixFuzzer4Type"]
 
 
 class AffixFuzzer4(datatypes.AffixFuzzer1):
@@ -22,18 +19,13 @@ class AffixFuzzer4(datatypes.AffixFuzzer1):
     pass
 
 
-class AffixFuzzer4Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer4"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer1Type
+class AffixFuzzer4Type(datatypes.AffixFuzzer1Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer4"
 
 
-class AffixFuzzer4Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer4"
-    _EXTENSION_TYPE = AffixFuzzer4Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer1Array
+class AffixFuzzer4Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer4Type()
 
-
-AffixFuzzer4Type._ARRAY_TYPE = AffixFuzzer4Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer4Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer5.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer5", "AffixFuzzer5Array", "AffixFuzzer5Type"]
+__all__ = ["AffixFuzzer5", "AffixFuzzer5Batch", "AffixFuzzer5Type"]
 
 
 class AffixFuzzer5(datatypes.AffixFuzzer1):
@@ -22,18 +19,13 @@ class AffixFuzzer5(datatypes.AffixFuzzer1):
     pass
 
 
-class AffixFuzzer5Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer5"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer1Type
+class AffixFuzzer5Type(datatypes.AffixFuzzer1Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer5"
 
 
-class AffixFuzzer5Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer5"
-    _EXTENSION_TYPE = AffixFuzzer5Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer1Array
+class AffixFuzzer5Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer5Type()
 
-
-AffixFuzzer5Type._ARRAY_TYPE = AffixFuzzer5Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer5Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer6.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer6.py
@@ -5,14 +5,11 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import (
-    BaseDelegatingExtensionArray,
-    BaseDelegatingExtensionType,
-)
+from rerun._baseclasses import ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer6", "AffixFuzzer6Array", "AffixFuzzer6Type"]
+__all__ = ["AffixFuzzer6", "AffixFuzzer6Batch", "AffixFuzzer6Type"]
 
 
 class AffixFuzzer6(datatypes.AffixFuzzer1):
@@ -22,18 +19,13 @@ class AffixFuzzer6(datatypes.AffixFuzzer1):
     pass
 
 
-class AffixFuzzer6Type(BaseDelegatingExtensionType):
-    _TYPE_NAME = "rerun.testing.components.AffixFuzzer6"
-    _DELEGATED_EXTENSION_TYPE = datatypes.AffixFuzzer1Type
+class AffixFuzzer6Type(datatypes.AffixFuzzer1Type):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer6"
 
 
-class AffixFuzzer6Array(BaseDelegatingExtensionArray[datatypes.AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer6"
-    _EXTENSION_TYPE = AffixFuzzer6Type
-    _DELEGATED_ARRAY_TYPE = datatypes.AffixFuzzer1Array
+class AffixFuzzer6Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer6Type()
 
-
-AffixFuzzer6Type._ARRAY_TYPE = AffixFuzzer6Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer6Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -9,14 +9,11 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer7", "AffixFuzzer7Array", "AffixFuzzer7ArrayLike", "AffixFuzzer7Like", "AffixFuzzer7Type"]
+__all__ = ["AffixFuzzer7", "AffixFuzzer7ArrayLike", "AffixFuzzer7Batch", "AffixFuzzer7Like", "AffixFuzzer7Type"]
 
 
 @define
@@ -33,10 +30,9 @@ AffixFuzzer7ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer7Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer7"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -80,20 +76,17 @@ class AffixFuzzer7Type(BaseExtensionType):
                     metadata={},
                 )
             ),
-            "rerun.testing.components.AffixFuzzer7",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer7Array(BaseExtensionArray[AffixFuzzer7ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer7"
-    _EXTENSION_TYPE = AffixFuzzer7Type
+class AffixFuzzer7Batch(BaseBatch[AffixFuzzer7ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer7Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer7ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer7_ext.py
 
-
-AffixFuzzer7Type._ARRAY_TYPE = AffixFuzzer7Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer7Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -11,15 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 from rerun._converters import (
     float_or_none,
 )
 
-__all__ = ["AffixFuzzer8", "AffixFuzzer8Array", "AffixFuzzer8ArrayLike", "AffixFuzzer8Like", "AffixFuzzer8Type"]
+__all__ = ["AffixFuzzer8", "AffixFuzzer8ArrayLike", "AffixFuzzer8Batch", "AffixFuzzer8Like", "AffixFuzzer8Type"]
 
 
 @define
@@ -40,24 +37,20 @@ AffixFuzzer8ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer8Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer8"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), "rerun.testing.components.AffixFuzzer8")
+        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
 
 
-class AffixFuzzer8Array(BaseExtensionArray[AffixFuzzer8ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer8"
-    _EXTENSION_TYPE = AffixFuzzer8Type
+class AffixFuzzer8Batch(BaseBatch[AffixFuzzer8ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer8Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer8ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer8_ext.py
 
-
-AffixFuzzer8Type._ARRAY_TYPE = AffixFuzzer8Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer8Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -9,12 +9,9 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
 
-__all__ = ["AffixFuzzer9", "AffixFuzzer9Array", "AffixFuzzer9ArrayLike", "AffixFuzzer9Like", "AffixFuzzer9Type"]
+__all__ = ["AffixFuzzer9", "AffixFuzzer9ArrayLike", "AffixFuzzer9Batch", "AffixFuzzer9Like", "AffixFuzzer9Type"]
 
 
 @define
@@ -34,24 +31,20 @@ AffixFuzzer9ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer9Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer9"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), "rerun.testing.components.AffixFuzzer9")
+        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
 
 
-class AffixFuzzer9Array(BaseExtensionArray[AffixFuzzer9ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.components.AffixFuzzer9"
-    _EXTENSION_TYPE = AffixFuzzer9Type
+class AffixFuzzer9Batch(BaseBatch[AffixFuzzer9ArrayLike], ComponentBatchMixin):
+    _ARROW_TYPE = AffixFuzzer9Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer9ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer9_ext.py
 
-
-AffixFuzzer9Type._ARRAY_TYPE = AffixFuzzer9Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer9Type())

--- a/rerun_py/tests/test_types/datatypes/__init__.py
+++ b/rerun_py/tests/test_types/datatypes/__init__.py
@@ -2,96 +2,96 @@
 
 from __future__ import annotations
 
-from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1Array, AffixFuzzer1ArrayLike, AffixFuzzer1Like, AffixFuzzer1Type
-from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2Array, AffixFuzzer2ArrayLike, AffixFuzzer2Like, AffixFuzzer2Type
-from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3Array, AffixFuzzer3ArrayLike, AffixFuzzer3Like, AffixFuzzer3Type
-from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4Array, AffixFuzzer4ArrayLike, AffixFuzzer4Like, AffixFuzzer4Type
-from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5Array, AffixFuzzer5ArrayLike, AffixFuzzer5Like, AffixFuzzer5Type
+from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1ArrayLike, AffixFuzzer1Batch, AffixFuzzer1Like, AffixFuzzer1Type
+from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2ArrayLike, AffixFuzzer2Batch, AffixFuzzer2Like, AffixFuzzer2Type
+from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3ArrayLike, AffixFuzzer3Batch, AffixFuzzer3Like, AffixFuzzer3Type
+from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4ArrayLike, AffixFuzzer4Batch, AffixFuzzer4Like, AffixFuzzer4Type
+from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5ArrayLike, AffixFuzzer5Batch, AffixFuzzer5Like, AffixFuzzer5Type
 from .affix_fuzzer20 import (
     AffixFuzzer20,
-    AffixFuzzer20Array,
     AffixFuzzer20ArrayLike,
+    AffixFuzzer20Batch,
     AffixFuzzer20Like,
     AffixFuzzer20Type,
 )
 from .affix_fuzzer21 import (
     AffixFuzzer21,
-    AffixFuzzer21Array,
     AffixFuzzer21ArrayLike,
+    AffixFuzzer21Batch,
     AffixFuzzer21Like,
     AffixFuzzer21Type,
 )
 from .flattened_scalar import (
     FlattenedScalar,
-    FlattenedScalarArray,
     FlattenedScalarArrayLike,
+    FlattenedScalarBatch,
     FlattenedScalarLike,
     FlattenedScalarType,
 )
 from .primitive_component import (
     PrimitiveComponent,
-    PrimitiveComponentArray,
     PrimitiveComponentArrayLike,
+    PrimitiveComponentBatch,
     PrimitiveComponentLike,
     PrimitiveComponentType,
 )
 from .string_component import (
     StringComponent,
-    StringComponentArray,
     StringComponentArrayLike,
+    StringComponentBatch,
     StringComponentLike,
     StringComponentType,
 )
 
 __all__ = [
     "AffixFuzzer1",
-    "AffixFuzzer1Array",
     "AffixFuzzer1ArrayLike",
+    "AffixFuzzer1Batch",
     "AffixFuzzer1Like",
     "AffixFuzzer1Type",
     "AffixFuzzer2",
     "AffixFuzzer20",
-    "AffixFuzzer20Array",
     "AffixFuzzer20ArrayLike",
+    "AffixFuzzer20Batch",
     "AffixFuzzer20Like",
     "AffixFuzzer20Type",
     "AffixFuzzer21",
-    "AffixFuzzer21Array",
     "AffixFuzzer21ArrayLike",
+    "AffixFuzzer21Batch",
     "AffixFuzzer21Like",
     "AffixFuzzer21Type",
-    "AffixFuzzer2Array",
     "AffixFuzzer2ArrayLike",
+    "AffixFuzzer2Batch",
     "AffixFuzzer2Like",
     "AffixFuzzer2Type",
     "AffixFuzzer3",
-    "AffixFuzzer3Array",
     "AffixFuzzer3ArrayLike",
+    "AffixFuzzer3Batch",
     "AffixFuzzer3Like",
     "AffixFuzzer3Type",
     "AffixFuzzer4",
-    "AffixFuzzer4Array",
     "AffixFuzzer4ArrayLike",
+    "AffixFuzzer4Batch",
     "AffixFuzzer4Like",
     "AffixFuzzer4Type",
     "AffixFuzzer5",
-    "AffixFuzzer5Array",
     "AffixFuzzer5ArrayLike",
+    "AffixFuzzer5Batch",
     "AffixFuzzer5Like",
     "AffixFuzzer5Type",
     "FlattenedScalar",
-    "FlattenedScalarArray",
     "FlattenedScalarArrayLike",
+    "FlattenedScalarBatch",
     "FlattenedScalarLike",
     "FlattenedScalarType",
     "PrimitiveComponent",
-    "PrimitiveComponentArray",
     "PrimitiveComponentArrayLike",
+    "PrimitiveComponentBatch",
     "PrimitiveComponentLike",
     "PrimitiveComponentType",
     "StringComponent",
-    "StringComponentArray",
     "StringComponentArrayLike",
+    "StringComponentBatch",
     "StringComponentLike",
     "StringComponentType",
 ]

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
@@ -11,10 +11,7 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 from rerun._converters import (
     bool_or_none,
     float_or_none,
@@ -24,7 +21,7 @@ from rerun._converters import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer1", "AffixFuzzer1Array", "AffixFuzzer1ArrayLike", "AffixFuzzer1Like", "AffixFuzzer1Type"]
+__all__ = ["AffixFuzzer1", "AffixFuzzer1ArrayLike", "AffixFuzzer1Batch", "AffixFuzzer1Like", "AffixFuzzer1Type"]
 
 
 def _affix_fuzzer1__almost_flattened_scalar__special_field_converter_override(
@@ -60,10 +57,9 @@ AffixFuzzer1ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer1Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer1"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -100,20 +96,17 @@ class AffixFuzzer1Type(BaseExtensionType):
                     pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
                 ]
             ),
-            "rerun.testing.datatypes.AffixFuzzer1",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer1Array(BaseExtensionArray[AffixFuzzer1ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer1"
-    _EXTENSION_TYPE = AffixFuzzer1Type
+class AffixFuzzer1Batch(BaseBatch[AffixFuzzer1ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer1Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer1ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer1_ext.py
 
-
-AffixFuzzer1Type._ARRAY_TYPE = AffixFuzzer1Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer1Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
@@ -11,15 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 from rerun._converters import (
     float_or_none,
 )
 
-__all__ = ["AffixFuzzer2", "AffixFuzzer2Array", "AffixFuzzer2ArrayLike", "AffixFuzzer2Like", "AffixFuzzer2Type"]
+__all__ = ["AffixFuzzer2", "AffixFuzzer2ArrayLike", "AffixFuzzer2Batch", "AffixFuzzer2Like", "AffixFuzzer2Type"]
 
 
 @define
@@ -40,24 +37,20 @@ AffixFuzzer2ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer2Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer2"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), "rerun.testing.datatypes.AffixFuzzer2")
+        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
 
 
-class AffixFuzzer2Array(BaseExtensionArray[AffixFuzzer2ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer2"
-    _EXTENSION_TYPE = AffixFuzzer2Type
+class AffixFuzzer2Batch(BaseBatch[AffixFuzzer2ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer2Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer2ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer2_ext.py
 
-
-AffixFuzzer2Type._ARRAY_TYPE = AffixFuzzer2Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer2Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
@@ -9,14 +9,11 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer20", "AffixFuzzer20Array", "AffixFuzzer20ArrayLike", "AffixFuzzer20Like", "AffixFuzzer20Type"]
+__all__ = ["AffixFuzzer20", "AffixFuzzer20ArrayLike", "AffixFuzzer20Batch", "AffixFuzzer20Like", "AffixFuzzer20Type"]
 
 
 def _affix_fuzzer20__p__special_field_converter_override(
@@ -50,10 +47,9 @@ AffixFuzzer20ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer20Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer20"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -63,20 +59,17 @@ class AffixFuzzer20Type(BaseExtensionType):
                     pa.field("s", pa.utf8(), nullable=False, metadata={}),
                 ]
             ),
-            "rerun.testing.datatypes.AffixFuzzer20",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer20Array(BaseExtensionArray[AffixFuzzer20ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer20"
-    _EXTENSION_TYPE = AffixFuzzer20Type
+class AffixFuzzer20Batch(BaseBatch[AffixFuzzer20ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer20Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer20ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer20_ext.py
 
-
-AffixFuzzer20Type._ARRAY_TYPE = AffixFuzzer20Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer20Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
@@ -11,15 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 from rerun._converters import (
     to_np_float16,
 )
 
-__all__ = ["AffixFuzzer21", "AffixFuzzer21Array", "AffixFuzzer21ArrayLike", "AffixFuzzer21Like", "AffixFuzzer21Type"]
+__all__ = ["AffixFuzzer21", "AffixFuzzer21ArrayLike", "AffixFuzzer21Batch", "AffixFuzzer21Like", "AffixFuzzer21Type"]
 
 
 @define
@@ -37,10 +34,9 @@ AffixFuzzer21ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer21Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer21"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -55,20 +51,17 @@ class AffixFuzzer21Type(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.testing.datatypes.AffixFuzzer21",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer21Array(BaseExtensionArray[AffixFuzzer21ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer21"
-    _EXTENSION_TYPE = AffixFuzzer21Type
+class AffixFuzzer21Batch(BaseBatch[AffixFuzzer21ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer21Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer21ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer21_ext.py
 
-
-AffixFuzzer21Type._ARRAY_TYPE = AffixFuzzer21Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer21Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -11,14 +11,11 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer3", "AffixFuzzer3Array", "AffixFuzzer3ArrayLike", "AffixFuzzer3Like", "AffixFuzzer3Type"]
+__all__ = ["AffixFuzzer3", "AffixFuzzer3ArrayLike", "AffixFuzzer3Batch", "AffixFuzzer3Like", "AffixFuzzer3Type"]
 
 
 @define
@@ -57,10 +54,10 @@ else:
     AffixFuzzer3Like = Any
     AffixFuzzer3ArrayLike = Any
 
-# --- Arrow support ---
-
 
 class AffixFuzzer3Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer3"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -122,20 +119,17 @@ class AffixFuzzer3Type(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.testing.datatypes.AffixFuzzer3",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer3Array(BaseExtensionArray[AffixFuzzer3ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer3"
-    _EXTENSION_TYPE = AffixFuzzer3Type
+class AffixFuzzer3Batch(BaseBatch[AffixFuzzer3ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer3Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer3ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer3_ext.py
 
-
-AffixFuzzer3Type._ARRAY_TYPE = AffixFuzzer3Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer3Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
@@ -9,14 +9,11 @@ from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer4", "AffixFuzzer4Array", "AffixFuzzer4ArrayLike", "AffixFuzzer4Like", "AffixFuzzer4Type"]
+__all__ = ["AffixFuzzer4", "AffixFuzzer4ArrayLike", "AffixFuzzer4Batch", "AffixFuzzer4Like", "AffixFuzzer4Type"]
 
 
 @define
@@ -51,10 +48,10 @@ else:
     AffixFuzzer4Like = Any
     AffixFuzzer4ArrayLike = Any
 
-# --- Arrow support ---
-
 
 class AffixFuzzer4Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer4"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -381,20 +378,17 @@ class AffixFuzzer4Type(BaseExtensionType):
                     ),
                 ]
             ),
-            "rerun.testing.datatypes.AffixFuzzer4",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer4Array(BaseExtensionArray[AffixFuzzer4ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer4"
-    _EXTENSION_TYPE = AffixFuzzer4Type
+class AffixFuzzer4Batch(BaseBatch[AffixFuzzer4ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer4Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer4ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer4_ext.py
 
-
-AffixFuzzer4Type._ARRAY_TYPE = AffixFuzzer4Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer4Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -9,14 +9,11 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer5", "AffixFuzzer5Array", "AffixFuzzer5ArrayLike", "AffixFuzzer5Like", "AffixFuzzer5Type"]
+__all__ = ["AffixFuzzer5", "AffixFuzzer5ArrayLike", "AffixFuzzer5Batch", "AffixFuzzer5Like", "AffixFuzzer5Type"]
 
 
 def _affix_fuzzer5__single_optional_union__special_field_converter_override(
@@ -46,10 +43,9 @@ AffixFuzzer5ArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class AffixFuzzer5Type(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer5"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
             self,
@@ -443,20 +439,17 @@ class AffixFuzzer5Type(BaseExtensionType):
                     )
                 ]
             ),
-            "rerun.testing.datatypes.AffixFuzzer5",
+            self._TYPE_NAME,
         )
 
 
-class AffixFuzzer5Array(BaseExtensionArray[AffixFuzzer5ArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.AffixFuzzer5"
-    _EXTENSION_TYPE = AffixFuzzer5Type
+class AffixFuzzer5Batch(BaseBatch[AffixFuzzer5ArrayLike]):
+    _ARROW_TYPE = AffixFuzzer5Type()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer5ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer5_ext.py
 
-
-AffixFuzzer5Type._ARRAY_TYPE = AffixFuzzer5Array
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(AffixFuzzer5Type())

--- a/rerun_py/tests/test_types/datatypes/flattened_scalar.py
+++ b/rerun_py/tests/test_types/datatypes/flattened_scalar.py
@@ -11,15 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 __all__ = [
     "FlattenedScalar",
-    "FlattenedScalarArray",
     "FlattenedScalarArrayLike",
+    "FlattenedScalarBatch",
     "FlattenedScalarLike",
     "FlattenedScalarType",
 ]
@@ -46,28 +43,22 @@ FlattenedScalarArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class FlattenedScalarType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.FlattenedScalar"
+
     def __init__(self) -> None:
         pa.ExtensionType.__init__(
-            self,
-            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
-            "rerun.testing.datatypes.FlattenedScalar",
+            self, pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]), self._TYPE_NAME
         )
 
 
-class FlattenedScalarArray(BaseExtensionArray[FlattenedScalarArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.FlattenedScalar"
-    _EXTENSION_TYPE = FlattenedScalarType
+class FlattenedScalarBatch(BaseBatch[FlattenedScalarArrayLike]):
+    _ARROW_TYPE = FlattenedScalarType()
 
     @staticmethod
     def _native_to_pa_array(data: FlattenedScalarArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in flattened_scalar_ext.py
 
-
-FlattenedScalarType._ARRAY_TYPE = FlattenedScalarArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(FlattenedScalarType())

--- a/rerun_py/tests/test_types/datatypes/primitive_component.py
+++ b/rerun_py/tests/test_types/datatypes/primitive_component.py
@@ -11,15 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 __all__ = [
     "PrimitiveComponent",
-    "PrimitiveComponentArray",
     "PrimitiveComponentArrayLike",
+    "PrimitiveComponentBatch",
     "PrimitiveComponentLike",
     "PrimitiveComponentType",
 ]
@@ -46,24 +43,20 @@ PrimitiveComponentArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class PrimitiveComponentType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.PrimitiveComponent"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint32(), "rerun.testing.datatypes.PrimitiveComponent")
+        pa.ExtensionType.__init__(self, pa.uint32(), self._TYPE_NAME)
 
 
-class PrimitiveComponentArray(BaseExtensionArray[PrimitiveComponentArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.PrimitiveComponent"
-    _EXTENSION_TYPE = PrimitiveComponentType
+class PrimitiveComponentBatch(BaseBatch[PrimitiveComponentArrayLike]):
+    _ARROW_TYPE = PrimitiveComponentType()
 
     @staticmethod
     def _native_to_pa_array(data: PrimitiveComponentArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in primitive_component_ext.py
 
-
-PrimitiveComponentType._ARRAY_TYPE = PrimitiveComponentArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(PrimitiveComponentType())

--- a/rerun_py/tests/test_types/datatypes/string_component.py
+++ b/rerun_py/tests/test_types/datatypes/string_component.py
@@ -9,15 +9,12 @@ from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import (
-    BaseExtensionArray,
-    BaseExtensionType,
-)
+from rerun._baseclasses import BaseBatch, BaseExtensionType
 
 __all__ = [
     "StringComponent",
-    "StringComponentArray",
     "StringComponentArrayLike",
+    "StringComponentBatch",
     "StringComponentLike",
     "StringComponentType",
 ]
@@ -40,24 +37,20 @@ StringComponentArrayLike = Union[
 ]
 
 
-# --- Arrow support ---
-
-
 class StringComponentType(BaseExtensionType):
+    _TYPE_NAME: str = "rerun.testing.datatypes.StringComponent"
+
     def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), "rerun.testing.datatypes.StringComponent")
+        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
 
 
-class StringComponentArray(BaseExtensionArray[StringComponentArrayLike]):
-    _EXTENSION_NAME = "rerun.testing.datatypes.StringComponent"
-    _EXTENSION_TYPE = StringComponentType
+class StringComponentBatch(BaseBatch[StringComponentArrayLike]):
+    _ARROW_TYPE = StringComponentType()
 
     @staticmethod
     def _native_to_pa_array(data: StringComponentArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in string_component_ext.py
 
-
-StringComponentType._ARRAY_TYPE = StringComponentArray
 
 # TODO(cmc): bring back registration to pyarrow once legacy types are gone
 # pa.register_extension_type(StringComponentType())

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -52,11 +52,11 @@ vec2ds_arrays: list[rrd.Vec2DArrayLike] = [
 
 def vec2ds_expected(obj: Any, type_: Any | None) -> Any:
     if type_ is None:
-        type_ = rrd.Vec2DArray
+        type_ = rrd.Vec2DBatch
 
     expected = none_empty_or_value(obj, [[1.0, 2.0], [3.0, 4.0]])
 
-    return type_.optional_from_similar(expected)
+    return type_._optional(expected)
 
 
 vec3ds_arrays: list[rrd.Vec3DArrayLike] = [
@@ -85,11 +85,11 @@ vec3ds_arrays: list[rrd.Vec3DArrayLike] = [
 
 def vec3ds_expected(obj: Any, type_: Any | None) -> Any:
     if type_ is None:
-        type_ = rrd.Vec3DArray
+        type_ = rrd.Vec3DBatch
 
     expected = none_empty_or_value(obj, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
-    return type_.optional_from_similar(expected)
+    return type_._optional(expected)
 
 
 rotations_arrays: list[rrd.Rotation3DArrayLike] = [
@@ -106,7 +106,7 @@ rotations_arrays: list[rrd.Rotation3DArrayLike] = [
     rrd.RotationAxisAngle([1.0, 2.0, 3.0], rrd.Angle(4)),
     rrd.RotationAxisAngle(rrd.Vec3D([1, 2, 3]), rrd.Angle(4)),
     rrd.RotationAxisAngle(np.array([1, 2, 3], dtype=np.uint8), rrd.Angle(rad=4)),
-    # Sequence[Rotation3DArray]
+    # Sequence[Rotation3DBatch]
     [
         rrd.Rotation3D(rrd.Quaternion(xyzw=[1, 2, 3, 4])),
         [1, 2, 3, 4],
@@ -118,19 +118,17 @@ rotations_arrays: list[rrd.Rotation3DArrayLike] = [
 
 def expected_rotations(rotations: rrd.Rotation3DArrayLike, type_: Any) -> Any:
     if rotations is None:
-        return type_.optional_from_similar(None)
+        return type_._optional(None)
     elif hasattr(rotations, "__len__") and len(rotations) == 0:
-        return type_.optional_from_similar(rotations)
+        return type_._optional(rotations)
     elif isinstance(rotations, rrd.Rotation3D):
-        return type_.optional_from_similar(rotations)
+        return type_._optional(rotations)
     elif isinstance(rotations, rrd.RotationAxisAngle):
-        return type_.optional_from_similar(rrd.RotationAxisAngle([1, 2, 3], 4))
+        return type_._optional(rrd.RotationAxisAngle([1, 2, 3], 4))
     elif isinstance(rotations, rrd.Quaternion):
-        return type_.optional_from_similar(rrd.Quaternion(xyzw=[1, 2, 3, 4]))
+        return type_._optional(rrd.Quaternion(xyzw=[1, 2, 3, 4]))
     else:  # sequence of Rotation3DLike
-        return type_.optional_from_similar(
-            [rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 3 + [rrd.RotationAxisAngle([1, 2, 3], 4)]
-        )
+        return type_._optional([rrd.Quaternion(xyzw=[1, 2, 3, 4])] * 3 + [rrd.RotationAxisAngle([1, 2, 3], 4)])
 
 
 radii_arrays: list[rrc.RadiusArrayLike | None] = [
@@ -152,7 +150,7 @@ radii_arrays: list[rrc.RadiusArrayLike | None] = [
 def radii_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [1, 10])
 
-    return rrc.RadiusArray.optional_from_similar(expected)
+    return rrc.RadiusBatch._optional(expected)
 
 
 colors_arrays: list[rrd.ColorArrayLike | None] = [
@@ -256,7 +254,7 @@ colors_arrays: list[rrd.ColorArrayLike | None] = [
 
 def colors_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [0xAA0000CC, 0x00BB00DD])
-    return rrc.ColorArray.optional_from_similar(expected)
+    return rrc.ColorBatch._optional(expected)
 
 
 labels_arrays: list[rrd.Utf8ArrayLike | None] = [
@@ -274,7 +272,7 @@ labels_arrays: list[rrd.Utf8ArrayLike | None] = [
 
 def labels_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, ["hello", "friend"])
-    return rrc.TextArray.optional_from_similar(expected)
+    return rrc.TextBatch._optional(expected)
 
 
 draw_orders: list[rrc.DrawOrderLike | None] = [
@@ -288,7 +286,7 @@ draw_orders: list[rrc.DrawOrderLike | None] = [
 
 def draw_order_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [300])
-    return rrc.DrawOrderArray.optional_from_similar(expected)
+    return rrc.DrawOrderBatch._optional(expected)
 
 
 class_ids_arrays = [
@@ -311,7 +309,7 @@ class_ids_arrays = [
 
 def class_ids_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [126, 127])
-    return rrc.ClassIdArray.optional_from_similar(expected)
+    return rrc.ClassIdBatch._optional(expected)
 
 
 keypoint_ids_arrays = [
@@ -334,7 +332,7 @@ keypoint_ids_arrays = [
 
 def keypoint_ids_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [2, 3])
-    return rrc.KeypointIdArray.optional_from_similar(expected)
+    return rrc.KeypointIdBatch._optional(expected)
 
 
 instance_keys_arrays = [
@@ -351,4 +349,4 @@ instance_keys_arrays = [
 
 def instance_keys_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [U64_MAX_MINUS_1, U64_MAX])
-    return rrc.InstanceKeyArray.optional_from_similar(expected)
+    return rrc.InstanceKeyBatch._optional(expected)

--- a/rerun_py/tests/unit/test_arrows3d.py
+++ b/rerun_py/tests/unit/test_arrows3d.py
@@ -72,8 +72,8 @@ def test_arrows3d() -> None:
         )
         print(f"A: {arch}\n")
 
-        assert arch.vectors == vec3ds_expected(vectors, rrc.Vector3DArray)
-        assert arch.origins == vec3ds_expected(origins, rrc.Origin3DArray)
+        assert arch.vectors == vec3ds_expected(vectors, rrc.Vector3DBatch)
+        assert arch.origins == vec3ds_expected(origins, rrc.Origin3DBatch)
         assert arch.radii == radii_expected(radii)
         assert arch.colors == colors_expected(colors)
         assert arch.labels == labels_expected(labels)

--- a/rerun_py/tests/unit/test_box2d.py
+++ b/rerun_py/tests/unit/test_box2d.py
@@ -84,8 +84,8 @@ def test_boxes2d() -> None:
         )
         print(f"{arch}\n")
 
-        assert arch.half_sizes == half_sizes_expected(half_sizes, rrc.HalfSizes2DArray)
-        assert arch.centers == centers_expected(centers, rrc.Position2DArray)
+        assert arch.half_sizes == half_sizes_expected(half_sizes, rrc.HalfSizes2DBatch)
+        assert arch.centers == centers_expected(centers, rrc.Position2DBatch)
         assert arch.colors == colors_expected(colors)
         assert arch.radii == radii_expected(radii)
         assert arch.labels == labels_expected(labels)

--- a/rerun_py/tests/unit/test_box3d.py
+++ b/rerun_py/tests/unit/test_box3d.py
@@ -83,9 +83,9 @@ def test_boxes3d() -> None:
         )
         print(f"{arch}\n")
 
-        assert arch.half_sizes == half_sizes_expected(half_sizes, rrc.HalfSizes3DArray)
-        assert arch.centers == centers_expected(centers, rrc.Position3DArray)
-        assert arch.rotations == expected_rotations(rotations, rrc.Rotation3DArray)
+        assert arch.half_sizes == half_sizes_expected(half_sizes, rrc.HalfSizes3DBatch)
+        assert arch.centers == centers_expected(centers, rrc.Position3DBatch)
+        assert arch.rotations == expected_rotations(rotations, rrc.Rotation3DBatch)
         assert arch.colors == colors_expected(colors)
         assert arch.radii == radii_expected(radii)
         assert arch.labels == labels_expected(labels)

--- a/rerun_py/tests/unit/test_clear.py
+++ b/rerun_py/tests/unit/test_clear.py
@@ -23,7 +23,7 @@ def test_clear() -> None:
         arch = rr2.Clear(settings)
         print(f"{arch}\n")
 
-        assert arch.settings == rr_cmp.ClearSettingsArray.from_similar([True])
+        assert arch.settings == rr_cmp.ClearSettingsBatch([True])
 
 
 if __name__ == "__main__":

--- a/rerun_py/tests/unit/test_disconnected_space.py
+++ b/rerun_py/tests/unit/test_disconnected_space.py
@@ -23,7 +23,7 @@ def test_disconnected_space() -> None:
         arch = rr2.DisconnectedSpace(disconnected_space)
         print(f"{arch}\n")
 
-        assert arch.disconnected_space == rr_cmp.DisconnectedSpaceArray.from_similar([True])
+        assert arch.disconnected_space == rr_cmp.DisconnectedSpaceBatch([True])
 
 
 if __name__ == "__main__":

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -35,12 +35,12 @@ CHECK_FIELDS: list[list[int]] = [
 
 
 def tensor_data_expected() -> Any:
-    return rrc.TensorDataArray.from_similar(IMAGE_INPUTS[0])
+    return rrc.TensorDataBatch(IMAGE_INPUTS[0])
 
 
 def compare_images(left: Any, right: Any, check_fields: list[int]) -> None:
     for field in check_fields:
-        assert left.storage.field(field) == right.storage.field(field)
+        assert left.as_arrow_array().storage.field(field) == right.as_arrow_array().storage.field(field)
 
 
 def test_image() -> None:

--- a/rerun_py/tests/unit/test_line_strips2d.py
+++ b/rerun_py/tests/unit/test_line_strips2d.py
@@ -61,7 +61,7 @@ def line_strips2d_expected(obj: Any) -> Any:
         ],
     )
 
-    return rrc.LineStrip2DArray.from_similar(expected)
+    return rrc.LineStrip2DBatch(expected)
 
 
 def test_line_strips2d() -> None:
@@ -128,7 +128,7 @@ def test_line_strips2d() -> None:
 def test_line_segments2d(data: rrc.LineStrip2DArrayLike) -> None:
     arch = rr2.LineStrips2D(data)
 
-    assert arch.strips == rrc.LineStrip2DArray.from_similar(
+    assert arch.strips == rrc.LineStrip2DBatch(
         [
             [[0, 0], [2, 1]],
             [[4, -1], [6, 0]],

--- a/rerun_py/tests/unit/test_line_strips3d.py
+++ b/rerun_py/tests/unit/test_line_strips3d.py
@@ -59,7 +59,7 @@ def line_strips3d_expected(obj: Any) -> Any:
             [[0, 0, 0], [0, 0, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1], [0, 1, 0], [0, 1, 1]],
         ],
     )
-    return rrc.LineStrip3DArray.from_similar(expected)
+    return rrc.LineStrip3DBatch(expected)
 
 
 def test_line_strips3d() -> None:
@@ -132,7 +132,7 @@ def test_line_strips3d() -> None:
 def test_line_segments3d(data: rrc.LineStrip3DArrayLike) -> None:
     arch = rr2.LineStrips3D(data)
 
-    assert arch.strips == rrc.LineStrip3DArray.from_similar(
+    assert arch.strips == rrc.LineStrip3DBatch(
         [[[0, 0, 0], [0, 0, 1]], [[1, 0, 0], [1, 0, 1]], [[1, 1, 0], [1, 1, 1]], [[0, 1, 0], [0, 1, 1]]],
     )
 

--- a/rerun_py/tests/unit/test_matnxn.py
+++ b/rerun_py/tests/unit/test_matnxn.py
@@ -72,7 +72,7 @@ def test_mat3x3(data: rr_dt.Mat3x3Like) -> None:
 
 
 def test_mat3x3array() -> None:
-    assert rr_dt.Mat3x3Array.from_similar(cast(rr_dt.Mat3x3ArrayLike, MAT_3X3_INPUT)) == rr_dt.Mat3x3Array.from_similar(
+    assert rr_dt.Mat3x3Batch(cast(rr_dt.Mat3x3ArrayLike, MAT_3X3_INPUT)) == rr_dt.Mat3x3Batch(
         [[1, 2, 3, 4, 5, 6, 7, 8, 9]] * len(MAT_3X3_INPUT)
     )
 
@@ -106,7 +106,7 @@ def test_mat4x4(data: rr_dt.Mat4x4Like) -> None:
 
 
 def test_mat4x4array() -> None:
-    assert rr_dt.Mat4x4Array.from_similar(cast(rr_dt.Mat4x4ArrayLike, MAT_4X4_INPUT)) == rr_dt.Mat4x4Array.from_similar(
+    assert rr_dt.Mat4x4Batch(cast(rr_dt.Mat4x4ArrayLike, MAT_4X4_INPUT)) == rr_dt.Mat4x4Batch(
         [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]] * len(MAT_4X4_INPUT)
     )
 

--- a/rerun_py/tests/unit/test_mesh3d.py
+++ b/rerun_py/tests/unit/test_mesh3d.py
@@ -29,7 +29,7 @@ mesh_properties_arrays: list[rrd.MeshPropertiesArrayLike] = [
 def mesh_properties_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, rrc.MeshProperties(vertex_indices=[1, 2, 3, 4, 5, 6]))
 
-    return rrc.MeshPropertiesArray.optional_from_similar(expected)
+    return rrc.MeshPropertiesBatch._optional(expected)
 
 
 mesh_material_arrays: list[rrd.MaterialArrayLike] = [
@@ -42,7 +42,7 @@ mesh_material_arrays: list[rrd.MaterialArrayLike] = [
 def mesh_material_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, rrc.Material(albedo_factor=0xAA0000CC))
 
-    return rrc.MaterialArray.optional_from_similar(expected)
+    return rrc.MaterialBatch._optional(expected)
 
 
 def test_mesh3d() -> None:
@@ -105,8 +105,8 @@ def test_mesh3d() -> None:
         )
         print(f"A: {arch}\n")
 
-        assert arch.vertex_positions == vec3ds_expected(vertex_positions, rrc.Position3DArray)
-        assert arch.vertex_normals == vec3ds_expected(vertex_normals, rrc.Vector3DArray)
+        assert arch.vertex_positions == vec3ds_expected(vertex_positions, rrc.Position3DBatch)
+        assert arch.vertex_normals == vec3ds_expected(vertex_normals, rrc.Vector3DBatch)
         assert arch.vertex_colors == colors_expected(vertex_colors)
         assert arch.mesh_properties == mesh_properties_expected(mesh_properties)
         assert arch.mesh_material == mesh_material_expected(mesh_material)
@@ -118,7 +118,7 @@ def test_nullable_albedo_factor() -> None:
     # NOTE: We're just making sure that this doesn't crash... trust me, it used to.
     assert (
         len(
-            rr2.cmp.MaterialArray.from_similar(
+            rr2.cmp.MaterialBatch(
                 [
                     rr2.cmp.Material(albedo_factor=[0xCC, 0x00, 0xCC, 0xFF]),
                     rr2.cmp.Material(),
@@ -133,7 +133,7 @@ def test_nullable_vertex_indices() -> None:
     # NOTE: We're just making sure that this doesn't crash... trust me, it used to.
     assert (
         len(
-            rr2.cmp.MeshPropertiesArray.from_similar(
+            rr2.cmp.MeshPropertiesBatch(
                 [
                     rr2.cmp.MeshProperties(vertex_indices=[1, 2, 3, 4, 5, 6]),
                     rr2.cmp.MeshProperties(),

--- a/rerun_py/tests/unit/test_pinhole.py
+++ b/rerun_py/tests/unit/test_pinhole.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-from typing import Optional, cast
 
 import numpy as np
 import rerun.experimental as rr2
@@ -25,16 +24,17 @@ def test_pinhole() -> None:
     for image_from_camera, resolution in all_arrays:
         image_from_camera = image_from_camera if image_from_camera is not None else image_from_cameras[-1]
 
-        # make Pyright happy as it's apparently not able to track typing info trough zip_longest
-        image_from_camera = cast(rrc.PinholeProjectionArray, image_from_camera)
-        resolution = cast(Optional[rrc.ResolutionArray], resolution)
-
-        print(f"rr2.Pinhole(\n" f"    image_from_camera={image_from_camera}\n" f"    resolution={resolution}\n" f")")
+        print(
+            f"rr2.Pinhole(\n"
+            f"    image_from_camera={str(image_from_camera)}\n"
+            f"    resolution={str(resolution)}\n"
+            f")"
+        )
         arch = rr2.Pinhole(image_from_camera=image_from_camera, resolution=resolution)
         print(f"{arch}\n")
 
-        assert arch.image_from_camera == rrc.PinholeProjectionArray.optional_from_similar([1, 2, 3, 4, 5, 6, 7, 8, 9])
-        assert arch.resolution == rrc.ResolutionArray.optional_from_similar([1, 2] if resolution is not None else None)
+        assert arch.image_from_camera == rrc.PinholeProjectionBatch._optional([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        assert arch.resolution == rrc.ResolutionBatch._optional([1, 2] if resolution is not None else None)
 
 
 if __name__ == "__main__":

--- a/rerun_py/tests/unit/test_points2d.py
+++ b/rerun_py/tests/unit/test_points2d.py
@@ -82,7 +82,7 @@ def test_points2d() -> None:
         )
         print(f"{arch}\n")
 
-        assert arch.positions == positions_expected(positions, rrc.Position2DArray)
+        assert arch.positions == positions_expected(positions, rrc.Position2DBatch)
         assert arch.radii == radii_expected(radii)
         assert arch.colors == colors_expected(colors)
         assert arch.labels == labels_expected(labels)
@@ -105,7 +105,7 @@ def test_points2d() -> None:
 def test_point2d_single_color(data: rrd.ColorArrayLike) -> None:
     pts = rr2.Points2D(positions=np.zeros((5, 2)), colors=data)
 
-    assert pts.colors == rrc.ColorArray.from_similar(rrd.Color([0, 128, 0, 255]))
+    assert pts.colors == rrc.ColorBatch(rrd.Color([0, 128, 0, 255]))
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_point2d_single_color(data: rrd.ColorArrayLike) -> None:
 def test_point2d_multiple_colors(data: rrd.ColorArrayLike) -> None:
     pts = rr2.Points2D(positions=np.zeros((5, 2)), colors=data)
 
-    assert pts.colors == rrc.ColorArray.from_similar(
+    assert pts.colors == rrc.ColorBatch(
         [
             rrd.Color([0, 128, 0, 255]),
             rrd.Color([128, 0, 0, 255]),

--- a/rerun_py/tests/unit/test_points3d.py
+++ b/rerun_py/tests/unit/test_points3d.py
@@ -76,7 +76,7 @@ def test_points3d() -> None:
         )
         print(f"{arch}\n")
 
-        assert arch.positions == positions_expected(positions, rrc.Position3DArray)
+        assert arch.positions == positions_expected(positions, rrc.Position3DBatch)
         assert arch.radii == radii_expected(radii)
         assert arch.colors == colors_expected(colors)
         assert arch.labels == labels_expected(labels)
@@ -98,7 +98,7 @@ def test_points3d() -> None:
 def test_point3d_single_color(data: rrd.ColorArrayLike) -> None:
     pts = rr2.Points3D(positions=np.zeros((5, 3)), colors=data)
 
-    assert pts.colors == rrc.ColorArray.from_similar(rrd.Color([0, 128, 0, 255]))
+    assert pts.colors == rrc.ColorBatch(rrd.Color([0, 128, 0, 255]))
 
 
 @pytest.mark.parametrize(
@@ -124,7 +124,7 @@ def test_point3d_single_color(data: rrd.ColorArrayLike) -> None:
 def test_point3d_multiple_colors(data: rrd.ColorArrayLike) -> None:
     pts = rr2.Points3D(positions=np.zeros((5, 3)), colors=data)
 
-    assert pts.colors == rrc.ColorArray.from_similar(
+    assert pts.colors == rrc.ColorBatch(
         [
             rrd.Color([0, 128, 0, 255]),
             rrd.Color([128, 0, 0, 255]),

--- a/rerun_py/tests/unit/test_rotation3d.py
+++ b/rerun_py/tests/unit/test_rotation3d.py
@@ -10,11 +10,11 @@ from .common_arrays import (
 
 def test_rotation3d() -> None:
     for rotations in rotations_arrays:
-        print(f"rrd.Rotation3DArray.from_similar({rotations})")
-        datatype = rrd.Rotation3DArray.from_similar(rotations)
+        print(f"rrd.Rotation3DBatch({rotations})")
+        datatype = rrd.Rotation3DBatch(rotations)
         print(f"{datatype}\n")
 
-        assert datatype == expected_rotations(rotations, rrd.Rotation3DArray)
+        assert datatype == expected_rotations(rotations, rrd.Rotation3DBatch)
 
 
 if __name__ == "__main__":

--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -45,12 +45,12 @@ CHECK_FIELDS: list[list[int]] = [
 
 
 def tensor_data_expected() -> Any:
-    return rrc.TensorDataArray.from_similar(TENSOR_DATA_INPUTS[0])
+    return rrc.TensorDataBatch(TENSOR_DATA_INPUTS[0])
 
 
 def compare_tensors(left: Any, right: Any, check_fields: list[int]) -> None:
     for field in check_fields:
-        assert left.storage.field(field) == right.storage.field(field)
+        assert left.as_arrow_array().storage.field(field) == right.as_arrow_array().storage.field(field)
 
 
 def test_tensor() -> None:

--- a/rerun_py/tests/unit/test_transform3d.py
+++ b/rerun_py/tests/unit/test_transform3d.py
@@ -159,7 +159,6 @@ def test_transform3d_translation_and_mat3x3(trans: rr_dt.Vec3DLike | None, mat: 
 
     tm = rr_arch.Transform3D(rr_dt.TranslationAndMat3x3(translation=trans, matrix=mat))
 
-
     assert tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(
             rr_dt.TranslationAndMat3x3(

--- a/rerun_py/tests/unit/test_transform3d.py
+++ b/rerun_py/tests/unit/test_transform3d.py
@@ -159,17 +159,6 @@ def test_transform3d_translation_and_mat3x3(trans: rr_dt.Vec3DLike | None, mat: 
 
     tm = rr_arch.Transform3D(rr_dt.TranslationAndMat3x3(translation=trans, matrix=mat))
 
-    print(tm.transform.pa_array)
-    print(
-        rr_cmp.Transform3DBatch(
-            rr_dt.Transform3D(
-                rr_dt.TranslationAndMat3x3(
-                    translation=expected_trans,
-                    matrix=expected_mat,
-                )
-            )
-        ).pa_array
-    )
 
     assert tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(

--- a/rerun_py/tests/unit/test_transform3d.py
+++ b/rerun_py/tests/unit/test_transform3d.py
@@ -159,7 +159,19 @@ def test_transform3d_translation_and_mat3x3(trans: rr_dt.Vec3DLike | None, mat: 
 
     tm = rr_arch.Transform3D(rr_dt.TranslationAndMat3x3(translation=trans, matrix=mat))
 
-    assert tm.transform == rr_cmp.Transform3DArray.from_similar(
+    print(tm.transform.pa_array)
+    print(
+        rr_cmp.Transform3DBatch(
+            rr_dt.Transform3D(
+                rr_dt.TranslationAndMat3x3(
+                    translation=expected_trans,
+                    matrix=expected_mat,
+                )
+            )
+        ).pa_array
+    )
+
+    assert tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(
             rr_dt.TranslationAndMat3x3(
                 translation=expected_trans,
@@ -170,7 +182,7 @@ def test_transform3d_translation_and_mat3x3(trans: rr_dt.Vec3DLike | None, mat: 
 
     tm2 = rr_arch.Transform3D(rr_dt.TranslationAndMat3x3(translation=trans, matrix=mat, from_parent=True))
 
-    assert tm2.transform == rr_cmp.Transform3DArray.from_similar(
+    assert tm2.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(
             rr_dt.TranslationAndMat3x3(
                 translation=expected_trans,
@@ -187,13 +199,13 @@ def test_transform3d_translation_and_mat3x3(trans: rr_dt.Vec3DLike | None, mat: 
 def test_transform3d_translation_rotation_scale3d_translation(trans: rr_dt.Vec3DLike) -> None:
     tm = rr_arch.Transform3D(rr_dt.TranslationRotationScale3D(translation=trans))
 
-    assert tm.transform == rr_cmp.Transform3DArray.from_similar(
+    assert tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(rr_dt.TranslationRotationScale3D(translation=rr_dt.Vec3D([1, 2, 3])))
     )
 
     tm2 = rr_arch.Transform3D(rr_dt.TranslationRotationScale3D(translation=trans, from_parent=True))
 
-    assert tm2.transform == rr_cmp.Transform3DArray.from_similar(
+    assert tm2.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(rr_dt.TranslationRotationScale3D(translation=rr_dt.Vec3D([1, 2, 3]), from_parent=True))
     )
 
@@ -204,11 +216,11 @@ def test_transform3d_translation_rotation_scale3d_translation(trans: rr_dt.Vec3D
 def test_transform3d_translation_rotation_scale3d_rotation(rot: rr_dt.Rotation3DLike) -> None:
     tm = rr_arch.Transform3D(rr_dt.TranslationRotationScale3D(rotation=rot))
 
-    assert tm.transform == rr_cmp.Transform3DArray.from_similar(
+    assert tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(
             rr_dt.TranslationRotationScale3D(rotation=rr_dt.Rotation3D(rr_dt.Quaternion(xyzw=[1, 2, 3, 4])))
         )
-    ) or tm.transform == rr_cmp.Transform3DArray.from_similar(
+    ) or tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(
             rr_dt.TranslationRotationScale3D(
                 rotation=rr_dt.Rotation3D(rr_dt.RotationAxisAngle(rr_dt.Vec3D([1, 2, 3]), rr_dt.Angle(rad=4)))
@@ -221,8 +233,8 @@ def test_transform3d_translation_rotation_scale3d_rotation(rot: rr_dt.Rotation3D
 def test_transform3d_translation_rotation_scale3d_scale(scale: rr_dt.Scale3DLike) -> None:
     tm = rr_arch.Transform3D(rr_dt.TranslationRotationScale3D(scale=scale))
 
-    assert tm.transform == rr_cmp.Transform3DArray.from_similar(
+    assert tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(rr_dt.TranslationRotationScale3D(scale=rr_dt.Scale3D([1, 2, 3])))
-    ) or tm.transform == rr_cmp.Transform3DArray.from_similar(
+    ) or tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(rr_dt.TranslationRotationScale3D(scale=rr_dt.Scale3D(4.0)))
     )

--- a/rerun_py/tests/unit/test_view_coordinates.py
+++ b/rerun_py/tests/unit/test_view_coordinates.py
@@ -3,18 +3,17 @@ from __future__ import annotations
 from typing import Any
 
 import rerun.components as rrc
-import rerun.experimental as rr2
-from rerun.archetypes.view_coordinates import ViewCoordinates
+from rerun.archetypes import ViewCoordinates
 
 from .common_arrays import none_empty_or_value
 
 
-def view_coordinates_expected(obj: Any) -> rrc.ViewCoordinatesArray:
+def view_coordinates_expected(obj: Any) -> rrc.ViewCoordinatesBatch:
     expected = none_empty_or_value(
         obj, [rrc.ViewCoordinates.ViewDir.Right, rrc.ViewCoordinates.ViewDir.Down, rrc.ViewCoordinates.ViewDir.Forward]
     )
 
-    return rrc.ViewCoordinatesArray.from_similar(expected)
+    return rrc.ViewCoordinatesBatch(expected)
 
 
 VIEW_COORDINATES_INPUTS: list[rrc.ViewCoordinatesArrayLike | None] = [
@@ -38,12 +37,10 @@ VIEW_COORDINATES_INPUTS: list[rrc.ViewCoordinatesArrayLike | None] = [
 
 def test_view_coordinates() -> None:
     for coordinates in VIEW_COORDINATES_INPUTS:
-        arch = ViewCoordinates(coordinates)
+        # TODO(jleibs): Figure out why mypy is confused by this arg-type
+        arch = ViewCoordinates(coordinates)  # type: ignore[arg-type]
 
         print(f"rr2.ViewCoordinates(\n    {str(coordinates)}\n)")
-        arch = rr2.ViewCoordinates(
-            coordinates,
-        )
         print(f"{arch}\n")
 
         assert arch.xyz == view_coordinates_expected(coordinates)


### PR DESCRIPTION
### What

Best reviewed commit-by-commit.

The primary goal of this change was to get rid of `from_similar` and make it so ComponentBatches are constructable via `__init__`, For example:
```
rr.components.Position3DBatch([1,2,3])
```

Additionally, we rename ComponentArray -> ComponentBatch for clarity.

Rather than ComponentBatches subclasses directly from `pa.ExtensionArray`, batches now subclass from a common type: `BaseBatch`, which has a single field `self.pa_array`.

This makes Components act much more like user-components.  The way to access the arrow data is to call `.as_arrow_array()`, instead of accessing `.storage` directly.

The inheritance patterns are cleaned up in a way that I find to be more legible:
 - DataTypes subclass `BaseBatch`
 - Non-delegating components subclass `BaseBatch`
 - Delegating-components subclass the `DataTypeBatch` they delegate to.
 
 Vec / Position show the new pattern:
 
 Vec3D defines its types and converts.
 ```
 class Vec3DType(BaseExtensionType):
    _TYPE_NAME: str = "rerun.datatypes.Vec3D"

    def __init__(self) -> None:
        pa.ExtensionType.__init__(
            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3), self._TYPE_NAME
        )

class Vec3DBatch(BaseBatch[Vec3DArrayLike]):
    _ARROW_TYPE = Vec3DType()

    @staticmethod
    def _native_to_pa_array(data: Vec3DArrayLike, data_type: pa.DataType) -> pa.Array:
        return Vec3DExt.native_to_pa_array_override(data, data_type)
```

Position3D inherits from Vec3D, but changes the Types.
```
class Position3DType(datatypes.Vec3DType):
    _TYPE_NAME: str = "rerun.components.Position3D"


class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
    _ARROW_TYPE = Position3DType()
``` 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3422) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3422)
- [Docs preview](https://rerun.io/preview/ec393bfb1d07f9cf17292695694978a816bf8c37/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ec393bfb1d07f9cf17292695694978a816bf8c37/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)