### PR TITLE
Fix no default colors showing for class ids when there's no annotation context

### DIFF
--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -94,7 +94,7 @@ impl<'a> ResolvedClassDescription<'a> {
     #[inline]
     pub fn annotation_info(&self) -> ResolvedAnnotationInfo {
         ResolvedAnnotationInfo {
-            class_id: self.class_description.map(|desc| desc.info.id.into()),
+            class_id: self.class_id,
             annotation_info: self.class_description.map(|desc| desc.info.clone()),
         }
     }


### PR DESCRIPTION
### What

* Fixes #3425

It seems during refactor in #2910 we lost class_id during `ResolvedClassDescription`->`ResolvedAnnotationInfo`

![image](https://github.com/rerun-io/rerun/assets/1220815/0b9301cc-208c-4ecc-b91f-588ede6691fa)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3451) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3451)
- [Docs preview](https://rerun.io/preview/6c4cdf6b13f075161145a772212c154d456fdee1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6c4cdf6b13f075161145a772212c154d456fdee1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)