### PR TITLE
Improve how indicator components show up in the UI

### DIFF
--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -135,7 +135,7 @@ impl DataStore {
                     kind = "gc",
                     id = self.gc_id,
                     %options.target,
-                    initial_num_rows = re_format::format_large_number(initial_num_rows as _),
+                    initial_num_rows = re_format::format_number(initial_num_rows as _),
                     initial_num_bytes = re_format::format_bytes(initial_num_bytes),
                     target_num_bytes = re_format::format_bytes(target_num_bytes),
                     drop_at_least_num_bytes = re_format::format_bytes(num_bytes_to_drop),
@@ -153,7 +153,7 @@ impl DataStore {
                     kind = "gc",
                     id = self.gc_id,
                     %options.target,
-                    initial_num_rows = re_format::format_large_number(initial_num_rows as _),
+                    initial_num_rows = re_format::format_number(initial_num_rows as _),
                     initial_num_bytes = re_format::format_bytes(initial_num_bytes),
                     "starting GC"
                 );
@@ -178,9 +178,9 @@ impl DataStore {
             kind = "gc",
             id = self.gc_id,
             %options.target,
-            initial_num_rows = re_format::format_large_number(initial_num_rows as _),
+            initial_num_rows = re_format::format_number(initial_num_rows as _),
             initial_num_bytes = re_format::format_bytes(initial_num_bytes),
-            new_num_rows = re_format::format_large_number(new_num_rows as _),
+            new_num_rows = re_format::format_number(new_num_rows as _),
             new_num_bytes = re_format::format_bytes(new_num_bytes),
             "GC done"
         );

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -94,7 +94,7 @@ impl DataUi for EntityComponentWithInstances {
         } else if one_line {
             ui.label(format!(
                 "{} values",
-                re_format::format_large_number(num_instances as _)
+                re_format::format_number(num_instances)
             ));
         } else {
             egui_extras::TableBuilder::new(ui)
@@ -146,7 +146,7 @@ impl DataUi for EntityComponentWithInstances {
             if num_instances > displayed_row {
                 ui.label(format!(
                     "…and {} more.",
-                    re_format::format_large_number((num_instances - displayed_row) as _)
+                    re_format::format_number(num_instances - displayed_row)
                 ));
             }
         }

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -18,7 +18,11 @@ impl DataUi for ComponentPath {
 
         let store = &ctx.store_db.entity_db.data_store;
 
-        if let Some((_, component_data)) =
+        if let Some(archetype_name) = crate::indicator_component_archetype(component_name) {
+            ui.label(format!(
+                "Indicator component for the {archetype_name} archetype"
+            ));
+        } else if let Some((_, component_data)) =
             re_query::get_component_with_instances(store, query, entity_path, *component_name)
         {
             super::component::EntityComponentWithInstances {

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -322,7 +322,7 @@ impl DataUi for MeshProperties {
             if let Some(vertex_indices) = self.vertex_indices.as_ref() {
                 ui.label(format!(
                     "{} triangles",
-                    re_format::format_large_number((vertex_indices.len() / 3) as _)
+                    re_format::format_number(vertex_indices.len() / 3)
                 ));
             } else {
                 ui.weak("(empty)");

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -6,15 +6,12 @@ use re_viewer_context::{UiVerbosity, ViewerContext};
 use super::DataUi;
 use crate::item_ui;
 
-const HIDDEN_COMPONENTS_FOR_ALL_VERBOSITY: &[&str] = &["rerun.components.InstanceKey"];
-const HIDDEN_COMPONENTS_FOR_LOW_VERBOSITY: &[&str] = &[];
-
 impl DataUi for InstancePath {
     fn data_ui(
         &self,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        _verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
         let Self {
@@ -45,26 +42,15 @@ impl DataUi for InstancePath {
             .num_columns(2)
             .show(ui, |ui| {
                 for component_name in components {
+                    if !crate::is_component_visible_in_ui(&component_name) {
+                        continue;
+                    }
+
                     let Some((_, component_data)) =
                         get_component_with_instances(store, query, entity_path, component_name)
                     else {
                         continue; // no need to show components that are unset at this point in time
                     };
-
-                    // Certain fields are hidden.
-                    if HIDDEN_COMPONENTS_FOR_ALL_VERBOSITY.contains(&component_name.as_ref()) {
-                        continue;
-                    }
-                    match verbosity {
-                        UiVerbosity::Small | UiVerbosity::Reduced => {
-                            if HIDDEN_COMPONENTS_FOR_LOW_VERBOSITY
-                                .contains(&component_name.as_ref())
-                            {
-                                continue;
-                            }
-                        }
-                        UiVerbosity::All => {}
-                    }
 
                     item_ui::component_path_button(
                         ctx,

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -58,7 +58,9 @@ impl DataUi for InstancePath {
                         &ComponentPath::new(entity_path.clone(), component_name),
                     );
 
-                    if instance_key.is_splat() {
+                    if crate::is_indicator_component(&component_name) {
+                        // no content to show
+                    } else if instance_key.is_splat() {
                         super::component::EntityComponentWithInstances {
                             entity_path: entity_path.clone(),
                             component_data,

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -40,6 +40,16 @@ pub fn is_indicator_component(component_name: &re_types::ComponentName) -> bool 
     component_name.starts_with("rerun.components.") && component_name.ends_with("Indicator")
 }
 
+/// If this is an indicator component, for which archetype?
+pub fn indicator_component_archetype(component_name: &re_types::ComponentName) -> Option<String> {
+    if let Some(name) = component_name.strip_prefix("rerun.components.") {
+        if let Some(name) = name.strip_suffix("Indicator") {
+            return Some(name.to_owned());
+        }
+    }
+    None
+}
+
 /// Types implementing [`DataUi`] can display themselves in an [`egui::Ui`].
 pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -35,6 +35,11 @@ pub fn is_component_visible_in_ui(component_name: &re_types::ComponentName) -> b
     !HIDDEN_COMPONENTS.contains(&component_name.as_ref())
 }
 
+/// Is this an indicator component for an archetype?
+pub fn is_indicator_component(component_name: &re_types::ComponentName) -> bool {
+    component_name.starts_with("rerun.components.") && component_name.ends_with("Indicator")
+}
+
 /// Types implementing [`DataUi`] can display themselves in an [`egui::Ui`].
 pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -29,6 +29,12 @@ pub use crate::image::{
 pub use component_ui_registry::create_component_ui_registry;
 pub use image_meaning::image_meaning_for_entity;
 
+/// Show this component in the UI.
+pub fn is_component_visible_in_ui(component_name: &re_types::ComponentName) -> bool {
+    const HIDDEN_COMPONENTS: &[&str] = &["rerun.components.InstanceKey"];
+    !HIDDEN_COMPONENTS.contains(&component_name.as_ref())
+}
+
 /// Types implementing [`DataUi`] can display themselves in an [`egui::Ui`].
 pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.

--- a/crates/re_format/src/lib.rs
+++ b/crates/re_format/src/lib.rs
@@ -81,7 +81,7 @@ fn test_format_float() {
 /// assert_eq!(approximate_large_number(123_456_789 as _), "123M");
 /// ```
 ///
-/// Prefer to use [`Self::format_number`], which outputs an exact string,
+/// Prefer to use [`format_number`], which outputs an exact string,
 /// while still being readable thanks to half-width spaces used as thousands-separators.
 pub fn approximate_large_number(number: f64) -> String {
     if number < 0.0 {

--- a/crates/re_format/src/lib.rs
+++ b/crates/re_format/src/lib.rs
@@ -74,15 +74,18 @@ fn test_format_float() {
 /// Pretty format a large number by using SI notation (base 10), e.g.
 ///
 /// ```
-/// # use re_format::format_large_number;
-/// assert_eq!(format_large_number(123 as _), "123");
-/// assert_eq!(format_large_number(12_345 as _), "12k");
-/// assert_eq!(format_large_number(1_234_567 as _), "1.2M");
-/// assert_eq!(format_large_number(123_456_789 as _), "123M");
+/// # use re_format::approximate_large_number;
+/// assert_eq!(approximate_large_number(123 as _), "123");
+/// assert_eq!(approximate_large_number(12_345 as _), "12k");
+/// assert_eq!(approximate_large_number(1_234_567 as _), "1.2M");
+/// assert_eq!(approximate_large_number(123_456_789 as _), "123M");
 /// ```
-pub fn format_large_number(number: f64) -> String {
+///
+/// Prefer to use [`Self::format_number`], which outputs an exact string,
+/// while still being readable thanks to half-width spaces used as thousands-separators.
+pub fn approximate_large_number(number: f64) -> String {
     if number < 0.0 {
-        return format!("-{}", format_large_number(-number));
+        return format!("-{}", approximate_large_number(-number));
     }
 
     if number < 1000.0 {
@@ -118,7 +121,7 @@ fn test_format_large_number() {
     ];
 
     for (value, expected) in test_cases {
-        assert_eq!(expected, format_large_number(value));
+        assert_eq!(expected, approximate_large_number(value));
     }
 }
 

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -550,6 +550,10 @@ impl TimePanel {
                     continue; // ignore fields that have no data for the current timeline
                 }
 
+                if !re_data_ui::is_component_visible_in_ui(component_name) {
+                    continue;
+                }
+
                 let component_path = ComponentPath::new(tree.path.clone(), *component_name);
                 let component_name = component_path.component_name.short_name();
                 let item = Item::ComponentPath(component_path);


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/3438

See commit messages for details

![image](https://github.com/rerun-io/rerun/assets/1148717/4db38e4f-094b-4413-ac3e-cd685549af68)

![image](https://github.com/rerun-io/rerun/assets/1148717/6ff73189-27d4-4823-be00-c4ea8aa99674)

![image](https://github.com/rerun-io/rerun/assets/1148717/36a4a10b-ce20-4f3f-9125-f6029dd2ba5a)

![image](https://github.com/rerun-io/rerun/assets/1148717/9daff81f-f8ce-4c22-a6fd-b56292ca61cf)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3457) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3457)
- [Docs preview](https://rerun.io/preview/0730bacacbb58b6f34a504f1bbfc98d7e6445d27/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0730bacacbb58b6f34a504f1bbfc98d7e6445d27/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)