### PR TITLE
Add `ArchetypeView` helpers for mono-components

### DIFF
--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -303,7 +303,30 @@ impl<A: Archetype> ArchetypeView<A> {
 
             Ok(component_value_iter)
         } else {
-            Err(re_types::DeserializationError::MissingData {
+            Err(DeserializationError::MissingComponent {
+                component: C::name(),
+                backtrace: ::backtrace::Backtrace::new_unresolved(),
+            })
+        }
+    }
+
+    /// Get a single required mono-component.
+    #[inline]
+    pub fn required_mono_component<C: Component>(&self) -> DeserializationResult<C> {
+        let mut iter = self.iter_required_component::<C>()?;
+        let  value = iter
+            .next()
+            .ok_or_else(|| DeserializationError::MissingComponent {
+                component: C::name(),
+                backtrace: re_types::_Backtrace::new_unresolved(),
+            })?;
+        let count = 1 + iter.count();
+        if count == 1 {
+            Ok(value)
+        } else {
+            Err(DeserializationError::MultipleOfMono {
+                component: C::name(),
+                count,
                 backtrace: ::backtrace::Backtrace::new_unresolved(),
             })
         }

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -36,13 +36,9 @@ impl Asset3DPart {
         ent_path: &EntityPath,
         ent_context: &SpatialSceneEntityContext<'_>,
     ) -> Result<(), QueryError> {
-        let entity_from_pose = arch_view
-            .iter_raw_optional_component::<OutOfTreeTransform3D>()?
-            .and_then(|mut batch| batch.next());
+        let entity_from_pose = arch_view.raw_optional_mono_component::<OutOfTreeTransform3D>()?;
 
-        let media_type = arch_view
-            .iter_raw_optional_component::<MediaType>()?
-            .and_then(|mut batch| batch.next());
+        let media_type = arch_view.raw_optional_mono_component::<MediaType>()?;
 
         let mesh = Asset3D {
             data: arch_view.required_mono_component::<Blob>()?,

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -45,12 +45,7 @@ impl Asset3DPart {
             .and_then(|mut batch| batch.next());
 
         let mesh = Asset3D {
-            data: arch_view
-                .iter_required_component::<Blob>()?
-                .next()
-                .ok_or_else(|| re_types::DeserializationError::MissingData {
-                    backtrace: re_types::_Backtrace::new_unresolved(),
-                })?,
+            data: arch_view.required_mono_component::<Blob>()?,
             media_type: media_type.clone(),
             // NOTE: Don't even try to cache the transform!
             transform: None,

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -76,12 +76,8 @@ impl Mesh3DPart {
                 } else {
                     None
                 },
-                mesh_properties: arch_view
-                    .iter_raw_optional_component::<MeshProperties>()?
-                    .and_then(|mut comp_batch| comp_batch.next()),
-                mesh_material: arch_view
-                    .iter_raw_optional_component::<Material>()?
-                    .and_then(|mut comp_batch| comp_batch.next()),
+                mesh_properties: arch_view.raw_optional_mono_component::<MeshProperties>()?,
+                mesh_material: arch_view.raw_optional_mono_component::<Material>()?,
                 class_ids: None,
                 instance_keys: None,
             }

--- a/crates/re_types/src/result.rs
+++ b/crates/re_types/src/result.rs
@@ -1,3 +1,5 @@
+use crate::ComponentName;
+
 // NOTE: We have to make an alias, otherwise we'll trigger `thiserror`'s magic codepath which will
 // attempt to use nightly features.
 pub type _Backtrace = backtrace::Backtrace;
@@ -59,6 +61,19 @@ pub enum DeserializationError {
 
     #[error("Expected non-nullable data but didn't find any")]
     MissingData { backtrace: _Backtrace },
+
+    #[error("Expected non-nullable data but didn't find any for compoent {component}")]
+    MissingComponent {
+        component: ComponentName,
+        backtrace: _Backtrace,
+    },
+
+    #[error("Expected a single value of {component} but found {count}")]
+    MultipleOfMono {
+        component: ComponentName,
+        count: usize,
+        backtrace: _Backtrace,
+    },
 
     #[error("Expected field {field_name:?} to be present in {datatype:#?}")]
     MissingStructField {
@@ -188,6 +203,8 @@ impl DeserializationError {
             | DeserializationError::MissingStructField { backtrace, .. }
             | DeserializationError::MissingUnionArm { backtrace, .. }
             | DeserializationError::MissingData { backtrace }
+            | DeserializationError::MissingComponent { backtrace, .. }
+            | DeserializationError::MultipleOfMono { backtrace, .. }
             | DeserializationError::DatatypeMismatch { backtrace, .. }
             | DeserializationError::OffsetOutOfBounds { backtrace, .. }
             | DeserializationError::OffsetSliceOutOfBounds { backtrace, .. } => {

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -23,10 +23,8 @@ pub struct Annotations {
 impl Annotations {
     pub fn try_from_view(view: &ArchetypeView<AnnotationContext>) -> Option<Self> {
         re_tracing::profile_function!();
-        // TODO(jleibs): Mono helpers for ArchetypeView.
-        view.iter_required_component::<re_types::components::AnnotationContext>()
+        view.required_mono_component::<re_types::components::AnnotationContext>()
             .ok()
-            .and_then(|mut iter| iter.next())
             .map(|ctx| Self {
                 row_id: view.primary_row_id(),
                 class_map: ctx


### PR DESCRIPTION
* Closes #3415

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
