### PR TITLE
Introduce splatted indicator components

### DIFF
--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -231,8 +231,8 @@ impl EntityTree {
 
         fn filter_out_clear_components(comp_name: &ComponentName) -> bool {
             let is_clear_component = [
-                Clear::indicator_component(), //
-                ClearIsRecursive::name(),     //
+                Clear::indicator().name(), //
+                ClearIsRecursive::name(),  //
             ]
             .contains(comp_name);
             !is_clear_component

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -231,8 +231,8 @@ impl EntityTree {
 
         fn filter_out_clear_components(comp_name: &ComponentName) -> bool {
             let is_clear_component = [
-                Clear::indicator().name(), //
-                ClearIsRecursive::name(),  //
+                Clear::indicator().as_ref().name(), //
+                ClearIsRecursive::name(),           //
             ]
             .contains(comp_name);
             !is_clear_component

--- a/crates/re_data_ui/src/image_meaning.rs
+++ b/crates/re_data_ui/src/image_meaning.rs
@@ -12,12 +12,16 @@ pub fn image_meaning_for_entity(
 ) -> TensorDataMeaning {
     let store = &ctx.store_db.entity_db.data_store;
     let timeline = &ctx.current_query().timeline;
-    if store.entity_has_component(timeline, entity_path, &DepthImage::indicator().name()) {
+    if store.entity_has_component(
+        timeline,
+        entity_path,
+        &DepthImage::indicator().as_ref().name(),
+    ) {
         TensorDataMeaning::Depth
     } else if store.entity_has_component(
         timeline,
         entity_path,
-        &SegmentationImage::indicator().name(),
+        &SegmentationImage::indicator().as_ref().name(),
     ) {
         TensorDataMeaning::ClassId
     } else {

--- a/crates/re_data_ui/src/image_meaning.rs
+++ b/crates/re_data_ui/src/image_meaning.rs
@@ -12,12 +12,12 @@ pub fn image_meaning_for_entity(
 ) -> TensorDataMeaning {
     let store = &ctx.store_db.entity_db.data_store;
     let timeline = &ctx.current_query().timeline;
-    if store.entity_has_component(timeline, entity_path, &DepthImage::indicator_component()) {
+    if store.entity_has_component(timeline, entity_path, &DepthImage::indicator().name()) {
         TensorDataMeaning::Depth
     } else if store.entity_has_component(
         timeline,
         entity_path,
-        &SegmentationImage::indicator_component(),
+        &SegmentationImage::indicator().name(),
     ) {
         TensorDataMeaning::ClassId
     } else {

--- a/crates/re_log_types/src/load_file.rs
+++ b/crates/re_log_types/src/load_file.rs
@@ -68,7 +68,7 @@ pub fn data_cells_from_file_path(
             use re_types::Archetype;
             let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
-                re_types::archetypes::Image::indicator_component(),
+                re_types::archetypes::Image::indicator().name(),
                 indicator.to_arrow(),
             );
 
@@ -135,7 +135,7 @@ pub fn data_cells_from_file_contents(
             use re_types::Archetype;
             let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
-                re_types::archetypes::Image::indicator_component(),
+                re_types::archetypes::Image::indicator().name(),
                 indicator.to_arrow(),
             );
 

--- a/crates/re_log_types/src/load_file.rs
+++ b/crates/re_log_types/src/load_file.rs
@@ -68,7 +68,7 @@ pub fn data_cells_from_file_path(
             use re_types::Archetype;
             let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
-                re_types::archetypes::Image::indicator().name(),
+                re_types::archetypes::Image::indicator().as_ref().name(),
                 indicator.to_arrow(),
             );
 
@@ -135,7 +135,7 @@ pub fn data_cells_from_file_contents(
             use re_types::Archetype;
             let indicator = <re_types::archetypes::Image as Archetype>::Indicator::batch(1);
             let indicator_cell = DataCell::from_arrow(
-                re_types::archetypes::Image::indicator().name(),
+                re_types::archetypes::Image::indicator().as_ref().name(),
                 indicator.to_arrow(),
             );
 

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -30,7 +30,7 @@ impl ViewPartSystem for BarChartViewPartSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(BarChart::indicator().name()).collect()
+        std::iter::once(BarChart::indicator().as_ref().name()).collect()
     }
 
     fn heuristic_filter(

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -30,7 +30,7 @@ impl ViewPartSystem for BarChartViewPartSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(BarChart::indicator_component()).collect()
+        std::iter::once(BarChart::indicator().name()).collect()
     }
 
     fn heuristic_filter(

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -177,7 +177,7 @@ impl ViewPartSystem for Arrows3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Arrows3D::indicator_component()).collect()
+        std::iter::once(Arrows3D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -177,7 +177,7 @@ impl ViewPartSystem for Arrows3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Arrows3D::indicator().name()).collect()
+        std::iter::once(Arrows3D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -108,7 +108,7 @@ impl ViewPartSystem for Asset3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Asset3D::indicator().name()).collect()
+        std::iter::once(Asset3D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -108,7 +108,7 @@ impl ViewPartSystem for Asset3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Asset3D::indicator_component()).collect()
+        std::iter::once(Asset3D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -174,7 +174,7 @@ impl ViewPartSystem for Boxes2DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Boxes2D::indicator().name()).collect()
+        std::iter::once(Boxes2D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -174,7 +174,7 @@ impl ViewPartSystem for Boxes2DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Boxes2D::indicator_component()).collect()
+        std::iter::once(Boxes2D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -137,7 +137,7 @@ impl ViewPartSystem for Boxes3DPart {
         _ent_path: &EntityPath,
         components: &std::collections::BTreeSet<re_types::ComponentName>,
     ) -> bool {
-        components.contains(&Boxes3D::indicator().name())
+        components.contains(&Boxes3D::indicator().as_ref().name())
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -137,7 +137,7 @@ impl ViewPartSystem for Boxes3DPart {
         _ent_path: &EntityPath,
         components: &std::collections::BTreeSet<re_types::ComponentName>,
     ) -> bool {
-        components.contains(&Boxes3D::indicator_component())
+        components.contains(&Boxes3D::indicator().name())
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -183,7 +183,7 @@ impl ViewPartSystem for CamerasPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(re_types::archetypes::Pinhole::indicator_component()).collect()
+        std::iter::once(re_types::archetypes::Pinhole::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -183,7 +183,7 @@ impl ViewPartSystem for CamerasPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(re_types::archetypes::Pinhole::indicator().name()).collect()
+        std::iter::once(re_types::archetypes::Pinhole::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -219,7 +219,7 @@ impl ImagesPart {
         if !ctx.store_db.store().entity_has_component(
             &ctx.current_query().timeline,
             ent_path,
-            &Image::indicator().name(),
+            &Image::indicator().as_ref().name(),
         ) {
             return Ok(());
         }
@@ -307,7 +307,7 @@ impl ImagesPart {
         if !ctx.store_db.store().entity_has_component(
             &ctx.current_query().timeline,
             ent_path,
-            &DepthImage::indicator().name(),
+            &DepthImage::indicator().as_ref().name(),
         ) {
             return Ok(());
         }
@@ -428,7 +428,7 @@ impl ImagesPart {
         if !ctx.store_db.store().entity_has_component(
             &ctx.current_query().timeline,
             ent_path,
-            &SegmentationImage::indicator().name(),
+            &SegmentationImage::indicator().as_ref().name(),
         ) {
             return Ok(());
         }
@@ -631,9 +631,9 @@ impl ViewPartSystem for ImagesPart {
 
     fn indicator_components(&self) -> ComponentNameSet {
         [
-            Image::indicator().name(),
-            DepthImage::indicator().name(),
-            SegmentationImage::indicator().name(),
+            Image::indicator().as_ref().name(),
+            DepthImage::indicator().as_ref().name(),
+            SegmentationImage::indicator().as_ref().name(),
         ]
         .into_iter()
         .collect()

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -219,7 +219,7 @@ impl ImagesPart {
         if !ctx.store_db.store().entity_has_component(
             &ctx.current_query().timeline,
             ent_path,
-            &Image::indicator_component(),
+            &Image::indicator().name(),
         ) {
             return Ok(());
         }
@@ -307,7 +307,7 @@ impl ImagesPart {
         if !ctx.store_db.store().entity_has_component(
             &ctx.current_query().timeline,
             ent_path,
-            &DepthImage::indicator_component(),
+            &DepthImage::indicator().name(),
         ) {
             return Ok(());
         }
@@ -428,7 +428,7 @@ impl ImagesPart {
         if !ctx.store_db.store().entity_has_component(
             &ctx.current_query().timeline,
             ent_path,
-            &SegmentationImage::indicator_component(),
+            &SegmentationImage::indicator().name(),
         ) {
             return Ok(());
         }
@@ -631,9 +631,9 @@ impl ViewPartSystem for ImagesPart {
 
     fn indicator_components(&self) -> ComponentNameSet {
         [
-            Image::indicator_component(),
-            DepthImage::indicator_component(),
-            SegmentationImage::indicator_component(),
+            Image::indicator().name(),
+            DepthImage::indicator().name(),
+            SegmentationImage::indicator().name(),
         ]
         .into_iter()
         .collect()

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -169,7 +169,7 @@ impl ViewPartSystem for Lines2DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(LineStrips2D::indicator_component()).collect()
+        std::iter::once(LineStrips2D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -169,7 +169,7 @@ impl ViewPartSystem for Lines2DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(LineStrips2D::indicator().name()).collect()
+        std::iter::once(LineStrips2D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -177,7 +177,7 @@ impl ViewPartSystem for Lines3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(LineStrips3D::indicator().name()).collect()
+        std::iter::once(LineStrips3D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -177,7 +177,7 @@ impl ViewPartSystem for Lines3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(LineStrips3D::indicator_component()).collect()
+        std::iter::once(LineStrips3D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -140,7 +140,7 @@ impl ViewPartSystem for Mesh3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Mesh3D::indicator_component()).collect()
+        std::iter::once(Mesh3D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -140,7 +140,7 @@ impl ViewPartSystem for Mesh3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Mesh3D::indicator().name()).collect()
+        std::iter::once(Mesh3D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -196,7 +196,7 @@ impl ViewPartSystem for Points2DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Points2D::indicator_component()).collect()
+        std::iter::once(Points2D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -196,7 +196,7 @@ impl ViewPartSystem for Points2DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Points2D::indicator().name()).collect()
+        std::iter::once(Points2D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -199,7 +199,7 @@ impl ViewPartSystem for Points3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Points3D::indicator().name()).collect()
+        std::iter::once(Points3D::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -199,7 +199,7 @@ impl ViewPartSystem for Points3DPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Points3D::indicator_component()).collect()
+        std::iter::once(Points3D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -40,7 +40,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(re_types::archetypes::Transform3D::indicator_component()).collect()
+        std::iter::once(re_types::archetypes::Transform3D::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -40,7 +40,12 @@ impl ViewPartSystem for Transform3DArrowsPart {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(re_types::archetypes::Transform3D::indicator().name()).collect()
+        std::iter::once(
+            re_types::archetypes::Transform3D::indicator()
+                .as_ref()
+                .name(),
+        )
+        .collect()
     }
 
     fn execute(

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -32,7 +32,7 @@ impl ViewPartSystem for TensorSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Tensor::indicator_component()).collect()
+        std::iter::once(Tensor::indicator().name()).collect()
     }
 
     /// Tensor view doesn't handle 2D images, see [`TensorSystem::load_tensor_entity`]

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -32,7 +32,7 @@ impl ViewPartSystem for TensorSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(Tensor::indicator().name()).collect()
+        std::iter::once(Tensor::indicator().as_ref().name()).collect()
     }
 
     /// Tensor view doesn't handle 2D images, see [`TensorSystem::load_tensor_entity`]

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -38,7 +38,7 @@ impl ViewPartSystem for TextDocumentSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(TextDocument::indicator_component()).collect()
+        std::iter::once(TextDocument::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -38,7 +38,7 @@ impl ViewPartSystem for TextDocumentSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(TextDocument::indicator().name()).collect()
+        std::iter::once(TextDocument::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -50,7 +50,7 @@ impl ViewPartSystem for TextLogSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(TextLog::indicator_component()).collect()
+        std::iter::once(TextLog::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -50,7 +50,7 @@ impl ViewPartSystem for TextLogSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(TextLog::indicator().name()).collect()
+        std::iter::once(TextLog::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -79,7 +79,7 @@ impl ViewPartSystem for TimeSeriesSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(TimeSeriesScalar::indicator().name()).collect()
+        std::iter::once(TimeSeriesScalar::indicator().as_ref().name()).collect()
     }
 
     fn execute(

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -79,7 +79,7 @@ impl ViewPartSystem for TimeSeriesSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(TimeSeriesScalar::indicator_component()).collect()
+        std::iter::once(TimeSeriesScalar::indicator().name()).collect()
     }
 
     fn execute(

--- a/crates/re_types/src/archetype.rs
+++ b/crates/re_types/src/archetype.rs
@@ -64,8 +64,8 @@ pub trait Archetype {
     /// This allows for associating arbitrary indicator components with arbitrary data.
     /// Check out the `manual_indicator` API example to see what's possible.
     #[inline]
-    fn indicator() -> Box<dyn ComponentBatch> {
-        Box::<<Self as Archetype>::Indicator>::default()
+    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+        MaybeOwnedComponentBatch::Owned(Box::<<Self as Archetype>::Indicator>::default())
     }
 
     /// Returns the names of all components that _must_ be provided by the user when constructing
@@ -76,7 +76,7 @@ pub trait Archetype {
     /// this archetype.
     #[inline]
     fn recommended_components() -> std::borrow::Cow<'static, [ComponentName]> {
-        std::borrow::Cow::Owned(vec![Self::indicator().name()])
+        std::borrow::Cow::Owned(vec![Self::indicator().as_ref().name()])
     }
 
     /// Returns the names of all components that _may_ be provided by the user when constructing
@@ -240,11 +240,15 @@ pub struct GenericIndicatorComponent<A: Archetype> {
     _phantom: std::marker::PhantomData<A>,
 }
 
+impl<A: Archetype> GenericIndicatorComponent<A> {
+    pub const DEFAULT: Self = Self {
+        _phantom: std::marker::PhantomData::<A>,
+    };
+}
+
 impl<A: Archetype> Default for GenericIndicatorComponent<A> {
     fn default() -> Self {
-        Self {
-            _phantom: Default::default(),
-        }
+        Self::DEFAULT
     }
 }
 

--- a/crates/re_types/src/archetype.rs
+++ b/crates/re_types/src/archetype.rs
@@ -142,7 +142,7 @@ pub trait Archetype {
     #[inline]
     fn try_to_arrow(
         &self,
-    ) -> SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn::arrow2::array::Array>)>>
+    ) -> SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>>
     {
         self.as_component_batches()
             .into_iter()
@@ -163,7 +163,7 @@ pub trait Archetype {
     ///
     /// For the fallible version, see [`Archetype::try_to_arrow`].
     #[inline]
-    fn to_arrow(&self) -> Vec<(::arrow2::datatypes::Field, Box<dyn::arrow2::array::Array>)> {
+    fn to_arrow(&self) -> Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)> {
         self.try_to_arrow().detailed_unwrap()
     }
 
@@ -176,7 +176,7 @@ pub trait Archetype {
     /// logged to stderr.
     #[inline]
     fn try_from_arrow(
-        data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn::arrow2::array::Array>)>,
+        data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     ) -> DeserializationResult<Self>
     where
         Self: Sized,

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -98,6 +98,12 @@ impl crate::Archetype for AnnotationContext {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: AnnotationContextIndicator = AnnotationContextIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -124,7 +130,7 @@ impl crate::Archetype for AnnotationContext {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.context as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -124,7 +124,7 @@ impl crate::Archetype for AnnotationContext {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.context as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -164,7 +164,7 @@ impl crate::Archetype for Arrows3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.vectors as &dyn crate::ComponentBatch).into()),
             self.origins
                 .as_ref()

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -138,6 +138,12 @@ impl crate::Archetype for Arrows3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Arrows3DIndicator = Arrows3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -164,7 +170,7 @@ impl crate::Archetype for Arrows3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.vectors as &dyn crate::ComponentBatch).into()),
             self.origins
                 .as_ref()

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -83,7 +83,6 @@
 ///         rec.log_component_batches(
 ///             "world/asset",
 ///             false,
-///             1,
 ///             [&OutOfTreeTransform3D::from(translation) as _],
 ///         )?;
 ///     }
@@ -185,7 +184,7 @@ impl crate::Archetype for Asset3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.media_type
                 .as_ref()

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -158,6 +158,12 @@ impl crate::Archetype for Asset3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Asset3DIndicator = Asset3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -184,7 +190,7 @@ impl crate::Archetype for Asset3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.media_type
                 .as_ref()

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -76,6 +76,12 @@ impl crate::Archetype for BarChart {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: BarChartIndicator = BarChartIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -102,7 +108,7 @@ impl crate::Archetype for BarChart {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.values as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -102,7 +102,7 @@ impl crate::Archetype for BarChart {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.values as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -150,7 +150,7 @@ impl crate::Archetype for Boxes2D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.half_sizes as &dyn crate::ComponentBatch).into()),
             self.centers
                 .as_ref()

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -124,6 +124,12 @@ impl crate::Archetype for Boxes2D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Boxes2DIndicator = Boxes2DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -150,7 +156,7 @@ impl crate::Archetype for Boxes2D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.half_sizes as &dyn crate::ComponentBatch).into()),
             self.centers
                 .as_ref()

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -177,7 +177,7 @@ impl crate::Archetype for Boxes3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.half_sizes as &dyn crate::ComponentBatch).into()),
             self.centers
                 .as_ref()

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -151,6 +151,12 @@ impl crate::Archetype for Boxes3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Boxes3DIndicator = Boxes3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -177,7 +183,7 @@ impl crate::Archetype for Boxes3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.half_sizes as &dyn crate::ComponentBatch).into()),
             self.centers
                 .as_ref()

--- a/crates/re_types/src/archetypes/clear.rs
+++ b/crates/re_types/src/archetypes/clear.rs
@@ -161,7 +161,7 @@ impl crate::Archetype for Clear {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.recursive as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/clear.rs
+++ b/crates/re_types/src/archetypes/clear.rs
@@ -135,6 +135,12 @@ impl crate::Archetype for Clear {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: ClearIndicator = ClearIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -161,7 +167,7 @@ impl crate::Archetype for Clear {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.recursive as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -99,6 +99,12 @@ impl crate::Archetype for DepthImage {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: DepthImageIndicator = DepthImageIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -125,7 +131,7 @@ impl crate::Archetype for DepthImage {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.meter
                 .as_ref()

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -125,7 +125,7 @@ impl crate::Archetype for DepthImage {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.meter
                 .as_ref()

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -85,6 +85,12 @@ impl crate::Archetype for DisconnectedSpace {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: DisconnectedSpaceIndicator = DisconnectedSpaceIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -111,7 +117,7 @@ impl crate::Archetype for DisconnectedSpace {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.disconnected_space as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -111,7 +111,7 @@ impl crate::Archetype for DisconnectedSpace {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.disconnected_space as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -121,7 +121,7 @@ impl crate::Archetype for Image {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -95,6 +95,12 @@ impl crate::Archetype for Image {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: ImageIndicator = ImageIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -121,7 +127,7 @@ impl crate::Archetype for Image {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -181,7 +181,7 @@ impl crate::Archetype for LineStrips2D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -155,6 +155,12 @@ impl crate::Archetype for LineStrips2D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: LineStrips2DIndicator = LineStrips2DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -181,7 +187,7 @@ impl crate::Archetype for LineStrips2D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -148,6 +148,12 @@ impl crate::Archetype for LineStrips3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: LineStrips3DIndicator = LineStrips3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -174,7 +180,7 @@ impl crate::Archetype for LineStrips3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -174,7 +174,7 @@ impl crate::Archetype for LineStrips3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.strips as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -164,6 +164,12 @@ impl crate::Archetype for Mesh3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Mesh3DIndicator = Mesh3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -190,7 +196,7 @@ impl crate::Archetype for Mesh3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.vertex_positions as &dyn crate::ComponentBatch).into()),
             self.mesh_properties
                 .as_ref()

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -75,7 +75,7 @@
 ///             (glam::Vec3::from(vertex_positions[1]) * factor).into(),
 ///             (glam::Vec3::from(vertex_positions[2]) * factor).into(),
 ///         ];
-///         rec.log_component_batches("triangle", false, 3, [&vertex_positions as _])?;
+///         rec.log_component_batches("triangle", false, [&vertex_positions as _])?;
 ///     }
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -190,7 +190,7 @@ impl crate::Archetype for Mesh3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.vertex_positions as &dyn crate::ComponentBatch).into()),
             self.mesh_properties
                 .as_ref()

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -133,6 +133,12 @@ impl crate::Archetype for Pinhole {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: PinholeIndicator = PinholeIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -159,7 +165,7 @@ impl crate::Archetype for Pinhole {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.image_from_camera as &dyn crate::ComponentBatch).into()),
             self.resolution
                 .as_ref()

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -159,7 +159,7 @@ impl crate::Archetype for Pinhole {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.image_from_camera as &dyn crate::ComponentBatch).into()),
             self.resolution
                 .as_ref()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -154,7 +154,7 @@ impl crate::Archetype for Points2D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.positions as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -128,6 +128,12 @@ impl crate::Archetype for Points2D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Points2DIndicator = Points2DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -154,7 +160,7 @@ impl crate::Archetype for Points2D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.positions as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -142,7 +142,7 @@ impl crate::Archetype for Points3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.positions as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -116,6 +116,12 @@ impl crate::Archetype for Points3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Points3DIndicator = Points3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -142,7 +148,7 @@ impl crate::Archetype for Points3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.positions as &dyn crate::ComponentBatch).into()),
             self.radii
                 .as_ref()

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -107,6 +107,12 @@ impl crate::Archetype for SegmentationImage {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: SegmentationImageIndicator = SegmentationImageIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -133,7 +139,7 @@ impl crate::Archetype for SegmentationImage {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -133,7 +133,7 @@ impl crate::Archetype for SegmentationImage {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
             self.draw_order
                 .as_ref()

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -102,7 +102,7 @@ impl crate::Archetype for Tensor {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -76,6 +76,12 @@ impl crate::Archetype for Tensor {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: TensorIndicator = TensorIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -102,7 +108,7 @@ impl crate::Archetype for Tensor {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.data as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -68,6 +68,12 @@ impl crate::Archetype for TextDocument {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: TextDocumentIndicator = TextDocumentIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -94,7 +100,7 @@ impl crate::Archetype for TextDocument {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.body as &dyn crate::ComponentBatch).into()),
             self.media_type
                 .as_ref()

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -94,7 +94,7 @@ impl crate::Archetype for TextDocument {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.body as &dyn crate::ComponentBatch).into()),
             self.media_type
                 .as_ref()

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -61,6 +61,12 @@ impl crate::Archetype for TextLog {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: TextLogIndicator = TextLogIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -87,7 +93,7 @@ impl crate::Archetype for TextLog {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.body as &dyn crate::ComponentBatch).into()),
             self.level
                 .as_ref()

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -87,7 +87,7 @@ impl crate::Archetype for TextLog {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.body as &dyn crate::ComponentBatch).into()),
             self.level
                 .as_ref()

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -204,7 +204,7 @@ impl crate::Archetype for TimeSeriesScalar {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.scalar as &dyn crate::ComponentBatch).into()),
             self.radius
                 .as_ref()

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -178,6 +178,12 @@ impl crate::Archetype for TimeSeriesScalar {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: TimeSeriesScalarIndicator = TimeSeriesScalarIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -204,7 +210,7 @@ impl crate::Archetype for TimeSeriesScalar {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.scalar as &dyn crate::ComponentBatch).into()),
             self.radius
                 .as_ref()

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -105,6 +105,12 @@ impl crate::Archetype for Transform3D {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: Transform3DIndicator = Transform3DIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -131,7 +137,7 @@ impl crate::Archetype for Transform3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.transform as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -131,7 +131,7 @@ impl crate::Archetype for Transform3D {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.transform as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -112,7 +112,7 @@ impl crate::Archetype for ViewCoordinates {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.xyz as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -86,6 +86,12 @@ impl crate::Archetype for ViewCoordinates {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: ViewCoordinatesIndicator = ViewCoordinatesIndicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -112,7 +118,7 @@ impl crate::Archetype for ViewCoordinates {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.xyz as &dyn crate::ComponentBatch).into()),
         ]
         .into_iter()

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -210,6 +210,12 @@ impl crate::Archetype for AffixFuzzer1 {
     }
 
     #[inline]
+    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+        static INDICATOR: AffixFuzzer1Indicator = AffixFuzzer1Indicator::DEFAULT;
+        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
+    }
+
+    #[inline]
     fn required_components() -> ::std::borrow::Cow<'static, [crate::ComponentName]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
@@ -236,7 +242,7 @@ impl crate::Archetype for AffixFuzzer1 {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::indicator().into()),
+            Some(Self::indicator()),
             Some((&self.fuzz1001 as &dyn crate::ComponentBatch).into()),
             Some((&self.fuzz1002 as &dyn crate::ComponentBatch).into()),
             Some((&self.fuzz1003 as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -236,7 +236,7 @@ impl crate::Archetype for AffixFuzzer1 {
 
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
         [
-            Some(Self::Indicator::batch(self.num_instances() as _).into()),
+            Some(Self::indicator().into()),
             Some((&self.fuzz1001 as &dyn crate::ComponentBatch).into()),
             Some((&self.fuzz1002 as &dyn crate::ComponentBatch).into()),
             Some((&self.fuzz1003 as &dyn crate::ComponentBatch).into()),

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -832,7 +832,7 @@ fn quote_trait_impls_from_obj(
 
             let all_component_batches = {
                 std::iter::once(quote!{
-                    Some(Self::indicator().into())
+                    Some(Self::indicator())
                 }).chain(obj.fields.iter().map(|obj_field| {
                     let field_name = format_ident!("{}", obj_field.name);
                     let is_plural = obj_field.typ.is_plural();
@@ -1006,6 +1006,12 @@ fn quote_trait_impls_from_obj(
                     #[inline]
                     fn name() -> crate::ArchetypeName {
                         #fqname.into()
+                    }
+
+                    #[inline]
+                    fn indicator() -> crate::MaybeOwnedComponentBatch<'static> {
+                        static INDICATOR: #quoted_indicator_name = #quoted_indicator_name::DEFAULT;
+                        crate::MaybeOwnedComponentBatch::Ref(&INDICATOR)
                     }
 
                     #[inline]

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -832,7 +832,7 @@ fn quote_trait_impls_from_obj(
 
             let all_component_batches = {
                 std::iter::once(quote!{
-                    Some(Self::Indicator::batch(self.num_instances() as _).into())
+                    Some(Self::indicator().into())
                 }).chain(obj.fields.iter().map(|obj_field| {
                     let field_name = format_ident!("{}", obj_field.name);
                     let is_plural = obj_field.typ.is_plural();

--- a/docs/code-examples/Cargo.toml
+++ b/docs/code-examples/Cargo.toml
@@ -96,6 +96,10 @@ name = "line_strip3d_batch"
 path = "line_strip3d_batch.rs"
 
 [[bin]]
+name = "manual_indicator"
+path = "manual_indicator.rs"
+
+[[bin]]
 name = "mesh3d_simple"
 path = "mesh3d_simple.rs"
 

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -36,7 +36,6 @@ fn main() -> Result<(), anyhow::Error> {
         rec.log_component_batches(
             "world/asset",
             false,
-            1,
             [&OutOfTreeTransform3D::from(translation) as _],
         )?;
     }

--- a/docs/code-examples/custom_data.py
+++ b/docs/code-examples/custom_data.py
@@ -35,7 +35,7 @@ class CustomPoints3D(rr.AsComponents):
         points3d = np.asarray(self.points3d)
         return (
             list(rr.Points3D(points3d).as_component_batches())  # The components from Points3D
-            + [rr.IndicatorComponentBatch("user.CustomPoints3D", len(points3d))]  # Our custom indicator
+            + [rr.IndicatorComponentBatch("user.CustomPoints3D")]  # Our custom indicator
             + [ConfidenceBatch(self.confidences)]  # Custom confidence data
         )
 

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -54,7 +54,7 @@ impl Archetype for CustomPoints3D {
             .into_iter()
             .chain(
                 [
-                    Some(Self::indicator().into()),
+                    Some(Self::indicator()),
                     self.confidences
                         .as_ref()
                         .map(|v| (v as &dyn ComponentBatch).into()),

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -54,7 +54,7 @@ impl Archetype for CustomPoints3D {
             .into_iter()
             .chain(
                 [
-                    Some(Self::Indicator::batch(self.num_instances()).into()),
+                    Some(Self::indicator().into()),
                     self.confidences
                         .as_ref()
                         .map(|v| (v as &dyn ComponentBatch).into()),

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -1,0 +1,34 @@
+// Log some very simple points.
+
+#include <rerun.hpp>
+
+namespace rr = rerun;
+
+int main() {
+    auto rec = rr::RecordingStream("rerun_example_manual_indicator");
+    rec.connect("127.0.0.1:9876").throw_on_failure();
+
+    std::vector<rr::components::Position3D> positions = {
+        {0.0, 0.0, 0.0},
+        {10.0, 0.0, 0.0},
+        {0.0, 10.0, 0.0},
+    };
+    std::vector<rr::components::Color> colors = {
+        {255, 0, 0},
+        {0, 255, 0},
+        {0, 0, 255},
+    };
+    std::vector<rr::components::Radius> radii = {1.0};
+
+    // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
+    // 3D mesh _and_ a point cloud by default.
+    rec.log_component_batches(
+        "points_and_mesh",
+        3,
+        rr::Points3D::indicator(),
+        rr::Mesh3D::indicator(),
+        positions,
+        colors,
+        radii
+    );
+}

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -1,4 +1,4 @@
-// Log some very simple points.
+// Shows how to manually associate one or more indicator components with arbitrary data.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/manual_indicator.py
+++ b/docs/code-examples/manual_indicator.py
@@ -1,0 +1,17 @@
+"""Shows how to manually associate one or more indicator components with arbitrary data."""
+import rerun as rr
+
+rr.init("rerun_example_manual_indicator", spawn=True)
+
+# Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
+# 3D mesh _and_ a point cloud by default.
+rr.log(
+    "points_and_mesh",
+    [
+        rr.Points3D.indicator(),
+        rr.Mesh3D.indicator(),
+        rr.components.Position3DBatch([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]]),
+        rr.components.ColorBatch([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+        rr.components.RadiusBatch([1.0]),
+    ],
+)

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -1,0 +1,28 @@
+//! Shows how to manually associate one or more indicator components with arbitrary data.
+
+use rerun::{
+    archetypes::{Mesh3D, Points3D},
+    components::{Color, Position3D, Radius},
+    Archetype, ComponentBatch, RecordingStreamBuilder,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_manual_indicator").memory()?;
+
+    // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
+    // 3D mesh _and_ a point cloud by default.
+    rec.log_component_batches(
+        "points_and_mesh",
+        false,
+        [
+            Points3D::indicator().as_ref() as &dyn ComponentBatch,
+            Mesh3D::indicator().as_ref(),
+            &[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]].map(Position3D::from),
+            &[[255, 0, 0], [0, 255, 0], [0, 0, 255]].map(|[r, g, b]| Color::from_rgb(r, g, b)),
+            &[1.0].map(Radius::from),
+        ],
+    )?;
+
+    rerun::native_viewer::show(storage.take())?;
+    Ok(())
+}

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             (glam::Vec3::from(vertex_positions[1]) * factor).into(),
             (glam::Vec3::from(vertex_positions[2]) * factor).into(),
         ];
-        rec.log_component_batches("triangle", false, 3, [&vertex_positions as _])?;
+        rec.log_component_batches("triangle", false, [&vertex_positions as _])?;
     }
 
     rerun::native_viewer::show(storage.take())?;

--- a/examples/python/notebook/blueprint.ipynb
+++ b/examples/python/notebook/blueprint.ipynb
@@ -1,128 +1,132 @@
 {
-    "cells": [
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Set up environment"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import numpy as np\n",
-                "import rerun as rr  # pip install rerun-sdk\n",
-                "import rerun.experimental as rr2  # Note: blueprint support is still experimental"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Initialize Rerun"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "rr.init(\"rerun_example_blueprint_demo\")\n",
-                "rr.start_web_viewer_server()\n",
-                "\n",
-                "rec = rr.memory_recording()"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Log Some Data"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "img = np.zeros([128, 128, 3], dtype=\"uint8\")\n",
-                "for i in range(8):\n",
-                "    img[(i * 16) + 4 : (i * 16) + 12, :] = (0, 0, 200)\n",
-                "    rr.log_image(\"image\", img)\n",
-                "    rr.log_rect(\"rect/0\", [16, 16, 64, 64], label=\"Rect1\", color=(255, 0, 0))\n",
-                "    rr.log_rect(\"rect/1\", [48, 48, 64, 64], label=\"Rect2\", color=(0, 255, 0))\n",
-                "\n",
-                "# Show rec with default blueprint\n",
-                "rec"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Add a space view to the default blueprint"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "bp = rr2.new_blueprint(\"Blueprint demo\", add_to_app_default_blueprint=True)\n",
-                "rr2.add_space_view(name=\"overlaid\", space_view_class=\"2D\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp)\n",
-                "bp.memory_recording().show(rec)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "bp = rr2.new_blueprint(\"Blueprint demo\")\n",
-                "rr2.set_panels(all_expanded=False, blueprint=bp)\n",
-                "\n",
-                "rr2.add_space_view(name=\"overlaid\", space_view_class=\"2D\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp)\n",
-                "bp.memory_recording().show(rec)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": []
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3 (ipykernel)",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.10.7"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set up environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import rerun as rr  # pip install rerun-sdk\n",
+    "import rerun.experimental as rr2  # Note: blueprint support is still experimental"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Rerun"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rr.init(\"rerun_example_blueprint_demo\")\n",
+    "rr.start_web_viewer_server()\n",
+    "\n",
+    "rec = rr.memory_recording()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Log Some Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = np.zeros([128, 128, 3], dtype=\"uint8\")\n",
+    "for i in range(8):\n",
+    "    img[(i * 16) + 4 : (i * 16) + 12, :] = (0, 0, 200)\n",
+    "    rr.log_image(\"image\", img)\n",
+    "    rr.log_rect(\"rect/0\", [16, 16, 64, 64], label=\"Rect1\", color=(255, 0, 0))\n",
+    "    rr.log_rect(\"rect/1\", [48, 48, 64, 64], label=\"Rect2\", color=(0, 255, 0))\n",
+    "\n",
+    "# Show rec with default blueprint\n",
+    "rec"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add a space view to the default blueprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bp = rr2.new_blueprint(\"Blueprint demo\", add_to_app_default_blueprint=True)\n",
+    "rr2.add_space_view(\n",
+    "    name=\"overlaid\", space_view_class=\"2D\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp\n",
+    ")\n",
+    "bp.memory_recording().show(rec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bp = rr2.new_blueprint(\"Blueprint demo\")\n",
+    "rr2.set_panels(all_expanded=False, blueprint=bp)\n",
+    "\n",
+    "rr2.add_space_view(\n",
+    "    name=\"overlaid\", space_view_class=\"2D\", origin=\"/\", entity_paths=[\"image\", \"rect/0\", \"rect/1\"], blueprint=bp\n",
+    ")\n",
+    "bp.memory_recording().show(rec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -10,18 +10,20 @@ namespace rerun {
         const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AnnotationContextIndicator";
 
+        AnonymousComponentBatch AnnotationContext::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> AnnotationContext::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(context);
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(AnnotationContext::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -76,6 +76,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
 
+        AnonymousComponentBatch Arrows3D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Arrows3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(7);
@@ -32,12 +37,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Arrows3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -208,6 +208,11 @@ namespace rerun {
                 return vectors.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Asset3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Asset3DIndicator";
 
+        AnonymousComponentBatch Asset3D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Asset3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Asset3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(3);
@@ -20,12 +25,7 @@ namespace rerun {
             if (transform.has_value()) {
                 comp_batches.emplace_back(transform.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Asset3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Asset3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -132,6 +132,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -9,17 +9,17 @@ namespace rerun {
     namespace archetypes {
         const char BarChart::INDICATOR_COMPONENT_NAME[] = "rerun.components.BarChartIndicator";
 
+        AnonymousComponentBatch BarChart::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<BarChart::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> BarChart::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(values);
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<BarChart::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(BarChart::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -37,6 +37,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Boxes2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes2DIndicator";
 
+        AnonymousComponentBatch Boxes2D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Boxes2D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Boxes2D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(8);
@@ -35,12 +40,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Boxes2D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Boxes2D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -221,6 +221,11 @@ namespace rerun {
                 return half_sizes.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Boxes3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes3DIndicator";
 
+        AnonymousComponentBatch Boxes3D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Boxes3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Boxes3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(8);
@@ -35,12 +40,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Boxes3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Boxes3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -252,6 +252,11 @@ namespace rerun {
                 return half_sizes.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -9,17 +9,19 @@ namespace rerun {
     namespace archetypes {
         const char Clear::INDICATOR_COMPONENT_NAME[] = "rerun.components.ClearIndicator";
 
+        AnonymousComponentBatch Clear::indicator() {
+            return ComponentBatch<components::IndicatorComponent<Clear::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> Clear::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(recursive);
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Clear::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Clear::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -142,6 +142,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
 
+        AnonymousComponentBatch DepthImage::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> DepthImage::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(3);
@@ -20,13 +25,7 @@ namespace rerun {
             if (draw_order.has_value()) {
                 comp_batches.emplace_back(draw_order.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(DepthImage::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -68,6 +68,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -10,18 +10,20 @@ namespace rerun {
         const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.DisconnectedSpaceIndicator";
 
+        AnonymousComponentBatch DisconnectedSpace::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> DisconnectedSpace::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(disconnected_space);
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(DisconnectedSpace::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -63,6 +63,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -9,6 +9,13 @@ namespace rerun {
     namespace archetypes {
         const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
 
+        AnonymousComponentBatch Image::indicator() {
+            return ComponentBatch<components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> Image::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(2);
@@ -17,12 +24,7 @@ namespace rerun {
             if (draw_order.has_value()) {
                 comp_batches.emplace_back(draw_order.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Image::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -55,6 +55,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -10,6 +10,11 @@ namespace rerun {
         const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips2DIndicator";
 
+        AnonymousComponentBatch LineStrips2D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> LineStrips2D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(7);
@@ -33,13 +38,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(LineStrips2D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -199,6 +199,11 @@ namespace rerun {
                 return strips.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -10,6 +10,11 @@ namespace rerun {
         const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips3DIndicator";
 
+        AnonymousComponentBatch LineStrips3D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> LineStrips3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(6);
@@ -30,13 +35,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(LineStrips3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -195,6 +195,11 @@ namespace rerun {
                 return strips.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -9,6 +9,13 @@ namespace rerun {
     namespace archetypes {
         const char Mesh3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Mesh3DIndicator";
 
+        AnonymousComponentBatch Mesh3D::indicator() {
+            return ComponentBatch<components::IndicatorComponent<Mesh3D::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> Mesh3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(7);
@@ -32,12 +39,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Mesh3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Mesh3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -138,6 +138,11 @@ namespace rerun {
                 return vertex_positions.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Pinhole::INDICATOR_COMPONENT_NAME[] = "rerun.components.PinholeIndicator";
 
+        AnonymousComponentBatch Pinhole::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Pinhole::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Pinhole::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(3);
@@ -20,12 +25,7 @@ namespace rerun {
             if (camera_xyz.has_value()) {
                 comp_batches.emplace_back(camera_xyz.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Pinhole::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Pinhole::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -181,6 +181,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
 
+        AnonymousComponentBatch Points2D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Points2D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(8);
@@ -35,12 +40,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Points2D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -192,6 +192,11 @@ namespace rerun {
                 return positions.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
 
+        AnonymousComponentBatch Points3D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Points3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(7);
@@ -32,12 +37,7 @@ namespace rerun {
             if (instance_keys.has_value()) {
                 comp_batches.emplace_back(instance_keys.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Points3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -177,6 +177,11 @@ namespace rerun {
                 return positions.size();
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -10,6 +10,14 @@ namespace rerun {
         const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.SegmentationImageIndicator";
 
+        AnonymousComponentBatch SegmentationImage::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<SegmentationImage::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> SegmentationImage::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(2);
@@ -18,13 +26,7 @@ namespace rerun {
             if (draw_order.has_value()) {
                 comp_batches.emplace_back(draw_order.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<SegmentationImage::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(SegmentationImage::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -53,6 +53,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -9,17 +9,19 @@ namespace rerun {
     namespace archetypes {
         const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
 
+        AnonymousComponentBatch Tensor::indicator() {
+            return ComponentBatch<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> Tensor::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(data);
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Tensor::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -34,6 +34,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -10,6 +10,11 @@ namespace rerun {
         const char TextDocument::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TextDocumentIndicator";
 
+        AnonymousComponentBatch TextDocument::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<TextDocument::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> TextDocument::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(2);
@@ -18,13 +23,7 @@ namespace rerun {
             if (media_type.has_value()) {
                 comp_batches.emplace_back(media_type.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<TextDocument::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(TextDocument::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -56,6 +56,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -9,6 +9,11 @@ namespace rerun {
     namespace archetypes {
         const char TextLog::INDICATOR_COMPONENT_NAME[] = "rerun.components.TextLogIndicator";
 
+        AnonymousComponentBatch TextLog::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<TextLog::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> TextLog::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(3);
@@ -20,12 +25,7 @@ namespace rerun {
             if (color.has_value()) {
                 comp_batches.emplace_back(color.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<components::IndicatorComponent<TextLog::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(TextLog::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -50,6 +50,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -10,6 +10,14 @@ namespace rerun {
         const char TimeSeriesScalar::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TimeSeriesScalarIndicator";
 
+        AnonymousComponentBatch TimeSeriesScalar::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<TimeSeriesScalar::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> TimeSeriesScalar::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(5);
@@ -27,13 +35,7 @@ namespace rerun {
             if (scattered.has_value()) {
                 comp_batches.emplace_back(scattered.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<TimeSeriesScalar::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(TimeSeriesScalar::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -138,6 +138,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -10,18 +10,17 @@ namespace rerun {
         const char Transform3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.Transform3DIndicator";
 
+        AnonymousComponentBatch Transform3D::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<Transform3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> Transform3D::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(transform);
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<Transform3D::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(Transform3D::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -249,6 +249,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -10,18 +10,20 @@ namespace rerun {
         const char ViewCoordinates::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.ViewCoordinatesIndicator";
 
+        AnonymousComponentBatch ViewCoordinates::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<ViewCoordinates::INDICATOR_COMPONENT_NAME>>(
+                nullptr,
+                1
+            );
+        }
+
         std::vector<AnonymousComponentBatch> ViewCoordinates::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(1);
 
             comp_batches.emplace_back(xyz);
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<ViewCoordinates::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(ViewCoordinates::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -137,6 +137,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_cpp/src/rerun/arrow.cpp
+++ b/rerun_cpp/src/rerun/arrow.cpp
@@ -20,12 +20,10 @@ namespace rerun {
         }
     }
 
-    Result<rerun::DataCell> create_indicator_component(
-        const char* indicator_fqname, size_t num_instances
-    ) {
+    Result<rerun::DataCell> create_indicator_component(const char* indicator_fqname) {
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto builder = std::make_shared<arrow::NullBuilder>(pool);
-        ARROW_RETURN_NOT_OK(builder->AppendNulls(static_cast<int64_t>(num_instances)));
+        ARROW_RETURN_NOT_OK(builder->AppendNulls(1));
         std::shared_ptr<arrow::Array> array;
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 

--- a/rerun_cpp/src/rerun/arrow.hpp
+++ b/rerun_cpp/src/rerun/arrow.hpp
@@ -17,5 +17,5 @@ namespace rerun {
     /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
     Result<std::shared_ptr<arrow::Buffer>> ipc_from_table(const arrow::Table& table);
 
-    Result<rerun::DataCell> create_indicator_component(const char* arch_name, size_t num_instances);
+    Result<rerun::DataCell> create_indicator_component(const char* arch_name);
 } // namespace rerun

--- a/rerun_cpp/src/rerun/indicator_component.hpp
+++ b/rerun_cpp/src/rerun/indicator_component.hpp
@@ -15,9 +15,9 @@ namespace rerun {
 
             /// Creates a Rerun DataCell from an array of IndicatorComponent components.
             static Result<rerun::DataCell> to_data_cell(
-                const IndicatorComponent<Name>*, size_t num_instances
+                const IndicatorComponent<Name>*, size_t _num_instances
             ) {
-                return rerun::create_indicator_component(Name, num_instances);
+                return rerun::create_indicator_component(Name);
             }
         };
     } // namespace components

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -10,6 +10,11 @@ namespace rerun {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer1Indicator";
 
+        AnonymousComponentBatch AffixFuzzer1::indicator() {
+            return ComponentBatch<
+                components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
+        }
+
         std::vector<AnonymousComponentBatch> AffixFuzzer1::as_component_batches() const {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(75);
@@ -161,13 +166,7 @@ namespace rerun {
             if (fuzz2118.has_value()) {
                 comp_batches.emplace_back(fuzz2118.value());
             }
-            comp_batches.emplace_back(
-                ComponentBatch<
-                    components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME>>(
-                    nullptr,
-                    num_instances()
-                )
-            );
+            comp_batches.emplace_back(AffixFuzzer1::indicator());
 
             return comp_batches;
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -631,6 +631,11 @@ namespace rerun {
                 return 1;
             }
 
+            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
+            /// allows for associating arbitrary indicator components with arbitrary data. Check out
+            /// the `manual_indicator` API example to see what's possible.
+            static AnonymousComponentBatch indicator();
+
             /// Collections all component lists into a list of component collections. *Attention:*
             /// The returned vector references this instance and does not take ownership of any
             /// data. Adding any new components to this archetype will invalidate the returned

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -71,8 +71,21 @@ class Archetype:
 
         return s
 
-    def archetype_name(self) -> str:
-        return "rerun.archetypes." + type(self).__name__
+    @classmethod
+    def archetype_name(cls) -> str:
+        return "rerun.archetypes." + cls.__name__
+
+    @classmethod
+    def indicator(cls) -> ComponentBatchLike:
+        """
+        Creates a `ComponentBatchLike` out of the associated indicator component.
+
+        This allows for associating arbitrary indicator components with arbitrary data.
+        Check out the `manual_indicator` API example to see what's possible.
+        """
+        from ._log import IndicatorComponentBatch
+
+        return IndicatorComponentBatch(cls.archetype_name())
 
     def num_instances(self) -> int:
         """
@@ -92,9 +105,7 @@ class Archetype:
 
         Part of the `AsComponents` logging interface.
         """
-        from ._log import IndicatorComponentBatch
-
-        yield IndicatorComponentBatch(self.archetype_name(), self.num_instances())
+        yield self.indicator()
 
         for fld in fields(type(self)):
             if "component" in fld.metadata:

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -29,18 +29,19 @@ class IndicatorComponentBatch:
     where multiple archetypes would otherwise be overlapping.
 
     This implements the `ComponentBatchLike` interface.
-
-    Parameters
-    ----------
-    archetype_name:
-        The fully qualified name of the Archetype.
-    num_instances:
-        The number of instances of the in this batch.
     """
 
     data: pa.Array
 
     def __init__(self, archetype_name: str) -> None:
+        """
+        Creates a new indicator component based on a given `archetype_name`.
+
+        Parameters
+        ----------
+        archetype_name:
+            The fully qualified name of the Archetype.
+        """
         self.data = pa.nulls(1, type=pa.null())
         self._archetype_name = archetype_name
 

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -38,15 +38,17 @@ class IndicatorComponentBatch:
         The number of instances of the in this batch.
     """
 
-    def __init__(self, archetype_name: str, num_instances: int) -> None:
+    data: pa.Array
+
+    def __init__(self, archetype_name: str) -> None:
+        self.data = pa.nulls(1, type=pa.null())
         self._archetype_name = archetype_name
-        self._num_instances = num_instances
 
     def component_name(self) -> str:
         return self._archetype_name.replace("archetypes", "components") + "Indicator"
 
     def as_arrow_array(self) -> pa.Array:
-        return pa.nulls(self._num_instances, type=pa.null())
+        return self.data
 
 
 # adapted from rerun.log_deprecated._add_extension_components


### PR DESCRIPTION
This implements splatted indicator components for all languages, which allows for nicer indicator-component-creation APIs, which in turn allows for some pretty sleek use cases as demo'd in the new `manual_indicator` example.

- Fixes #3432

---

```python
rr.log(
    "points_and_mesh",
    [
        rr.Points3D.indicator(),
        rr.Mesh3D.indicator(),
        rr.components.Position3DBatch([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]]),
        rr.components.ColorBatch([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
        rr.components.RadiusBatch([1.0]),
    ],
)
```

```rust
rec.log_component_batches(
    "points_and_mesh",
    false,
    [
        Points3D::indicator().as_ref() as &dyn ComponentBatch,
        Mesh3D::indicator().as_ref(),
        &[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]].map(Position3D::from),
        &[[255, 0, 0], [0, 255, 0], [0, 0, 255]].map(|[r, g, b]| Color::from_rgb(r, g, b)),
        &[1.0].map(Radius::from),
    ],
)?;
```

```cpp
std::vector<rr::components::Position3D> positions = {
    {0.0, 0.0, 0.0},
    {10.0, 0.0, 0.0},
    {0.0, 10.0, 0.0},
};
std::vector<rr::components::Color> colors = {
    {255, 0, 0},
    {0, 255, 0},
    {0, 0, 255},
};
std::vector<rr::components::Radius> radii = {1.0};

rec.log_component_batches(
    "points_and_mesh",
    3,
    rr::Points3D::indicator(),
    rr::Mesh3D::indicator(),
    positions,
    colors,
    radii
);
```

![image (18)](https://github.com/rerun-io/rerun/assets/2910679/6d7e4557-1883-4161-ba49-e12acdeed481)


--- 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3479) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3479)
- [Docs preview](https://rerun.io/preview/871eb8c6c7b207ad10016888e76805c47a95de27/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/871eb8c6c7b207ad10016888e76805c47a95de27/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)