### PR TITLE
Consistent naming for instantiated recording streams

### DIFF
--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -8,12 +8,12 @@ namespace rr = rerun;
 namespace rrd = rr::datatypes;
 
 int main() {
-    auto rr_stream = rr::RecordingStream("rerun_example_text_document");
-    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
+    auto rec = rr::RecordingStream("rerun_example_text_document");
+    rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    rr_stream.log("text_document", rr::archetypes::TextDocument("Hello, TextDocument!"));
+    rec.log("text_document", rr::archetypes::TextDocument("Hello, TextDocument!"));
 
-    rr_stream.log(
+    rec.log(
         "markdown",
         rr::archetypes::TextDocument(R"#(# Hello Markdown!
 [Click here to see the raw text](recording://markdown.Text).

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -8,10 +8,10 @@ namespace rr = rerun;
 namespace rrd = rr::datatypes;
 
 int main() {
-    auto rr_stream = rr::RecordingStream("rerun_example_text_log");
-    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
+    auto rec = rr::RecordingStream("rerun_example_text_log");
+    rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    rr_stream.log(
+    rec.log(
         "log",
         rr::archetypes::TextLog("Application started.")
             .with_level(rr::components::TextLogLevel::INFO)

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -13,11 +13,11 @@ int main(int argc, char** argv) {
 
     LOG_F(INFO, "Rerun C++ SDK version: %s", rr::version_string());
 
-    auto rr_stream = rr::RecordingStream("rerun_example_cpp_app");
-    rr_stream.connect("127.0.0.1:9876").throw_on_failure();
+    auto rec = rr::RecordingStream("rerun_example_cpp_app");
+    rec.connect("127.0.0.1:9876").throw_on_failure();
 
     // Log points with the archetype api - this is the preferred way of logging.
-    rr_stream.log(
+    rec.log(
         "3d/points",
         rr::Points3D({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}})
             .with_radii({0.42f, 0.43f})
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
     // Log points with the components api - this is the advanced way of logging components in a
     // fine-grained matter. It supports passing various types of containers.
     rrc::Text c_style_array[3] = {rrc::Text("hello"), rrc::Text("friend"), rrc::Text("yo")};
-    rr_stream.log_component_batches(
+    rec.log_component_batches(
         "2d/points",
         3,
         std::vector{

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -102,6 +102,9 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if any_todo_pattern.search(line) and not legal_todo_inner_pattern.search(line):
         return "TODOs should be formatted as either TODO(name), TODO(#42) or TODO(org/repo#42)"
 
+    if "rec_stream" in line or "rr_stream" in line:
+        return "Instantiated RecordingStreams should be named `rec`"
+
     return None
 
 
@@ -138,6 +141,7 @@ def test_lint_line() -> None:
         "instances_count",
         "let Some(foo) = bar else { return; };",
         "{foo:?}",
+        "rec",
     ]
 
     should_error = [
@@ -166,6 +170,8 @@ def test_lint_line() -> None:
         r'println!("Problem: \"{0}\"")',
         r'println!("Problem: \"{string}\"")',
         "trailing whitespace ",
+        "rr_stream",
+        "rec_stream",
     ]
 
     for line in should_pass:

--- a/tests/cpp/roundtrips/text_document/main.cpp
+++ b/tests/cpp/roundtrips/text_document/main.cpp
@@ -3,10 +3,10 @@
 namespace rr = rerun;
 
 int main(int argc, char** argv) {
-    auto rr_stream = rr::RecordingStream("rerun_example_text_document");
-    rr_stream.save(argv[1]).throw_on_failure();
-    rr_stream.log("text_document", rr::archetypes::TextDocument("Hello, TextDocument!"));
-    rr_stream.log(
+    auto rec = rr::RecordingStream("rerun_example_text_document");
+    rec.save(argv[1]).throw_on_failure();
+    rec.log("text_document", rr::archetypes::TextDocument("Hello, TextDocument!"));
+    rec.log(
         "markdown",
         rr::archetypes::TextDocument("# Hello\n"
                                      "Markdown with `code`!\n"

--- a/tests/cpp/roundtrips/text_log/main.cpp
+++ b/tests/cpp/roundtrips/text_log/main.cpp
@@ -3,12 +3,12 @@
 namespace rr = rerun;
 
 int main(int argc, char** argv) {
-    auto rr_stream = rr::RecordingStream("rerun_example_roundtrip_text_log");
-    rr_stream.save(argv[1]).throw_on_failure();
-    rr_stream.log("log", rr::archetypes::TextLog("No level"));
-    rr_stream.log(
+    auto rec = rr::RecordingStream("rerun_example_roundtrip_text_log");
+    rec.save(argv[1]).throw_on_failure();
+    rec.log("log", rr::archetypes::TextLog("No level"));
+    rec.log(
         "log",
         rr::archetypes::TextLog("INFO level").with_level(rr::components::TextLogLevel::INFO)
     );
-    rr_stream.log("log", rr::archetypes::TextLog("WILD level").with_level("WILD"));
+    rec.log("log", rr::archetypes::TextLog("WILD level").with_level("WILD"));
 }

--- a/tests/cpp/roundtrips/view_coordinates/main.cpp
+++ b/tests/cpp/roundtrips/view_coordinates/main.cpp
@@ -3,7 +3,7 @@
 namespace rr = rerun;
 
 int main(int argc, char** argv) {
-    auto rr_stream = rr::RecordingStream("rerun_example_roundtrip_view_coordinates");
-    rr_stream.save(argv[1]).throw_on_failure();
-    rr_stream.log("/", rr::archetypes::ViewCoordinates::RDF);
+    auto rec = rr::RecordingStream("rerun_example_roundtrip_view_coordinates");
+    rec.save(argv[1]).throw_on_failure();
+    rec.log("/", rr::archetypes::ViewCoordinates::RDF);
 }


### PR DESCRIPTION
Title.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3509) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3509)
- [Docs preview](https://rerun.io/preview/fd1616a5df6a1947d1ac47bcbf04e4f8ca0e6496/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fd1616a5df6a1947d1ac47bcbf04e4f8ca0e6496/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)