### PR TITLE
Rename Asset3D.data → blob, TextLog.body & TextDocument.body → text

### DIFF
--- a/crates/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/re_space_view_spatial/src/mesh_loader.rs
@@ -67,14 +67,14 @@ impl LoadedMesh {
         re_tracing::profile_function!();
 
         let Asset3D {
-            data,
+            blob,
             media_type,
             transform: _,
         } = asset3d;
 
-        let media_type = MediaType::or_guess_from_data(media_type.clone(), data.0.as_slice())
+        let media_type = MediaType::or_guess_from_data(media_type.clone(), blob.0.as_slice())
             .ok_or_else(|| anyhow::anyhow!("couldn't guess media type"))?;
-        let slf = Self::load_asset3d_parts(name, &media_type, data.0.as_slice(), render_ctx)?;
+        let slf = Self::load_asset3d_parts(name, &media_type, blob.0.as_slice(), render_ctx)?;
 
         Ok(slf)
     }

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -41,7 +41,7 @@ impl Asset3DPart {
         let media_type = arch_view.raw_optional_mono_component::<MediaType>()?;
 
         let mesh = Asset3D {
-            data: arch_view.required_mono_component::<Blob>()?,
+            blob: arch_view.required_mono_component::<Blob>()?,
             media_type: media_type.clone(),
             // NOTE: Don't even try to cache the transform!
             transform: None,

--- a/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
@@ -18,7 +18,7 @@ table Asset3D (
   // --- Required ---
 
   /// The asset's bytes.
-  data: rerun.components.Blob ("attr.rerun.component_required", order: 1000);
+  blob: rerun.components.Blob ("attr.rerun.component_required", order: 1000);
 
   // --- Recommended ---
 
@@ -28,7 +28,7 @@ table Asset3D (
   /// * `model/gltf-binary`
   /// * `model/obj`
   ///
-  /// If omitted, the viewer will try to guess from the data.
+  /// If omitted, the viewer will try to guess from the data blob.
   /// If it cannot guess, it won't be able to render the asset.
   media_type: rerun.components.MediaType  ("attr.rerun.component_recommended", nullable, order: 2000);
 

--- a/crates/re_types/definitions/rerun/archetypes/boxes2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/boxes2d.fbs
@@ -30,7 +30,7 @@ table Boxes2D (
 
   // TODO(#3247): Add 2D rotation.
   // Optional rotations of the boxes.
-  //rotations: [rerun.components.Rotation2D] ("attr.rerun.component_recommended", nullable, order: 2000);
+  //rotations: [rerun.components.Rotation2D] ("attr.rerun.component_recommended", nullable, order: 2050);
 
   /// Optional colors for the boxes.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
@@ -38,7 +38,7 @@ table Boxes2D (
   // --- Optional ---
 
   /// Optional radii for the lines that make up the boxes.
-  radii: [rerun.components.Radius] ("attr.rerun.component_optional", nullable, order: 2000);
+  radii: [rerun.components.Radius] ("attr.rerun.component_optional", nullable, order: 2500);
 
   /// Optional text labels for the boxes.
   labels: [rerun.components.Text] ("attr.rerun.component_optional", nullable, order: 3000);

--- a/crates/re_types/definitions/rerun/archetypes/text_document.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/text_document.fbs
@@ -13,7 +13,7 @@ table TextDocument (
   order: 100
 ) {
   /// Contents of the text document.
-  body: rerun.components.Text ("attr.rerun.component_required", order: 100);
+  text: rerun.components.Text ("attr.rerun.component_required", order: 100);
 
   /// The Media Type of the text.
   ///

--- a/crates/re_types/definitions/rerun/archetypes/text_document.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/text_document.fbs
@@ -22,5 +22,5 @@ table TextDocument (
   /// * `text/markdown`
   ///
   /// If omitted, `text/plain` is assumed.
-  media_type: rerun.components.MediaType ("attr.rerun.component_optional", nullable, order: 100);
+  media_type: rerun.components.MediaType ("attr.rerun.component_optional", nullable, order: 200);
 }

--- a/crates/re_types/definitions/rerun/archetypes/text_log.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/text_log.fbs
@@ -12,7 +12,7 @@ table TextLog (
   "attr.rust.derive": "PartialEq, Eq",
   order: 100
 ) {
-  body: rerun.components.Text ("attr.rerun.component_required", order: 100);
+  text: rerun.components.Text ("attr.rerun.component_required", order: 100);
   level: rerun.components.TextLogLevel ("attr.rerun.component_recommended", nullable, order: 200);
   color: rerun.components.Color (nullable, order: 300);
 }

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -95,7 +95,7 @@
 #[derive(Clone, Debug, PartialEq)]
 pub struct Asset3D {
     /// The asset's bytes.
-    pub data: crate::components::Blob,
+    pub blob: crate::components::Blob,
 
     /// The Media Type of the asset.
     ///
@@ -103,7 +103,7 @@ pub struct Asset3D {
     /// * `model/gltf-binary`
     /// * `model/obj`
     ///
-    /// If omitted, the viewer will try to guess from the data.
+    /// If omitted, the viewer will try to guess from the data blob.
     /// If it cannot guess, it won't be able to render the asset.
     pub media_type: Option<crate::components::MediaType>,
 
@@ -195,18 +195,18 @@ impl crate::Archetype for Asset3D {
             .into_iter()
             .map(|(field, array)| (field.name, array))
             .collect();
-        let data = {
+        let blob = {
             let array = arrays_by_name
                 .get("rerun.components.Blob")
                 .ok_or_else(crate::DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Asset3D#data")?;
+                .with_context("rerun.archetypes.Asset3D#blob")?;
             <crate::components::Blob>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Asset3D#data")?
+                .with_context("rerun.archetypes.Asset3D#blob")?
                 .into_iter()
                 .next()
                 .flatten()
                 .ok_or_else(crate::DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Asset3D#data")?
+                .with_context("rerun.archetypes.Asset3D#blob")?
         };
         let media_type = if let Some(array) = arrays_by_name.get("rerun.components.MediaType") {
             Some({
@@ -236,7 +236,7 @@ impl crate::Archetype for Asset3D {
                 None
             };
         Ok(Self {
-            data,
+            blob,
             media_type,
             transform,
         })
@@ -248,7 +248,7 @@ impl crate::AsComponents for Asset3D {
         use crate::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.data as &dyn crate::ComponentBatch).into()),
+            Some((&self.blob as &dyn crate::ComponentBatch).into()),
             self.media_type
                 .as_ref()
                 .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
@@ -268,9 +268,9 @@ impl crate::AsComponents for Asset3D {
 }
 
 impl Asset3D {
-    pub fn new(data: impl Into<crate::components::Blob>) -> Self {
+    pub fn new(blob: impl Into<crate::components::Blob>) -> Self {
         Self {
-            data: data.into(),
+            blob: blob.into(),
             media_type: None,
             transform: None,
         }

--- a/crates/re_types/src/archetypes/asset3d_ext.rs
+++ b/crates/re_types/src/archetypes/asset3d_ext.rs
@@ -31,7 +31,7 @@ impl Asset3D {
         let bytes = bytes.as_ref();
         let media_type = media_type.map(Into::into);
         Self {
-            data: bytes.to_vec().into(),
+            blob: bytes.to_vec().into(),
             media_type: MediaType::or_guess_from_data(media_type, bytes),
             transform: None,
         }

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -47,11 +47,11 @@ pub struct Boxes2D {
     /// Optional center positions of the boxes.
     pub centers: Option<Vec<crate::components::Position2D>>,
 
-    /// Optional radii for the lines that make up the boxes.
-    pub radii: Option<Vec<crate::components::Radius>>,
-
     /// Optional colors for the boxes.
     pub colors: Option<Vec<crate::components::Color>>,
+
+    /// Optional radii for the lines that make up the boxes.
+    pub radii: Option<Vec<crate::components::Radius>>,
 
     /// Optional text labels for the boxes.
     pub labels: Option<Vec<crate::components::Text>>,
@@ -185,18 +185,6 @@ impl crate::Archetype for Boxes2D {
         } else {
             None
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
-            Some({
-                <crate::components::Radius>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Boxes2D#radii")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(crate::DeserializationError::missing_data))
-                    .collect::<crate::DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Boxes2D#radii")?
-            })
-        } else {
-            None
-        };
         let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
@@ -205,6 +193,18 @@ impl crate::Archetype for Boxes2D {
                     .map(|v| v.ok_or_else(crate::DeserializationError::missing_data))
                     .collect::<crate::DeserializationResult<Vec<_>>>()
                     .with_context("rerun.archetypes.Boxes2D#colors")?
+            })
+        } else {
+            None
+        };
+        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+            Some({
+                <crate::components::Radius>::from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.Boxes2D#radii")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(crate::DeserializationError::missing_data))
+                    .collect::<crate::DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.archetypes.Boxes2D#radii")?
             })
         } else {
             None
@@ -262,8 +262,8 @@ impl crate::Archetype for Boxes2D {
         Ok(Self {
             half_sizes,
             centers,
-            radii,
             colors,
+            radii,
             labels,
             draw_order,
             class_ids,
@@ -281,10 +281,10 @@ impl crate::AsComponents for Boxes2D {
             self.centers
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
-            self.radii
+            self.colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
-            self.colors
+            self.radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn crate::ComponentBatch).into()),
             self.labels
@@ -318,8 +318,8 @@ impl Boxes2D {
         Self {
             half_sizes: half_sizes.into_iter().map(Into::into).collect(),
             centers: None,
-            radii: None,
             colors: None,
+            radii: None,
             labels: None,
             draw_order: None,
             class_ids: None,
@@ -335,19 +335,19 @@ impl Boxes2D {
         self
     }
 
-    pub fn with_radii(
-        mut self,
-        radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
-    ) -> Self {
-        self.radii = Some(radii.into_iter().map(Into::into).collect());
-        self
-    }
-
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
     ) -> Self {
         self.colors = Some(colors.into_iter().map(Into::into).collect());
+        self
+    }
+
+    pub fn with_radii(
+        mut self,
+        radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
+    ) -> Self {
+        self.radii = Some(radii.into_iter().map(Into::into).collect());
         self
     }
 

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -18,7 +18,7 @@
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextDocument {
     /// Contents of the text document.
-    pub body: crate::components::Text,
+    pub text: crate::components::Text,
 
     /// The Media Type of the text.
     ///
@@ -106,18 +106,18 @@ impl crate::Archetype for TextDocument {
             .into_iter()
             .map(|(field, array)| (field.name, array))
             .collect();
-        let body = {
+        let text = {
             let array = arrays_by_name
                 .get("rerun.components.Text")
                 .ok_or_else(crate::DeserializationError::missing_data)
-                .with_context("rerun.archetypes.TextDocument#body")?;
+                .with_context("rerun.archetypes.TextDocument#text")?;
             <crate::components::Text>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.TextDocument#body")?
+                .with_context("rerun.archetypes.TextDocument#text")?
                 .into_iter()
                 .next()
                 .flatten()
                 .ok_or_else(crate::DeserializationError::missing_data)
-                .with_context("rerun.archetypes.TextDocument#body")?
+                .with_context("rerun.archetypes.TextDocument#text")?
         };
         let media_type = if let Some(array) = arrays_by_name.get("rerun.components.MediaType") {
             Some({
@@ -132,7 +132,7 @@ impl crate::Archetype for TextDocument {
         } else {
             None
         };
-        Ok(Self { body, media_type })
+        Ok(Self { text, media_type })
     }
 }
 
@@ -141,7 +141,7 @@ impl crate::AsComponents for TextDocument {
         use crate::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.body as &dyn crate::ComponentBatch).into()),
+            Some((&self.text as &dyn crate::ComponentBatch).into()),
             self.media_type
                 .as_ref()
                 .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
@@ -158,9 +158,9 @@ impl crate::AsComponents for TextDocument {
 }
 
 impl TextDocument {
-    pub fn new(body: impl Into<crate::components::Text>) -> Self {
+    pub fn new(text: impl Into<crate::components::Text>) -> Self {
         Self {
-            body: body.into(),
+            text: text.into(),
             media_type: None,
         }
     }

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -17,7 +17,7 @@
 /// A log entry in a text log, comprised of a text body and its log level.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextLog {
-    pub body: crate::components::Text,
+    pub text: crate::components::Text,
     pub level: Option<crate::components::TextLogLevel>,
     pub color: Option<crate::components::Color>,
 }
@@ -98,18 +98,18 @@ impl crate::Archetype for TextLog {
             .into_iter()
             .map(|(field, array)| (field.name, array))
             .collect();
-        let body = {
+        let text = {
             let array = arrays_by_name
                 .get("rerun.components.Text")
                 .ok_or_else(crate::DeserializationError::missing_data)
-                .with_context("rerun.archetypes.TextLog#body")?;
+                .with_context("rerun.archetypes.TextLog#text")?;
             <crate::components::Text>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.TextLog#body")?
+                .with_context("rerun.archetypes.TextLog#text")?
                 .into_iter()
                 .next()
                 .flatten()
                 .ok_or_else(crate::DeserializationError::missing_data)
-                .with_context("rerun.archetypes.TextLog#body")?
+                .with_context("rerun.archetypes.TextLog#text")?
         };
         let level = if let Some(array) = arrays_by_name.get("rerun.components.TextLogLevel") {
             Some({
@@ -137,7 +137,7 @@ impl crate::Archetype for TextLog {
         } else {
             None
         };
-        Ok(Self { body, level, color })
+        Ok(Self { text, level, color })
     }
 }
 
@@ -146,7 +146,7 @@ impl crate::AsComponents for TextLog {
         use crate::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.body as &dyn crate::ComponentBatch).into()),
+            Some((&self.text as &dyn crate::ComponentBatch).into()),
             self.level
                 .as_ref()
                 .map(|comp| (comp as &dyn crate::ComponentBatch).into()),
@@ -166,9 +166,9 @@ impl crate::AsComponents for TextLog {
 }
 
 impl TextLog {
-    pub fn new(body: impl Into<crate::components::Text>) -> Self {
+    pub fn new(text: impl Into<crate::components::Text>) -> Self {
         Self {
-            body: body.into(),
+            text: text.into(),
             level: None,
             color: None,
         }

--- a/crates/re_types/tests/asset3d.rs
+++ b/crates/re_types/tests/asset3d.rs
@@ -14,7 +14,7 @@ fn roundtrip() {
     const BYTES: &[u8] = &[1, 2, 3, 4, 5, 6];
 
     let expected = Asset3D {
-        data: Blob(BYTES.to_vec().into()),
+        blob: Blob(BYTES.to_vec().into()),
         media_type: Some(MediaType(Utf8(MediaType::GLTF.into()))),
         transform: Some(OutOfTreeTransform3D(
             re_types::datatypes::Transform3D::TranslationRotationScale(

--- a/crates/re_types/tests/text_document.rs
+++ b/crates/re_types/tests/text_document.rs
@@ -7,7 +7,7 @@ use re_types::{
 #[test]
 fn roundtrip() {
     let expected = TextDocument {
-        body: "This is the contents of the text document.".into(),
+        text: "This is the contents of the text document.".into(),
         media_type: Some(MediaType::markdown()),
     };
 
@@ -16,7 +16,7 @@ fn roundtrip() {
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
-        ("body", vec!["rerun.components.Text"]),
+        ("text", vec!["rerun.components.Text"]),
         ("media_type", vec!["rerun.components.MediaType"]),
     ]
     .into();

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -460,6 +460,16 @@ impl Object {
                 })
                 .collect();
             fields.sort_by_key(|field| field.order);
+
+            for (a, b) in fields.iter().tuple_windows() {
+                assert!(
+                    a.order != b.order,
+                    "{name:?}: Fields {:?} and {:?} have the same order",
+                    a.name,
+                    b.name
+                );
+            }
+
             fields
         };
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -461,6 +461,7 @@ impl Object {
                 .collect();
             fields.sort_by_key(|field| field.order);
 
+            // Make sure no two fields have the same order:
             for (a, b) in fields.iter().tuple_windows() {
                 assert!(
                     a.order != b.order,

--- a/docs/code-examples/text_log.py
+++ b/docs/code-examples/text_log.py
@@ -6,4 +6,4 @@ import rerun as rr
 rr.init("rerun_example_text_log", spawn=True)
 
 # TODO(emilk): show how to hook up to the log stream.
-rr.log("log", rr.TextLog(body="Application started.", level="INFO"))
+rr.log("log", rr.TextLog("Application started.", level="INFO"))

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(3);
 
-            comp_batches.emplace_back(data);
+            comp_batches.emplace_back(blob);
             if (media_type.has_value()) {
                 comp_batches.emplace_back(media_type.value());
             }

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -57,7 +57,7 @@ namespace rerun {
         /// ```
         struct Asset3D {
             /// The asset's bytes.
-            rerun::components::Blob data;
+            rerun::components::Blob blob;
 
             /// The Media Type of the asset.
             ///
@@ -65,7 +65,7 @@ namespace rerun {
             /// * `model/gltf-binary`
             /// * `model/obj`
             ///
-            /// If omitted, the viewer will try to guess from the data.
+            /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
             std::optional<rerun::components::MediaType> media_type;
 
@@ -137,7 +137,7 @@ namespace rerun {
           public:
             Asset3D() = default;
 
-            Asset3D(rerun::components::Blob _data) : data(std::move(_data)) {}
+            Asset3D(rerun::components::Blob _blob) : blob(std::move(_blob)) {}
 
             /// The Media Type of the asset.
             ///
@@ -145,7 +145,7 @@ namespace rerun {
             /// * `model/gltf-binary`
             /// * `model/obj`
             ///
-            /// If omitted, the viewer will try to guess from the data.
+            /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
             Asset3D& with_media_type(rerun::components::MediaType _media_type) {
                 media_type = std::move(_media_type);

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -22,11 +22,11 @@ namespace rerun {
             if (centers.has_value()) {
                 comp_batches.emplace_back(centers.value());
             }
-            if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
-            }
             if (colors.has_value()) {
                 comp_batches.emplace_back(colors.value());
+            }
+            if (radii.has_value()) {
+                comp_batches.emplace_back(radii.value());
             }
             if (labels.has_value()) {
                 comp_batches.emplace_back(labels.value());

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -53,11 +53,11 @@ namespace rerun {
             /// Optional center positions of the boxes.
             std::optional<std::vector<rerun::components::Position2D>> centers;
 
-            /// Optional radii for the lines that make up the boxes.
-            std::optional<std::vector<rerun::components::Radius>> radii;
-
             /// Optional colors for the boxes.
             std::optional<std::vector<rerun::components::Color>> colors;
+
+            /// Optional radii for the lines that make up the boxes.
+            std::optional<std::vector<rerun::components::Radius>> radii;
 
             /// Optional text labels for the boxes.
             std::optional<std::vector<rerun::components::Text>> labels;
@@ -142,18 +142,6 @@ namespace rerun {
                 return *this;
             }
 
-            /// Optional radii for the lines that make up the boxes.
-            Boxes2D& with_radii(std::vector<rerun::components::Radius> _radii) {
-                radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the lines that make up the boxes.
-            Boxes2D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
-            }
-
             /// Optional colors for the boxes.
             Boxes2D& with_colors(std::vector<rerun::components::Color> _colors) {
                 colors = std::move(_colors);
@@ -163,6 +151,18 @@ namespace rerun {
             /// Optional colors for the boxes.
             Boxes2D& with_colors(rerun::components::Color _colors) {
                 colors = std::vector(1, std::move(_colors));
+                return *this;
+            }
+
+            /// Optional radii for the lines that make up the boxes.
+            Boxes2D& with_radii(std::vector<rerun::components::Radius> _radii) {
+                radii = std::move(_radii);
+                return *this;
+            }
+
+            /// Optional radii for the lines that make up the boxes.
+            Boxes2D& with_radii(rerun::components::Radius _radii) {
+                radii = std::vector(1, std::move(_radii));
                 return *this;
             }
 

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(2);
 
-            comp_batches.emplace_back(body);
+            comp_batches.emplace_back(text);
             if (media_type.has_value()) {
                 comp_batches.emplace_back(media_type.value());
             }

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -20,7 +20,7 @@ namespace rerun {
         /// A text element intended to be displayed in its own text-box.
         struct TextDocument {
             /// Contents of the text document.
-            rerun::components::Text body;
+            rerun::components::Text text;
 
             /// The Media Type of the text.
             ///
@@ -38,7 +38,7 @@ namespace rerun {
           public:
             TextDocument() = default;
 
-            TextDocument(rerun::components::Text _body) : body(std::move(_body)) {}
+            TextDocument(rerun::components::Text _text) : text(std::move(_text)) {}
 
             /// The Media Type of the text.
             ///

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             std::vector<AnonymousComponentBatch> comp_batches;
             comp_batches.reserve(3);
 
-            comp_batches.emplace_back(body);
+            comp_batches.emplace_back(text);
             if (level.has_value()) {
                 comp_batches.emplace_back(level.value());
             }

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -20,7 +20,7 @@ namespace rerun {
     namespace archetypes {
         /// A log entry in a text log, comprised of a text body and its log level.
         struct TextLog {
-            rerun::components::Text body;
+            rerun::components::Text text;
 
             std::optional<rerun::components::TextLogLevel> level;
 
@@ -33,7 +33,7 @@ namespace rerun {
           public:
             TextLog() = default;
 
-            TextLog(rerun::components::Text _body) : body(std::move(_body)) {}
+            TextLog(rerun::components::Text _text) : text(std::move(_text)) {}
 
             TextLog& with_level(rerun::components::TextLogLevel _level) {
                 level = std::move(_level);

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -75,7 +75,7 @@ class Asset3D(Asset3DExt, Archetype):
 
     def __init__(
         self: Any,
-        data: components.BlobLike,
+        blob: components.BlobLike,
         media_type: datatypes.Utf8Like | None = None,
         transform: datatypes.Transform3DLike | None = None,
     ):
@@ -84,7 +84,7 @@ class Asset3D(Asset3DExt, Archetype):
 
         Parameters
         ----------
-        data:
+        blob:
              The asset's bytes.
         media_type:
              The Media Type of the asset.
@@ -93,7 +93,7 @@ class Asset3D(Asset3DExt, Archetype):
              * `model/gltf-binary`
              * `model/obj`
 
-             If omitted, the viewer will try to guess from the data.
+             If omitted, the viewer will try to guess from the data blob.
              If it cannot guess, it won't be able to render the asset.
         transform:
              An out-of-tree transform.
@@ -102,9 +102,9 @@ class Asset3D(Asset3DExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of Asset3DExt in asset3d_ext.py
-        self.__attrs_init__(data=data, media_type=media_type, transform=transform)
+        self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
 
-    data: components.BlobBatch = field(
+    blob: components.BlobBatch = field(
         metadata={"component": "required"},
         converter=components.BlobBatch,  # type: ignore[misc]
     )
@@ -124,7 +124,7 @@ class Asset3D(Asset3DExt, Archetype):
     * `model/gltf-binary`
     * `model/obj`
 
-    If omitted, the viewer will try to guess from the data.
+    If omitted, the viewer will try to guess from the data blob.
     If it cannot guess, it won't be able to render the asset.
     """
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
@@ -40,7 +40,7 @@ class Asset3DExt:
             return Asset3D.from_bytes(file.read(), guess_media_type(path))
 
     @staticmethod
-    def from_bytes(data: bytes, media_type: MediaType | None) -> Asset3D:
+    def from_bytes(blob: bytes, media_type: MediaType | None) -> Asset3D:
         """
         Creates a new [`Asset3D`] from the given `bytes`.
 
@@ -50,4 +50,4 @@ class Asset3DExt:
         from . import Asset3D
 
         # TODO(cmc): we could try and guess using magic bytes here, like rust does.
-        return Asset3D(data=data, media_type=media_type)
+        return Asset3D(blob=blob, media_type=media_type)

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -53,15 +53,6 @@ class Boxes2D(Boxes2DExt, Archetype):
     Optional center positions of the boxes.
     """
 
-    radii: components.RadiusBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.RadiusBatch._optional,  # type: ignore[misc]
-    )
-    """
-    Optional radii for the lines that make up the boxes.
-    """
-
     colors: components.ColorBatch | None = field(
         metadata={"component": "optional"},
         default=None,
@@ -69,6 +60,15 @@ class Boxes2D(Boxes2DExt, Archetype):
     )
     """
     Optional colors for the boxes.
+    """
+
+    radii: components.RadiusBatch | None = field(
+        metadata={"component": "optional"},
+        default=None,
+        converter=components.RadiusBatch._optional,  # type: ignore[misc]
+    )
+    """
+    Optional radii for the lines that make up the boxes.
     """
 
     labels: components.TextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -19,13 +19,13 @@ __all__ = ["TextDocument"]
 class TextDocument(Archetype):
     """A text element intended to be displayed in its own text-box."""
 
-    def __init__(self: Any, body: datatypes.Utf8Like, media_type: datatypes.Utf8Like | None = None):
+    def __init__(self: Any, text: datatypes.Utf8Like, media_type: datatypes.Utf8Like | None = None):
         """
         Create a new instance of the TextDocument archetype.
 
         Parameters
         ----------
-        body:
+        text:
              Contents of the text document.
         media_type:
              The Media Type of the text.
@@ -38,9 +38,9 @@ class TextDocument(Archetype):
         """
 
         # You can define your own __init__ function as a member of TextDocumentExt in text_document_ext.py
-        self.__attrs_init__(body=body, media_type=media_type)
+        self.__attrs_init__(text=text, media_type=media_type)
 
-    body: components.TextBatch = field(
+    text: components.TextBatch = field(
         metadata={"component": "required"},
         converter=components.TextBatch,  # type: ignore[misc]
     )

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -21,16 +21,16 @@ class TextLog(Archetype):
 
     def __init__(
         self: Any,
-        body: datatypes.Utf8Like,
+        text: datatypes.Utf8Like,
         level: datatypes.Utf8Like | None = None,
         color: datatypes.ColorLike | None = None,
     ):
         """Create a new instance of the TextLog archetype."""
 
         # You can define your own __init__ function as a member of TextLogExt in text_log_ext.py
-        self.__attrs_init__(body=body, level=level, color=color)
+        self.__attrs_init__(text=text, level=level, color=color)
 
-    body: components.TextBatch = field(
+    text: components.TextBatch = field(
         metadata={"component": "required"},
         converter=components.TextBatch,  # type: ignore[misc]
     )

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -38,5 +38,5 @@ def _send_warning(
     context_descriptor = _build_warning_context_string(skip_first=depth_to_user_code + 2)
     warning = f"{message}\n{context_descriptor}"
 
-    log("rerun", TextLog(body=warning, level="WARN"), recording=recording)
+    log("rerun", TextLog(warning, level="WARN"), recording=recording)
     logging.warning(warning)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/log_decorator.py
@@ -52,7 +52,7 @@ def log_decorator(func: _TFunc) -> _TFunc:
                 return func(*args, **kwargs)
             except Exception as e:
                 warning = "".join(traceback.format_exception(e.__class__, e, e.__traceback__))
-                log("rerun", TextLog(body=warning, level="WARN"), recording=recording)
+                log("rerun", TextLog(warning, level="WARN"), recording=recording)
                 warnings.warn(f"Ignoring rerun log call: {warning}", category=RerunWarning, stacklevel=2)
 
     return cast(_TFunc, wrapper)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/text.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/text.py
@@ -106,6 +106,4 @@ def log_text_entry(
     if color is not None:
         color = _normalize_colors(color)
 
-    return log(
-        entity_path, TextLog(body=text, level=level, color=color), ext=ext, timeless=timeless, recording=recording
-    )
+    return log(entity_path, TextLog(text, level=level, color=color), ext=ext, timeless=timeless, recording=recording)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/text_internal.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/text_internal.py
@@ -51,4 +51,4 @@ def log_text_entry_internal(
     if color is not None:
         color = _normalize_colors(color)
 
-    return log(entity_path, TextLog(body=text, level=level), timeless=timeless, recording=recording)
+    return log(entity_path, TextLog(text, level=level), timeless=timeless, recording=recording)

--- a/tests/python/roundtrips/text_document/main.py
+++ b/tests/python/roundtrips/text_document/main.py
@@ -20,7 +20,7 @@ def main() -> None:
     rr.log(
         "markdown",
         rr.TextDocument(
-            body="# Hello\nMarkdown with `code`!\n\nA random image:\n\n![A random image](https://picsum.photos/640/480)",
+            "# Hello\nMarkdown with `code`!\n\nA random image:\n\n![A random image](https://picsum.photos/640/480)",
             media_type=rr.MediaType.MARKDOWN,
         ),
     )

--- a/tests/python/roundtrips/text_log/main.py
+++ b/tests/python/roundtrips/text_log/main.py
@@ -16,9 +16,9 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_roundtrip_text_log")
 
-    rr.log("log", rr.TextLog(body="No level"))
-    rr.log("log", rr.TextLog(body="INFO level", level="INFO"))
-    rr.log("log", rr.TextLog(body="WILD level", level="WILD"))
+    rr.log("log", rr.TextLog("No level"))
+    rr.log("log", rr.TextLog("INFO level", level="INFO"))
+    rr.log("log", rr.TextLog("WILD level", level="WILD"))
 
     rr.script_teardown(args)
 


### PR DESCRIPTION
### What
We should match field names to component names, when it makes sense.

Also fixes the `order` of some fields

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3518) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3518)
- [Docs preview](https://rerun.io/preview/0871ca356fb58f638f2acbb0eb75e64d7ecffdcb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0871ca356fb58f638f2acbb0eb75e64d7ecffdcb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)