### PR TITLE
Click `recording://entity/path` links in markdown 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "egui_commonmark"
 version = "0.7.4"
-source = "git+https://github.com/lampsitter/egui_commonmark.git?rev=a133564f26a95672e756079ac5583817e0cdaa1f#a133564f26a95672e756079ac5583817e0cdaa1f"
+source = "git+https://github.com/lampsitter/egui_commonmark.git?rev=a4470c253b06a4a350e17418a7c6cbc413ade644#a4470c253b06a4a350e17418a7c6cbc413ade644"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ emath = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
 epaint = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
 
 # Temporary patch until next egui_commonmark release
-egui_commonmark = { git = "https://github.com/lampsitter/egui_commonmark.git", rev = "a133564f26a95672e756079ac5583817e0cdaa1f" }
+egui_commonmark = { git = "https://github.com/lampsitter/egui_commonmark.git", rev = "a4470c253b06a4a350e17418a7c6cbc413ade644" }
 
 # Temporary patch until next egui_tiles release
 egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "c66d6cba7ddb5b236be614d1816be4561260274e" }

--- a/crates/re_data_store/src/instance_path.rs
+++ b/crates/re_data_store/src/instance_path.rs
@@ -19,6 +19,13 @@ pub struct InstancePath {
     pub instance_key: InstanceKey,
 }
 
