### PR TITLE
Remove `source_hash.txt`es from git

### DIFF
--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -74,7 +74,7 @@ jobs:
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
               run_tests="true"
-              container="{'image': 'rerunio/ci_docker:0.9.1'}"
+              container="{'image': 'rerunio/ci_docker:0.10.0'}"
               ;;
             windows)
               runner="windows-latest-8-cores"

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -94,7 +94,7 @@ jobs:
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
               run_tests="true"
-              container="{'image': 'rerunio/ci_docker:0.9.1'}"
+              container="{'image': 'rerunio/ci_docker:0.10.0'}"
               lib_name="librerun_c.a"
               ;;
             windows)

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_build_web_demo.yml
+++ b/.github/workflows/reusable_build_web_demo.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -109,17 +109,18 @@ jobs:
 
   # ---------------------------------------------------------------------------
 
-  rs-lints:
-    name: Rust lints (fmt, check, cranky, tests, doc)
+  no-codegen-changes:
+    name: Check if running codegen would produce any changes
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.10.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
+      # Note: We explicitly don't override `ref` here. We need to see if changes would be made
+      # in a context where we have merged with main. Otherwise we might miss changes such as one
+      # PR introduces a new type and another PR changes the codegen.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -139,6 +140,26 @@ jobs:
       - name: No Diffs From Running Codegen
         run: |
           git diff --exit-code
+
+  rs-lints:
+    name: Rust lints (fmt, check, cranky, tests, doc)
+    runs-on: ubuntu-latest-16-cores
+    container:
+      image: rerunio/ci_docker:0.10.0
+    env:
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache_key: "build-linux"
+          save_cache: true
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       # First do our check with --locked to make sure `Cargo.lock` is up to date
       - name: Check all features

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -142,6 +142,15 @@ jobs:
           command: fmt
           args: --all -- --check
 
+      - name: Codegen
+        uses: actions-rs/cargo@v1
+        with:
+          command: codegen
+
+      - name: No Diffs From Running Codegen
+        run: |
+          git diff --exit-code
+
       - name: Cranky
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -130,8 +130,6 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
-      # It's important that we run codegen and check for diffs first because
-      # `cargo check` also causes other diffs, such as patching `examples_manifest.json`
       - name: Codegen
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -113,7 +113,7 @@ jobs:
     name: Rust lints (fmt, check, cranky, tests, doc)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
@@ -213,7 +213,7 @@ jobs:
     name: Check Rust web build (wasm32 + wasm-bindgen)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
@@ -325,7 +325,7 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
     steps:
       - uses: actions/checkout@v4
         with:
@@ -357,7 +357,7 @@ jobs:
     name: C++ tests
     runs-on: ubuntu-latest
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -129,6 +129,17 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      # It's important that we run codegen and check for diffs first because
+      # `cargo check` also causes other diffs, such as patching `examples_manifest.json`
+      - name: Codegen
+        uses: actions-rs/cargo@v1
+        with:
+          command: codegen
+
+      - name: No Diffs From Running Codegen
+        run: |
+          git diff --exit-code
+
       # First do our check with --locked to make sure `Cargo.lock` is up to date
       - name: Check all features
         uses: actions-rs/cargo@v1
@@ -141,15 +152,6 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-      - name: Codegen
-        uses: actions-rs/cargo@v1
-        with:
-          command: codegen
-
-      - name: No Diffs From Running Codegen
-        run: |
-          git diff --exit-code
 
       - name: Cranky
         uses: actions-rs/cargo@v1

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -106,7 +106,7 @@ jobs:
     name: Rust
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
     steps:
       - name: Show context
         run: |

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_upload_wheels.yml
+++ b/.github/workflows/reusable_upload_wheels.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rerunio/ci_docker:0.9.1
+      image: rerunio/ci_docker:0.10.0
 
     permissions:
       contents: "read"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+# Codegen stuff:
+crates/re_types/source_hash.txt
+crates/re_types_builder/source_hash.txt
+
 # C++ and CMake stuff:
 *.bin
 *.o

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 LABEL maintainer="opensource@rerun.io"
 # Remember to update the version in publish.sh
 # TODO(jleibs) use this version in the publish.sh script and below in the CACHE_KEY
-LABEL version="0.9.1"
+LABEL version="0.10.0"
 LABEL description="Docker image used for the CI of https://github.com/rerun-io/rerun"
 
 # Install the ubuntu package dependencies
@@ -17,7 +17,6 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
     libarrow-dev \
     build-essential \
