### PR TITLE
Make visually distinguish indicator components in GUI

### DIFF
--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -48,11 +48,13 @@ impl DataUi for InstancePath {
                         continue; // no need to show components that are unset at this point in time
                     };
 
-                    item_ui::component_path_button(
-                        ctx,
-                        ui,
-                        &ComponentPath::new(entity_path.clone(), component_name),
-                    );
+                    crate::temporary_style_ui_for_component(ui, &component_name, |ui| {
+                        item_ui::component_path_button(
+                            ctx,
+                            ui,
+                            &ComponentPath::new(entity_path.clone(), component_name),
+                        );
+                    });
 
                     if crate::is_indicator_component(&component_name) {
                         // no content to show

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -41,11 +41,7 @@ impl DataUi for InstancePath {
         egui::Grid::new("entity_instance")
             .num_columns(2)
             .show(ui, |ui| {
-                for component_name in components {
-                    if !crate::is_component_visible_in_ui(&component_name) {
-                        continue;
-                    }
-
+                for &component_name in crate::ui_visible_components(&components) {
                     let Some((_, component_data)) =
                         get_component_with_instances(store, query, entity_path, component_name)
                     else {

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -56,8 +56,12 @@ impl DataUi for InstancePath {
                         );
                     });
 
-                    if crate::is_indicator_component(&component_name) {
-                        // no content to show
+                    if let Some(archetype_name) =
+                        crate::indicator_component_archetype(&component_name)
+                    {
+                        ui.weak(format!(
+                            "Indicator component for the {archetype_name} archetype"
+                        ));
                     } else if instance_key.is_splat() {
                         super::component::EntityComponentWithInstances {
                             entity_path: entity_path.clone(),

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -3,7 +3,9 @@
 //! This crate provides ui elements for Rerun component data for the Rerun Viewer.
 
 use itertools::Itertools;
+
 use re_log_types::{DataCell, EntityPath, PathOp, TimePoint};
+use re_types::ComponentName;
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
 mod annotation_context;
@@ -29,19 +31,35 @@ pub use crate::image::{
 pub use component_ui_registry::create_component_ui_registry;
 pub use image_meaning::image_meaning_for_entity;
 
+/// Filter out components that should not be shown in the UI,
+/// and order the other components in a cosnsiten way.
+pub fn ui_visible_components<'a>(
+    iter: impl IntoIterator<Item = &'a ComponentName> + 'a,
+) -> impl Iterator<Item = &'a ComponentName> {
+    let mut components: Vec<&ComponentName> = iter
+        .into_iter()
+        .filter(|c| is_component_visible_in_ui(c))
+        .collect();
+
+    // Put indicator components first:
+    components.sort_by_key(|c| !is_indicator_component(c));
+
+    components.into_iter()
+}
+
 /// Show this component in the UI.
-pub fn is_component_visible_in_ui(component_name: &re_types::ComponentName) -> bool {
+fn is_component_visible_in_ui(component_name: &ComponentName) -> bool {
     const HIDDEN_COMPONENTS: &[&str] = &["rerun.components.InstanceKey"];
     !HIDDEN_COMPONENTS.contains(&component_name.as_ref())
 }
 
 /// Is this an indicator component for an archetype?
-pub fn is_indicator_component(component_name: &re_types::ComponentName) -> bool {
+pub fn is_indicator_component(component_name: &ComponentName) -> bool {
     component_name.starts_with("rerun.components.") && component_name.ends_with("Indicator")
 }
 
 /// If this is an indicator component, for which archetype?
-pub fn indicator_component_archetype(component_name: &re_types::ComponentName) -> Option<String> {
+pub fn indicator_component_archetype(component_name: &ComponentName) -> Option<String> {
     if let Some(name) = component_name.strip_prefix("rerun.components.") {
         if let Some(name) = name.strip_suffix("Indicator") {
             return Some(name.to_owned());

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -68,6 +68,28 @@ pub fn indicator_component_archetype(component_name: &ComponentName) -> Option<S
     None
 }
 
+pub fn temporary_style_ui_for_component<R>(
+    ui: &mut egui::Ui,
+    component_name: &ComponentName,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    let old_style: egui::Style = (**ui.style()).clone();
+
+    if crate::is_indicator_component(component_name) {
+        // Make indicator components stand out by making them slightly fainter:
+
+        let inactive = &mut ui.style_mut().visuals.widgets.inactive;
+        // TODO(emilk): get a color from the design-tokens
+        inactive.fg_stroke.color = inactive.fg_stroke.color.linear_multiply(0.45);
+    }
+
+    let ret = add_contents(ui);
+
+    ui.set_style(old_style);
+
+    ret
+}
+
 /// Types implementing [`DataUi`] can display themselves in an [`egui::Ui`].
 pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -543,15 +543,13 @@ impl TimePanel {
         if !tree.components.is_empty() {
             let clip_rect_save = ui.clip_rect();
 
-            for (component_name, data) in &tree.components {
+            for component_name in re_data_ui::ui_visible_components(tree.components.keys()) {
+                let data = &tree.components[component_name];
+
                 if !data.times.has_timeline(ctx.rec_cfg.time_ctrl.timeline())
                     && data.num_timeless_messages() == 0
                 {
                     continue; // ignore fields that have no data for the current timeline
-                }
-
-                if !re_data_ui::is_component_visible_in_ui(component_name) {
-                    continue;
                 }
 
                 let component_path = ComponentPath::new(tree.path.clone(), *component_name);

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -553,25 +553,28 @@ impl TimePanel {
                 }
 
                 let component_path = ComponentPath::new(tree.path.clone(), *component_name);
-                let component_name = component_path.component_name.short_name();
+                let short_component_name = component_path.component_name.short_name();
                 let item = Item::ComponentPath(component_path);
 
                 let mut clip_rect = clip_rect_save;
                 clip_rect.max.x = tree_max_y;
                 ui.set_clip_rect(clip_rect);
 
-                let response = ListItem::new(ctx.re_ui, component_name)
-                    .selected(ctx.selection().contains(&item))
-                    .width_allocation_mode(WidthAllocationMode::Compact)
-                    .force_hovered(
-                        ctx.selection_state().highlight_for_ui_element(&item)
-                            == HoverHighlight::Hovered,
-                    )
-                    .with_icon_fn(|_, ui, rect, visual| {
-                        ui.painter()
-                            .circle_filled(rect.center(), 2.0, visual.text_color());
-                    })
-                    .show(ui);
+                let response =
+                    re_data_ui::temporary_style_ui_for_component(ui, component_name, |ui| {
+                        ListItem::new(ctx.re_ui, short_component_name)
+                            .selected(ctx.selection().contains(&item))
+                            .width_allocation_mode(WidthAllocationMode::Compact)
+                            .force_hovered(
+                                ctx.selection_state().highlight_for_ui_element(&item)
+                                    == HoverHighlight::Hovered,
+                            )
+                            .with_icon_fn(|_, ui, rect, visual| {
+                                ui.painter()
+                                    .circle_filled(rect.center(), 2.0, visual.text_color());
+                            })
+                            .show(ui)
+                    });
 
                 ui.set_clip_rect(clip_rect_save);
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3438

Moved the indicator components first, and gives them a slightly fainter color.

<img width="149" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/73801cd9-ba55-4679-9475-ac7600dd495c">
<img width="422" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/a42d7a1f-ddfe-4a20-baa5-7487710ddb83">
<img width="309" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/f2e8d839-6761-46a8-95b6-8e8cca1aec32">
<img width="419" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/dd634426-8c90-41a9-9b7d-0d6fba99fcb8">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
