### PR TITLE
Make new space views active in whatever tab container they are in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.2.0"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=c66d6cba7ddb5b236be614d1816be4561260274e#c66d6cba7ddb5b236be614d1816be4561260274e"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=66e8abfd755db92a386764dcdafa3fb272a936e7#66e8abfd755db92a386764dcdafa3fb272a936e7"
 dependencies = [
  "ahash 0.8.3",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.2.0"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=66e8abfd755db92a386764dcdafa3fb272a936e7#66e8abfd755db92a386764dcdafa3fb272a936e7"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=f093f065c048a69be1ea125e9706ef3db302d255#f093f065c048a69be1ea125e9706ef3db302d255"
 dependencies = [
  "ahash 0.8.3",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,9 @@ egui = { version = "0.22.0", features = [
 egui_commonmark = { version = "0.7", default-features = false }
 egui_extras = { version = "0.22.0", features = ["http", "image", "puffin"] }
 egui_plot = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754b160dd68a34ab2093" } # egui_plot is not yet published on crates.io
-egui_tiles = { version = "0.2" }
+egui_tiles = "0.2"
 egui-wgpu = "0.22.0"
-ehttp = { version = "0.3" }
+ehttp = "0.3"
 emath = "0.22.0"
 enumset = "1.0.12"
 epaint = "0.22.0"
@@ -182,4 +182,5 @@ epaint = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754
 egui_commonmark = { git = "https://github.com/lampsitter/egui_commonmark.git", rev = "d42d340d2d617f19e3d52697faa9cfcfa3eafa27" }
 
 # Temporary patch until next egui_tiles release
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "c66d6cba7ddb5b236be614d1816be4561260274e" }
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "66e8abfd755db92a386764dcdafa3fb272a936e7" }
+# egui_tiles = { path = "../egui_tiles" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,5 +182,5 @@ epaint = { git = "https://github.com/emilk/egui", rev = "e8986b1e59e60fa97349754
 egui_commonmark = { git = "https://github.com/lampsitter/egui_commonmark.git", rev = "d42d340d2d617f19e3d52697faa9cfcfa3eafa27" }
 
 # Temporary patch until next egui_tiles release
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "66e8abfd755db92a386764dcdafa3fb272a936e7" }
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "f093f065c048a69be1ea125e9706ef3db302d255" }
 # egui_tiles = { path = "../egui_tiles" }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -12,16 +12,9 @@ use re_viewer_context::{
 
 use crate::{
     space_view_heuristics::{all_possible_space_views, identify_entities_per_system_per_class},
+    viewport_blueprint::TreeActions,
     SpaceInfoCollection, SpaceViewBlueprint, ViewportBlueprint,
 };
-
-// We delay any modifications to the tree until the end of the frame,
-// so that we don't iterate over something while modifying it.
-#[derive(Default)]
-struct TreeActions {
-    focus_tab: Option<SpaceViewId>,
-    remove: Vec<egui_tiles::TileId>,
-}
 
 impl ViewportBlueprint<'_> {
     /// Show the blueprint panel tree view.
@@ -33,32 +26,31 @@ impl ViewportBlueprint<'_> {
             .auto_shrink([true, false])
             .show(ui, |ui| {
                 if let Some(root) = self.tree.root() {
-                    let mut tree_actions = TreeActions::default();
-
-                    self.tile_ui(ctx, ui, &mut tree_actions, root);
-
-                    let TreeActions { focus_tab, remove } = tree_actions;
-
-                    if let Some(tab) = &focus_tab {
-                        self.tree.make_active(|tile| match tile {
-                            egui_tiles::Tile::Pane(space_view_id) => space_view_id == tab,
-                            egui_tiles::Tile::Container(_) => false,
-                        });
-                    }
-
-                    for tile_id in remove {
-                        for tile in self.tree.tiles.remove_recursively(tile_id) {
-                            if let egui_tiles::Tile::Pane(space_view_id) = tile {
-                                self.remove(&space_view_id);
-                            }
-                        }
-
-                        if Some(tile_id) == self.tree.root {
-                            self.tree.root = None;
-                        }
-                    }
+                    self.tile_ui(ctx, ui, root);
                 }
             });
