### PR TITLE
Make 'Print datastore' viable with real world data

### DIFF
--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -245,8 +245,8 @@ where
                     Cell::new(
                         chars
                             .into_iter()
-                            .take(WIDTH_UPPER_BOUNDARY.saturating_sub(3).into())
-                            .chain(['.', '.', '.'])
+                            .take(WIDTH_UPPER_BOUNDARY.saturating_sub(1).into())
+                            .chain(['…'])
                             .collect::<String>(),
                     )
                 } else {


### PR DESCRIPTION
It's currently impossible to debug issues with real-world data using `Print datastore` as it dumps 600MB worth of data to your terminal... This fixes that.

Before:
![image](https://github.com/rerun-io/rerun/assets/2910679/5a67a2a4-b36c-4aa7-b4fb-581fb2815b38)


After:
![image](https://github.com/rerun-io/rerun/assets/2910679/245964a1-9d20-40fd-af6e-82f10d2ce456)


### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3452) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3452)
- [Docs preview](https://rerun.io/preview/0edd8eb7479ea43705fbfa5aeaf68d6d806551ec/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0edd8eb7479ea43705fbfa5aeaf68d6d806551ec/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)