### PR TITLE
Simplify MatNxN construction to make it more permissive

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
@@ -41,7 +41,7 @@ namespace rerun.datatypes;
 /// \py ```
 struct Mat3x3 (
   "attr.arrow.transparent",
-  "attr.python.aliases": "Sequence[float], Sequence[Sequence[float]], npt.ArrayLike",
+  "attr.python.aliases": "npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
   "attr.rust.tuple_struct",
   order: 500

--- a/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
@@ -43,7 +43,7 @@ namespace rerun.datatypes;
 /// \py ```
 struct Mat4x4 (
   "attr.arrow.transparent",
-  "attr.python.aliases": "Sequence[float], Sequence[Sequence[float]], npt.ArrayLike",
+  "attr.python.aliases": "npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
   "attr.rust.tuple_struct",
   order: 600

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -71,7 +71,7 @@ class Mat3x3(Mat3x3Ext):
 
 
 if TYPE_CHECKING:
-    Mat3x3Like = Union[Mat3x3, Sequence[float], Sequence[Sequence[float]], npt.ArrayLike]
+    Mat3x3Like = Union[Mat3x3, npt.ArrayLike]
 else:
     Mat3x3Like = Any
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -47,7 +47,7 @@ class Mat3x3Ext:
                 # Will raise ValueError if the wrong shape
                 matrices = [Mat3x3(data)]  # type: ignore[arg-type]
             except ValueError:
-                # Otherwise try to convert it to a single Mat3x3
+                # Otherwise try to convert it to a sequence of Mat3x3s
                 # Let this value error propagate as the fallback
                 matrices = [Mat3x3(d) for d in data]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -35,28 +35,21 @@ class Mat3x3Ext:
 
     @staticmethod
     def native_to_pa_array_override(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Mat3x3, Mat3x3Like
+        from . import Mat3x3
 
-        # Normalize into list of Mat3x3
-        if isinstance(data, Sequence):
-            # single matrix made up of flat float array.
-            if len(data) > 0 and (isinstance(data[0], float) or isinstance(data[0], int)):
-                matrices = [Mat3x3(cast(Mat3x3Like, data))]
-            # if there's a sequence nested, either it's several matrices in various formats
-            # where the first happens to be either a flat or nested sequence of floats,
-            # or it's a single matrix with a nested sequence of floats.
-            # for that to be true, the nested sequence must be 3 floats.
-            elif (
-                isinstance(data[0], Sequence)
-                and len(data[0]) == 3
-                and all((isinstance(elem, float) or isinstance(elem, int)) for elem in data[0])
-            ):
-                matrices = [Mat3x3(cast(Mat3x3Like, data))]
-            # several matrices otherwise!
-            else:
-                matrices = [Mat3x3(m) for m in data]
+        if isinstance(data, Mat3x3):
+            matrices = [data]
+        elif len(data) == 0:
+            matrices = []
         else:
-            matrices = [Mat3x3(data)]
+            try:
+                # Try to convert it to a single Mat3x3
+                # Will raise ValueError if the wrong shape
+                matrices = [Mat3x3(data)]  # type: ignore[arg-type]
+            except ValueError:
+                # Otherwise try to convert it to a single Mat3x3
+                # Let this value error propagate as the fallback
+                matrices = [Mat3x3(d) for d in data]
 
         float_arrays = np.asarray([matrix.flat_columns for matrix in matrices], dtype=np.float32).reshape(-1)
         return pa.FixedSizeListArray.from_arrays(float_arrays, type=data_type)

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pyarrow as pa

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -73,7 +73,7 @@ class Mat4x4(Mat4x4Ext):
 
 
 if TYPE_CHECKING:
-    Mat4x4Like = Union[Mat4x4, Sequence[float], Sequence[Sequence[float]], npt.ArrayLike]
+    Mat4x4Like = Union[Mat4x4, npt.ArrayLike]
 else:
     Mat4x4Like = Any
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pyarrow as pa

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -47,7 +47,7 @@ class Mat4x4Ext:
                 # Will raise ValueError if the wrong shape
                 matrices = [Mat4x4(data)]  # type: ignore[arg-type]
             except ValueError:
-                # Otherwise try to convert it to a single Mat4x4
+                # Otherwise try to convert it to a sequence of Mat4x4
                 # Let this value error propagate as the fallback
                 matrices = [Mat4x4(d) for d in data]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -25,7 +25,7 @@ class Mat4x4Ext:
                 arr = np.array(rows, dtype=np.float32).reshape(4, 4)
                 self.flat_columns = arr.flatten("F")
         elif columns is not None:
-            # Equalize the format of the columns to a 3x3 matrix.
+            # Equalize the format of the columns to a 4x4 matrix.
             # Numpy expects rows _and_ stores row-major. Therefore the flattened list will have flat columns.
             arr = np.array(columns, dtype=np.float32).reshape(4, 4)
             self.flat_columns = arr.flatten()
@@ -35,28 +35,21 @@ class Mat4x4Ext:
 
     @staticmethod
     def native_to_pa_array_override(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Mat4x4, Mat4x4Like
+        from . import Mat4x4
 
-        # Normalize into list of Mat4x4
-        if isinstance(data, Sequence):
-            # single matrix made up of flat float array.
-            if len(data) > 0 and (isinstance(data[0], float) or isinstance(data[0], int)):
-                matrices = [Mat4x4(cast(Mat4x4Like, data))]
-            # if there's a sequence nested, either it's several matrices in various formats
-            # where the first happens to be either a flat or nested sequence of floats,
-            # or it's a single matrix with a nested sequence of floats.
-            # for that to be true, the nested sequence must be 4 floats.
-            elif (
-                isinstance(data[0], Sequence)
-                and len(data[0]) == 4
-                and all((isinstance(elem, float) or isinstance(elem, int)) for elem in data[0])
-            ):
-                matrices = [Mat4x4(cast(Mat4x4Like, data))]
-            # several matrices otherwise!
-            else:
-                matrices = [Mat4x4(m) for m in data]
+        if isinstance(data, Mat4x4):
+            matrices = [data]
+        elif len(data) == 0:
+            matrices = []
         else:
-            matrices = [Mat4x4(data)]
+            try:
+                # Try to convert it to a single Mat4x4
+                # Will raise ValueError if the wrong shape
+                matrices = [Mat4x4(data)]  # type: ignore[arg-type]
+            except ValueError:
+                # Otherwise try to convert it to a single Mat4x4
+                # Let this value error propagate as the fallback
+                matrices = [Mat4x4(d) for d in data]
 
         float_arrays = np.asarray([matrix.flat_columns for matrix in matrices], dtype=np.float32).reshape(-1)
         return pa.FixedSizeListArray.from_arrays(float_arrays, type=data_type)


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/3417

The old Matrix constructors did explicit checks for float / int that were too restrictive compared to what numpy will handle.

Also, Sequence[float] and Sequence[Sequence[float]] are redundant with ArrayLike, so I removed them.

This uses a try/catch on the MatNxN constructors to first try constructing as a single array and then as a batch.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3505) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3505)
- [Docs preview](https://rerun.io/preview/9b7192ac90226d14e2c081b7bc4bd2ed3c2b4ad0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9b7192ac90226d14e2c081b7bc4bd2ed3c2b4ad0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)