### PR TITLE
Make `FileSink` actually flush its data when asked to

### DIFF
--- a/crates/re_log_encoding/src/encoder.rs
+++ b/crates/re_log_encoding/src/encoder.rs
@@ -108,6 +108,10 @@ impl<W: std::io::Write> Encoder<W> {
 
         Ok(())
     }
+
+    pub fn flush_blocking(&mut self) -> std::io::Result<()> {
+        self.write.flush()
+    }
 }
 
 pub fn encode<'a>(

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -31,7 +31,9 @@ impl crate::sink::LogSink for re_log_encoding::FileSink {
     }
 
     #[inline]
-    fn flush_blocking(&self) {}
+    fn flush_blocking(&self) {
+        re_log_encoding::FileSink::flush_blocking(self);
+    }
 }
 
 // ---------------


### PR DESCRIPTION
`FileSink` currently ignores flushing requests, which leads to [very hard to track down issues where data is silently dropped even though you're really really trying very hard to flush that dang RecordingStream](https://github.com/rerun-io/rerun/pull/3522#discussion_r1340386604).

- Unblocks https://github.com/rerun-io/rerun/pull/3522

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3525) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3525)
- [Docs preview](https://rerun.io/preview/13d7b65417111c8e12356396f6bdc0ecd94b7168/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/13d7b65417111c8e12356396f6bdc0ecd94b7168/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)