### PR TITLE
Test the component rather than the datatype in test_tensor.py

### DIFF
--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -5,9 +5,8 @@ from typing import Any
 import numpy as np
 import pytest
 import rerun as rr
-from rerun.datatypes.tensor_buffer import TensorBuffer
-from rerun.datatypes.tensor_data import TensorData, TensorDataBatch, TensorDataLike
-from rerun.datatypes.tensor_dimension import TensorDimension
+from rerun.components import TensorData, TensorDataBatch
+from rerun.datatypes import TensorBuffer, TensorDataLike, TensorDimension
 
 rng = np.random.default_rng(12345)
 RANDOM_TENSOR_SOURCE = rng.uniform(0.0, 1.0, (8, 6, 3, 5))


### PR DESCRIPTION
### What
The PR:
 - https://github.com/rerun-io/rerun/pull/3480
surprisingly still passed CI.

Turns out we were testing the TensorData datatype, rather than the TensorData component in the unit-tests.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3486) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3486)
- [Docs preview](https://rerun.io/preview/ff67e552ee43469a7f19109223f61620c70b7af2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ff67e552ee43469a7f19109223f61620c70b7af2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)