### PR TITLE
Remove the need for an `order` of objects

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
@@ -18,8 +18,7 @@ namespace rerun.archetypes;
 /// \example annotation_context_segmentation title="Segmentation" image="https://static.rerun.io/annotation_context_segmentation/0e21c0a04e456fec41d16b0deaa12c00cddf2d9b/1200w.png"
 /// \example annotation_context_connections title="Connections" image="https://static.rerun.io/annotation_context_connections/4a8422bc154699c5334f574ff01b55c5cd1748e3/1200w.png"
 table AnnotationContext (
-  "attr.rust.derive": "Eq, PartialEq",
-  order: 100
+  "attr.rust.derive": "Eq, PartialEq"
 ) {
   context: rerun.components.AnnotationContext ("attr.rerun.component_required", order: 1000);
 }

--- a/crates/re_types/definitions/rerun/archetypes/arrows3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/arrows3d.fbs
@@ -15,8 +15,7 @@ namespace rerun.archetypes;
 table Arrows3D (
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",
-  "attr.cpp.no_field_ctors",
-  order: 100
+  "attr.cpp.no_field_ctors"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
@@ -12,8 +12,7 @@ namespace rerun.archetypes;
 /// \example asset3d_simple "Simple 3D asset"
 /// \example asset3d_out_of_tree "3D asset with out-of-tree transform"
 table Asset3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/bar_chart.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/bar_chart.fbs
@@ -12,8 +12,7 @@ namespace rerun.archetypes;
 ///
 /// \example bar_chart
 table BarChart (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/boxes2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/boxes2d.fbs
@@ -15,8 +15,7 @@ namespace rerun.archetypes;
 table Boxes2D (
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",
-  "attr.cpp.no_field_ctors",
-  order: 100
+  "attr.cpp.no_field_ctors"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/boxes3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/boxes3d.fbs
@@ -16,8 +16,7 @@ namespace rerun.archetypes;
 table Boxes3D (
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",
-  "attr.cpp.no_field_ctors",
-  order: 100
+  "attr.cpp.no_field_ctors"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/clear.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/clear.fbs
@@ -12,8 +12,7 @@ namespace rerun.archetypes;
 /// \example clear_simple "Flat"
 /// \example clear_recursive "Recursive"
 table Clear (
-  "attr.rust.derive": "PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   recursive: rerun.components.ClearIsRecursive ("attr.rerun.component_required", order: 100);
 }

--- a/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -14,8 +14,7 @@ namespace rerun.archetypes;
 /// \example depth_image_simple title="Simple example" image="https://static.rerun.io/depth_image_simple/9598554977873ace2577bddd79184ac120ceb0b0/1200w.png"
 /// \example depth_image_3d title="Depth to 3D example" image="https://static.rerun.io/depth_image_3d/f78674bdae0eb25786c6173307693c5338f38b87/1200w.png"
 table DepthImage (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
@@ -14,8 +14,7 @@ namespace rerun.archetypes;
 ///
 /// \example disconnected_space
 table DisconnectedSpace (
-  "attr.rust.derive": "Copy, PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, Eq"
 ) {
   disconnected_space: rerun.components.DisconnectedSpace ("attr.rerun.component_required", order: 1000);
 }

--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -18,8 +18,7 @@ namespace rerun.archetypes;
 ///
 /// \example image_simple image="https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/1200w.png"
 table Image (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/line_strips2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/line_strips2d.fbs
@@ -13,8 +13,7 @@ namespace rerun.archetypes;
 /// \example line_segments2d_simple image="https://static.rerun.io/line_segment2d_simple/53df596662dd9ffaaea5d09d091ef95220346c83/1200w.png"
 /// \example line_strip2d_batch image="https://static.rerun.io/line_strip2d_batch/d8aae7ca3d6c3b0e3b636de60b8067fa2f0b6db9/1200w.png"
 table LineStrips2D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/line_strips3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/line_strips3d.fbs
@@ -13,8 +13,7 @@ namespace rerun.archetypes;
 /// \example line_segments3d_simple title="Many individual segments" image="https://static.rerun.io/line_segment3d_simple/aa800b2a6e6a7b8e32e762b42861bae36f5014bb/1200w.png"
 /// \example line_strip3d_batch title="Many strips" image="https://static.rerun.io/line_strip3d_batch/102e5ec5271475657fbc76b469267e4ec8e84337/1200w.png"
 table LineStrips3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/mesh3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/mesh3d.fbs
@@ -12,8 +12,7 @@ namespace rerun.archetypes;
 /// \example mesh3d_indexed "Simple indexed 3D mesh"
 /// \example mesh3d_partial_updates "3D mesh with partial updates"
 table Mesh3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/pinhole.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/pinhole.fbs
@@ -10,8 +10,7 @@ namespace rerun.archetypes;
 ///
 /// \example pinhole_simple image="https://static.rerun.io/pinhole_simple/9af9441a94bcd9fd54e1fea44fb0c59ff381a7f2/1200w.png"
 table Pinhole (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -15,8 +15,7 @@ namespace rerun.archetypes;
 /// \example point2d_simple image="https://static.rerun.io/point2d_simple/a8e801958bce5aa4e080659c033630f86ce95f71/1200w.png"
 /// \example point2d_random image="https://static.rerun.io/point2d_random/8e8ac75373677bd72bd3f56a15e44fcab309a168/1200w.png"
 table Points2D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points3d.fbs
@@ -12,8 +12,7 @@ namespace rerun.archetypes;
 /// \example point3d_simple image="https://static.rerun.io/point3d_simple/32fb3e9b65bea8bd7ffff95ad839f2f8a157a933/1200w.png"
 /// \example point3d_random image="https://static.rerun.io/point3d_random/7e94e1806d2c381943748abbb3bedb68d564de24/1200w.png"
 table Points3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
@@ -16,8 +16,7 @@ namespace rerun.archetypes;
 ///
 /// \example segmentation_image_simple image="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/1200w.png"
 table SegmentationImage (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/tensor.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/tensor.fbs
@@ -11,8 +11,7 @@ namespace rerun.archetypes;
 /// \example tensor_simple image="https://static.rerun.io/tensor_simple/1aead2554496737e9267a5ab5220dbc89da851ee/1200w.png"
 /// \example tensor_one_dim image="https://static.rerun.io/tensor_one_dim/cbf24b466fe9d9639777aefb34f1a00c3f30d7ab/1200w.png"
 table Tensor (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   /// The tensor data
   data: rerun.components.TensorData ("attr.rerun.component_required", order: 1000);

--- a/crates/re_types/definitions/rerun/archetypes/text_document.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/text_document.fbs
@@ -9,8 +9,7 @@ namespace rerun.archetypes;
 
 /// A text element intended to be displayed in its own text-box.
 table TextDocument (
-  "attr.rust.derive": "PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   /// Contents of the text document.
   body: rerun.components.Text ("attr.rerun.component_required", order: 100);

--- a/crates/re_types/definitions/rerun/archetypes/text_log.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/text_log.fbs
@@ -9,8 +9,7 @@ namespace rerun.archetypes;
 
 /// A log entry in a text log, comprised of a text body and its log level.
 table TextLog (
-  "attr.rust.derive": "PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   body: rerun.components.Text ("attr.rerun.component_required", order: 100);
   level: rerun.components.TextLogLevel ("attr.rerun.component_recommended", nullable, order: 200);

--- a/crates/re_types/definitions/rerun/archetypes/time_series_scalar.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/time_series_scalar.fbs
@@ -15,8 +15,7 @@ namespace rerun.archetypes;
 /// \example scalar_simple
 /// \example scalar_multiple_plots
 table TimeSeriesScalar (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---
 

--- a/crates/re_types/definitions/rerun/archetypes/transform3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/transform3d.fbs
@@ -10,8 +10,7 @@ namespace rerun.archetypes;
 ///
 /// \example transform3d_simple image="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png"
 table Transform3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   /// The transform
   transform: rerun.components.Transform3D ("attr.rerun.component_required", order: 1000);

--- a/crates/re_types/definitions/rerun/archetypes/view_coordinates.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/view_coordinates.fbs
@@ -17,8 +17,7 @@ namespace rerun.archetypes;
 ///
 /// \example view_coordinates_simple
 table ViewCoordinates (
-  "attr.rust.derive": "Copy, PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, Eq"
 ) {
   xyz: rerun.components.ViewCoordinates ("attr.rerun.component_required", required, order: 1000);
 }

--- a/crates/re_types/definitions/rerun/components/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/components/annotation_context.fbs
@@ -18,8 +18,7 @@ namespace rerun.components;
 /// path.
 table AnnotationContext (
   "attr.python.aliases": "datatypes.ClassDescriptionArrayLike, Sequence[datatypes.ClassDescriptionMapElemLike]",
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   class_map: [rerun.datatypes.ClassDescriptionMapElem] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/blob.fbs
+++ b/crates/re_types/definitions/rerun/components/blob.fbs
@@ -15,8 +15,7 @@ table Blob (
   "attr.python.aliases": "bytes, npt.NDArray[np.uint8]",
   "attr.python.array_aliases": "bytes, npt.NDArray[np.uint8]",
   "attr.rust.derive": "PartialEq, Eq",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   data: [ubyte] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/class_id.fbs
+++ b/crates/re_types/definitions/rerun/components/class_id.fbs
@@ -18,8 +18,7 @@ table ClassId (
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash",
   "attr.rust.repr": "transparent",
   "attr.rust.custom_clause":
-    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))',
-  order: 100
+    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'
 ) {
   id: rerun.datatypes.ClassId (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/clear_is_recursive.fbs
+++ b/crates/re_types/definitions/rerun/components/clear_is_recursive.fbs
@@ -15,8 +15,7 @@ struct ClearIsRecursive (
   "attr.python.aliases": "bool",
   "attr.python.array_aliases": "bool, npt.NDArray[np.bool_]",
   "attr.rust.derive": "Copy, PartialEq, Eq",
-  "attr.rust.tuple_struct",
-  order: 100
+  "attr.rust.tuple_struct"
 ) {
   /// If true, also clears all recursive children entities.
   recursive: bool (order: 100);

--- a/crates/re_types/definitions/rerun/components/color.fbs
+++ b/crates/re_types/definitions/rerun/components/color.fbs
@@ -22,8 +22,7 @@ table Color (
   "attr.python.aliases": "int, Sequence[int], npt.NDArray[Union[np.uint8, np.float32, np.float64]]",
   "attr.python.array_aliases": "int, Sequence[Sequence[int]], npt.NDArray[Union[np.uint8, np.uint32, np.float32, np.float64]]",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, bytemuck::Pod, bytemuck::Zeroable",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   rgba: rerun.datatypes.Color (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/depth_meter.fbs
+++ b/crates/re_types/definitions/rerun/components/depth_meter.fbs
@@ -13,8 +13,7 @@ namespace rerun.components;
 struct DepthMeter (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float32]",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
 ) {
   value: float (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/components/disconnected_space.fbs
@@ -17,8 +17,7 @@ namespace rerun.components;
 struct DisconnectedSpace (
   "attr.python.aliases": "bool",
   "attr.python.array_aliases": "bool, npt.NDArray[np.bool_]",
-  "attr.rust.derive": "Copy, PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, Eq"
 ) {
   is_disconnected: bool (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/draw_order.fbs
+++ b/crates/re_types/definitions/rerun/components/draw_order.fbs
@@ -20,8 +20,7 @@ struct DrawOrder (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float32]",
   "attr.rust.derive": "Copy",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
    value: float (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/half_sizes2d.fbs
+++ b/crates/re_types/definitions/rerun/components/half_sizes2d.fbs
@@ -14,8 +14,7 @@ namespace rerun.components;
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 struct HalfSizes2D (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   xy: rerun.datatypes.Vec2D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/half_sizes3d.fbs
+++ b/crates/re_types/definitions/rerun/components/half_sizes3d.fbs
@@ -14,8 +14,7 @@ namespace rerun.components;
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 struct HalfSizes3D (
-  "attr.rust.derive": "Default, Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, Copy, PartialEq"
 ) {
   xyz: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/instance_key.fbs
+++ b/crates/re_types/definitions/rerun/components/instance_key.fbs
@@ -15,8 +15,7 @@ struct InstanceKey (
   "attr.python.array_aliases": "int, npt.NDArray[np.uint64]",
   "attr.rust.derive": "Copy, Hash, PartialEq, Eq, PartialOrd, Ord",
   "attr.rust.custom_clause":
-    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))',
-  order: 100
+    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'
 ) {
   value: uint64 (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/keypoint_id.fbs
+++ b/crates/re_types/definitions/rerun/components/keypoint_id.fbs
@@ -24,8 +24,7 @@ struct KeypointId (
   "attr.python.array_aliases": "int, npt.NDArray[np.uint8], npt.NDArray[np.uint16], npt.NDArray[np.uint32], npt.NDArray[np.uint64]",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash",
   "attr.rust.custom_clause":
-    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))',
-  order: 200
+    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'
 ) {
   id: rerun.datatypes.KeypointId (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/line_strip2d.fbs
+++ b/crates/re_types/definitions/rerun/components/line_strip2d.fbs
@@ -24,8 +24,7 @@ namespace rerun.components;
 table LineStrip2D (
   "attr.python.aliases": "datatypes.Vec2DArrayLike, npt.NDArray[np.float32]",
   "attr.python.array_aliases": "npt.NDArray[np.float32]",
-  "attr.rust.derive": "Default, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   points: [rerun.datatypes.Vec2D] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/line_strip3d.fbs
+++ b/crates/re_types/definitions/rerun/components/line_strip3d.fbs
@@ -24,8 +24,7 @@ namespace rerun.components;
 table LineStrip3D (
   "attr.python.aliases": "datatypes.Vec3DArrayLike, npt.NDArray[np.float32]",
   "attr.python.array_aliases": "npt.NDArray[np.float32]",
-  "attr.rust.derive": "Default, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   points: [rerun.datatypes.Vec3D] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/material.fbs
+++ b/crates/re_types/definitions/rerun/components/material.fbs
@@ -11,8 +11,7 @@ namespace rerun.components;
 
 // Material properties of a mesh.
 table Material (
-  "attr.rust.derive": "PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   material: rerun.datatypes.Material (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/media_type.fbs
+++ b/crates/re_types/definitions/rerun/components/media_type.fbs
@@ -20,8 +20,7 @@ table MediaType (
   "attr.python.aliases": "str",
   "attr.python.array_aliases": "str, Sequence[str]",
   "attr.rust.derive": "PartialEq, Eq, PartialOrd, Ord, Hash",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   value: rerun.datatypes.Utf8 (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/mesh_properties.fbs
+++ b/crates/re_types/definitions/rerun/components/mesh_properties.fbs
@@ -11,8 +11,7 @@ namespace rerun.components;
 
 // Global properties of a mesh.
 table MeshProperties (
-  "attr.rust.derive": "PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   props: rerun.datatypes.MeshProperties (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/origin2d.fbs
+++ b/crates/re_types/definitions/rerun/components/origin2d.fbs
@@ -11,8 +11,7 @@ namespace rerun.components;
 
 /// A point of origin in 2D space.
 struct Origin2D (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   origin: rerun.datatypes.Vec2D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/origin3d.fbs
+++ b/crates/re_types/definitions/rerun/components/origin3d.fbs
@@ -11,8 +11,7 @@ namespace rerun.components;
 
 /// A point of origin in 3D space.
 struct Origin3D (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   origin: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/out_of_tree_transform3d.fbs
+++ b/crates/re_types/definitions/rerun/components/out_of_tree_transform3d.fbs
@@ -10,8 +10,7 @@ namespace rerun.components;
 ///
 /// "Out-of-tree" means that the transform only affects its own entity: children don't inherit from it.
 table OutOfTreeTransform3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   /// Representation of the transform.
   repr: rerun.datatypes.Transform3D (order: 100);

--- a/crates/re_types/definitions/rerun/components/pinhole_projection.fbs
+++ b/crates/re_types/definitions/rerun/components/pinhole_projection.fbs
@@ -18,8 +18,7 @@ namespace rerun.components;
 ///    0.0     0.0    1.0
 /// ```
 struct PinholeProjection (
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
 ) {
   image_from_camera: rerun.datatypes.Mat3x3 (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/position2d.fbs
+++ b/crates/re_types/definitions/rerun/components/position2d.fbs
@@ -14,8 +14,7 @@ struct Position2D (
   "attr.python.aliases": "npt.NDArray[np.float32], Sequence[float], Tuple[float, float]",
   "attr.python.array_aliases": "npt.NDArray[np.float32], Sequence[float]",
   "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   xy: rerun.datatypes.Vec2D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/position3d.fbs
+++ b/crates/re_types/definitions/rerun/components/position3d.fbs
@@ -14,8 +14,7 @@ struct Position3D (
   "attr.python.aliases": "npt.NDArray[np.float32], Sequence[float], Tuple[float, float, float]",
   "attr.python.array_aliases": "npt.NDArray[np.float32], Sequence[float]",
   "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   xyz: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/radius.fbs
+++ b/crates/re_types/definitions/rerun/components/radius.fbs
@@ -13,8 +13,7 @@ namespace rerun.components;
 struct Radius (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.ArrayLike",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
 ) {
   value: float (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/resolution.fbs
+++ b/crates/re_types/definitions/rerun/components/resolution.fbs
@@ -10,8 +10,7 @@ namespace rerun.components;
 ///
 /// Typically in integer units, but for some usecases floating point may be used.
 struct Resolution (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   resolution: rerun.datatypes.Vec2D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/rotation3d.fbs
+++ b/crates/re_types/definitions/rerun/components/rotation3d.fbs
@@ -8,8 +8,7 @@ namespace rerun.components;
 
 /// A 3D rotation, represented either by a quaternion or a rotation around axis.
 table Rotation3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   /// Representation of the rotation.
   repr: rerun.datatypes.Rotation3D (order: 100);

--- a/crates/re_types/definitions/rerun/components/scalar.fbs
+++ b/crates/re_types/definitions/rerun/components/scalar.fbs
@@ -15,8 +15,7 @@ namespace rerun.components;
 struct Scalar (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float64]",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
 ) {
   value: double (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/scalar_scattering.fbs
+++ b/crates/re_types/definitions/rerun/components/scalar_scattering.fbs
@@ -13,8 +13,7 @@ namespace rerun.components;
 struct ScalarScattering (
   "attr.python.aliases": "bool",
   "attr.python.array_aliases": "bool, npt.NDArray[np.bool_]",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd, Eq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd, Eq"
 ) {
   scattered: bool (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/tensor_data.fbs
+++ b/crates/re_types/definitions/rerun/components/tensor_data.fbs
@@ -12,7 +12,6 @@ namespace rerun.components;
 // A Multi-dimensional `Tensor` of data.
 table TensorData (
   "attr.arrow.transparent",
-  order: 100,
   "attr.rust.derive": "PartialEq",
   "attr.rust.repr": "transparent"
 ) {

--- a/crates/re_types/definitions/rerun/components/text.fbs
+++ b/crates/re_types/definitions/rerun/components/text.fbs
@@ -15,8 +15,7 @@ table Text (
   "attr.python.aliases": "str",
   "attr.python.array_aliases": "str, Sequence[str]",
   "attr.rust.derive": "PartialEq, Eq, PartialOrd, Ord",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   value: rerun.datatypes.Utf8 (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/text_log_level.fbs
+++ b/crates/re_types/definitions/rerun/components/text_log_level.fbs
@@ -23,8 +23,7 @@ table TextLogLevel (
   "attr.python.aliases": "str",
   "attr.python.array_aliases": "str, Sequence[str]",
   "attr.rust.derive": "PartialEq, Eq, PartialOrd, Ord",
-  "attr.rust.repr": "transparent",
-  order: 100
+  "attr.rust.repr": "transparent"
 ) {
   value: rerun.datatypes.Utf8 (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/transform3d.fbs
+++ b/crates/re_types/definitions/rerun/components/transform3d.fbs
@@ -8,8 +8,7 @@ namespace rerun.components;
 
 /// An affine transform between two 3D spaces, represented in a given direction.
 table Transform3D (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   /// Representation of the transform.
   repr: rerun.datatypes.Transform3D (order: 100);

--- a/crates/re_types/definitions/rerun/components/vector3d.fbs
+++ b/crates/re_types/definitions/rerun/components/vector3d.fbs
@@ -11,8 +11,7 @@ namespace rerun.components;
 
 /// A vector in 3D space.
 struct Vector3D (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   vector: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/view_coordinates.fbs
+++ b/crates/re_types/definitions/rerun/components/view_coordinates.fbs
@@ -38,8 +38,7 @@ enum ViewDir: byte {
 struct ViewCoordinates (
   "attr.python.aliases": "npt.ArrayLike",
   "attr.python.array_aliases": "npt.ArrayLike",
-  "attr.rust.derive": "Copy, PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, Eq"
 ) {
   /// The directions of the [x, y, z] axes.
   coordinates: [ubyte: 3] (order: 100);

--- a/crates/re_types/definitions/rerun/datatypes/angle.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/angle.fbs
@@ -10,8 +10,7 @@ namespace rerun.datatypes;
 
 /// Angle in either radians or degrees.
 union Angle (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 200
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// \py 3D rotation angle in radians. Only one of `degrees` or `radians` should be set.
   Radians: rerun.datatypes.Float32 (order: 100, transparent),

--- a/crates/re_types/definitions/rerun/datatypes/annotation_info.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/annotation_info.fbs
@@ -13,8 +13,7 @@ namespace rerun.datatypes;
 /// The id refers either to a class or key-point id
 table AnnotationInfo (
   "attr.python.aliases": "int, Tuple[int, str], Tuple[int, str, datatypes.ColorLike]",
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 500
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   /// `ClassId` or `KeypointId` to which this annotation info belongs.
   // TODO(jleibs): make this typed

--- a/crates/re_types/definitions/rerun/datatypes/class_description.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_description.fbs
@@ -23,8 +23,7 @@ namespace rerun.datatypes;
 /// colored as described by the class's `AnnotationInfo`.
 table ClassDescription (
   "attr.python.aliases": "datatypes.AnnotationInfoLike",
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   /// The `AnnotationInfo` for the class.
   info: rerun.datatypes.AnnotationInfo (order: 100);

--- a/crates/re_types/definitions/rerun/datatypes/class_description_map_elem.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_description_map_elem.fbs
@@ -12,8 +12,7 @@ namespace rerun.datatypes;
 /// This is internal to the `AnnotationContext` structure.
 table ClassDescriptionMapElem (
   "attr.python.aliases": "datatypes.ClassDescriptionLike",
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   class_id: rerun.datatypes.ClassId (order: 100);
   class_description: rerun.datatypes.ClassDescription (order: 200);

--- a/crates/re_types/definitions/rerun/datatypes/class_id.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_id.fbs
@@ -19,8 +19,7 @@ struct ClassId (
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct",
   "attr.rust.custom_clause":
-    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))',
-  order: 100
+    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'
 ) {
   id: ushort (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/color.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/color.fbs
@@ -22,8 +22,7 @@ struct Color (
   "attr.python.array_aliases": "int, npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
-  order: 100
+  "attr.rust.tuple_struct"
 ) {
   rgba: uint (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/keypoint_id.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/keypoint_id.fbs
@@ -26,8 +26,7 @@ struct KeypointId (
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct",
   "attr.rust.custom_clause":
-    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))',
-  order: 200
+    'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'
 ) {
   id: ushort (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/keypoint_pair.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/keypoint_pair.fbs
@@ -10,8 +10,7 @@ namespace rerun.datatypes;
 /// A connection between two `Keypoints`.
 table KeypointPair (
   "attr.python.aliases": "Sequence[datatypes.KeypointIdLike]",
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   keypoint0: rerun.datatypes.KeypointId (order: 100);
   keypoint1: rerun.datatypes.KeypointId (order: 200);

--- a/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
@@ -43,8 +43,7 @@ struct Mat3x3 (
   "attr.arrow.transparent",
   "attr.python.aliases": "npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  "attr.rust.tuple_struct",
-  order: 500
+  "attr.rust.tuple_struct"
 ) {
   /// \py Flat list of matrix coefficients in column-major order.
   /// \cpp Flat list of matrix coefficients in column-major order.

--- a/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
@@ -45,8 +45,7 @@ struct Mat4x4 (
   "attr.arrow.transparent",
   "attr.python.aliases": "npt.ArrayLike",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  "attr.rust.tuple_struct",
-  order: 600
+  "attr.rust.tuple_struct"
 ) {
   /// \py Flat list of matrix coefficients in column-major order.
   /// \cpp Flat list of matrix coefficients in column-major order.

--- a/crates/re_types/definitions/rerun/datatypes/material.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/material.fbs
@@ -10,8 +10,7 @@ namespace rerun.datatypes;
 
 // Material properties of a mesh.
 struct Material (
-  "attr.rust.derive": "Copy, PartialEq, Eq, Hash",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq, Eq, Hash"
 ) {
   /// Optional color multiplier.
   albedo_factor: rerun.datatypes.Color (nullable, order: 100);

--- a/crates/re_types/definitions/rerun/datatypes/mesh_properties.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mesh_properties.fbs
@@ -10,8 +10,7 @@ namespace rerun.datatypes;
 
 // Global properties of a mesh.
 table MeshProperties (
-  "attr.rust.derive": "PartialEq, Eq",
-  order: 100
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   // TODO(#3353): this is what this should be.
   // triangle_indices: [rerun.datatypes.UVec3D] (nullable, order: 100);

--- a/crates/re_types/definitions/rerun/datatypes/quaternion.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/quaternion.fbs
@@ -15,8 +15,7 @@ namespace rerun.datatypes;
 struct Quaternion (
   "attr.arrow.transparent",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  "attr.rust.tuple_struct",
-  order: 100
+  "attr.rust.tuple_struct"
 ) {
   xyzw: [float: 4] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/rotation3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/rotation3d.fbs
@@ -9,8 +9,7 @@ namespace rerun.datatypes;
 /// A 3D rotation.
 union Rotation3D (
   "attr.rust.derive": "Copy, PartialEq",
-  "attr.python.aliases": "Sequence[SupportsFloat]",
-  order: 400
+  "attr.python.aliases": "Sequence[SupportsFloat]"
 ) {
   /// Rotation defined by a quaternion.
   Quaternion: Quaternion (order: 100),

--- a/crates/re_types/definitions/rerun/datatypes/rotation_axis_angle.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/rotation_axis_angle.fbs
@@ -10,8 +10,7 @@ namespace rerun.datatypes;
 
 /// 3D rotation represented by a rotation around a given axis.
 table RotationAxisAngle (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 300
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// Axis to rotate around.
   ///

--- a/crates/re_types/definitions/rerun/datatypes/scalars.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/scalars.fbs
@@ -8,8 +8,7 @@ namespace rerun.datatypes;
 struct Float32 (
   "attr.arrow.transparent",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
-  "attr.rust.tuple_struct",
-  order: 100
+  "attr.rust.tuple_struct"
 ) {
   value: float (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/scale3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/scale3d.fbs
@@ -24,8 +24,7 @@ namespace rerun.datatypes;
 /// \py ```
 union Scale3D (
   "attr.python.aliases": "datatypes.Vec3DLike",
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 100
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// Individual scaling factors for each axis, distorting the original object.
   ThreeD: rerun.datatypes.Vec3D (order: 100),

--- a/crates/re_types/definitions/rerun/datatypes/tensor_buffer.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/tensor_buffer.fbs
@@ -58,7 +58,6 @@ table JPEGBuffer(order: 100, transparent) {
 ///
 /// Tensor elements are stored in a contiguous buffer of a single type.
 union TensorBuffer (
-  order: 100,
   "attr.rust.derive_only": "Clone, PartialEq"
 ) {
   U8: U8Buffer (transparent, order:100),

--- a/crates/re_types/definitions/rerun/datatypes/tensor_data.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/tensor_data.fbs
@@ -17,7 +17,6 @@ namespace rerun.datatypes;
 /// These dimensions are combined with an index to look up values from the `buffer` field,
 /// which stores a contiguous array of typed values.
 table TensorData (
-  order: 100,
   "attr.python.aliases": "npt.ArrayLike",
   "attr.python.array_aliases": "npt.ArrayLike",
   "attr.rust.derive": "PartialEq,"

--- a/crates/re_types/definitions/rerun/datatypes/tensor_dimension.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/tensor_dimension.fbs
@@ -8,7 +8,6 @@ namespace rerun.datatypes;
 /// A single dimension within a multi-dimensional tensor.
 // TODO(jleibs): Support for stride.
 table TensorDimension (
-  order: 100,
   "attr.rust.derive_only": "Clone, Default, Eq, PartialEq"
 ) {
   size: ulong (order: 100);

--- a/crates/re_types/definitions/rerun/datatypes/transform3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/transform3d.fbs
@@ -10,8 +10,7 @@ namespace rerun.datatypes;
 /// \rs Rarely used directly, prefer using the underlying representation classes and pass them
 /// \rs directly to `Transform3D::child_from_parent` or `Transform3D::parent_from_child`.
 union Transform3D (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 700
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   TranslationAndMat3x3: TranslationAndMat3x3 (order: 100),
   TranslationRotationScale: TranslationRotationScale3D (order: 200),

--- a/crates/re_types/definitions/rerun/datatypes/translation_and_mat3x3.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/translation_and_mat3x3.fbs
@@ -11,8 +11,7 @@ namespace rerun.datatypes;
 ///
 /// First applies the matrix, then the translation.
 table TranslationAndMat3x3 (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 500
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// 3D translation, applied after the matrix.
   //

--- a/crates/re_types/definitions/rerun/datatypes/translation_rotation_scale3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/translation_rotation_scale3d.fbs
@@ -11,8 +11,7 @@ namespace rerun.datatypes;
 
 /// Representation of an affine transform via separate translation, rotation & scale.
 table TranslationRotationScale3D (
-  "attr.rust.derive": "Copy, PartialEq",
-  order: 600
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// 3D translation vector, applied last.
   //

--- a/crates/re_types/definitions/rerun/datatypes/utf8.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/utf8.fbs
@@ -16,8 +16,7 @@ table Utf8 (
   "attr.python.array_aliases": "str, Sequence[str]",
   "attr.rust.derive": "PartialEq, Eq, PartialOrd, Ord, Hash",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
-  order: 100
+  "attr.rust.tuple_struct"
 ) {
   value: string (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/uvec2d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/uvec2d.fbs
@@ -14,8 +14,7 @@ struct UVec2D (
   "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[int]], Sequence[int]",
   "attr.rust.derive": "Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
-  "attr.rust.repr": "C",
-  order: 100
+  "attr.rust.repr": "C"
 ) {
   xy: [uint: 2] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/uvec3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/uvec3d.fbs
@@ -14,8 +14,7 @@ struct UVec3D (
   "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[int]], Sequence[int]",
   "attr.rust.derive": "Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
-  "attr.rust.repr": "C",
-  order: 100
+  "attr.rust.repr": "C"
 ) {
   xyz: [uint: 3] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/uvec4d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/uvec4d.fbs
@@ -14,8 +14,7 @@ struct UVec4D (
   "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[int]], Sequence[int]",
   "attr.rust.derive": "Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
-  "attr.rust.repr": "C",
-  order: 100
+  "attr.rust.repr": "C"
 ) {
   xyzw: [uint: 4] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/vec2d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/vec2d.fbs
@@ -14,8 +14,7 @@ struct Vec2D (
   "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]], Sequence[float]",
   "attr.rust.derive": "Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
-  "attr.rust.repr": "C",
-  order: 100
+  "attr.rust.repr": "C"
 ) {
   xy: [float: 2] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/vec3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/vec3d.fbs
@@ -14,8 +14,7 @@ struct Vec3D (
   "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]], Sequence[float]",
   "attr.rust.derive": "Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
-  "attr.rust.repr": "C",
-  order: 100
+  "attr.rust.repr": "C"
 ) {
   xyz: [float: 3] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/vec4d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/vec4d.fbs
@@ -14,8 +14,7 @@ struct Vec4D (
   "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]], Sequence[float]",
   "attr.rust.derive": "Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
-  "attr.rust.repr": "C",
-  order: 100
+  "attr.rust.repr": "C"
 ) {
   xyzw: [float: 4] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/testing/archetypes/fuzzy.fbs
+++ b/crates/re_types/definitions/rerun/testing/archetypes/fuzzy.fbs
@@ -12,8 +12,7 @@ namespace rerun.testing.archetypes;
 // - required affects the nullability of the element values for the underlying array (both native and arrow)
 
 table AffixFuzzer1 (
-  "attr.rust.derive": "PartialEq",
-  order: 100
+  "attr.rust.derive": "PartialEq"
 ) {
   fuzz1001: rerun.testing.components.AffixFuzzer1 ("attr.rerun.component_required", order: 1001);
   fuzz1002: rerun.testing.components.AffixFuzzer2 ("attr.rerun.component_required", order: 1002);
@@ -39,8 +38,7 @@ table AffixFuzzer1 (
 }
 
 table AffixFuzzer2 (
-  "attr.rust.derive": "PartialEq",
-  order: 200
+  "attr.rust.derive": "PartialEq"
 ) {
   fuzz1101: [rerun.testing.components.AffixFuzzer1] ("attr.rerun.component_required", order: 1101);
   fuzz1102: [rerun.testing.components.AffixFuzzer2] ("attr.rerun.component_required", order: 1102);
@@ -63,8 +61,7 @@ table AffixFuzzer2 (
 }
 
 table AffixFuzzer3 (
-  "attr.rust.derive": "PartialEq",
-  order: 300
+  "attr.rust.derive": "PartialEq"
 ) {
   fuzz2001: rerun.testing.components.AffixFuzzer1 ("attr.rerun.component_optional", nullable, order: 2001);
   fuzz2002: rerun.testing.components.AffixFuzzer2 ("attr.rerun.component_optional", nullable, order: 2002);
@@ -88,8 +85,7 @@ table AffixFuzzer3 (
 }
 
 table AffixFuzzer4 (
-  "attr.rust.derive": "PartialEq",
-  order: 400
+  "attr.rust.derive": "PartialEq"
 ) {
   fuzz2101: [rerun.testing.components.AffixFuzzer1] ("attr.rerun.component_optional", nullable, order: 2101);
   fuzz2102: [rerun.testing.components.AffixFuzzer2] ("attr.rerun.component_optional", nullable, order: 2102);

--- a/crates/re_types/definitions/rerun/testing/components/fuzzy.fbs
+++ b/crates/re_types/definitions/rerun/testing/components/fuzzy.fbs
@@ -9,158 +9,136 @@ namespace rerun.testing.components;
 // ---
 
 table AffixFuzzer1 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_required: rerun.testing.datatypes.AffixFuzzer1 (order: 101);
 }
 
 table AffixFuzzer2 (
   "attr.rust.derive": "Default, PartialEq",
-  "attr.rust.tuple_struct",
-  order: 200
+  "attr.rust.tuple_struct"
 ) {
   single_required: rerun.testing.datatypes.AffixFuzzer1 (order: 102);
 }
 
 table AffixFuzzer3 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 300
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_required: rerun.testing.datatypes.AffixFuzzer1 (order: 103);
 }
 
 table AffixFuzzer4 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 400
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_optional: rerun.testing.datatypes.AffixFuzzer1 (nullable, order: 104);
 }
 
 table AffixFuzzer5 (
   "attr.rust.derive": "Default, PartialEq",
-  "attr.rust.tuple_struct",
-  order: 500
+  "attr.rust.tuple_struct"
 ) {
   single_optional: rerun.testing.datatypes.AffixFuzzer1 (nullable, order: 105);
 }
 
 table AffixFuzzer6 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 600
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_optional: rerun.testing.datatypes.AffixFuzzer1 (nullable, order: 106);
 }
 
 table AffixFuzzer7 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 700
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   many_optional: [rerun.testing.datatypes.AffixFuzzer1] (nullable, order: 107);
 }
 
 table AffixFuzzer8 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 800
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_float_optional: float (nullable, order: 108);
 }
 
 table AffixFuzzer9 (
-  "attr.rust.derive": "Default, PartialEq, Eq",
-  order: 900
+  "attr.rust.derive": "Default, PartialEq, Eq"
 ) {
   single_string_required: string (order: 109);
 }
 
 table AffixFuzzer10 (
-  "attr.rust.derive": "Default, PartialEq, Eq",
-  order: 1000
+  "attr.rust.derive": "Default, PartialEq, Eq"
 ) {
   single_string_optional: string (nullable, order: 110);
 }
 
 table AffixFuzzer11 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1100
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   many_floats_optional: [float] (nullable, order: 111);
 }
 
 table AffixFuzzer12 (
-  "attr.rust.derive": "Default, PartialEq, Eq",
-  order: 1200
+  "attr.rust.derive": "Default, PartialEq, Eq"
 ) {
   many_strings_required: [string] (order: 112);
 }
 
 table AffixFuzzer13 (
-  "attr.rust.derive": "Default, PartialEq, Eq",
-  order: 1300
+  "attr.rust.derive": "Default, PartialEq, Eq"
 ) {
   many_strings_optional: [string] (nullable, order: 113);
 }
 
 table AffixFuzzer14 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1400
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_required_union: rerun.testing.datatypes.AffixFuzzer3 (order: 114);
 }
 
 table AffixFuzzer15 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1500
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_optional_union: rerun.testing.datatypes.AffixFuzzer3 (nullable, order: 115);
 }
 
 table AffixFuzzer16 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1600
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   many_required_unions: [rerun.testing.datatypes.AffixFuzzer3] (order: 116);
 }
 
 table AffixFuzzer17 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1700
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   many_optional_unions: [rerun.testing.datatypes.AffixFuzzer3] (nullable, order: 117);
 }
 
 table AffixFuzzer18 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1800
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   many_optional_unions: [rerun.testing.datatypes.AffixFuzzer4] (nullable, order: 118);
 }
 
 table AffixFuzzer19 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 1900
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   just_a_table_nothing_shady: rerun.testing.datatypes.AffixFuzzer5 (order: 119);
 }
 
 table AffixFuzzer20 (
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 2000
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   nested_transparent: rerun.testing.datatypes.AffixFuzzer20 (order: 120);
 }
 
 table AffixFuzzer21 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 2100
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   nested_halves: rerun.testing.datatypes.AffixFuzzer21 (order: 120);
 }
 
 // TODO(cmc): the ugly bug we need to take care of at some point
 // table AffixFuzzer14 (
-//   "attr.rust.derive": "Default, PartialEq",
-//   order: 1400
+//   "attr.rust.derive": "Default, PartialEq"
 // ) {
 //
 //   many_transparent_optionals: rerun.testing.datatypes.AffixFuzzer2 (nullable, order: 107);

--- a/crates/re_types/definitions/rerun/testing/components/fuzzy_deps.fbs
+++ b/crates/re_types/definitions/rerun/testing/components/fuzzy_deps.fbs
@@ -13,8 +13,7 @@ struct PrimitiveComponent (
   "attr.arrow.transparent",
   "attr.rust.derive": "Default, Eq, PartialEq",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
-  order: 001
+  "attr.rust.tuple_struct"
 ) {
   value: uint (order: 100);
 }
@@ -23,8 +22,7 @@ table StringComponent (
   "attr.arrow.transparent",
   "attr.rust.derive": "Default, Eq, PartialEq",
   "attr.rust.repr": "transparent",
-  "attr.rust.tuple_struct",
-  order: 002
+  "attr.rust.tuple_struct"
 ) {
   value: string (order: 100);
 }

--- a/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
+++ b/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
@@ -29,8 +29,7 @@ struct ArrayOfFloats (transparent, order: 001) {
 }
 
 table AffixFuzzer1 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 100
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_float_optional: float (nullable, order: 101);
   single_string_required: string (order: 102);
@@ -50,15 +49,13 @@ table __AffixFuzzer1Vec (transparent, order: 0) {
 table AffixFuzzer2 (
   "attr.arrow.transparent",
   "attr.rust.derive": "Default, PartialEq",
-  "attr.rust.tuple_struct",
-  order: 200
+  "attr.rust.tuple_struct"
 ) {
   single_float_optional: float (nullable, order: 101);
 }
 
 union AffixFuzzer3 (
-  "attr.rust.derive": "PartialEq",
-  order: 300
+  "attr.rust.derive": "PartialEq"
 ) {
   degrees: FlattenedScalar (transparent, order: 100),
   radians: FlattenedScalar (transparent, nullable, order: 101),
@@ -75,8 +72,7 @@ table __AffixFuzzer3Vec (transparent, order: 0) {
 }
 
 union AffixFuzzer4 (
-  "attr.rust.derive": "PartialEq",
-  order: 400
+  "attr.rust.derive": "PartialEq"
 ) {
   single_required: __AffixFuzzer3 (transparent, order: 100),
   many_required: __AffixFuzzer3Vec (transparent, order: 101),
@@ -84,23 +80,20 @@ union AffixFuzzer4 (
 }
 
 table AffixFuzzer5 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 500
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_optional_union: AffixFuzzer4 (order: 100, nullable);
 }
 
 table AffixFuzzer20 (
-  "attr.rust.derive": "Default, Eq, PartialEq",
-  order: 600
+  "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
   p: rerun.testing.datatypes.PrimitiveComponent  (order: 100);
   s: rerun.testing.datatypes.StringComponent  (order: 200);
 }
 
 table AffixFuzzer21 (
-  "attr.rust.derive": "Default, PartialEq",
-  order: 700
+  "attr.rust.derive": "Default, PartialEq"
 ) {
   single_half: ushort (order: 100, "attr.rerun.override_type": "float16");
   many_halves: [ushort] (order: 200, "attr.rerun.override_type": "float16");

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -47,7 +47,6 @@ impl CodeGenerator for DocsCodeGenerator {
                 continue;
             }
 
-            let order = object.order;
             let top_level_docs = get_documentation(&object.docs, &[]);
             let examples = object
                 .docs
@@ -60,7 +59,7 @@ impl CodeGenerator for DocsCodeGenerator {
 
             let mut o = String::new();
 
-            frontmatter(&mut o, &object.name, order);
+            frontmatter(&mut o, &object.name);
             putln!(o);
             for mut line in top_level_docs {
                 if line.starts_with(char::is_whitespace) {
@@ -84,10 +83,9 @@ impl CodeGenerator for DocsCodeGenerator {
     }
 }
 
-fn frontmatter(o: &mut String, title: &str, order: u32) {
+fn frontmatter(o: &mut String, title: &str) {
     putln!(o, "---");
     putln!(o, "title: {title:?}");
-    putln!(o, "order: {order}");
     putln!(o, "---");
 }
 

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -655,18 +655,7 @@ fn quote_trait_impls_from_obj(
     obj: &Object,
 ) -> TokenStream {
     let Object {
-        virtpath: _,
-        filepath: _,
-        fqname,
-        pkg_name: _,
-        name,
-        docs: _,
-        kind,
-        attrs: _,
-        order: _,
-        fields: _,
-        specifics: _,
-        datatype: _,
+        fqname, name, kind, ..
     } = obj;
 
     let name = format_ident!("{name}");
@@ -1140,20 +1129,7 @@ fn quote_builder_from_obj(obj: &Object) -> TokenStream {
         return TokenStream::new();
     }
 
-    let Object {
-        virtpath: _,
-        filepath: _,
-        fqname: _,
-        pkg_name: _,
-        name,
-        docs: _,
-        kind: _,
-        attrs: _,
-        order: _,
-        fields,
-        specifics: _,
-        datatype: _,
-    } = obj;
+    let Object { name, fields, .. } = obj;
 
     let name = format_ident!("{name}");
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -146,29 +146,19 @@ impl Objects {
     /// Returns all available objects, pre-sorted in ascending order based on their `order`
     /// attribute.
     pub fn ordered_objects_mut(&mut self, kind: Option<ObjectKind>) -> Vec<&mut Object> {
-        let objs = self
-            .objects
+        self.objects
             .values_mut()
-            .filter(|obj| kind.map_or(true, |kind| obj.kind == kind));
-
-        let mut objs = objs.collect::<Vec<_>>();
-        objs.sort_by_key(|anyobj| anyobj.order);
-
-        objs
+            .filter(|obj| kind.map_or(true, |kind| obj.kind == kind))
+            .collect()
     }
 
     /// Returns all available objects, pre-sorted in ascending order based on their `order`
     /// attribute.
     pub fn ordered_objects(&self, kind: Option<ObjectKind>) -> Vec<&Object> {
-        let objs = self
-            .objects
+        self.objects
             .values()
-            .filter(|obj| kind.map_or(true, |kind| obj.kind == kind));
-
-        let mut objs = objs.collect::<Vec<_>>();
-        objs.sort_by_key(|anyobj| anyobj.order);
-
-        objs
+            .filter(|obj| kind.map_or(true, |kind| obj.kind == kind))
+            .collect()
     }
 }
 
@@ -383,9 +373,6 @@ pub struct Object {
     /// The object's attributes.
     pub attrs: Attributes,
 
-    /// The object's `order` attribute's value, which is always mandatory.
-    pub order: u32,
-
     /// The object's inner fields, which can be either struct members or union values.
     ///
     /// These are pre-sorted, in ascending order, using their `order` attribute.
@@ -435,7 +422,6 @@ impl Object {
         let docs = Docs::from_raw_docs(&filepath, obj.documentation());
         let kind = ObjectKind::from_pkg_name(&pkg_name);
         let attrs = Attributes::from_raw_attrs(obj.attributes());
-        let order = attrs.get::<u32>(&fqname, crate::ATTR_ORDER);
 
         let fields: Vec<_> = {
             let mut fields: Vec<_> = obj
@@ -469,7 +455,6 @@ impl Object {
             docs,
             kind,
             attrs,
-            order,
             fields,
             specifics: ObjectSpecifics::Struct {},
             datatype: None,
@@ -518,7 +503,6 @@ impl Object {
                 ))
             }
         };
-        let order = attrs.get::<u32>(&fqname, crate::ATTR_ORDER);
 
         let fields: Vec<_> = enm
             .values()
@@ -549,7 +533,6 @@ impl Object {
             docs,
             kind,
             attrs,
-            order,
             fields,
             specifics: ObjectSpecifics::Union { utype },
             datatype: None,

--- a/docs/content/reference/data_types/annotation_context.md
+++ b/docs/content/reference/data_types/annotation_context.md
@@ -1,6 +1,5 @@
 ---
 title: "AnnotationContext"
-order: 100
 ---
 
 The `AnnotationContext` provides additional information on how to display entities.

--- a/docs/content/reference/data_types/arrows3d.md
+++ b/docs/content/reference/data_types/arrows3d.md
@@ -1,6 +1,5 @@
 ---
 title: "Arrows3D"
-order: 100
 ---
 
 A batch of 3D arrows with optional colors, radii, labels, etc.

--- a/docs/content/reference/data_types/asset3d.md
+++ b/docs/content/reference/data_types/asset3d.md
@@ -1,6 +1,5 @@
 ---
 title: "Asset3D"
-order: 100
 ---
 
 A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc).

--- a/docs/content/reference/data_types/bar_chart.md
+++ b/docs/content/reference/data_types/bar_chart.md
@@ -1,6 +1,5 @@
 ---
 title: "BarChart"
-order: 100
 ---
 
 A bar chart.

--- a/docs/content/reference/data_types/boxes2d.md
+++ b/docs/content/reference/data_types/boxes2d.md
@@ -1,6 +1,5 @@
 ---
 title: "Boxes2D"
-order: 100
 ---
 
 A batch of 2d boxes with half-extents and optional center, rotations, rotations, colors etc.

--- a/docs/content/reference/data_types/boxes3d.md
+++ b/docs/content/reference/data_types/boxes3d.md
@@ -1,6 +1,5 @@
 ---
 title: "Boxes3D"
-order: 100
 ---
 
 A batch of 3d boxes with half-extents and optional center, rotations, rotations, colors etc.

--- a/docs/content/reference/data_types/clear.md
+++ b/docs/content/reference/data_types/clear.md
@@ -1,6 +1,5 @@
 ---
 title: "Clear"
-order: 100
 ---
 
 Empties all the components of an entity.

--- a/docs/content/reference/data_types/depth_image.md
+++ b/docs/content/reference/data_types/depth_image.md
@@ -1,6 +1,5 @@
 ---
 title: "DepthImage"
-order: 100
 ---
 
 A depth image.

--- a/docs/content/reference/data_types/disconnected_space.md
+++ b/docs/content/reference/data_types/disconnected_space.md
@@ -1,6 +1,5 @@
 ---
 title: "DisconnectedSpace"
-order: 100
 ---
 
 Specifies that the entity path at which this is logged is disconnected from its parent.

--- a/docs/content/reference/data_types/image.md
+++ b/docs/content/reference/data_types/image.md
@@ -1,6 +1,5 @@
 ---
 title: "Image"
-order: 100
 ---
 
 A monochrome or color image.

--- a/docs/content/reference/data_types/line_strips2d.md
+++ b/docs/content/reference/data_types/line_strips2d.md
@@ -1,6 +1,5 @@
 ---
 title: "LineStrips2D"
-order: 100
 ---
 
 A batch of line strips with positions and optional colors, radii, labels, etc.

--- a/docs/content/reference/data_types/line_strips3d.md
+++ b/docs/content/reference/data_types/line_strips3d.md
@@ -1,6 +1,5 @@
 ---
 title: "LineStrips3D"
-order: 100
 ---
 
 A batch of line strips with positions and optional colors, radii, labels, etc.

--- a/docs/content/reference/data_types/mesh3d.md
+++ b/docs/content/reference/data_types/mesh3d.md
@@ -1,6 +1,5 @@
 ---
 title: "Mesh3D"
-order: 100
 ---
 
 A 3D triangle mesh as specified by its per-mesh and per-vertex properties.

--- a/docs/content/reference/data_types/pinhole.md
+++ b/docs/content/reference/data_types/pinhole.md
@@ -1,6 +1,5 @@
 ---
 title: "Pinhole"
-order: 100
 ---
 
 Camera perspective projection (a.k.a. intrinsics).

--- a/docs/content/reference/data_types/points2d.md
+++ b/docs/content/reference/data_types/points2d.md
@@ -1,6 +1,5 @@
 ---
 title: "Points2D"
-order: 100
 ---
 
 A 2D point cloud with positions and optional colors, radii, labels, etc.

--- a/docs/content/reference/data_types/points3d.md
+++ b/docs/content/reference/data_types/points3d.md
@@ -1,6 +1,5 @@
 ---
 title: "Points3D"
-order: 100
 ---
 
 A 3D point cloud with positions and optional colors, radii, labels, etc.

--- a/docs/content/reference/data_types/segmentation_image.md
+++ b/docs/content/reference/data_types/segmentation_image.md
@@ -1,6 +1,5 @@
 ---
 title: "SegmentationImage"
-order: 100
 ---
 
 An image made up of integer class-ids

--- a/docs/content/reference/data_types/tensor.md
+++ b/docs/content/reference/data_types/tensor.md
@@ -1,6 +1,5 @@
 ---
 title: "Tensor"
-order: 100
 ---
 
 A generic n-dimensional Tensor.

--- a/docs/content/reference/data_types/text_document.md
+++ b/docs/content/reference/data_types/text_document.md
@@ -1,6 +1,5 @@
 ---
 title: "TextDocument"
-order: 100
 ---
 
 A text element intended to be displayed in its own text-box.

--- a/docs/content/reference/data_types/text_log.md
+++ b/docs/content/reference/data_types/text_log.md
@@ -1,6 +1,5 @@
 ---
 title: "TextLog"
-order: 100
 ---
 
 A log entry in a text log, comprised of a text body and its log level.

--- a/docs/content/reference/data_types/time_series_scalar.md
+++ b/docs/content/reference/data_types/time_series_scalar.md
@@ -1,6 +1,5 @@
 ---
 title: "TimeSeriesScalar"
-order: 100
 ---
 
 Log a double-precision scalar that will be visualized as a time-series plot.

--- a/docs/content/reference/data_types/transform3d.md
+++ b/docs/content/reference/data_types/transform3d.md
@@ -1,6 +1,5 @@
 ---
 title: "Transform3D"
-order: 100
 ---
 
 A 3D transform.

--- a/docs/content/reference/data_types/view_coordinates.md
+++ b/docs/content/reference/data_types/view_coordinates.md
@@ -1,6 +1,5 @@
 ---
 title: "ViewCoordinates"
-order: 100
 ---
 
 How we interpret the coordinate system of an entity/space.


### PR DESCRIPTION
It was originally added when we would output several type definitions to the same file, but we don't do that anymore.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3519) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3519)
- [Docs preview](https://rerun.io/preview/5f1bc465c92da9bf098f3d5bea731dd8b6553584/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5f1bc465c92da9bf098f3d5bea731dd8b6553584/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)