### PR TITLE
Fix `re_types_builder` falsely triggering rebuilds 

### DIFF
--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -1,5 +1,7 @@
 //! Generates flatbuffers reflection code from `reflection.fbs`.
 
+use std::path::Path;
+
 use xshell::{cmd, Shell};
 
 use re_build_tools::{
@@ -26,6 +28,11 @@ fn main() {
     if is_tracked_env_var_set("RERUN_IS_PUBLISHING") {
         // We don't need to rebuild - we should have done so beforehand!
         // See `RELEASES.md`
+        return;
+    }
+
+    // Only re-build if source-hash exists
+    if !Path::new(SOURCE_HASH_PATH).exists() {
         return;
     }
 


### PR DESCRIPTION
#3460 removed committed hashes, but `re_types_builder` is still subscribed to changes to `source_hash.txt`.

Even though the build script will early exit as soon as it realizes that the hash is `None`, this is enough to invalidate `rustc`'s cache, which then invalidates every crate downstream.

`main`:
![image](https://github.com/rerun-io/rerun/assets/2910679/80ff901e-926e-4695-a305-c88a483a9c0f)

this branch:
![image](https://github.com/rerun-io/rerun/assets/2910679/acaec63e-660c-43ee-8d9e-4e0ecaea06b9)


Fixes:
- The roundtrip test suite execution time regression
- #3266

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3474) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3474)
- [Docs preview](https://rerun.io/preview/ea449009416498c258c9672706dc3ebc362f16e2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ea449009416498c258c9672706dc3ebc362f16e2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)