+impl From<EntityPath> for InstancePath {
+    #[inline]
+    fn from(entity_path: EntityPath) -> Self {
+        Self::entity_splat(entity_path)
+    }
+}
+
 impl InstancePath {
     /// Indicate the whole entity (all instances of it) - i.e. a splat.
     ///

--- a/crates/re_data_store/src/instance_path.rs
+++ b/crates/re_data_store/src/instance_path.rs
@@ -110,9 +110,9 @@ impl FromStr for InstancePath {
 #[test]
 fn test_parse_instance_path() {
     assert_eq!(
-        InstancePath::from_str("points[#123]"),
+        InstancePath::from_str("world/points[#123]"),
         Ok(InstancePath {
-            entity_path: EntityPath::from_str("points").unwrap(),
+            entity_path: EntityPath::from_str("world/points").unwrap(),
             instance_key: InstanceKey(123)
         })
     );

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -55,6 +55,11 @@ impl EntityDb {
         self.entity_path_from_hash.get(entity_path_hash)
     }
 
+    #[inline]
+    pub fn knows_of_entity(&self, entity_path: &EntityPath) -> bool {
+        self.entity_path_from_hash.contains_key(&entity_path.hash())
+    }
+
     fn register_entity_path(&mut self, entity_path: &EntityPath) {
         self.entity_path_from_hash
             .entry(entity_path.hash())

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -11,21 +11,34 @@ impl DataUi for ComponentPath {
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
+        let Self {
+            entity_path,
+            component_name,
+        } = self;
+
         let store = &ctx.store_db.entity_db.data_store;
 
-        if let Some((_, component_data)) = re_query::get_component_with_instances(
-            store,
-            query,
-            self.entity_path(),
-            self.component_name,
-        ) {
+        if let Some((_, component_data)) =
+            re_query::get_component_with_instances(store, query, entity_path, *component_name)
+        {
             super::component::EntityComponentWithInstances {
                 entity_path: self.entity_path.clone(),
                 component_data,
             }
             .data_ui(ctx, ui, verbosity, query);
+        } else if let Some(entity_tree) = ctx.store_db.entity_db.tree.subtree(entity_path) {
+            if entity_tree.components.contains_key(component_name) {
+                ui.label("<unset>");
+            } else {
+                ui.label(format!(
+                    "Entity {entity_path:?} has no component {component_name:?}"
+                ));
+            }
         } else {
-            ui.label("<unset>");
+            ui.label(
+                ctx.re_ui
+                    .error_text(format!("Unknown entity: {entity_path:?}")),
+            );
         }
     }
 }

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -1,6 +1,7 @@
 use re_arrow_store::LatestAtQuery;
 use re_log_types::{external::arrow2, EntityPath};
 use re_query::ComponentWithInstances;
+use re_types::external::arrow2::array::Utf8Array;
 use re_viewer_context::{ComponentUiRegistry, UiVerbosity, ViewerContext};
 
 use super::EntityDataUi;
@@ -54,7 +55,7 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
 fn fallback_component_ui(
     _ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    verbosity: UiVerbosity,
     _query: &LatestAtQuery,
     _entity_path: &EntityPath,
     component: &ComponentWithInstances,
@@ -62,25 +63,80 @@ fn fallback_component_ui(
 ) {
     // No special ui implementation - use a generic one:
     if let Some(value) = component.lookup_arrow(instance_key) {
-        ui.label(format_arrow(&*value));
+        arrow_ui(ui, verbosity, &*value);
     } else {
         ui.weak("(null)");
     }
 }
 
-fn format_arrow(value: &dyn arrow2::array::Array) -> String {
+fn arrow_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, array: &dyn arrow2::array::Array) {
     use re_log_types::SizeBytes as _;
 
-    let bytes = value.total_size_bytes();
-    if bytes < 256 {
+    // Special-treat text.
+    // Note: we match on the raw data here, so this works for any component containing text.
+    if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i32>>() {
+        if utf8.len() == 1 {
+            let string = utf8.value(0);
+            text_ui(string, ui, verbosity);
+            return;
+        }
+    }
+    if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i64>>() {
+        if utf8.len() == 1 {
+            let string = utf8.value(0);
+            text_ui(string, ui, verbosity);
+            return;
+        }
+    }
+
+    let num_bytes = array.total_size_bytes();
+    if num_bytes < 256 {
         // Print small items:
         let mut string = String::new();
-        let display = arrow2::array::get_display(value, "null");
+        let display = arrow2::array::get_display(array, "null");
         if display(&mut string, 0).is_ok() {
-            return string;
+            ui.label(string);
+            return;
         }
     }
 
     // Fallback:
-    format!("{bytes} bytes")
+    ui.label(format!(
+        "{} of {:?}",
+        re_format::format_bytes(num_bytes as _),
+        array.data_type()
+    ));
+}
+
+fn text_ui(string: &str, ui: &mut egui::Ui, verbosity: UiVerbosity) {
+    let font_id = egui::TextStyle::Body.resolve(ui.style());
+    let color = ui.visuals().text_color();
+    let wrap_width = ui.available_width();
+    let mut layout_job =
+        egui::text::LayoutJob::simple(string.to_owned(), font_id, color, wrap_width);
+
+    let mut needs_scroll_area = false;
+
+    match verbosity {
+        UiVerbosity::Small => {
+            // Elide
+            layout_job.wrap.max_rows = 1;
+            layout_job.wrap.break_anywhere = true;
+        }
+        UiVerbosity::Reduced => {
+            layout_job.wrap.max_rows = 3;
+        }
+        UiVerbosity::All => {
+            let num_newlines = string.chars().filter(|&c| c == '\n').count();
+            needs_scroll_area = 10 < num_newlines || 300 < string.len();
+        }
+    }
+
+    if needs_scroll_area {
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            ui.label(layout_job);
+        });
+    } else {
+        ui.label(layout_job);
+    }
 }

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -109,7 +109,7 @@ fn arrow_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, array: &dyn arrow2::array
 }
 
 fn text_ui(string: &str, ui: &mut egui::Ui, verbosity: UiVerbosity) {
-    let font_id = egui::TextStyle::Body.resolve(ui.style());
+    let font_id = egui::TextStyle::Monospace.resolve(ui.style());
     let color = ui.visuals().text_color();
     let wrap_width = ui.available_width();
     let mut layout_job =

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -32,7 +32,10 @@ impl DataUi for InstancePath {
                     query.timeline.name()
                 ));
             } else {
-                ui.label(format!("Unknown entity: {entity_path:?}"));
+                ui.label(
+                    ctx.re_ui
+                        .error_text(format!("Unknown entity: {entity_path:?}")),
+                );
             }
             return;
         };

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -17,10 +17,23 @@ impl DataUi for InstancePath {
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
+        let Self {
+            entity_path,
+            instance_key,
+        } = self;
+
         let store = &ctx.store_db.entity_db.data_store;
 
-        let Some(mut components) = store.all_components(&query.timeline, &self.entity_path) else {
-            ui.label(format!("No components in entity {}", self.entity_path));
+        let Some(mut components) = store.all_components(&query.timeline, entity_path) else {
+            if ctx.store_db.entity_db.knows_of_entity(entity_path) {
+                ui.label(format!(
+                    "No components in entity {:?} on timeline {:?}",
+                    entity_path,
+                    query.timeline.name()
+                ));
+            } else {
+                ui.label(format!("Unknown entity: {entity_path:?}"));
+            }
             return;
         };
         components.sort();
@@ -29,12 +42,9 @@ impl DataUi for InstancePath {
             .num_columns(2)
             .show(ui, |ui| {
                 for component_name in components {
-                    let Some((_, component_data)) = get_component_with_instances(
-                        store,
-                        query,
-                        &self.entity_path,
-                        component_name,
-                    ) else {
+                    let Some((_, component_data)) =
+                        get_component_with_instances(store, query, entity_path, component_name)
+                    else {
                         continue; // no need to show components that are unset at this point in time
                     };
 
@@ -56,12 +66,12 @@ impl DataUi for InstancePath {
                     item_ui::component_path_button(
                         ctx,
                         ui,
-                        &ComponentPath::new(self.entity_path.clone(), component_name),
+                        &ComponentPath::new(entity_path.clone(), component_name),
                     );
 
-                    if self.instance_key.is_splat() {
+                    if instance_key.is_splat() {
                         super::component::EntityComponentWithInstances {
-                            entity_path: self.entity_path.clone(),
+                            entity_path: entity_path.clone(),
                             component_data,
                         }
                         .data_ui(ctx, ui, UiVerbosity::Small, query);
@@ -71,9 +81,9 @@ impl DataUi for InstancePath {
                             ui,
                             UiVerbosity::Small,
                             query,
-                            &self.entity_path,
+                            entity_path,
                             &component_data,
-                            &self.instance_key,
+                            instance_key,
                         );
                     }
 

--- a/crates/re_log_types/src/index.rs
+++ b/crates/re_log_types/src/index.rs
@@ -9,9 +9,6 @@ pub enum Index {
     /// For arrays, assumed to be dense (0, 1, 2, …).
     Sequence(u64),
 
-    /// X,Y pixel coordinates, from top left.
-    Pixel([u64; 2]),
-
     /// Any integer, e.g. a hash or an arbitrary identifier.
     Integer(i128),
 
@@ -56,7 +53,6 @@ impl std::fmt::Display for Index {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Sequence(seq) => format!("#{seq}").fmt(f),
-            Self::Pixel([x, y]) => format!("[{x}, {y}]").fmt(f),
             Self::Integer(value) => value.fmt(f),
             Self::Uuid(value) => value.fmt(f),
             Self::String(value) => format!("{value:?}").fmt(f), // put it in quotes

--- a/crates/re_log_types/src/path/data_path.rs
+++ b/crates/re_log_types/src/path/data_path.rs
@@ -10,13 +10,32 @@ use crate::EntityPath;
 /// For instance:
 ///
 /// * `points`
-/// * `points.color`
+/// * `points.Color`
 /// * `points[#42]`
-/// * `points[#42].color`
+/// * `points[#42].Color`
 pub struct DataPath {
     pub entity_path: EntityPath,
 
     pub instance_key: Option<InstanceKey>,
 
     pub component_name: Option<ComponentName>,
+}
+
+impl std::fmt::Display for DataPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.entity_path.fmt(f)?;
+        if let Some(instance_key) = &self.instance_key {
+            write!(f, "[#{}]", instance_key.0)?;
+        }
+        if let Some(component_name) = &self.component_name {
+            write!(f, ".{component_name:?}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for DataPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_string().fmt(f)
+    }
 }

--- a/crates/re_log_types/src/path/data_path.rs
+++ b/crates/re_log_types/src/path/data_path.rs
@@ -1,0 +1,22 @@
+use re_types::{components::InstanceKey, ComponentName};
+
+use crate::EntityPath;
+
+/// A general path to some data.
+///
+/// This always starts with an [`EntityPath`], followed
+/// by an optional [`InstanceKey`], followed by an optional [`ComponentName`].
+///
+/// For instance:
+///
+/// * `points`
+/// * `points.color`
+/// * `points[#42]`
+/// * `points[#42].color`
+pub struct DataPath {
+    pub entity_path: EntityPath,
+
+    pub instance_key: Option<InstanceKey>,
+
+    pub component_name: Option<ComponentName>,
+}

--- a/crates/re_log_types/src/path/data_path.rs
+++ b/crates/re_log_types/src/path/data_path.rs
@@ -13,6 +13,7 @@ use crate::EntityPath;
 /// * `points.Color`
 /// * `points[#42]`
 /// * `points[#42].Color`
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct DataPath {
     pub entity_path: EntityPath,
 

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -210,7 +210,7 @@ impl From<&[EntityPathPart]> for EntityPath {
     }
 }
 
-#[allow(clippy::fallible_impl_from)] // TODO(emilk): we should force users to handle errors instead, and have a nice macro for constructing entity path
+#[allow(clippy::fallible_impl_from)] // TODO(#3393): we should force users to handle errors instead, and have a nice macro for constructing entity path
 impl From<&str> for EntityPath {
     #[inline]
     fn from(path: &str) -> Self {
@@ -218,7 +218,7 @@ impl From<&str> for EntityPath {
     }
 }
 
-#[allow(clippy::fallible_impl_from)] // TODO(emilk): we should force users to handle errors instead, and have a nice macro for constructing entity path
+#[allow(clippy::fallible_impl_from)] // TODO(#3393): we should force users to handle errors instead, and have a nice macro for constructing entity path
 impl From<String> for EntityPath {
     #[inline]
     fn from(path: String) -> Self {

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -123,6 +123,11 @@ impl EntityPath {
     }
 
     #[inline]
+    pub fn to_vec(&self) -> Vec<EntityPathPart> {
+        self.path.to_vec()
+    }
+
+    #[inline]
     pub fn is_root(&self) -> bool {
         self.path.is_root()
     }

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use crate::{
-    hash::Hash64, parse_entity_path, path::entity_path_impl::EntityPathImpl, EntityPathPart,
-    SizeBytes,
-};
+use crate::{hash::Hash64, path::entity_path_impl::EntityPathImpl, EntityPathPart, SizeBytes};
+
+use super::parse_path::parse_entity_path_components;
 
 // ----------------------------------------------------------------------------
 
@@ -212,7 +211,7 @@ impl From<&[EntityPathPart]> for EntityPath {
 impl From<&str> for EntityPath {
     #[inline]
     fn from(path: &str) -> Self {
-        Self::from(parse_entity_path(path).unwrap())
+        Self::from(parse_entity_path_components(path).unwrap())
     }
 }
 
@@ -345,5 +344,13 @@ impl std::fmt::Debug for EntityPath {
 impl std::fmt::Display for EntityPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.path.fmt(f)
+    }
+}
+
+impl std::str::FromStr for EntityPath {
+    type Err = crate::PathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_entity_path_components(s).map(Self::new)
     }
 }

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -2,8 +2,6 @@ use std::sync::Arc;
 
 use crate::{hash::Hash64, path::entity_path_impl::EntityPathImpl, EntityPathPart, SizeBytes};
 
-use super::parse_path::parse_entity_path_components;
-
 // ----------------------------------------------------------------------------
 
 /// A 64 bit hash of [`EntityPath`] with very small risk of collision.
@@ -207,18 +205,19 @@ impl From<&[EntityPathPart]> for EntityPath {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // TODO(emilk): we should force users to handle errors instead, and have a nice macro for constructing entity path
 impl From<&str> for EntityPath {
     #[inline]
     fn from(path: &str) -> Self {
-        Self::from(parse_entity_path_components(path).unwrap())
+        path.parse().unwrap()
     }
 }
 
+#[allow(clippy::fallible_impl_from)] // TODO(emilk): we should force users to handle errors instead, and have a nice macro for constructing entity path
 impl From<String> for EntityPath {
     #[inline]
     fn from(path: String) -> Self {
-        Self::from(path.as_str())
+        path.parse().unwrap()
     }
 }
 
@@ -344,13 +343,5 @@ impl std::fmt::Debug for EntityPath {
 impl std::fmt::Display for EntityPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.path.fmt(f)
-    }
-}
-
-impl std::str::FromStr for EntityPath {
-    type Err = crate::PathParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_entity_path_components(s).map(Self::new)
     }
 }

--- a/crates/re_log_types/src/path/entity_path_impl.rs
+++ b/crates/re_log_types/src/path/entity_path_impl.rs
@@ -26,6 +26,11 @@ impl EntityPathImpl {
     }
 
     #[inline]
+    pub fn to_vec(&self) -> Vec<EntityPathPart> {
+        self.parts.clone()
+    }
+
+    #[inline]
     pub fn is_root(&self) -> bool {
         self.parts.is_empty()
     }

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -72,13 +72,13 @@ impl From<Index> for EntityPathPart {
 /// ```
 #[macro_export]
 macro_rules! entity_path_vec {
-        () => {
-            vec![]
-        };
-        ($($part: expr),* $(,)?) => {
-            vec![ $($crate::EntityPathPart::from($part),)+ ]
-        };
-    }
+    () => {
+        vec![]
+    };
+    ($($part: expr),* $(,)?) => {
+        vec![ $($crate::EntityPathPart::from($part),)+ ]
+    };
+}
 
 /// Build a `EntityPath`:
 /// ```
@@ -87,10 +87,10 @@ macro_rules! entity_path_vec {
 /// ```
 #[macro_export]
 macro_rules! entity_path {
-        () => {
-            vec![]
-        };
-        ($($part: expr),* $(,)?) => {
-            $crate::EntityPath::from(vec![ $($crate::EntityPathPart::from($part),)+ ])
-        };
-    }
+    () => {
+        vec![]
+    };
+    ($($part: expr),* $(,)?) => {
+        $crate::EntityPath::from(vec![ $($crate::EntityPathPart::from($part),)+ ])
+    };
+}

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -14,7 +14,7 @@ mod parse_path;
 pub use component_path::ComponentPath;
 pub use entity_path::{EntityPath, EntityPathHash};
 pub use entity_path_impl::EntityPathImpl;
-pub use parse_path::{parse_entity_path, PathParseError};
+pub use parse_path::PathParseError;
 
 use re_string_interner::InternedString;
 

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -26,10 +26,12 @@ use crate::Index;
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum EntityPathPart {
-    /// Struct member. Each member can have a different type.
+    /// Corresponds to the name of a struct field.
+    ///
+    /// Only a limited set of characters are allowed in a name.
     Name(InternedString),
 
-    /// Array/table/map member. Each member must be of the same type (homogeneous).
+    /// Array/table/map member.
     Index(Index),
 }
 

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -7,11 +7,13 @@
 //! The [`Index`]es are for tables, arrays etc.
 
 mod component_path;
+mod data_path;
 mod entity_path;
 mod entity_path_impl;
 mod parse_path;
 
 pub use component_path::ComponentPath;
+pub use data_path::DataPath;
 pub use entity_path::{EntityPath, EntityPathHash};
 pub use entity_path_impl::EntityPathImpl;
 pub use parse_path::PathParseError;

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -174,43 +174,6 @@ impl FromStr for ComponentPath {
     }
 }
 
-#[test]
-fn test_parse_component_path() {
-    assert_eq!(
-        ComponentPath::from_str("world/points.rerun.components.Color"),
-        Ok(ComponentPath {
-            entity_path: EntityPath::from_str("world/points").unwrap(),
-            component_name: "rerun.components.Color".into(),
-        })
-    );
-    assert_eq!(
-        ComponentPath::from_str("world/points.Color"),
-        Ok(ComponentPath {
-            entity_path: EntityPath::from_str("world/points").unwrap(),
-            component_name: "rerun.components.Color".into(),
-        })
-    );
-    assert_eq!(
-        ComponentPath::from_str("world/points.my.custom.color"),
-        Ok(ComponentPath {
-            entity_path: EntityPath::from_str("world/points").unwrap(),
-            component_name: "my.custom.color".into(),
-        })
-    );
-    assert_eq!(
-        ComponentPath::from_str("world/points."),
-        Err(PathParseError::TrailingDot)
-    );
-    assert_eq!(
-        ComponentPath::from_str("world/points"),
-        Err(PathParseError::MissingComponentName)
-    );
-    assert_eq!(
-        ComponentPath::from_str("world/points[#42].rerun.components.Color"),
-        Err(PathParseError::UnexpectedInstanceKey(InstanceKey(42)))
-    );
-}
-
 fn entity_path_parts_from_tokens(mut tokens: &[&str]) -> Result<Vec<EntityPathPart>> {
     if tokens.is_empty() {
         return Err(PathParseError::MissingPath);
@@ -379,7 +342,7 @@ fn test_unescape_string() {
 }
 
 #[test]
-fn test_parse_path() {
+fn test_parse_entity_path() {
     use crate::entity_path_vec;
 
     fn parse(s: &str) -> Result<Vec<EntityPathPart>> {
@@ -428,4 +391,77 @@ fn test_parse_path() {
         parse(r#"entity[#123]"#),
         Err(PathParseError::UnexpectedInstanceKey(InstanceKey(123)))
     ));
+}
+
+#[test]
+fn test_parse_component_path() {
+    assert_eq!(
+        ComponentPath::from_str("world/points.rerun.components.Color"),
+        Ok(ComponentPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            component_name: "rerun.components.Color".into(),
+        })
+    );
+    assert_eq!(
+        ComponentPath::from_str("world/points.Color"),
+        Ok(ComponentPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            component_name: "rerun.components.Color".into(),
+        })
+    );
+    assert_eq!(
+        ComponentPath::from_str("world/points.my.custom.color"),
+        Ok(ComponentPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            component_name: "my.custom.color".into(),
+        })
+    );
+    assert_eq!(
+        ComponentPath::from_str("world/points."),
+        Err(PathParseError::TrailingDot)
+    );
+    assert_eq!(
+        ComponentPath::from_str("world/points"),
+        Err(PathParseError::MissingComponentName)
+    );
+    assert_eq!(
+        ComponentPath::from_str("world/points[#42].rerun.components.Color"),
+        Err(PathParseError::UnexpectedInstanceKey(InstanceKey(42)))
+    );
+}
+
+#[test]
+fn test_parse_data_path() {
+    assert_eq!(
+        DataPath::from_str("world/points[#42].rerun.components.Color"),
+        Ok(DataPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            instance_key: Some(InstanceKey(42)),
+            component_name: Some("rerun.components.Color".into()),
+        })
+    );
+    assert_eq!(
+        DataPath::from_str("world/points.rerun.components.Color"),
+        Ok(DataPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            instance_key: None,
+            component_name: Some("rerun.components.Color".into()),
+        })
+    );
+    assert_eq!(
+        DataPath::from_str("world/points[#42]"),
+        Ok(DataPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            instance_key: Some(InstanceKey(42)),
+            component_name: None,
+        })
+    );
+    assert_eq!(
+        DataPath::from_str("world/points"),
+        Ok(DataPath {
+            entity_path: EntityPath::from_str("world/points").unwrap(),
+            instance_key: None,
+            component_name: None,
+        })
+    );
 }

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -25,7 +25,7 @@ pub enum PathParseError {
 }
 
 /// Parses an entity path, e.g. `foo/bar/#1234/5678/"string index"/a6a5e96c-fd52-4d21-a394-ffbb6e5def1d`
-pub fn parse_entity_path(path: &str) -> Result<Vec<EntityPathPart>, PathParseError> {
+pub fn parse_entity_path_components(path: &str) -> Result<Vec<EntityPathPart>, PathParseError> {
     if path.is_empty() {
         return Err(PathParseError::EmptyString);
     }
@@ -146,20 +146,31 @@ fn test_unescape_string() {
 fn test_parse_path() {
     use crate::entity_path_vec;
 
-    assert_eq!(parse_entity_path(""), Err(PathParseError::EmptyString));
-    assert_eq!(parse_entity_path("/"), Ok(entity_path_vec!()));
-    assert_eq!(parse_entity_path("foo"), Ok(entity_path_vec!("foo")));
-    assert_eq!(parse_entity_path("/foo"), Err(PathParseError::LeadingSlash));
     assert_eq!(
-        parse_entity_path("foo/bar"),
+        parse_entity_path_components(""),
+        Err(PathParseError::EmptyString)
+    );
+    assert_eq!(parse_entity_path_components("/"), Ok(entity_path_vec!()));
+    assert_eq!(
+        parse_entity_path_components("foo"),
+        Ok(entity_path_vec!("foo"))
+    );
+    assert_eq!(
+        parse_entity_path_components("/foo"),
+        Err(PathParseError::LeadingSlash)
+    );
+    assert_eq!(
+        parse_entity_path_components("foo/bar"),
         Ok(entity_path_vec!("foo", "bar"))
     );
     assert_eq!(
-        parse_entity_path("foo//bar"),
+        parse_entity_path_components("foo//bar"),
         Err(PathParseError::DoubleSlash)
     );
     assert_eq!(
-        parse_entity_path(r#"foo/"bar"/#123/-1234/6d046bf4-e5d3-4599-9153-85dd97218cb3"#),
+        parse_entity_path_components(
+            r#"foo/"bar"/#123/-1234/6d046bf4-e5d3-4599-9153-85dd97218cb3"#
+        ),
         Ok(entity_path_vec!(
             "foo",
             Index::String("bar".into()),
@@ -169,7 +180,7 @@ fn test_parse_path() {
         ))
     );
     assert_eq!(
-        parse_entity_path(r#"foo/"bar""baz""#),
+        parse_entity_path_components(r#"foo/"bar""baz""#),
         Err(PathParseError::MissingSlash)
     );
 }

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -184,7 +184,7 @@ fn test_parse_component_path() {
         })
     );
     assert_eq!(
-        ComponentPath::from_str("world/points.color"),
+        ComponentPath::from_str("world/points.Color"),
         Ok(ComponentPath {
             entity_path: EntityPath::from_str("world/points").unwrap(),
             component_name: "rerun.components.Color".into(),

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -201,6 +201,14 @@ fn test_parse_component_path() {
         ComponentPath::from_str("world/points."),
         Err(PathParseError::TrailingDot)
     );
+    assert_eq!(
+        ComponentPath::from_str("world/points"),
+        Err(PathParseError::MissingComponentName)
+    );
+    assert_eq!(
+        ComponentPath::from_str("world/points[#42].rerun.components.Color"),
+        Err(PathParseError::UnexpectedInstanceKey(InstanceKey(42)))
+    );
 }
 
 fn entity_path_parts_from_tokens(mut tokens: &[&str]) -> Result<Vec<EntityPathPart>> {

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -1,4 +1,4 @@
-use crate::{EntityPathPart, Index};
+use crate::{EntityPath, EntityPathPart, Index};
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum PathParseError {
@@ -24,8 +24,16 @@ pub enum PathParseError {
     MissingSlash,
 }
 
+impl std::str::FromStr for EntityPath {
+    type Err = crate::PathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_entity_path_components(s).map(Self::new)
+    }
+}
+
 /// Parses an entity path, e.g. `foo/bar/#1234/5678/"string index"/a6a5e96c-fd52-4d21-a394-ffbb6e5def1d`
-pub fn parse_entity_path_components(path: &str) -> Result<Vec<EntityPathPart>, PathParseError> {
+fn parse_entity_path_components(path: &str) -> Result<Vec<EntityPathPart>, PathParseError> {
     if path.is_empty() {
         return Err(PathParseError::EmptyString);
     }

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -124,6 +124,14 @@ impl SpaceViewClass for TextDocumentSpaceView {
                             {
                                 if media_type == &re_types::components::MediaType::markdown() {
                                     re_tracing::profile_scope!("egui_commonmark");
+
+                                    // Make sure headers are big:
+                                    ui.style_mut()
+                                        .text_styles
+                                        .entry(egui::TextStyle::Heading)
+                                        .or_insert(egui::FontId::proportional(32.0))
+                                        .size = 32.0;
+
                                     egui_commonmark::CommonMarkViewer::new("markdown_viewer")
                                         .max_image_width(Some(ui.available_width().floor() as _))
                                         .show(ui, &mut state.commonmark_cache, body);

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -130,7 +130,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
                                         .text_styles
                                         .entry(egui::TextStyle::Heading)
                                         .or_insert(egui::FontId::proportional(32.0))
-                                        .size = 32.0;
+                                        .size = 24.0;
 
                                     egui_commonmark::CommonMarkViewer::new("markdown_viewer")
                                         .max_image_width(Some(ui.available_width().floor() as _))

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-d9d867fa69149e0d5b6a53def5de927c26c8e1c1468e8c1102f6623a4863da08
+3cd3f97b282ac8bc7e678f9f18108a67dfdd1337f65f8113d09ea39573a963ad

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-879d33df3fbb99178624e96a6ac1c6f05ee14b4683be2cb6c9b48b7469efb257
+d9d867fa69149e0d5b6a53def5de927c26c8e1c1468e8c1102f6623a4863da08

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -5,7 +5,7 @@ use re_log_types::{LogMsg, StoreId, TimeRangeF};
 use re_smart_channel::ReceiveSet;
 use re_viewer_context::{
     AppOptions, Caches, CommandSender, ComponentUiRegistry, PlayState, RecordingConfig,
-    SpaceViewClassRegistry, StoreContext, ViewerContext,
+    SelectionState, SpaceViewClassRegistry, StoreContext, ViewerContext,
 };
 use re_viewport::{SpaceInfoCollection, Viewport, ViewportState};
 
@@ -232,6 +232,9 @@ impl AppState {
         if WATERMARK {
             re_ui.paint_watermark();
         }
+
+        // This must run after any ui code, or other code that tells egui to open an url:
+        check_for_clicked_hyperlinks(&re_ui.egui_ctx, &mut rec_cfg.selection_state);
     }
 
     pub fn recording_config_mut(&mut self, rec_id: &StoreId) -> Option<&mut RecordingConfig> {
@@ -281,4 +284,36 @@ fn recording_config_entry<'cfgs>(
     configs
         .entry(id)
         .or_insert_with(|| new_recording_config(store_db))
+}
+
+/// We allow linking to entities and components via hyperlinks,
+/// e.g. in embedded markdown.
+///
+/// Detect and handle that here.
+///
+/// Must run after any ui code, or other code that tells egui to open an url.
+fn check_for_clicked_hyperlinks(egui_ctx: &egui::Context, selection_state: &mut SelectionState) {
+    let recording_scheme = "recording://";
+
+    let mut path = None;
+
+    egui_ctx.output_mut(|o| {
+        if let Some(open_url) = &o.open_url {
+            if let Some(path_str) = open_url.url.strip_prefix(recording_scheme) {
+                path = Some(path_str.to_owned());
+                o.open_url = None;
+            }
+        }
+    });
+
+    if let Some(path) = path {
+        match path.parse() {
+            Ok(item) => {
+                selection_state.set_single_selection(item);
+            }
+            Err(err) => {
+                re_log::warn!("Failed to parse entity path {path:?}: {err}");
+            }
+        }
+    }
 }

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use re_data_store::InstancePath;
-use re_log_types::ComponentPath;
+use re_log_types::{ComponentPath, EntityPath};
 
 use super::{DataBlueprintGroupHandle, SpaceViewId};
 
@@ -15,6 +15,44 @@ pub enum Item {
     SpaceView(SpaceViewId),
     InstancePath(Option<SpaceViewId>, InstancePath),
     DataBlueprintGroup(SpaceViewId, DataBlueprintGroupHandle),
+}
+
+impl From<SpaceViewId> for Item {
+    #[inline]
+    fn from(space_view_id: SpaceViewId) -> Self {
+        Self::SpaceView(space_view_id)
+    }
+}
+
+impl From<ComponentPath> for Item {
+    #[inline]
+    fn from(component_path: ComponentPath) -> Self {
+        Self::ComponentPath(component_path)
+    }
+}
+
+impl From<InstancePath> for Item {
+    #[inline]
+    fn from(instance_path: InstancePath) -> Self {
+        Self::InstancePath(None, instance_path)
+    }
+}
+
+impl From<EntityPath> for Item {
+    #[inline]
+    fn from(entity_path: EntityPath) -> Self {
+        Self::InstancePath(None, InstancePath::from(entity_path))
+    }
+}
+
+impl std::str::FromStr for Item {
+    type Err = re_log_types::PathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO(emilk): support component paths and instance paths
+        let entity_path = EntityPath::from_str(s)?;
+        Ok(Self::from(entity_path))
+    }
 }
 
 impl std::fmt::Debug for Item {

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -12,14 +12,45 @@ int main() {
     rr_stream.connect("127.0.0.1:9876").throw_on_failure();
 
     rr_stream.log("text_document", rr::archetypes::TextDocument("Hello, TextDocument!"));
+
     rr_stream.log(
         "markdown",
-        rr::archetypes::TextDocument("# Hello\n"
-                                     "Markdown with `code`!\n"
-                                     "\n"
-                                     "A random image:\n"
-                                     "\n"
-                                     "![A random image](https://picsum.photos/640/480)")
+        rr::archetypes::TextDocument(R"#(# Hello Markdown!
+[Click here to see the raw text](recording://markdown.Text).
+
+Basic formatting:
+
+| **Feature**       | **Alternative** |
+| ----------------- | --------------- |
+| Plain             |                 |
+| *italics*         | _italics_       |
+| **bold**          | __bold__        |
+| ~~strikethrough~~ |                 |
+| `inline code`     |                 |
+
+----------------------------------
+
+Some code:
+```rs
+fn main() {
+    println!("Hello, world!");
+}
+```
+
+## Support
+- [x] [Commonmark](https://commonmark.org/help/) support
+- [x] GitHub-style strikethrough, tables, and checkboxes
+- [ ] Syntax highlighting
+
+## Links
+You can link to [an entity](recording://markdown),
+a [specific instance of an entity](recording://markdown[#0]),
+or a [specific component](recording://markdown.Text).
+
+Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
+
+## Image
+![A random image](https://picsum.photos/640/480))#")
             .with_media_type(rr::components::MediaType::markdown())
     );
 }

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -40,7 +40,11 @@ fn main() {
 ## Support
 - [x] [Commonmark](https://commonmark.org/help/) support
 - [x] GitHub-style strikethrough, tables, and checkboxes
-- [ ] Syntax highlighting
+- Basic syntax highlighting for:
+  - [x] C and C++
+  - [x] Python
+  - [x] Rust
+  - [ ] Other languages
 
 ## Links
 You can link to [an entity](recording://markdown),

--- a/docs/code-examples/text_document.py
+++ b/docs/code-examples/text_document.py
@@ -6,11 +6,49 @@ import rerun.experimental as rr2
 
 rr.init("rerun_example_text_document", spawn=True)
 
-rr2.log("text_document", rr2.TextDocument(body="Hello, TextDocument!"))
+rr2.log("text_document", rr2.TextDocument("Hello, TextDocument!"))
+
 rr2.log(
     "markdown",
     rr2.TextDocument(
-        body="# Hello\nMarkdown with `code`!\n\nA random image:\n\n![A random image](https://picsum.photos/640/480)",
-        media_type=rr2.cmp.MediaType.markdown(),
+        """
+# Hello Markdown!
+[Click here to see the raw text](recording://markdown.Text).
+
+Basic formatting:
+
+| **Feature**       | **Alternative** |
+| ----------------- | --------------- |
+| Plain             |                 |
+| *italics*         | _italics_       |
+| **bold**          | __bold__        |
+| ~~strikethrough~~ |                 |
+| `inline code`     |                 |
+
+----------------------------------
+
+Some code:
+```rs
+fn main() {
+    println!("Hello, world!");
+}
+```
+
+## Support
+- [x] [Commonmark](https://commonmark.org/help/) support
+- [x] GitHub-style strikethrough, tables, and checkboxes
+- [ ] Syntax highlighting
+
+## Links
+You can link to [an entity](recording://markdown),
+a [specific instance of an entity](recording://markdown[#0]),
+or a [specific component](recording://markdown.Text).
+
+Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
+
+## Image
+![A random image](https://picsum.photos/640/480)
+""".strip(),
+        media_type="text/markdown",
     ),
 )

--- a/docs/code-examples/text_document.py
+++ b/docs/code-examples/text_document.py
@@ -37,7 +37,11 @@ fn main() {
 ## Support
 - [x] [Commonmark](https://commonmark.org/help/) support
 - [x] GitHub-style strikethrough, tables, and checkboxes
-- [ ] Syntax highlighting
+- Basic syntax highlighting for:
+  - [x] C and C++
+  - [x] Python
+  - [x] Rust
+  - [ ] Other languages
 
 ## Links
 You can link to [an entity](recording://markdown),

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -8,15 +8,48 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_text_document").memory()?;
 
     rec.log("text_document", &TextDocument::new("Hello, TextDocument!"))?;
+
     rec.log(
         "markdown",
         &TextDocument::new(
-            "# Hello\n\
-             Markdown with `code`!\n\
-             \n\
-             A random image:\n\
-             \n\
-             ![A random image](https://picsum.photos/640/480)",
+            r#"
+# Hello Markdown!
+[Click here to see the raw text](recording://markdown.Text).
+
+Basic formatting:
+
+| **Feature**       | **Alternative** |
+| ----------------- | --------------- |
+| Plain             |                 |
+| *italics*         | _italics_       |
+| **bold**          | __bold__        |
+| ~~strikethrough~~ |                 |
+| `inline code`     |                 |
+
+----------------------------------
+
+Some code:
+```rs
+fn main() {
+    println!("Hello, world!");
+}
+```
+
+## Support
+- [x] [Commonmark](https://commonmark.org/help/) support
+- [x] GitHub-style strikethrough, tables, and checkboxes
+- [ ] Syntax highlighting
+
+## Links
+You can link to [an entity](recording://markdown),
+a [specific instance of an entity](recording://markdown[#0]),
+or a [specific component](recording://markdown.Text).
+
+Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
+
+## Image
+![A random image](https://picsum.photos/640/480)
+"#.trim(),
         )
         .with_media_type(MediaType::markdown()),
     )?;

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -38,7 +38,11 @@ fn main() {
 ## Support
 - [x] [Commonmark](https://commonmark.org/help/) support
 - [x] GitHub-style strikethrough, tables, and checkboxes
-- [ ] Syntax highlighting
+- Basic syntax highlighting for:
+  - [x] C and C++
+  - [x] Python
+  - [x] Rust
+  - [ ] Other languages
 
 ## Links
 You can link to [an entity](recording://markdown),

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -50,9 +50,7 @@ rr.log_points("points", points, colors=point_colors, ext={"error": point_errors}
 ```
 **Note:** we added some [custom per-point errors](recording://points.ext.error) that you can see when you
 hover over the points in the 3D view.
-
-TODO: Finish description and use the new instead of the old api.
-"""
+""".strip()
 
 
 def scale_camera(camera: Camera, resize: tuple[int, int]) -> tuple[Camera, npt.NDArray[np.float_]]:

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -15,6 +15,7 @@ import numpy as np
 import numpy.typing as npt
 import requests
 import rerun as rr  # pip install rerun-sdk
+import rerun.experimental as rr2
 from read_write_model import Camera, read_model
 from tqdm import tqdm
 
@@ -22,6 +23,37 @@ DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
 DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/colmap"
 # When dataset filtering is turned on, drop views with less than this many valid points.
 FILTER_MIN_VISIBLE: Final = 500
+
+DESCRIPTION = """
+# Sparse Reconstruction by COLMAP
+
+This example was generated from the output of a sparse reconstruction
+done with COLMAP.
+
+[COLMAP](https://colmap.github.io/index.html) is a general-purpose
+Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline
+with a graphical and command-line interface.
+
+In this example a short video clip has been processed offline by the
+COLMAP pipeline, and we use Rerun to visualize the individual
+camera frames, estimated camera poses, and resulting point clouds over time.
+
+## How it was made
+The full source code for this example is available on Github
+[here](https://github.com/rerun-io/rerun/blob/latest/examples/python/structure_from_motion/main.py).
+
+### Colored 3D Points
+The colored 3D points were added to the scene by logging the
+[rr.Points3D archetype](https://www.rerun.io/docs/reference/data_types/point3d)
+to the [points entity](recording://points):
+```python
+rr.log_points("points", points, colors=point_colors, ext={"error": point_errors})
+```
+**Note:** we added some [custom per-point errors](recording://points.ext.error) that you can see when you
+hover over the points in the 3D view.
+
+TODO: Finish description and use the new instead of the old api.
+"""
 
 
 def scale_camera(camera: Camera, resize: tuple[int, int]) -> tuple[Camera, npt.NDArray[np.float_]]:
@@ -81,6 +113,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         # Filter out noisy points
         points3D = {id: point for id, point in points3D.items() if point.rgb.any() and len(point.image_ids) > 4}
 
+    rr2.log("description", rr2.TextDocument(DESCRIPTION, media_type="text/markdown"), timeless=True)
     rr.log_view_coordinates("/", up="-Y", timeless=True)
 
     # Iterate through images (video frames) logging data related to each frame.

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -39,8 +39,7 @@ COLMAP pipeline, and we use Rerun to visualize the individual
 camera frames, estimated camera poses, and resulting point clouds over time.
 
 ## How it was made
-The full source code for this example is available on Github
-[here](https://github.com/rerun-io/rerun/blob/latest/examples/python/structure_from_motion/main.py).
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/structure_from_motion/main.py).
 
 ### Colored 3D Points
 The colored 3D points were added to the scene by logging the

--- a/examples/python/text_logging/main.py
+++ b/examples/python/text_logging/main.py
@@ -82,7 +82,7 @@ def main() -> None:
     for frame_offset in range(args.repeat):
         log_stuff(frame_offset)
 
-    rr2.log("text_document", rr2.TextDocument(body="This is to show the difference between TextLog and TextDocument"))
+    rr2.log("text_document", rr2.TextDocument("This is to show the difference between TextLog and TextDocument"))
 
     rr.script_teardown(args)
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -28,7 +28,7 @@ class TensorBuffer(TensorBufferExt):
 
     # You can define your own __init__ function as a member of TensorBufferExt in tensor_buffer_ext.py
 
-    inner: npt.NDArray[np.float16] | (npt.NDArray[np.float32] | (npt.NDArray[np.float64] | (npt.NDArray[np.int16] | (npt.NDArray[np.int32] | (npt.NDArray[np.int64] | (npt.NDArray[np.int8] | (npt.NDArray[np.uint16] | (npt.NDArray[np.uint32] | (npt.NDArray[np.uint64] | npt.NDArray[np.uint8]))))))))) = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
+    inner: npt.NDArray[np.float16] | npt.NDArray[np.float32] | npt.NDArray[np.float64] | npt.NDArray[np.int16] | npt.NDArray[np.int32] | npt.NDArray[np.int64] | npt.NDArray[np.int8] | npt.NDArray[np.uint16] | npt.NDArray[np.uint32] | npt.NDArray[np.uint64] | npt.NDArray[np.uint8] = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
     """
     U8 (npt.NDArray[np.uint8]):
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1050,7 +1050,6 @@ fn convert_color(color: Vec<u8>) -> PyResult<[u8; 4]> {
 }
 
 fn parse_entity_path(entity_path: &str) -> PyResult<EntityPath> {
-    let components = re_log_types::parse_entity_path(entity_path)
-        .map_err(|err| PyTypeError::new_err(err.to_string()))?;
-    Ok(EntityPath::from(components))
+    use std::str::FromStr as _;
+    EntityPath::from_str(entity_path).map_err(|err| PyTypeError::new_err(err.to_string()))
 }

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -22,7 +22,7 @@ __all__ = ["AffixFuzzer3", "AffixFuzzer3ArrayLike", "AffixFuzzer3Batch", "AffixF
 class AffixFuzzer3:
     # You can define your own __init__ function as a member of AffixFuzzer3Ext in affix_fuzzer3_ext.py
 
-    inner: float | (list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32]) = field()
+    inner: float | list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32] = field()
     """
     degrees (float):
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -44,7 +44,7 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if "NOLINT" in line:
         return None  # NOLINT ignores the linter
 
-    if file_extension == "md":
+    if file_extension not in ("py", "txt", "yml"):
         if "Github" in line:
             return "It's 'GitHub', not 'Github'"
 
@@ -201,7 +201,7 @@ def is_missing_blank_line_between(prev_line: str, line: str) -> bool:
         line = line.strip()
         prev_line = prev_line.strip()
 
-        if is_empty(prev_line):
+        if is_empty(prev_line) or prev_line.strip().startswith("```"):
             return False
 
         if line.startswith("fn ") and line.endswith(";"):

--- a/tests/python/roundtrips/text_document/main.py
+++ b/tests/python/roundtrips/text_document/main.py
@@ -17,7 +17,7 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_roundtrip_text_document")
 
-    rr2.log("text_document", rr2.TextDocument(body="Hello, TextDocument!"))
+    rr2.log("text_document", rr2.TextDocument("Hello, TextDocument!"))
     rr2.log(
         "markdown",
         rr2.TextDocument(

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -46,7 +46,7 @@ def run_segmentation(experimental_api: bool) -> None:
             rr2.Points2D([[40, 50], [120, 70], [80, 30]], class_ids=np.array([13, 42, 99], dtype=np.uint8)),
         )
         rr2.log(
-            "seg_test/many points",
+            "seg_test/many_points",
             rr2.Points2D(
                 [[100 + (int(i / 5)) * 2, 100 + (i % 5) * 2] for i in range(25)],
                 class_ids=np.array([42], dtype=np.uint8),
@@ -62,7 +62,7 @@ def run_segmentation(experimental_api: bool) -> None:
             class_ids=np.array([13, 42, 99], dtype=np.uint8),
         )
         rr.log_points(
-            "seg_test/many points",
+            "seg_test/many_points",
             np.array([[100 + (int(i / 5)) * 2, 100 + (i % 5) * 2] for i in range(25)]),
             class_ids=np.array([42], dtype=np.uint8),
         )

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -332,7 +332,7 @@ fn test_segmentation(rec: &RecordingStream) -> anyhow::Result<()> {
         &Points2D::new([(40.0, 50.0), (120.0, 70.0), (80.0, 30.0)]).with_class_ids([13, 42, 99]),
     )?;
     rec.log(
-        "seg_test/many points",
+        "seg_test/many_points",
         &Points2D::new(
             (0..25).map(|i| (100.0 + (i / 5) as f32 * 2.0, 100.0 + (i % 5) as f32 * 2.0)),
         )


### PR DESCRIPTION
### What
You can now embed links to entities in markdown documents using `recording://entity/path`, and link to components using `recording://entity/path.Color`.

In order to support this, a new `DataPath` is introduced, with a stricter parsing of entity paths. Previously `foo bar` was a valid path, but now you are only allowed ASCII, numbers, underscore and dash as names (outside of quotes).

A (uncompleted) description of the SfM example as markdown to
- Test how that feels as documentation
- Try out the ability to link directly to entities and components from within the markdown

![image](https://github.com/rerun-io/rerun/assets/1148717/3883afe7-4c7b-42da-995d-3214fc773b52)

![image](https://github.com/rerun-io/rerun/assets/1148717/f55ddd85-297f-44ff-9dde-a0309931ade2)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3389) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3389)
- [Docs preview](https://rerun.io/preview/e14be611c235231fa3e91a7f106cf594bf245e51/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e14be611c235231fa3e91a7f106cf594bf245e51/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)