### PR TITLE
Make Tensor __init__ support the names argument.

### DIFF
--- a/docs/code-examples/tensor_simple.py
+++ b/docs/code-examples/tensor_simple.py
@@ -11,4 +11,4 @@ tensor = rng.uniform(0.0, 1.0, (8, 6, 3, 5))
 rr.init("rerun_example_tensors", spawn=True)
 
 # Log the tensor, assigning names to each dimension
-rr.log_tensor("tensor", tensor, names=("width", "height", "channel", "batch"))
+rr.log("tensor", rr.Tensor(array=tensor, names=("width", "height", "channel", "batch")))

--- a/docs/code-examples/tensor_simple.py
+++ b/docs/code-examples/tensor_simple.py
@@ -11,4 +11,4 @@ tensor = rng.uniform(0.0, 1.0, (8, 6, 3, 5))
 rr.init("rerun_example_tensors", spawn=True)
 
 # Log the tensor, assigning names to each dimension
-rr.log("tensor", rr.Tensor(array=tensor, names=("width", "height", "channel", "batch")))
+rr.log("tensor", rr.Tensor(tensor, names=("width", "height", "channel", "batch")))

--- a/docs/code-examples/tensor_simple.py
+++ b/docs/code-examples/tensor_simple.py
@@ -11,4 +11,4 @@ tensor = rng.uniform(0.0, 1.0, (8, 6, 3, 5))
 rr.init("rerun_example_tensors", spawn=True)
 
 # Log the tensor, assigning names to each dimension
-rr.log("tensor", rr.Tensor(tensor, names=("width", "height", "channel", "batch")))
+rr.log("tensor", rr.Tensor(tensor, dim_names=("width", "height", "channel", "batch")))

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -34,7 +34,7 @@ class Tensor(TensorExt, Archetype):
     rr.init("rerun_example_tensors", spawn=True)
 
     # Log the tensor, assigning names to each dimension
-    rr.log("tensor", rr.Tensor(tensor, names=("width", "height", "channel", "batch")))
+    rr.log("tensor", rr.Tensor(tensor, dim_names=("width", "height", "channel", "batch")))
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -9,12 +9,13 @@ from attrs import define, field
 
 from .. import components
 from .._baseclasses import Archetype
+from .tensor_ext import TensorExt
 
 __all__ = ["Tensor"]
 
 
-@define(str=False, repr=False)
-class Tensor(Archetype):
+@define(str=False, repr=False, init=False)
+class Tensor(TensorExt, Archetype):
     """
     A generic n-dimensional Tensor.
 
@@ -33,11 +34,11 @@ class Tensor(Archetype):
     rr.init("rerun_example_tensors", spawn=True)
 
     # Log the tensor, assigning names to each dimension
-    rr.log_tensor("tensor", tensor, names=("width", "height", "channel", "batch"))
+    rr.log("tensor", rr.Tensor(array=tensor, names=("width", "height", "channel", "batch")))
     ```
     """
 
