### PR TITLE
allows to log RotationAxisAngle directly in Python

### DIFF
--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle_ext.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, cast
 
 import pyarrow as pa
 
 if TYPE_CHECKING:
+    from ..log import ComponentBatchLike
     from . import Angle, AngleLike, RotationAxisAngleArrayLike
 
 
@@ -36,3 +37,14 @@ class RotationAxisAngleExt:
             ],
             fields=list(data_type),
         )
+
+    # Implement the ArchetypeLike
+    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+        from ..datatypes import TranslationRotationScale3D
+        from . import RotationAxisAngle
+
+        return TranslationRotationScale3D(rotation=cast(RotationAxisAngle, self)).as_component_batches()
+
+    def num_instances(self) -> int:
+        # Always a mono-component
+        return 1

--- a/rerun_py/tests/unit/test_transform3d.py
+++ b/rerun_py/tests/unit/test_transform3d.py
@@ -226,3 +226,10 @@ def test_transform3d_translation_rotation_scale3d_scale(scale: rr_dt.Scale3DLike
     ) or tm.transform == rr_cmp.Transform3DBatch(
         rr_dt.Transform3D(rr_dt.TranslationRotationScale3D(scale=rr_dt.Scale3D(4.0)))
     )
+
+
+def test_rotation_axis_angle_loggable() -> None:
+    assert [b.as_arrow_array() for b in rr_dt.RotationAxisAngle([1, 2, 3], 4).as_component_batches()] == [
+        b.as_arrow_array()
+        for b in rr_dt.TranslationRotationScale3D(rotation=rr_dt.RotationAxisAngle([1, 2, 3], 4)).as_component_batches()
+    ]


### PR DESCRIPTION
### What

I found myself wanting to write this:
```
rr2.log("world/child", rr2.dt.RotationAxisAngle(axis=(0, 1, 0), angle=i / 100.0))
```
In order to do so, I made it so that this now logs a Transform3D _archetype_, just like logging `TranslationRotationScale3D`  and `TranslationAndMat3x3` already do.

Now that I have it down, I see good reasons why we shouldn't do this: Why not also allow logging `Rotation3D` as an archetype (this is a component that is used inside Boxes3D archetype).

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3441) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3441)
- [Docs preview](https://rerun.io/preview/493e2719bf99319ffcb5a522b4aff6e6f1b4a52e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/493e2719bf99319ffcb5a522b4aff6e6f1b4a52e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)