+
+        let TreeActions { focus_tab, remove } = std::mem::take(&mut self.deferred_tree_actions);
+
+        if let Some(focus_tab) = &focus_tab {
+            let found = self.tree.make_active(|tile| match tile {
+                egui_tiles::Tile::Pane(space_view_id) => space_view_id == focus_tab,
+                egui_tiles::Tile::Container(_) => false,
+            });
+            re_log::trace!("Found {focus_tab}: {found}");
+        }
+
+        for tile_id in remove {
+            for tile in self.tree.tiles.remove_recursively(tile_id) {
+                if let egui_tiles::Tile::Pane(space_view_id) = tile {
+                    self.remove(&space_view_id);
+                }
+            }
+
+            if Some(tile_id) == self.tree.root {
+                self.tree.root = None;
+            }
+        }
     }
 
     /// If a group or spaceview has a total of this number of elements, show its subtree by default?
@@ -71,7 +63,6 @@ impl ViewportBlueprint<'_> {
         &mut self,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        tree_actions: &mut TreeActions,
         tile_id: egui_tiles::TileId,
     ) {
         // Temporarily remove the tile so we don't get borrow-checker fights:
@@ -81,11 +72,11 @@ impl ViewportBlueprint<'_> {
 
         match &mut tile {
             egui_tiles::Tile::Container(container) => {
-                self.container_tree_ui(ctx, ui, tree_actions, tile_id, container);
+                self.container_tree_ui(ctx, ui, tile_id, container);
             }
             egui_tiles::Tile::Pane(space_view_id) => {
                 // A space view
-                self.space_view_entry_ui(ctx, ui, tree_actions, tile_id, space_view_id);
+                self.space_view_entry_ui(ctx, ui, tile_id, space_view_id);
             }
         };
 
@@ -96,7 +87,6 @@ impl ViewportBlueprint<'_> {
         &mut self,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        tree_actions: &mut TreeActions,
         tile_id: egui_tiles::TileId,
         container: &mut egui_tiles::Container,
     ) {
@@ -106,7 +96,7 @@ impl ViewportBlueprint<'_> {
             // so if the child is made invisible, we should do the same for the parent.
             let child_is_visible = self.tree.is_visible(child_id);
             self.tree.set_visible(tile_id, child_is_visible);
-            return self.tile_ui(ctx, ui, tree_actions, child_id);
+            return self.tile_ui(ctx, ui, child_id);
         }
 
         let mut visibility_changed = false;
@@ -128,12 +118,12 @@ impl ViewportBlueprint<'_> {
             })
             .show_collapsing(ui, ui.id().with(tile_id), default_open, |_, ui| {
                 for &child in container.children() {
-                    self.tile_ui(ctx, ui, tree_actions, child);
+                    self.tile_ui(ctx, ui, child);
                 }
             });
 
         if remove {
-            tree_actions.remove.push(tile_id);
+            self.deferred_tree_actions.remove.push(tile_id);
         }
 
         if visibility_changed {
@@ -146,13 +136,12 @@ impl ViewportBlueprint<'_> {
         &mut self,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        tree_actions: &mut TreeActions,
         tile_id: egui_tiles::TileId,
         space_view_id: &SpaceViewId,
     ) {
         let Some(space_view) = self.space_views.get_mut(space_view_id) else {
             re_log::warn_once!("Bug: asked to show a ui for a Space View that doesn't exist");
-            tree_actions.remove.push(tile_id);
+            self.deferred_tree_actions.remove.push(tile_id);
             return;
         };
         debug_assert_eq!(space_view.id, *space_view_id);
@@ -179,7 +168,7 @@ impl ViewportBlueprint<'_> {
 
                 let response = remove_button_ui(re_ui, ui, "Remove Space View from the Viewport");
                 if response.clicked() {
-                    tree_actions.remove.push(tile_id);
+                    self.deferred_tree_actions.remove.push(tile_id);
                 }
 
                 response | vis_response
@@ -197,7 +186,7 @@ impl ViewportBlueprint<'_> {
             .on_hover_text("Space View");
 
         if response.clicked() {
-            tree_actions.focus_tab = Some(space_view.id);
+            self.deferred_tree_actions.focus_tab = Some(space_view.id);
         }
 
         item_ui::select_hovered_on_click(ctx, &response, &[item]);


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3462
* Closes https://github.com/rerun-io/rerun/issues/3455

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3472) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3472)
- [Docs preview](https://rerun.io/preview/c727984af189d3455f69d4a236baff50268bf287/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c727984af189d3455f69d4a236baff50268bf287/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)