### PR TITLE
New helper object for logging ImageEncoded in python

### DIFF
--- a/docs/code-examples/image_advanced.py
+++ b/docs/code-examples/image_advanced.py
@@ -20,20 +20,20 @@ image.save(file_path)
 rr.init("rerun_example_images_adv", spawn=True)
 
 # Log the image from the file.
-rr.log_image_file("from_file", img_path=Path(file_path))
+rr.log("from_file", rr.ImageEncoded(path=Path(file_path)))
 
 # Read with Pillow and NumPy, and log the image.
 image = np.array(Image.open(file_path))
-rr.log_image("from_pillow_rgba", image)
+rr.log("from_pillow_rgba", rr.Image(image))
 
 # Convert to RGB, fill transparent pixels with a color, and log the image.
 image_rgb = image[..., :3]
 image_rgb[image[:, :, 3] == 0] = (45, 15, 15)
-rr.log_image("from_pillow_rgb", image_rgb)
+rr.log("from_pillow_rgb", rr.Image(image_rgb))
 
 # Read with OpenCV
 image = cv2.imread(file_path)
 
 # OpenCV uses BGR ordering, so we need to convert to RGB.
 image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-rr.log_image("from_opencv", image)
+rr.log("from_opencv", rr.Image(image))

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "DepthImage",
     "DisconnectedSpace",
     "Image",
+    "ImageEncoded",
     "ImageFormat",
     "IndicatorComponentBatch",
     "LineStrips2D",
