### PR TITLE
Remove vector check for images

### DIFF
--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -653,7 +653,7 @@ impl ViewPartSystem for ImagesPart {
             ent_path,
             &LatestAtQuery::new(Timeline::log_time(), TimeInt::MAX),
         ) {
-            tensor.is_shaped_like_an_image() && !tensor.is_vector()
+            tensor.is_shaped_like_an_image()
         } else {
             false
         }


### PR DESCRIPTION
### What
* Part of: https://github.com/rerun-io/rerun/issues/3283

Now that we log IndicatorComponents, removes the check which disables images on tensors that look like vectors.

This works for small pixel values:
```
import numpy as np
import rerun as rr

rr.init("pixtest", spawn=True)

rr.experimental.log("/", rr.archetypes.AnnotationContext([(1, "red", (255, 0, 0))]))
rr.experimental.log("image", rr.archetypes.SegmentationImage(np.ones(shape=(20, 1, 1)).astype(np.uint8)))
```
![image](https://github.com/rerun-io/rerun/assets/3312232/1501a154-475f-4aea-bd70-faa56bb17ebf)

However, this uncovers a new bug with ultra-wide-aspect images.

If we instead use
```
rr.experimental.log("image", rr.archetypes.SegmentationImage(np.ones(shape=(4000, 1, 1)).astype(np.uint8)))
```
The viewer fails a resolution check. Presumably because we round down to < 1 pixel width.
![image](https://github.com/rerun-io/rerun/assets/3312232/b0aa5ee7-0636-40f3-ba18-9037bfd29847)

* Filed as: https://github.com/rerun-io/rerun/issues/3430

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3429) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3429)
- [Docs preview](https://rerun.io/preview/8bf3061e6d9be015ac8c11eb289d04d35acc27ed/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8bf3061e6d9be015ac8c11eb289d04d35acc27ed/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)