### PR TITLE
Update to latest egui and egui_commonmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1376,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "accesskit",
  "ahash 0.8.3",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "bytemuck",
  "epaint",
@@ -1439,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "arboard",
  "egui",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "egui_commonmark"
 version = "0.7.4"
-source = "git+https://github.com/lampsitter/egui_commonmark.git?rev=a4470c253b06a4a350e17418a7c6cbc413ade644#a4470c253b06a4a350e17418a7c6cbc413ade644"
+source = "git+https://github.com/lampsitter/egui_commonmark.git?rev=d42d340d2d617f19e3d52697faa9cfcfa3eafa27#d42d340d2d617f19e3d52697faa9cfcfa3eafa27"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "egui",
  "ehttp",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "egui",
 ]
@@ -1539,7 +1539,7 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 [[package]]
 name = "emath"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.22.0"
-source = "git+https://github.com/emilk/egui?rev=d949eaf#d949eaf682ea96784afb0f3463e11387db610646"
+source = "git+https://github.com/emilk/egui?rev=e8986b1e59e60fa97349754b160dd68a34ab2093#e8986b1e59e60fa97349754b160dd68a34ab2093"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ egui = { version = "0.22.0", features = [
 ] }
 egui_commonmark = { version = "0.7", default-features = false }
 egui_extras = { version = "0.22.0", features = ["http", "image", "puffin"] }
-egui_plot = { git = "https://github.com/emilk/egui", rev = "d949eaf" } # egui_lot is not yet published on crates.io
+egui_plot = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" } # egui_lot is not yet published on crates.io
 egui_tiles = { version = "0.2" }
 egui-wgpu = "0.22.0"
 ehttp = { version = "0.3" }
@@ -169,17 +169,17 @@ debug = true
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
 # Temporary patch until next egui release
-ecolor = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-eframe = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-egui-wgpu = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-egui-winit = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-egui = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-egui_extras = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-emath = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
-epaint = { git = "https://github.com/emilk/egui", rev = "d949eaf" }
+ecolor = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+eframe = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+egui-winit = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+egui = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+emath = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
+epaint = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" }
 
 # Temporary patch until next egui_commonmark release
-egui_commonmark = { git = "https://github.com/lampsitter/egui_commonmark.git", rev = "a4470c253b06a4a350e17418a7c6cbc413ade644" }
+egui_commonmark = { git = "https://github.com/lampsitter/egui_commonmark.git", rev = "d42d340d2d617f19e3d52697faa9cfcfa3eafa27" }
 
 # Temporary patch until next egui_tiles release
 egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "c66d6cba7ddb5b236be614d1816be4561260274e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ egui = { version = "0.22.0", features = [
 ] }
 egui_commonmark = { version = "0.7", default-features = false }
 egui_extras = { version = "0.22.0", features = ["http", "image", "puffin"] }
-egui_plot = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" } # egui_lot is not yet published on crates.io
+egui_plot = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" } # egui_plot is not yet published on crates.io
 egui_tiles = { version = "0.2" }
 egui-wgpu = "0.22.0"
 ehttp = { version = "0.3" }

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -387,7 +387,7 @@ impl<'a> ListItem<'a> {
             let mut text_job =
                 self.text
                     .into_text_job(ui.style(), egui::FontSelection::Default, Align::LEFT);
-            text_job.job.wrap = TextWrapping::elide_at_width(text_rect.width());
+            text_job.job.wrap = TextWrapping::truncate_at_width(text_rect.width());
 
             let text = ui.fonts(|f| text_job.into_galley(f));
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3399

Also properly adds an ellipsis (`…`) to the end of truncate multi-line text:

![image](https://github.com/rerun-io/rerun/assets/1148717/ba32eef0-52a4-4d2d-bd13-9200b1f3129d)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3459) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3459)
- [Docs preview](https://rerun.io/preview/19bd0254fce03d977e2af2b0cb8abd68e33e12e5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/19bd0254fce03d977e2af2b0cb8abd68e33e12e5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)