### PR TITLE
Fix Asset3D transform

### DIFF
--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -21,7 +21,7 @@ use re_viewer_context::{
 
 /// Context objects for a single entity in a spatial scene.
 pub struct SpatialSceneEntityContext<'a> {
-    pub world_from_obj: glam::Affine3A,
+    pub world_from_entity: glam::Affine3A,
     pub depth_offset: DepthOffset,
     pub annotations: std::sync::Arc<Annotations>,
     pub shared_render_builders: &'a SharedRenderBuilders,

--- a/crates/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/re_space_view_spatial/src/mesh_loader.rs
@@ -180,7 +180,7 @@ impl LoadedMesh {
         &self.name
     }
 
-    pub fn bbox(&self) -> &macaw::BoundingBox {
-        &self.bbox
+    pub fn bbox(&self) -> macaw::BoundingBox {
+        self.bbox
     }
 }

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -108,14 +108,14 @@ impl Arrows3DPart {
                 &instance_path_hashes_for_picking,
                 &colors,
                 &annotation_infos,
-                ent_context.world_from_obj,
+                ent_context.world_from_entity,
             )?);
         }
 
         let mut line_builder = ent_context.shared_render_builders.lines();
         let mut line_batch = line_builder
             .batch("arrows")
-            .world_from_obj(ent_context.world_from_obj)
+            .world_from_obj(ent_context.world_from_entity)
             .outline_mask_ids(ent_context.highlight.overall)
             .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -156,7 +156,7 @@ impl Arrows3DPart {
         }
 
         self.data