-    # You can define your own __init__ function as a member of TensorExt in tensor_ext.py
+    # __init__ can be found in tensor_ext.py
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},
@@ -49,3 +50,7 @@ class Tensor(Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
+
+
+if hasattr(TensorExt, "deferred_patch_class"):
+    TensorExt.deferred_patch_class(Tensor)

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -34,7 +34,7 @@ class Tensor(TensorExt, Archetype):
     rr.init("rerun_example_tensors", spawn=True)
 
     # Log the tensor, assigning names to each dimension
-    rr.log("tensor", rr.Tensor(array=tensor, names=("width", "height", "channel", "batch")))
+    rr.log("tensor", rr.Tensor(tensor, names=("width", "height", "channel", "batch")))
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
@@ -3,18 +3,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 if TYPE_CHECKING:
-    from ..datatypes import TensorBufferLike, TensorData, TensorDimensionLike
+    from ..datatypes import TensorDataLike
     from ..datatypes.tensor_data_ext import TensorLike
 
 
 class TensorExt:
     def __init__(
         self: Any,
+        data: TensorDataLike | TensorLike | None = None,
         *,
-        data: TensorData | None = None,
-        shape: Sequence[TensorDimensionLike] | None = None,
-        buffer: TensorBufferLike | None = None,
-        array: TensorLike | None = None,
         names: Sequence[str | None] | None = None,
     ):
         """
@@ -22,32 +19,26 @@ class TensorExt:
 
         The `Tensor` archetype internally contains a single component: `TensorData`.
 
-        You can construct a `Tensor` from an existing `TensorData` using the `data` kwarg,
-        or alternatively specify `array`, `shape` and `buffer` as in the `TensorData` constructor.
+        See the `TensorData` constructor for more advanced options to interpret buffers
+        as `TensorData` of varying shapes.
+
+        For simple cases, you can pass array objects and optionally specify the names of
+        the dimensions.
 
         Parameters
         ----------
         self:
             The TensorData object to construct.
-        data: TensorData | None
-            A TensorData object to initialize the tensor with.
-        shape: Sequence[TensorDimensionLike] | None
-            The shape of the tensor. If None, and an array is provided, the shape will be inferred
-            from the shape of the array.
-        buffer: TensorBufferLike | None
-            The buffer of the tensor. If None, and an array is provided, the buffer will be generated
-            from the array.
-        array: Tensor | None
-            A numpy array (or The array of the tensor. If None, the array will be inferred from the buffer.
+        data: TensorDataLike | None
+            A TensorData object or numpy array
         names: Sequence[str] | None
             The names of the tensor dimensions when generating the shape from an array.
         """
         from ..datatypes import TensorData
 
-        if len([x for x in (data, array, buffer) if x is not None]) != 1:
-            raise ValueError("Must specify exactly one of 'data', 'array', or 'buffer'.")
-
         if not isinstance(data, TensorData):
-            data = TensorData(shape=shape, buffer=buffer, array=array, names=names)
+            data = TensorData(array=data, names=names)
+        elif names is not None:
+            data = TensorData(buffer=data.buffer, names=names)
 
         self.__attrs_init__(data=data)

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Sequence
+
+from ..datatypes import TensorData
+
+if TYPE_CHECKING:
+    from ..datatypes import TensorBufferLike, TensorData, TensorDimensionLike
+    from ..datatypes.tensor_data_ext import TensorLike
+
+
+class TensorExt:
+    def __init__(
+        self: Any,
+        *,
+        data: TensorData | None = None,
+        shape: Sequence[TensorDimensionLike] | None = None,
+        buffer: TensorBufferLike | None = None,
+        array: TensorLike | None = None,
+        names: Sequence[str | None] | None = None,
+    ):
+        """
+        Construct a `Tensor` archetype.
+
+        The `Tensor` archetype internally contains a single component: `TensorData`.
+
+        You can construct a `Tensor` from an existing `TensorData` using the `data` kwarg,
+        or alternatively specify `array`, `shape` and `buffer` as in the `TensorData` constructor.
+
+        Parameters
+        ----------
+        self:
+            The TensorData object to construct.
+        data: TensorData | None
+            A TensorData object to initialize the tensor with.
+        shape: Sequence[TensorDimensionLike] | None
+            The shape of the tensor. If None, and an array is provided, the shape will be inferred
+            from the shape of the array.
+        buffer: TensorBufferLike | None
+            The buffer of the tensor. If None, and an array is provided, the buffer will be generated
+            from the array.
+        array: Tensor | None
+            A numpy array (or The array of the tensor. If None, the array will be inferred from the buffer.
+        names: Sequence[str] | None
+            The names of the tensor dimensions when generating the shape from an array.
+        """
+        from ..datatypes import TensorData
+
+        if len([x for x in (data, array, buffer) if x is not None]) != 1:
+            raise ValueError("Must specify exactly one of 'data', 'array', or 'buffer'.")
+
+        if not isinstance(data, TensorData):
+            data = TensorData(shape=shape, buffer=buffer, array=array, names=names)
+
+        self.__attrs_init__(data=data)

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
@@ -23,14 +23,14 @@ class TensorExt:
         as `TensorData` of varying shapes.
 
         For simple cases, you can pass array objects and optionally specify the names of
-        the dimensions.
+        the dimensions. The shape of the `TensorData` will be inferred from the array.
 
         Parameters
         ----------
         self:
             The TensorData object to construct.
         data: TensorDataLike | None
-            A TensorData object or numpy array
+            A TensorData object, or type that can be converted to a numpy array.
         names: Sequence[str] | None
             The names of the tensor dimensions when generating the shape from an array.
         """

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
@@ -12,7 +12,7 @@ class TensorExt:
         self: Any,
         data: TensorDataLike | TensorLike | None = None,
         *,
-        names: Sequence[str | None] | None = None,
+        dim_names: Sequence[str | None] | None = None,
     ):
         """
         Construct a `Tensor` archetype.
@@ -31,14 +31,14 @@ class TensorExt:
             The TensorData object to construct.
         data: TensorDataLike | None
             A TensorData object, or type that can be converted to a numpy array.
-        names: Sequence[str] | None
+        dim_names: Sequence[str] | None
             The names of the tensor dimensions when generating the shape from an array.
         """
         from ..datatypes import TensorData
 
         if not isinstance(data, TensorData):
-            data = TensorData(array=data, names=names)
-        elif names is not None:
-            data = TensorData(buffer=data.buffer, names=names)
+            data = TensorData(array=data, dim_names=dim_names)
+        elif dim_names is not None:
+            data = TensorData(buffer=data.buffer, dim_names=dim_names)
 
         self.__attrs_init__(data=data)

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
-from ..datatypes import TensorData
-
 if TYPE_CHECKING:
     from ..datatypes import TensorBufferLike, TensorData, TensorDimensionLike
     from ..datatypes.tensor_data_ext import TensorLike

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -87,8 +87,6 @@ class TensorDataExt:
             Note that compressing to JPEG costs a bit of CPU time, both when logging
             and later when viewing them.
         """
-        # TODO(jleibs): Need to figure out how to get the above docstring to show up in the TensorData class
-        # documentation.
         if array is None and buffer is None:
             raise ValueError("Must provide one of 'array' or 'buffer'")
         if array is not None and buffer is not None:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -25,11 +25,11 @@ class TorchTensorLike(Protocol):
 if TYPE_CHECKING:
     from . import TensorBufferLike, TensorDataArrayLike, TensorDataLike, TensorDimension, TensorDimensionLike
 
-    Tensor = Union[TensorDataLike, TorchTensorLike]
+    TensorLike = Union[TensorDataLike, TorchTensorLike]
     """Type helper for a tensor-like object that can be logged to Rerun."""
 
 
-def _to_numpy(tensor: Tensor) -> npt.NDArray[Any]:
+def _to_numpy(tensor: TensorLike) -> npt.NDArray[Any]:
     # isinstance is 4x faster than catching AttributeError
     if isinstance(tensor, np.ndarray):
         return tensor
@@ -51,7 +51,7 @@ class TensorDataExt:
         *,
         shape: Sequence[TensorDimensionLike] | None = None,
         buffer: TensorBufferLike | None = None,
-        array: Tensor | None = None,
+        array: TensorLike | None = None,
         names: Sequence[str | None] | None = None,
         jpeg_quality: int | None = None,
     ) -> None:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -52,7 +52,7 @@ class TensorDataExt:
         shape: Sequence[TensorDimensionLike] | None = None,
         buffer: TensorBufferLike | None = None,
         array: TensorLike | None = None,
