### PR TITLE
Fix crash on empty mesh

### DIFF
--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -44,7 +44,6 @@ impl LineStripSeriesBuilder {
                 &ctx.gpu_resources.buffers,
                 LineDrawData::MAX_NUM_STRIPS,
             )
-            .unwrap_debug_or_log_error()
             .expect("Failed to allocate picking instance id buffer"); // TODO(#3408): Should never happen but should propagate error anyways
 
         Self {

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -43,7 +43,9 @@ impl LineStripSeriesBuilder {
                 &ctx.device,
                 &ctx.gpu_resources.buffers,
                 LineDrawData::MAX_NUM_STRIPS,
-            );
+            )
+            .unwrap_debug_or_log_error()
+            .expect("Failed to allocate picking instance id buffer"); // TODO(#3408): Should never happen but should propagate error anyways
 
         Self {
             vertices: Vec::with_capacity(RESERVE_SIZE * 2),

--- a/crates/re_renderer/src/mesh.rs
+++ b/crates/re_renderer/src/mesh.rs
@@ -223,7 +223,7 @@ impl GpuMesh {
                 &ctx.device,
                 &ctx.gpu_resources.buffers,
                 vb_combined_size as _,
-            );
+            )?;
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_positions))?;
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_colors))?;
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.vertex_normals))?;
@@ -252,7 +252,7 @@ impl GpuMesh {
                 &ctx.device,
                 &ctx.gpu_resources.buffers,
                 data.triangle_indices.len(),
-            );
+            )?;
             staging_buffer.extend_from_slice(bytemuck::cast_slice(&data.triangle_indices))?;
             staging_buffer.copy_to_buffer(
                 ctx.active_frame.before_view_builder_encoder.lock().get(),

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -31,11 +31,16 @@ impl PointCloudBuilder {
         const RESERVE_SIZE: usize = 512;
 
         // TODO(andreas): Be more resourceful about the size allocated here. Typically we know in advance!
-        let color_buffer = ctx.cpu_write_gpu_read_belt.lock().allocate::<Color32>(
-            &ctx.device,
-            &ctx.gpu_resources.buffers,
-            PointCloudDrawData::MAX_NUM_POINTS,
-        );
+        let color_buffer = ctx
+            .cpu_write_gpu_read_belt
+            .lock()
+            .allocate::<Color32>(
+                &ctx.device,
+                &ctx.gpu_resources.buffers,
+                PointCloudDrawData::MAX_NUM_POINTS,
+            )
+            .unwrap_debug_or_log_error()
+            .expect("Failed to allocate color buffer"); // TODO(#3408): Should never happen but should propagate error anyways
         let picking_instance_ids_buffer = ctx
             .cpu_write_gpu_read_belt
             .lock()
@@ -43,7 +48,9 @@ impl PointCloudBuilder {
                 &ctx.device,
                 &ctx.gpu_resources.buffers,
                 PointCloudDrawData::MAX_NUM_POINTS,
-            );
+            )
+            .unwrap_debug_or_log_error()
+            .expect("Failed to allocate picking layer buffer"); // TODO(#3408): Should never happen but should propagate error anyways
 
         Self {
             vertices: Vec::with_capacity(RESERVE_SIZE),

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -39,7 +39,6 @@ impl PointCloudBuilder {
                 &ctx.gpu_resources.buffers,
                 PointCloudDrawData::MAX_NUM_POINTS,
             )
-            .unwrap_debug_or_log_error()
             .expect("Failed to allocate color buffer"); // TODO(#3408): Should never happen but should propagate error anyways
         let picking_instance_ids_buffer = ctx
             .cpu_write_gpu_read_belt
@@ -49,7 +48,6 @@ impl PointCloudBuilder {
                 &ctx.gpu_resources.buffers,
                 PointCloudDrawData::MAX_NUM_POINTS,
             )
-            .unwrap_debug_or_log_error()
             .expect("Failed to allocate picking layer buffer"); // TODO(#3408): Should never happen but should propagate error anyways
 
         Self {

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -204,7 +204,7 @@ impl MeshDrawData {
                 &ctx.device,
                 &ctx.gpu_resources.buffers,
                 instances.len(),
-            );
+            )?;
 
             let mesh_manager = ctx.mesh_manager.read();
             let mut num_processed_instances = 0;

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -296,7 +296,7 @@ impl PointCloudDrawData {
                 &ctx.device,
                 &ctx.gpu_resources.buffers,
                 num_points_written,
-            );
+            )?;
             staging_buffer.extend_from_slice(vertices)?;
             staging_buffer.fill_n(gpu_data::PositionRadius::zeroed(), num_elements_padding)?;
             staging_buffer.copy_to_texture2d(

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -38,16 +38,21 @@ impl Mesh3DPart {
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();
 
+        let vertex_positions: Vec<_> = {
+            re_tracing::profile_scope!("vertex_positions");
+            arch_view.iter_required_component::<Position3D>()?.collect()
+        };
+        if vertex_positions.is_empty() {
+            return Ok(());
+        }
+
         let mesh = {
             re_tracing::profile_scope!("collect");
             // NOTE:
             // - Per-vertex properties are joined using the cluster key as usual.
             // - Per-mesh properties are just treated as a "global var", essentially.
             Mesh3D {
-                vertex_positions: {
-                    re_tracing::profile_scope!("vertex_positions");
-                    arch_view.iter_required_component::<Position3D>()?.collect()
-                },
+                vertex_positions,
                 vertex_normals: if arch_view.has_component::<Vector3D>() {
                     re_tracing::profile_scope!("vertex_normals");
                     Some(


### PR DESCRIPTION
### What

* Fixes #3416

Two steps:
* make the crash merely a warning by propagating allocation failure on the belt
* fix that warning (previously crash) in meshes.rs

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3448) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3448)
- [Docs preview](https://rerun.io/preview/87e2824fe6d34c97720d53cc663211b09c1a5ecb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/87e2824fe6d34c97720d53cc663211b09c1a5ecb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)