@@ -109,6 +110,7 @@ __all__ = [
 
 import rerun_bindings as bindings  # type: ignore[attr-defined]
 
+from ._image import ImageEncoded, ImageFormat
 from ._log import AsComponents, ComponentBatchLike, IndicatorComponentBatch, log, log_components
 from .archetypes import (
     AnnotationContext,
@@ -142,7 +144,7 @@ from .log_deprecated.bounding_box import log_obb, log_obbs
 from .log_deprecated.camera import log_pinhole
 from .log_deprecated.clear import log_cleared
 from .log_deprecated.extension_components import log_extension_components
-from .log_deprecated.file import ImageFormat, MeshFormat, log_image_file, log_mesh_file
+from .log_deprecated.file import MeshFormat, log_image_file, log_mesh_file
 from .log_deprecated.image import log_depth_image, log_image, log_segmentation_image
 from .log_deprecated.lines import log_line_segments, log_line_strip, log_line_strips_2d, log_line_strips_3d
 from .log_deprecated.mesh import log_mesh, log_meshes

--- a/rerun_py/rerun_sdk/rerun/_image.py
+++ b/rerun_py/rerun_sdk/rerun/_image.py
@@ -48,17 +48,24 @@ class ImageEncoded(AsComponents):
         """
         A monochrome or color image encoded with a common format (PNG, JPEG, etc).
 
+        The encoded image can be loaded from either a a file using its `path` or
+        provided directly via `contents`.
+
         Parameters
         ----------
         path:
-            A path to an image file stored on the local filesystem.
+            A path to an image file stored on the local filesystem. Mutually
+            exclusive with contents.
         contents:
-            The contents of the image file. Can be a BufferedReader, BytesIO, or bytes.
+            The contents of the image file. Can be a BufferedReader, BytesIO, or
+            bytes. Mutually exclusive with contents.
         format:
-            The format of the image file. If not provided, it will be inferred from the file extension.
+            The format of the image file. If not provided, it will be inferred
+            from the file extension.
         draw_order:
-            An optional floating point value that specifies the 2D drawing order.
-            Objects with higher values are drawn on top of those with lower values.
+            An optional floating point value that specifies the 2D drawing
+            order. Objects with higher values are drawn on top of those with
+            lower values.
         """
         if len([x for x in (path, contents) if x is not None]) != 1:
             raise ValueError("Must provide exactly one of 'path' or 'contents'")
@@ -79,7 +86,7 @@ class ImageEncoded(AsComponents):
         if buffer is None:
             raise ValueError("Input data could not be coerced to IO[bytes]")
 
-        # Note that PIL loading is lazy. This will should only identify the type of file
+        # Note that PIL loading is lazy. This will only identify the type of file
         # and not decode the whole jpeg.
         img_data = PILImage.open(buffer, formats=formats)
 

--- a/rerun_py/rerun_sdk/rerun/_image.py
+++ b/rerun_py/rerun_sdk/rerun/_image.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import io
+import pathlib
+from enum import Enum
+from typing import IO, Iterable
+
+import numpy as np
+from PIL import Image as PILImage
+
+from ._log import AsComponents, ComponentBatchLike
+from .archetypes import Image
+from .components import DrawOrderArrayLike, TensorData
+from .datatypes import TensorBuffer, TensorDimension
+
+
+class ImageFormat(Enum):
+    """Image file format."""
+
+    BMP = "BMP"
+    """BMP format."""
+
+    GIF = "GIF"
+    """GIF format."""
+
+    JPEG = "JPEG"
+    """JPEG format."""
+
+    PNG = "PNG"
+    """PNG format."""
+
+    TIFF = "TIFF"
+    """TIFF format."""
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class ImageEncoded(AsComponents):
+    def __init__(
+        self,
+        *,
+        path: str | pathlib.Path | None = None,
+        contents: bytes | IO[bytes] | None = None,
+        format: ImageFormat | None = None,
+        draw_order: DrawOrderArrayLike | None = None,
+    ) -> None:
+        """
+        A monochrome or color image encoded with a common format (PNG, JPEG, etc).
+
+        Parameters
+        ----------
+        path:
+            A path to an image file stored on the local filesystem.
+        contents:
+            The contents of the image file. Can be a BufferedReader, BytesIO, or bytes.
+        format:
+            The format of the image file. If not provided, it will be inferred from the file extension.
+        draw_order:
+            An optional floating point value that specifies the 2D drawing order.
+            Objects with higher values are drawn on top of those with lower values.
+        """
+        if len([x for x in (path, contents) if x is not None]) != 1:
+            raise ValueError("Must provide exactly one of 'path' or 'contents'")
+
+        if format is not None:
+            formats = (str(format),)
+        else:
+            formats = None
+
+        buffer: IO[bytes] | None = None
+        if path is not None:
+            buffer = open(path, "rb")
+        elif isinstance(contents, bytes):
+            buffer = io.BytesIO(contents)
+        else:
+            buffer = contents
+
+        if buffer is None:
+            raise ValueError("Input data could not be coerced to IO[bytes]")
+
+        # Note that PIL loading is lazy. This will should only identify the type of file
+        # and not decode the whole jpeg.
+        img_data = PILImage.open(buffer, formats=formats)
+
+        if img_data.format == "JPEG":
+            buffer.seek(0)
+            np_buffer = buffer.read()
+            tensor_buffer = TensorBuffer(np.frombuffer(np_buffer, dtype=np.uint8))
+            tensor_buffer.kind = "jpeg"
+
+            tensor_shape = (
+                TensorDimension(img_data.height, "height"),
+                TensorDimension(img_data.width, "width"),
+                TensorDimension(3, "depth"),
+            )
+            tensor_data = TensorData(buffer=tensor_buffer, shape=tensor_shape)
+        else:
+            tensor_data = TensorData(array=np.asarray(img_data))
+
+        self.data = tensor_data
+        self.draw_order = draw_order
+
+    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+        return Image(self.data, draw_order=self.draw_order).as_component_batches()

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -167,12 +167,13 @@ class TensorDataExt:
         elif array is not None:
             self.buffer = TensorBuffer(array.flatten())
 
-        expected_buffer_size = prod(d.size for d in self.shape)
+        if self.buffer.kind != "jpeg":
+            expected_buffer_size = prod(d.size for d in self.shape)
 
-        if len(self.buffer.inner) != expected_buffer_size:
-            raise ValueError(
-                f"Shape and buffer size do not match. {len(self.buffer.inner)} {self.shape}->{expected_buffer_size}"
-            )
+            if len(self.buffer.inner) != expected_buffer_size:
+                raise ValueError(
+                    f"Shape and buffer size do not match. {len(self.buffer.inner)} {self.shape}->{expected_buffer_size}"
+                )
 
     ################################################################################
     # Arrow converters

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
 
-from rerun import bindings
 from rerun._log import log
 from rerun.archetypes import Asset3D
 from rerun.components import MediaType, OutOfTreeTransform3DBatch
@@ -15,9 +13,10 @@ from rerun.datatypes import TranslationAndMat3x3
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
 
+from .._image import ImageEncoded, ImageFormat
+
 __all__ = [
     "MeshFormat",
-    "ImageFormat",
     "log_mesh_file",
     "log_image_file",
 ]
@@ -36,17 +35,6 @@ class MeshFormat(Enum):
     # viewer.
     OBJ = "OBJ"
     """Wavefront .obj format."""
-
-
-@dataclass
-class ImageFormat(Enum):
-    """Image file format."""
-
-    JPEG = "jpeg"
-    """JPEG format."""
-
-    PNG = "png"
-    """PNG format."""
 
 
 @log_decorator
@@ -164,14 +152,13 @@ def log_image_file(
 
     recording = RecordingStream.to_native(recording)
 
-    img_format = getattr(img_format, "value", None)
-
-    # Image file arrow handling happens inside the python bridge
-    bindings.log_image_file(
+    log(
         entity_path,
-        img_bytes=img_bytes,
-        img_path=img_path,
-        img_format=img_format,
+        ImageEncoded(
+            path=img_path,
+            contents=img_bytes,
+            format=img_format,
+        ),
         timeless=timeless,
         recording=recording,
     )

--- a/rerun_py/tests/unit/test_image_encoded.py
+++ b/rerun_py/tests/unit/test_image_encoded.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import io
+import tempfile
+
+import rerun as rr
+from PIL import Image
+
+
+def test_image_encoded_png() -> None:
+    _, file_path = tempfile.mkstemp(suffix=".png")
+
+    image = Image.new("RGBA", (300, 200), color=(0, 0, 0, 0))
+    image.save(file_path)
+
+    img = rr.ImageEncoded(path=file_path)
+
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.buffer.kind == "u8"
+
+
+def test_image_encoded_jpg() -> None:
+    _, file_path = tempfile.mkstemp(suffix=".jpg")
+
+    image = Image.new("RGB", (300, 200), color=(0, 0, 0))
+    image.save(file_path)
+
+    img = rr.ImageEncoded(path=file_path)
+
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.buffer.kind == "jpeg"
+
+
+def test_image_encoded_jpg_from_bytes() -> None:
+    bin = io.BytesIO()
+
+    image = Image.new("RGB", (300, 200), color=(0, 0, 0))
+    image.save(bin, format="jpeg")
+
+    img = rr.ImageEncoded(contents=bin)
+
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.buffer.kind == "jpeg"
+
+    bin.seek(0)
+    img = rr.ImageEncoded(contents=bin.read())
+
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.buffer.kind == "jpeg"


### PR DESCRIPTION
### What
- Python implementation for: https://github.com/rerun-io/rerun/issues/3431

Introduces an object-like constructor that uses pillow to load images.
Handles the special-casing for JPEGs to keep them binary-encoded.
Implements AsComponents so that it can be logged via `rr.log`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3481) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3481)
- [Docs preview](https://rerun.io/preview/0625e7993b27805e18cb4bea54c1b53e288de998/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0625e7993b27805e18cb4bea54c1b53e288de998/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)