### PR TITLE
Make ColorBatch constructor more forgiving

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/color.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/color.fbs
@@ -19,7 +19,7 @@ namespace rerun.datatypes;
 struct Color (
   "attr.arrow.transparent",
   "attr.python.aliases": "int, Sequence[Union[int, float]], npt.NDArray[Union[np.uint8, np.float32, np.float64]]",
-  "attr.python.array_aliases": "int,  Sequence[Union[int, float]], Sequence[Sequence[Union[int, float]]], npt.NDArray[Union[np.uint8, np.uint32, np.float32, np.float64]]",
+  "attr.python.array_aliases": "int, npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct",

--- a/rerun_py/rerun_sdk/rerun/datatypes/color.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/color.py
@@ -54,14 +54,7 @@ if TYPE_CHECKING:
 else:
     ColorLike = Any
 
-ColorArrayLike = Union[
-    Color,
-    Sequence[ColorLike],
-    int,
-    Sequence[Union[int, float]],
-    Sequence[Sequence[Union[int, float]]],
-    npt.NDArray[Union[np.uint8, np.uint32, np.float32, np.float64]],
-]
+ColorArrayLike = Union[Color, Sequence[ColorLike], int, npt.ArrayLike]
 
 
 class ColorType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/color_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/color_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Union, cast
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -60,36 +60,46 @@ class ColorExt:
     def native_to_pa_array_override(data: ColorArrayLike, data_type: pa.DataType) -> pa.Array:
         from . import Color
 
-        if isinstance(data, (Color, int)):
-            data = [data]
-
-        if isinstance(data, np.ndarray):
-            if data.dtype == np.uint32:
-                # these are already packed values
-                array = data.flatten()
-            else:
-                # these are component values
-                if len(data.shape) == 1:
-                    if data.size > 4:
-                        # multiple RGBA colors
-                        data = data.reshape((-1, 4))
-                    else:
-                        # a single color
-                        data = data.reshape((1, -1))
-                array = _numpy_array_to_u32(cast(npt.NDArray[Union[np.uint8, np.float32, np.float64]], data))
+        if isinstance(data, int) or isinstance(data, Color):
+            # A single packed int or Color (which implements __int__())
+            int_array = np.array([data])
+        elif isinstance(data, Sequence) and len(data) == 0:
+            # An empty array
+            int_array = np.array([])
         else:
-            # Finally try to build a single color with the arguments
-            # if we cannot, data must represent an array of colors
-            data_list = list(data)
-
+            # Try to coerce it to a numpy array
             try:
-                data_list = [Color(data_list)]  # type: ignore[arg-type]
-            except (IndexError, ValueError):
-                pass
+                arr = np.asarray(data)
 
-            # Handle heterogeneous sequence of Color-like object, such as Color instances, ints, sub-sequence, etc.
-            # Note how this is simplified by the flexible implementation of `Color`, thanks to its converter function and
-            # the auto-generated `__int__()` method.
-            array = np.array([Color(datum) for datum in data_list], np.uint32)  # type: ignore[arg-type]
+                if arr.dtype == np.uint32:
+                    # these are already packed values
+                    int_array = arr.flatten()
+                else:
+                    # these are component values
+                    if len(arr.shape) == 1:
+                        if arr.size > 4:
+                            # multiple RGBA colors
+                            arr = arr.reshape((-1, 4))
+                        else:
+                            # a single color
+                            arr = arr.reshape((1, -1))
+                    int_array = _numpy_array_to_u32(arr)
+            except (ValueError, TypeError, IndexError):
+                # Fallback support
+                data_list = list(data)  # type: ignore[arg-type]
 
-        return pa.array(array, type=data_type)
+                # First try to coerce it to a single Color instance
+                try:
+                    data_list = [Color(data_list)]  # type: ignore[arg-type]
+                except (IndexError, ValueError):
+                    pass
+
+                # Fially, handle heterogeneous sequence of Color-like object,
+                # such as Color instances, ints, sub-sequence, etc.
+                #
+                # Note how this is simplified by the flexible implementation of
+                # `Color`, thanks to its converter function and the
+                # auto-generated `__int__()` method.
+                int_array = np.array([Color(datum) for datum in data_list], np.uint32)  # type: ignore[arg-type]
+
+        return pa.array(int_array, type=data_type)


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/3478

Avoid using `isinstance(np.array)` in favor of simply trying to call `asarray` and catching the ValueError.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3507) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3507)
- [Docs preview](https://rerun.io/preview/188ec45a30b683ad2da74e466d183085747042d0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/188ec45a30b683ad2da74e466d183085747042d0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)