-    clang-format \
     cmake \
     curl \
     git \
@@ -33,11 +32,31 @@ RUN set -eux; \
     libxkbcommon-dev \
     lsb-release \
     python3-pip \
+    software-properties-common \
     sudo; \
     rm -rf /var/lib/apt/lists/*;
 
 # Need a more recent pip for manylinux packages to work properly
 RUN python3 -m pip install -U pip
+
+# Need a more recent clang-format for codegen
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt update -y && \
+    apt upgrade -y && \
+    wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh 15 && \
+    apt-get install clang-format-15 && \
+    ln -sf clang-format-15 /usr/bin/clang-format && \
+    rm -rf /var/lib/apt/lists/*;
+
+# Need a more recent flatbuffers for codegen
+RUN git clone --depth 1 --branch v23.5.9 https://github.com/google/flatbuffers.git && \
+    cd flatbuffers && \
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release && \
+    make -j4 && \
+    make install && \
+    cd .. && rm -rf flatbuffers
 
 # We need a more modern patchelf than ships on ubuntu-20.04
 RUN curl -L https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-x86_64.tar.gz | tar -xz ./bin/patchelf
@@ -75,6 +94,8 @@ RUN cargo install cargo-benchcmp
 # Install the python build dependencies
 ADD rerun_py/requirements-build.txt requirements-build.txt
 RUN pip install -r requirements-build.txt
+ADD rerun_py/requirements-lint.txt requirements-lint.txt
+RUN pip install -r requirements-lint.txt
 
 # Install tools from setup_web.sh
 ADD scripts/setup_web.sh setup_web.sh
@@ -84,7 +105,7 @@ RUN ./setup_web.sh || true
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz | tar xzk --strip-components 1
 
 # Increment this to invalidate cache
-ENV CACHE_KEY=rerun_docker_v0.9.1
+ENV CACHE_KEY=rerun_docker_v0.10.0
 
 # See: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
 RUN git config --system --add safe.directory '*'

--- a/ci_docker/publish.sh
+++ b/ci_docker/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-VERSION=0.9.1 # Bump on each new version. Remember to update the version in the Dockerfile too.
+VERSION=0.10.0 # Bump on each new version. Remember to update the version in the Dockerfile too.
 
 # The build needs to run from top of repo to access the requirements.txt
 cd `git rev-parse --show-toplevel`

--- a/crates/re_build_tools/src/rebuild_detector.rs
+++ b/crates/re_build_tools/src/rebuild_detector.rs
@@ -7,6 +7,8 @@ use std::{
 
 use cargo_metadata::{CargoOpt, Metadata, MetadataCommand, Package, PackageId};
 
+use crate::should_output_cargo_build_instructions;
+
 /// Call from `build.rs` to trigger a rebuild whenever any source file of the given package
 /// _or any of its dependencies_ changes, recursively.
 ///
@@ -40,7 +42,9 @@ pub fn rebuild_if_crate_changed(pkg_name: &str) {
 
 /// Call from `build.rs` to trigger a rebuild whenever an environment variable changes.
 pub fn get_and_track_env_var(env_var_name: &str) -> Result<String, std::env::VarError> {
-    println!("cargo:rerun-if-env-changed={env_var_name}");
+    if should_output_cargo_build_instructions() {
+        println!("cargo:rerun-if-env-changed={env_var_name}");
+    }
     std::env::var(env_var_name)
 }
 
@@ -58,14 +62,18 @@ pub fn rerun_if_changed(path: impl AsRef<Path>) {
     let path = path.as_ref();
     // Make sure the file exists, otherwise we'll be rebuilding all the time.
     assert!(path.exists(), "Failed to find {path:?}");
-    println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+    if should_output_cargo_build_instructions() {
+        println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+    }
 }
 
 /// Call from `build.rs` to trigger a rebuild whenever the file at `path` changes, or it doesn't
 /// exist.
 pub fn rerun_if_changed_or_doesnt_exist(path: impl AsRef<Path>) {
     let path = path.as_ref();
-    println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+    if should_output_cargo_build_instructions() {
+        println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+    }
 }
 
 /// Call from `build.rs` to trigger a rebuild whenever any of the files identified by the given

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -1,10 +1,11 @@
 //! Generates Rust & Python code from flatbuffers definitions.
 
+use std::path::Path;
+
 use re_build_tools::{
-    compute_crate_hash, compute_dir_filtered_hash, compute_dir_hash, compute_strings_hash,
-    is_tracked_env_var_set, iter_dir, read_versioning_hash, rerun_if_changed,
-    rerun_if_changed_or_doesnt_exist, write_versioning_hash,
+    is_tracked_env_var_set, iter_dir, read_versioning_hash, rerun_if_changed, write_versioning_hash,
 };
+use re_types_builder::{compute_re_types_hash, SourceLocations};
 
 // ---
 
@@ -33,7 +34,12 @@ fn main() {
         return;
     }
 
-    rerun_if_changed_or_doesnt_exist(SOURCE_HASH_PATH);
+    // Only re-build if source-hash exists
+    if !<str as AsRef<Path>>::as_ref(SOURCE_HASH_PATH).exists() {
+        return;
+    }
+
+    rerun_if_changed(SOURCE_HASH_PATH);
     for path in iter_dir(DEFINITIONS_DIR_PATH, Some(&["fbs"])) {
         rerun_if_changed(&path);
     }
@@ -41,32 +47,14 @@ fn main() {
     // NOTE: We need to hash both the flatbuffers definitions as well as the source code of the
     // code generator itself!
     let cur_hash = read_versioning_hash(SOURCE_HASH_PATH);
-    let re_types_builder_hash = compute_crate_hash("re_types_builder");
-    let definitions_hash = compute_dir_hash(DEFINITIONS_DIR_PATH, Some(&["fbs"]));
-    let doc_examples_hash = compute_dir_hash(DOC_EXAMPLES_DIR_PATH, Some(&["rs", "py", "cpp"]));
-    let python_extensions_hash = compute_dir_filtered_hash(PYTHON_OUTPUT_DIR_PATH, |path| {
-        path.to_str().unwrap().ends_with("_ext.py")
-    });
-    let cpp_extensions_hash = compute_dir_filtered_hash(CPP_OUTPUT_DIR_PATH, |path| {
-        path.to_str().unwrap().ends_with("_ext.cpp")
-    });
-
-    let new_hash = compute_strings_hash(&[
-        &re_types_builder_hash,
-        &definitions_hash,
-        &doc_examples_hash,
-        &python_extensions_hash,
-        &cpp_extensions_hash,
-    ]);
-
-    // Leave these be please, very useful when debugging.
-    eprintln!("re_types_builder_hash: {re_types_builder_hash:?}");
-    eprintln!("definitions_hash: {definitions_hash:?}");
-    eprintln!("doc_examples_hash: {doc_examples_hash:?}");
-    eprintln!("python_extensions_hash: {python_extensions_hash:?}");
-    eprintln!("cpp_extensions_hash: {cpp_extensions_hash:?}");
-    eprintln!("new_hash: {new_hash:?}");
     eprintln!("cur_hash: {cur_hash:?}");
+
+    let new_hash = compute_re_types_hash(&SourceLocations {
+        definitions_dir: DEFINITIONS_DIR_PATH,
+        doc_examples_dir: DOC_EXAMPLES_DIR_PATH,
+        python_output_dir: PYTHON_OUTPUT_DIR_PATH,
+        cpp_output_dir: CPP_OUTPUT_DIR_PATH,
+    });
 
     if let Some(cur_hash) = cur_hash {
         if cur_hash == new_hash {

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -35,7 +35,7 @@ fn main() {
     }
 
     // Only re-build if source-hash exists
-    if Path::new(SOURCE_HASH_PATH).exists() {
+    if !Path::new(SOURCE_HASH_PATH).exists() {
         return;
     }
 

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -35,7 +35,7 @@ fn main() {
     }
 
     // Only re-build if source-hash exists
-    if !<str as AsRef<Path>>::as_ref(SOURCE_HASH_PATH).exists() {
+    if Path::new(SOURCE_HASH_PATH).exists() {
         return;
     }
 

--- a/crates/re_types/source_hash.txt
+++ b/crates/re_types/source_hash.txt
@@ -1,4 +1,0 @@
-# This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
-# It can be safely removed at anytime to force the build script to run again.
-# Check out build.rs to see how it's computed.
-320b9b4e778952dc3401b977182dd8b283080cd3fad77d5f75fafcac724def8a

--- a/crates/re_types_builder/Cargo.toml
+++ b/crates/re_types_builder/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 
 
 [dependencies]
+re_build_tools.workspace = true
 re_error.workspace = true
 re_log.workspace = true
 re_tracing = { workspace = true, features = ["server"] }

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -44,18 +44,9 @@ fn main() {
     eprintln!("cur_hash: {cur_hash:?}");
     eprintln!("new_hash: {new_hash:?}");
 
-    if let Some(cur_hash) = cur_hash {
-        if cur_hash == new_hash {
-            // Source definition hasn't changed, no need to do anything.
-            return;
-        }
-    }
-
-    // Detect desyncs between definitions and generated when running on CI, and
-    // crash the build accordingly.
-    #[allow(clippy::manual_assert)]
-    if std::env::var("CI").is_ok() {
-        panic!("re_types_builder's fbs definitions and generated code are out-of-sync!");
+    if cur_hash.is_none() || cur_hash.as_ref() == Some(&new_hash) {
+        // Source definition hasn't changed, no need to do anything.
+        return;
     }
 
     // NOTE: This requires `flatc` to be in $PATH, but only for contributors, not end users.

--- a/crates/re_types_builder/source_hash.txt
+++ b/crates/re_types_builder/source_hash.txt
@@ -1,4 +1,0 @@
-# This is a sha256 hash for all direct and indirect dependencies of this crate's build script.
-# It can be safely removed at anytime to force the build script to run again.
-# Check out build.rs to see how it's computed.
-df0f4e7e285f3013d345d2c850e92d8f69378fda8118a612e683b5f389f11702

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -4,9 +4,10 @@ use camino::Utf8Path;
 use re_build_tools::{
     read_versioning_hash, set_output_cargo_build_instructions, write_versioning_hash,
 };
-use re_types_builder::{compute_re_types_hash, SourceLocations};
+use re_types_builder::{compute_re_types_builder_hash, compute_re_types_hash, SourceLocations};
 
-const SOURCE_HASH_PATH: &str = "crates/re_types/source_hash.txt";
+const RE_TYPES_BUILDER_SOURCE_HASH_PATH: &str = "crates/re_types_builder/source_hash.txt";
+const RE_TYPES_SOURCE_HASH_PATH: &str = "crates/re_types/source_hash.txt";
 const DEFINITIONS_DIR_PATH: &str = "crates/re_types/definitions";
 const ENTRYPOINT_PATH: &str = "crates/re_types/definitions/rerun/archetypes.fbs";
 const DOC_EXAMPLES_DIR_PATH: &str = "docs/code-examples";
@@ -46,11 +47,8 @@ fn main() {
         .and_then(|p| p.parent())
         .unwrap();
 
-    let source_hash_path = workspace_dir.join(SOURCE_HASH_PATH);
-
-    let cur_hash = read_versioning_hash(&source_hash_path);
-    eprintln!("cur_hash: {cur_hash:?}");
-
+    let re_types_source_hash_path = workspace_dir.join(RE_TYPES_SOURCE_HASH_PATH);
+    let re_types_builder_source_hash_path = workspace_dir.join(RE_TYPES_BUILDER_SOURCE_HASH_PATH);
     let definitions_dir_path = workspace_dir.join(DEFINITIONS_DIR_PATH);
     let entrypoint_path = workspace_dir.join(ENTRYPOINT_PATH);
     let doc_examples_dir_path = workspace_dir.join(DOC_EXAMPLES_DIR_PATH);
@@ -58,6 +56,11 @@ fn main() {
     let rust_output_dir_path = workspace_dir.join(RUST_OUTPUT_DIR_PATH);
     let python_output_dir_path = workspace_dir.join(PYTHON_OUTPUT_DIR_PATH);
     let python_testing_output_dir_path = workspace_dir.join(PYTHON_TESTING_OUTPUT_DIR_PATH);
+
+    let cur_hash = read_versioning_hash(&re_types_source_hash_path);
+    eprintln!("cur_hash: {cur_hash:?}");
+
+    let builder_hash = compute_re_types_builder_hash();
 
     let new_hash = compute_re_types_hash(&SourceLocations {
         definitions_dir: definitions_dir_path.as_str(),
@@ -103,7 +106,8 @@ fn main() {
 
     report.panic_on_errors();
 
-    write_versioning_hash(source_hash_path, new_hash);
+    write_versioning_hash(re_types_source_hash_path, new_hash);
+    write_versioning_hash(re_types_builder_source_hash_path, builder_hash);
 
     re_log::info!("Done.");
 }

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -2,7 +2,7 @@
 
 use camino::Utf8Path;
 use re_build_tools::{
-    read_versioning_hash, set_ouput_cargo_build_instructions, write_versioning_hash,
+    read_versioning_hash, set_output_cargo_build_instructions, write_versioning_hash,
 };
 use re_types_builder::{compute_re_types_hash, SourceLocations};
 

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -1,7 +1,9 @@
 //! Helper binary for running the codegen manually. Useful during development!
 
 use camino::Utf8Path;
-use re_build_tools::{read_versioning_hash, write_versioning_hash};
+use re_build_tools::{
+    read_versioning_hash, set_ouput_cargo_build_instructions, write_versioning_hash,
+};
 use re_types_builder::{compute_re_types_hash, SourceLocations};
 
 const SOURCE_HASH_PATH: &str = "crates/re_types/source_hash.txt";
@@ -15,6 +17,8 @@ const PYTHON_TESTING_OUTPUT_DIR_PATH: &str = "rerun_py/tests/test_types";
 
 fn main() {
     re_log::setup_native_logging();
+    // This isn't a build.rs script, so opt out of cargo build instrctinsr
+    set_output_cargo_build_instructions(false);
 
     rayon::ThreadPoolBuilder::new()
         .thread_name(|i| format!("rayon-{i}"))

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -114,6 +114,9 @@
 mod reflection;
 
 use anyhow::Context as _;
+use re_build_tools::{
+    compute_crate_hash, compute_dir_filtered_hash, compute_dir_hash, compute_strings_hash,
+};
 
 pub use self::reflection::reflection::{
     root_as_schema, BaseType as FbsBaseType, Enum as FbsEnum, EnumVal as FbsEnumVal,
@@ -285,6 +288,49 @@ pub fn generate_gitattributes_for_generated_files(
     );
 
     codegen::write_file(&path, &content);
+}
+
+pub fn compute_re_types_builder_hash() -> String {
+    compute_crate_hash("re_types_builder")
+}
+
+pub struct SourceLocations<'a> {
+    pub definitions_dir: &'a str,
+    pub doc_examples_dir: &'a str,
+    pub python_output_dir: &'a str,
+    pub cpp_output_dir: &'a str,
+}
+
+pub fn compute_re_types_hash(locations: &SourceLocations<'_>) -> String {
+    // NOTE: We need to hash both the flatbuffers definitions as well as the source code of the
+    // code generator itself!
+    let re_types_builder_hash = compute_re_types_builder_hash();
+    let definitions_hash = compute_dir_hash(locations.definitions_dir, Some(&["fbs"]));
+    let doc_examples_hash =
+        compute_dir_hash(locations.doc_examples_dir, Some(&["rs", "py", "cpp"]));
+    let python_extensions_hash = compute_dir_filtered_hash(locations.python_output_dir, |path| {
+        path.to_str().unwrap().ends_with("_ext.py")
+    });
+    let cpp_extensions_hash = compute_dir_filtered_hash(locations.cpp_output_dir, |path| {
+        path.to_str().unwrap().ends_with("_ext.cpp")
+    });
+
+    let new_hash = compute_strings_hash(&[
+        &re_types_builder_hash,
+        &definitions_hash,
+        &doc_examples_hash,
+        &python_extensions_hash,
+        &cpp_extensions_hash,
+    ]);
+
+    eprintln!("re_types_builder_hash: {re_types_builder_hash:?}");
+    eprintln!("definitions_hash: {definitions_hash:?}");
+    eprintln!("doc_examples_hash: {doc_examples_hash:?}");
+    eprintln!("python_extensions_hash: {python_extensions_hash:?}");
+    eprintln!("cpp_extensions_hash: {cpp_extensions_hash:?}");
+    eprintln!("new_hash: {new_hash:?}");
+
+    new_hash
 }
 
 /// Generates C++ code.


### PR DESCRIPTION
### What
* Resolves: https://github.com/rerun-io/rerun/issues/3334

Main changes:
* Removes the `source_hash.txt` from git and adds it to gitignore.
* Doesn't run the codegen during `build.rs` unless `source_hash.txt` is present
* Makes `cargo codegen` produce the `source_hash.txt`
* Removes the printlns from the source_hash generation when run as part of cargo codegen.
* Adds the formatting dependencies to the docker image
* Adds a new CI check that codegen produces no diffs.

Confirmed that we catch it when codegen would produce changes: https://github.com/rerun-io/rerun/actions/runs/6302436017/job/17109617144?pr=3461

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3460) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3460)
- [Docs preview](https://rerun.io/preview/d4eaa3fb30cd2fad8b518bf8829286a3762a64fb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d4eaa3fb30cd2fad8b518bf8829286a3762a64fb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)