### PR TITLE
`log_timeless`: remove the extra `bool` parameter

### DIFF
--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -593,7 +593,27 @@ impl RecordingStream {
         ent_path: impl Into<EntityPath>,
         arch: &impl Archetype,
     ) -> RecordingStreamResult<()> {
-        self.log_timeless(ent_path, false, arch)
+        self.log_with_timeless(ent_path, false, arch)
+    }
+
+    /// Logs the contents of an [`Archetype`] into Rerun as timeless data.
+    ///
+    /// Timeless data is present on all timelines and behaves as if it was recorded infinitely far
+    /// into the past.
+    /// All timestamp data associated with this message will be dropped right before sending it to Rerun.
+    ///
+    /// Internally, the stream will automatically micro-batch multiple log calls to optimize
+    /// transport.
+    /// See [SDK Micro Batching] for more information.
+    ///
+    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
+    #[inline]
+    pub fn log_timeless(
+        &self,
+        ent_path: impl Into<EntityPath>,
+        arch: &impl Archetype,
+    ) -> RecordingStreamResult<()> {
+        self.log_with_timeless(ent_path, true, arch)
     }
 
     /// Logs the contents of an [`Archetype`] into Rerun.
@@ -613,7 +633,7 @@ impl RecordingStream {
     ///
     /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
     #[inline]
-    pub fn log_timeless(
+    pub fn log_with_timeless(
         &self,
         ent_path: impl Into<EntityPath>,
         timeless: bool,

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,4 @@
 # This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
 # It can be safely removed at anytime to force the build script to run again.
 # Check out build.rs to see how it's computed.
-dd9be6f53587d125772360c0ed8d286f2a8c863a91459d2fd8c75ebdf18998c1
+cd28edc326d0ee040825ce8b2e23fc8599607cd04ef15522968ed6e69542f2ed

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -35,7 +35,7 @@
 ///
 ///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
 ///
-///     rec.log_timeless("world", true, &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &Asset3D::from_file(path)?)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -65,7 +65,7 @@
 ///     let (rec, storage) =
 ///         RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
 ///
-///     rec.log_timeless("world", true, &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///
 ///     rec.set_time_sequence("frame", 0);
 ///     rec.log("world/asset", &Asset3D::from_file(path)?)?;

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -34,7 +34,7 @@
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
 ///
-///     rec.log_timeless("world", true, &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(
 ///         "world/xyz",
 ///         &Arrows3D::from_vectors(

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), anyhow::Error> {
     let (rec, storage) =
         RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
 
-    rec.log_timeless("world", true, &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 
     rec.set_time_sequence("frame", 0);
     rec.log("world/asset", &Asset3D::from_file(path)?)?;

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
 
-    rec.log_timeless("world", true, &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &Asset3D::from_file(path)?)?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -7,7 +7,7 @@ use rerun::{
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
 
-    rec.log_timeless("world", true, &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(
         "world/xyz",
         &Arrows3D::from_vectors(

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -127,12 +127,11 @@ fn log_baseline_objects(
         let path = format!("world/annotations/box-{id}");
         rec.log_timeless(
             path.clone(),
-            true,
             &rerun::archetypes::Boxes3D::from_half_sizes([bbox_half_size])
                 .with_labels([label])
                 .with_colors([Color::from_rgb(160, 230, 130)]),
         )?;
-        rec.log_timeless(path, true, &rerun::archetypes::Transform3D::new(transform))?;
+        rec.log_timeless(path, &rerun::archetypes::Transform3D::new(transform))?;
     }
 
     Ok(())
@@ -351,8 +350,8 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
     let annotations = read_annotations(&store_info.path_annotations)?;
 
     // See https://github.com/google-research-datasets/Objectron/issues/39
-    rec.log_timeless("world", true, &ViewCoordinates::RUB)?;
-    rec.log_timeless("world/camera", true, &ViewCoordinates::RDF)?;
+    rec.log_timeless("world", &ViewCoordinates::RUB)?;
+    rec.log_timeless("world/camera", &ViewCoordinates::RDF)?;
 
     log_baseline_objects(rec, &annotations.objects)?;
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -744,7 +744,7 @@ fn log_image_file(
     );
 
     recording
-        .log_timeless(
+        .log_with_timeless(
             entity_path,
             timeless,
             &rerun::archetypes::Image::new(tensor),


### PR DESCRIPTION
In 99% of cases the user knows at runtime if they want to log something as timeless or not, so the extra `true` argument is annoying.

Before:

```rs
rec.log_timeless(
    "world",
    true,
    &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
```

After:
```rs
rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3449) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3449)
- [Docs preview](https://rerun.io/preview/84f667f5f057b3dbf8f1ad598edf5f303fe16c03/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/84f667f5f057b3dbf8f1ad598edf5f303fe16c03/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)