-            .extend_bounding_box(bounding_box, ent_context.world_from_obj);
+            .extend_bounding_box(bounding_box, ent_context.world_from_entity);
 
         Ok(())
     }

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -37,7 +37,7 @@ impl Asset3DPart {
         ent_path: &EntityPath,
         ent_context: &SpatialSceneEntityContext<'_>,
     ) -> Result<(), QueryError> {
-        let transform = arch_view
+        let entity_from_pose = arch_view
             .iter_raw_optional_component::<OutOfTreeTransform3D>()?
             .and_then(|mut batch| batch.next());
 
@@ -76,30 +76,27 @@ impl Asset3DPart {
         });
 
         if let Some(mesh) = mesh {
-            let mut mesh_instances = mesh
+            let world_from_pose = ent_context.world_from_entity
+                * entity_from_pose.map_or(glam::Affine3A::IDENTITY, |t| t.0.into());
+
+            let mesh_instances = mesh
                 .mesh_instances
                 .iter()
-                .map(move |mesh_instance| MeshInstance {
-                    gpu_mesh: mesh_instance.gpu_mesh.clone(),
-                    world_from_mesh: ent_context.world_from_obj * mesh_instance.world_from_mesh,
-                    outline_mask_ids,
-                    picking_layer_id: picking_layer_id_from_instance_path_hash(
-                        picking_instance_hash,
-                    ),
-                    ..Default::default()
+                .map(move |mesh_instance| {
+                    let pose_from_mesh = mesh_instance.world_from_mesh;
+                    let world_from_mesh = world_from_pose * pose_from_mesh;
+
+                    MeshInstance {
+                        gpu_mesh: mesh_instance.gpu_mesh.clone(),
+                        world_from_mesh,
+                        outline_mask_ids,
+                        picking_layer_id: picking_layer_id_from_instance_path_hash(
+                            picking_instance_hash,
+                        ),
+                        ..Default::default()
+                    }
                 })
                 .collect_vec();
-
-            // Apply the out-of-tree transform.
-            if let Some(transform) = transform.as_ref() {
-                let (scale, rotation, translation) =
-                    glam::Affine3A::from(transform.0).to_scale_rotation_translation();
-                let transform =
-                    glam::Affine3A::from_scale_rotation_translation(scale, rotation, translation);
-                for instance in &mut mesh_instances {
-                    instance.world_from_mesh = transform * instance.world_from_mesh;
-                }
-            }
 
             let bbox = re_renderer::importer::calculate_bounding_box(&mesh_instances);
 
@@ -108,7 +105,8 @@ impl Asset3DPart {
                     .iter()
                     .map(move |mesh_instance| MeshInstance {
                         gpu_mesh: mesh_instance.gpu_mesh.clone(),
-                        world_from_mesh: ent_context.world_from_obj * mesh_instance.world_from_mesh,
+                        world_from_mesh: ent_context.world_from_entity
+                            * mesh_instance.world_from_mesh,
                         outline_mask_ids,
                         picking_layer_id: picking_layer_id_from_instance_path_hash(
                             picking_instance_hash,
@@ -117,7 +115,8 @@ impl Asset3DPart {
                     }),
             );
 
-            self.0.extend_bounding_box(bbox, ent_context.world_from_obj);
+            self.0
+                .extend_bounding_box(bbox, ent_context.world_from_entity);
         };
 
         Ok(())

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -117,7 +117,7 @@ impl Boxes2DPart {
         let mut line_batch = line_builder
             .batch("boxes2d")
             .depth_offset(ent_context.depth_offset)
-            .world_from_obj(ent_context.world_from_obj)
+            .world_from_obj(ent_context.world_from_entity)
             .outline_mask_ids(ent_context.highlight.overall)
             .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -134,7 +134,7 @@ impl Boxes2DPart {
                     min: min.extend(0.),
                     max: max.extend(0.),
                 },
-                ent_context.world_from_obj,
+                ent_context.world_from_entity,
             );
 
             let rectangle = line_batch

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -59,7 +59,7 @@ impl Boxes3DPart {
         let mut line_batch = line_builder
             .batch("boxes3d")
             .depth_offset(ent_context.depth_offset)
-            .world_from_obj(ent_context.world_from_obj)
+            .world_from_obj(ent_context.world_from_entity)
             .outline_mask_ids(ent_context.highlight.overall)
             .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -79,7 +79,7 @@ impl Boxes3DPart {
                     min: half_extent.box_min(position),
                     max: half_extent.box_max(position),
                 },
-                ent_context.world_from_obj,
+                ent_context.world_from_entity,
             );
 
             let position = position.into();
@@ -106,7 +106,7 @@ impl Boxes3DPart {
                     text,
                     color,
                     target: UiLabelTarget::Position3D(
-                        ent_context.world_from_obj.transform_point3(position),
+                        ent_context.world_from_entity.transform_point3(position),
                     ),
                     labeled_instance: instance_hash,
                 });

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -39,11 +39,11 @@ where
     let counter = view_ctx.get::<PrimitiveCounter>()?;
 
     for (ent_path, props) in query.iter_entities_for_system(System::name()) {
-        let Some(world_from_obj) = transforms.reference_from_entity(ent_path) else {
+        let Some(world_from_entity) = transforms.reference_from_entity(ent_path) else {
             continue;
         };
         let entity_context = SpatialSceneEntityContext {
-            world_from_obj,
+            world_from_entity,
             depth_offset: *depth_offsets
                 .per_entity
                 .get(&ent_path.hash())

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -102,13 +102,13 @@ fn to_textured_rect(
 
             Some(re_renderer::renderer::TexturedRect {
                 top_left_corner_position: ent_context
-                    .world_from_obj
+                    .world_from_entity
                     .transform_point3(glam::Vec3::ZERO),
                 extent_u: ent_context
-                    .world_from_obj
+                    .world_from_entity
                     .transform_vector3(glam::Vec3::X * width as f32),
                 extent_v: ent_context
-                    .world_from_obj
+                    .world_from_entity
                     .transform_vector3(glam::Vec3::Y * height as f32),
                 colormapped_texture,
                 options: RectangleOptions {

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -117,7 +117,7 @@ impl Lines2DPart {
         let mut line_batch = line_builder
             .batch("lines 2d")
             .depth_offset(ent_context.depth_offset)
-            .world_from_obj(ent_context.world_from_obj)
+            .world_from_obj(ent_context.world_from_entity)
             .outline_mask_ids(ent_context.highlight.overall)
             .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -148,7 +148,7 @@ impl Lines2DPart {
         }
 
         self.data
-            .extend_bounding_box(bounding_box, ent_context.world_from_obj);
+            .extend_bounding_box(bounding_box, ent_context.world_from_entity);
 
         Ok(())
     }

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -117,7 +117,7 @@ impl Lines3DPart {
                 &instance_path_hashes_for_picking,
                 &colors,
                 &annotation_infos,
-                ent_context.world_from_obj,
+                ent_context.world_from_entity,
             )?);
         }
 
@@ -125,7 +125,7 @@ impl Lines3DPart {
         let mut line_batch = line_builder
             .batch("lines 3d")
             .depth_offset(ent_context.depth_offset)
-            .world_from_obj(ent_context.world_from_obj)
+            .world_from_obj(ent_context.world_from_entity)
             .outline_mask_ids(ent_context.highlight.overall)
             .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -156,7 +156,7 @@ impl Lines3DPart {
         }
 
         self.data
-            .extend_bounding_box(bounding_box, ent_context.world_from_obj);
+            .extend_bounding_box(bounding_box, ent_context.world_from_entity);
 
         Ok(())
     }

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -117,7 +117,7 @@ impl Mesh3DPart {
             }));
 
             self.0
-                .extend_bounding_box(*mesh.bbox(), ent_context.world_from_entity);
+                .extend_bounding_box(mesh.bbox(), ent_context.world_from_entity);
         };
 
         Ok(())

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -101,22 +101,23 @@ impl Mesh3DPart {
         if let Some(mesh) = mesh {
             re_tracing::profile_scope!("mesh instances");
 
-            instances.extend(
-                mesh.mesh_instances
-                    .iter()
-                    .map(move |mesh_instance| MeshInstance {
-                        gpu_mesh: mesh_instance.gpu_mesh.clone(),
-                        world_from_mesh: ent_context.world_from_obj * mesh_instance.world_from_mesh,
-                        outline_mask_ids,
-                        picking_layer_id: picking_layer_id_from_instance_path_hash(
-                            picking_instance_hash,
-                        ),
-                        ..Default::default()
-                    }),
-            );
+            instances.extend(mesh.mesh_instances.iter().map(move |mesh_instance| {
+                let entity_from_mesh = mesh_instance.world_from_mesh;
+                let world_from_mesh = ent_context.world_from_entity * entity_from_mesh;
+
+                MeshInstance {
+                    gpu_mesh: mesh_instance.gpu_mesh.clone(),
+                    world_from_mesh,
+                    outline_mask_ids,
+                    picking_layer_id: picking_layer_id_from_instance_path_hash(
+                        picking_instance_hash,
+                    ),
+                    ..Default::default()
+                }
+            }));
 
             self.0
-                .extend_bounding_box(*mesh.bbox(), ent_context.world_from_obj);
+                .extend_bounding_box(*mesh.bbox(), ent_context.world_from_entity);
         };
 
         Ok(())

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -1,7 +1,7 @@
 //! Responsible for populating `SceneSpatialPrimitives` and `SceneSpatialUiData`
 
 mod arrows3d;
-mod assets;
+mod assets3d;
 mod boxes2d;
 mod boxes3d;
 mod cameras;
@@ -47,7 +47,7 @@ pub fn register_parts(
     system_registry: &mut SpaceViewSystemRegistry,
 ) -> Result<(), SpaceViewClassRegistryError> {
     system_registry.register_part_system::<arrows3d::Arrows3DPart>()?;
-    system_registry.register_part_system::<assets::Asset3DPart>()?;
+    system_registry.register_part_system::<assets3d::Asset3DPart>()?;
     system_registry.register_part_system::<boxes2d::Boxes2DPart>()?;
     system_registry.register_part_system::<boxes3d::Boxes3DPart>()?;
     system_registry.register_part_system::<cameras::CamerasPart>()?;
@@ -272,7 +272,7 @@ pub fn load_keypoint_connections(
     let mut line_builder = ent_context.shared_render_builders.lines();
     let mut line_batch = line_builder
         .batch("keypoint connections")
-        .world_from_obj(ent_context.world_from_obj)
+        .world_from_obj(ent_context.world_from_entity)
         .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
     for ((class_id, _time), keypoints_in_class) in keypoints {

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -117,7 +117,7 @@ impl Points2DPart {
                     re_renderer::renderer::PointCloudBatchFlags::FLAG_DRAW_AS_CIRCLES
                         | re_renderer::renderer::PointCloudBatchFlags::FLAG_ENABLE_SHADING,
                 )
-                .world_from_obj(ent_context.world_from_obj)
+                .world_from_obj(ent_context.world_from_entity)
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -174,7 +174,7 @@ impl Points2DPart {
             arch_view
                 .iter_required_component::<Position2D>()?
                 .map(|pt| pt.into()),
-            ent_context.world_from_obj,
+            ent_context.world_from_entity,
         );
 
         Ok(())

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -113,7 +113,7 @@ impl Points3DPart {
                 &instance_path_hashes_for_picking,
                 &colors,
                 &annotation_infos,
-                ent_context.world_from_obj,
+                ent_context.world_from_entity,
             )?);
         }
 
@@ -121,7 +121,7 @@ impl Points3DPart {
             let mut point_builder = ent_context.shared_render_builders.points();
             let point_batch = point_builder
                 .batch("3d points")
-                .world_from_obj(ent_context.world_from_obj)
+                .world_from_obj(ent_context.world_from_entity)
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(ent_path.hash64()));
 
@@ -174,7 +174,7 @@ impl Points3DPart {
 
             self.data.extend_bounding_box_with_points(
                 positions.iter().copied(),
-                ent_context.world_from_obj,
+                ent_context.world_from_entity,
             );
         }
 


### PR DESCRIPTION
### What

* Fixes #3426

first commit is extended cleanup (+ fixing ignoring skew on Asset3d, which isn't relevant for this bugfix), second is the actual fix.



Did an animated version of the submitted repro case because I couldn't see what's going on at first 😄 

https://github.com/rerun-io/rerun/assets/1220815/34796f06-ead2-4434-a35a-5e7e007944a4
(this is after the fix)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3439) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3439)
- [Docs preview](https://rerun.io/preview/14d00a078d15e8f518bcc1934b3e9a950e9ec544/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/14d00a078d15e8f518bcc1934b3e9a950e9ec544/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)