### PR TITLE
Fix auto-layout of space views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,8 +1514,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e518e35195aa95b52de6bac44f53b649efd2caa4a65d066a6bd3a704ad62799a"
+source = "git+https://github.com/rerun-io/egui_tiles.git?rev=b34432b2ff68eb2e087a41b241d70ec367a09334#b34432b2ff68eb2e087a41b241d70ec367a09334"
 dependencies = [
  "ahash 0.8.3",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,3 +164,6 @@ debug = true
 # If that is not possible, patch to a branch that has a PR open on the upstream repo.
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
+
+
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles.git", rev = "b34432b2ff68eb2e087a41b241d70ec367a09334" }

--- a/crates/re_viewport/src/blueprint_components/viewport.rs
+++ b/crates/re_viewport/src/blueprint_components/viewport.rs
@@ -60,7 +60,7 @@ re_log_types::arrow2convert_component_shim!(SpaceViewMaximized as "rerun.bluepri
 ///     ])
 /// );
 /// ```
-#[derive(Clone, Default, ArrowField, ArrowSerialize, ArrowDeserialize)]
+#[derive(Clone, ArrowField, ArrowSerialize, ArrowDeserialize)]
 pub struct ViewportLayout {
     #[arrow_field(type = "SerdeField<std::collections::BTreeSet<SpaceViewId>>")]
     pub space_view_keys: std::collections::BTreeSet<SpaceViewId>,
@@ -69,6 +69,16 @@ pub struct ViewportLayout {
     pub tree: egui_tiles::Tree<SpaceViewId>,
 
     pub auto_layout: bool,
+}
+
+impl Default for ViewportLayout {
+    fn default() -> Self {
+        Self {
+            space_view_keys: Default::default(),
+            tree: Default::default(),
+            auto_layout: true,
+        }
+    }
 }
 
 re_log_types::arrow2convert_component_shim!(ViewportLayout as "rerun.blueprint.ViewportLayout");

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -154,10 +154,6 @@ impl<'a, 'b> Viewport<'a, 'b> {
                 edited: false,
             };
 
-            // We simplify before we take the before-snapshot, because we
-            // don't want to detect automated simplifcation as user edits.
-            tree.simplify(&tab_viewer.simplification_options());
-
             tree.ui(&mut tab_viewer, ui);
 
             // Detect if the user has moved a tab or similar.

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -177,6 +177,10 @@ impl<'a> ViewportBlueprint<'a> {
     }
 
     pub fn mark_user_interaction(&mut self) {
+        if self.auto_layout {
+            re_log::trace!("User edits - will no longer auto-layout");
+        }
+
         self.auto_layout = false;
         self.auto_space_views = false;
     }
@@ -205,7 +209,7 @@ impl<'a> ViewportBlueprint<'a> {
 
         if self.auto_layout {
             // Re-run the auto-layout next frame:
-            re_log::trace!("No user edits yet - will re-run auto-layout");
+            re_log::trace!("Added a space view with no user edits yet - will re-run auto-layout");
             self.tree = Default::default();
         } else {
             // Try to insert it in the tree, in the top level:
@@ -214,11 +218,14 @@ impl<'a> ViewportBlueprint<'a> {
                 if let Some(egui_tiles::Tile::Container(container)) =
                     self.tree.tiles.get_mut(root_id)
                 {
+                    re_log::trace!("Inserting new space view into root container");
                     container.add_child(tile_id);
                 } else {
                     re_log::trace!("Root was not a container - will re-run auto-layout");
-                    self.tree = Default::default(); // we'll just re-initialize later instead
+                    self.tree = Default::default();
                 }
+            } else {
+                re_log::trace!("No root found - will re-run auto-layout");
             }
         }
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -37,7 +37,7 @@ impl ViewportBlueprint<'_> {
                 egui_tiles::Tile::Pane(space_view_id) => space_view_id == focus_tab,
                 egui_tiles::Tile::Container(_) => false,
             });
-            re_log::trace!("Found {focus_tab}: {found}");
+            re_log::trace!("Found tab {focus_tab}: {found}");
         }
 
         for tile_id in remove {
@@ -128,6 +128,10 @@ impl ViewportBlueprint<'_> {
         }
 
         if visibility_changed {
+            if self.auto_layout {
+                re_log::trace!("Container visibility changed - will no longer auto-layout");
+            }
+
             self.auto_layout = false; // Keep `auto_space_views` enabled.
             self.tree.set_visible(tile_id, visible);
         }
@@ -193,6 +197,10 @@ impl ViewportBlueprint<'_> {
         item_ui::select_hovered_on_click(ctx, &response, &[item]);
 
         if visibility_changed {
+            if self.auto_layout {
+                re_log::trace!("Space view visibility changed - will no longer auto-layout");
+            }
+
             self.auto_layout = false; // Keep `auto_space_views` enabled.
             self.tree.set_visible(tile_id, visible);
         }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3521

The problem was `auto_layout` being set to `false` too early.

This fix required a change to `egui_tiles`, so a patch-release of that needs to be done before we publish rerun 0.9:

* https://github.com/rerun-io/egui_tiles/pull/29

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3524) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3524)
- [Docs preview](https://rerun.io/preview/8abfdc1bbcd6ed36786600e59705f90b25017f7e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8abfdc1bbcd6ed36786600e59705f90b25017f7e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)