-        names: Sequence[str | None] | None = None,
+        dim_names: Sequence[str | None] | None = None,
         jpeg_quality: int | None = None,
     ) -> None:
         """
@@ -76,7 +76,7 @@ class TensorDataExt:
             from the array.
         array: Tensor | None
             A numpy array (or The array of the tensor. If None, the array will be inferred from the buffer.
-        names: Sequence[str] | None
+        dim_names: Sequence[str] | None
             The names of the tensor dimensions when generating the shape from an array.
         jpeg_quality:
             If set, encode the image as a JPEG to save storage space.
@@ -93,7 +93,7 @@ class TensorDataExt:
             raise ValueError("Can only provide one of 'array' or 'buffer'")
         if buffer is not None and shape is None:
             raise ValueError("If 'buffer' is provided, 'shape' is also required")
-        if shape is not None and names is not None:
+        if shape is not None and dim_names is not None:
             raise ValueError("Can only provide one of 'shape' or 'names'")
 
         from . import TensorBuffer, TensorDimension
@@ -122,16 +122,16 @@ class TensorDataExt:
                 resolved_shape = None
 
             if resolved_shape is None:
-                if names:
-                    if len(array.shape) != len(names):
+                if dim_names:
+                    if len(array.shape) != len(dim_names):
                         _send_warning(
                             (
                                 f"len(array.shape) = {len(array.shape)} != "
-                                + f"len(names) = {len(names)}. Dropping tensor dimension names."
+                                + f"len(dim_names) = {len(dim_names)}. Dropping tensor dimension names."
                             ),
                             2,
                         )
-                    resolved_shape = [TensorDimension(size, name) for size, name in zip(array.shape, names)]  # type: ignore[arg-type]
+                    resolved_shape = [TensorDimension(size, name) for size, name in zip(array.shape, dim_names)]  # type: ignore[arg-type]
                 else:
                     resolved_shape = [TensorDimension(size) for size in array.shape]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -60,7 +60,7 @@ class TensorDataExt:
 
         The `TensorData` object is internally represented by three fields: `shape` and `buffer`.
 
-        This constructor provides additional arguments 'array', and 'names'. When passing in a
+        This constructor provides additional arguments 'array', and 'dim_names'. When passing in a
         multi-dimensional array such as a `np.ndarray`, the `shape` and `buffer` fields will be
         populated automagically.
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
@@ -80,7 +80,7 @@ def _log_tensor(
 ) -> None:
     """Log a general tensor, perhaps with named dimensions."""
 
-    tensor_data = TensorData(array=tensor, names=names)
+    tensor_data = TensorData(array=tensor, dim_names=names)
 
     # Our legacy documentation is that 1D tensors were interpreted as barcharts
     if len(tensor_data.shape) == 1:

--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -29,9 +29,9 @@ TENSOR_DATA_INPUTS: list[TensorDataLike] = [
     # Explicit construction from array
     TensorData(array=RANDOM_TENSOR_SOURCE),
     # Explicit construction from array
-    TensorData(array=RANDOM_TENSOR_SOURCE, names=["a", "b", "c", "d"]),
+    TensorData(array=RANDOM_TENSOR_SOURCE, dim_names=["a", "b", "c", "d"]),
     # Explicit construction from array
-    TensorData(array=RANDOM_TENSOR_SOURCE, names=["a", "b", "c", "d"]),
+    TensorData(array=RANDOM_TENSOR_SOURCE, dim_names=["a", "b", "c", "d"]),
 ]
 
 # 0 = shape

--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -102,7 +102,7 @@ def test_bad_tensors() -> None:
     # Wrong number of names
     with pytest.raises(TypeError):
         TensorData(
-            names=["a", "b", "c"],
+            dim_names=["a", "b", "c"],
             array=RANDOM_TENSOR_SOURCE,
         ),
 


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/3419

When updating the example I realized creating Tensors in python was kind of annoying, so I made the Tensor constructor take the convenience arguments that TensorData takes.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3484) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3484)
- [Docs preview](https://rerun.io/preview/b62cfa4b4396cb385ebe8ee6e97e18ac68db11bf/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b62cfa4b4396cb385ebe8ee6e97e18ac68db11bf/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)