### PR TITLE
Add option to display timestamps in the local system timezone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,6 +3238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5861,6 +5870,8 @@ checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "js-sys",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",

--- a/crates/re_arrow_store/examples/range_components.rs
+++ b/crates/re_arrow_store/examples/range_components.rs
@@ -65,7 +65,7 @@ fn main() {
             "Found data at time {} from {}'s PoV (outer-joining):\n{}",
             time.map_or_else(
                 || "<timeless>".into(),
-                |time| TimeType::Sequence.format(time)
+                |time| TimeType::Sequence.format(time, false)
             ),
             LargeStruct::name(),
             df,
@@ -87,7 +87,7 @@ fn main() {
             "Found data at time {} from {}'s PoV (outer-joining):\n{}",
             time.map_or_else(
                 || "<timeless>".into(),
-                |time| TimeType::Sequence.format(time)
+                |time| TimeType::Sequence.format(time, false)
             ),
             Position2D::name(),
             df,

--- a/crates/re_arrow_store/src/store_format.rs
+++ b/crates/re_arrow_store/src/store_format.rs
@@ -102,7 +102,10 @@ impl std::fmt::Display for IndexedTable {
             f.write_str(&indent::indent_all_by(4, "IndexedBucket {\n"))?;
             f.write_str(&indent::indent_all_by(
                 8,
-                format!("index time bound: >= {}\n", timeline.typ().format(*time),),
+                format!(
+                    "index time bound: >= {}\n",
+                    timeline.typ().format(*time, false)
+                ),
             ))?;
             f.write_str(&indent::indent_all_by(8, bucket.to_string()))?;
             f.write_str(&indent::indent_all_by(4, "}\n"))?;
@@ -123,8 +126,9 @@ impl std::fmt::Display for IndexedBucket {
 
         let time_range = {
             let time_range = &self.inner.read().time_range;
+            // TODO(paris): Understand if this is correct or if we should use show_timestamps_in_local_timezone. Same with other store_* files.
             if time_range.min.as_i64() != i64::MAX && time_range.max.as_i64() != i64::MIN {
-                self.timeline.format_time_range(time_range)
+                self.timeline.format_time_range(time_range, false)
             } else {
                 "time range: N/A\n".to_owned()
             }

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -23,7 +23,7 @@ impl std::fmt::Debug for LatestAtQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
             "<latest at {} on {:?} (including timeless)>",
-            self.timeline.typ().format(self.at),
+            self.timeline.typ().format(self.at, false),
             self.timeline.name(),
         ))
     }
@@ -58,8 +58,8 @@ impl std::fmt::Debug for RangeQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
             "<ranging from {} to {} (all inclusive) on {:?} ({} timeless)>",
-            self.timeline.typ().format(self.range.min),
-            self.timeline.typ().format(self.range.max),
+            self.timeline.typ().format(self.range.min, false),
+            self.timeline.typ().format(self.range.max, false),
             self.timeline.name(),
             if self.range.min == TimeInt::MIN {
                 "including"
@@ -513,11 +513,11 @@ impl IndexedTable {
             trace!(
                 kind = "latest_at",
                 timeline = %timeline.name(),
-                time = timeline.typ().format(time),
+                time = timeline.typ().format(time, false),
                 %primary,
                 ?components,
                 attempt,
-                bucket_time_range = timeline.typ().format_range(bucket.inner.read().time_range),
+                bucket_time_range = timeline.typ().format_range(bucket.inner.read().time_range, false),
                 "found candidate bucket"
             );
             if let cells @ Some(_) = bucket.latest_at(time, primary, components) {
@@ -560,7 +560,7 @@ impl IndexedTable {
                     kind = "range",
                     bucket_nr,
                     bucket_time_range =
-                        timeline.typ().format_range(bucket.inner.read().time_range),
+                        timeline.typ().format_range(bucket.inner.read().time_range, false),
                     timeline = %timeline.name(),
                     ?time_range,
                     ?components,
@@ -715,7 +715,7 @@ impl IndexedBucket {
             %primary,
             ?components,
             timeline = %self.timeline.name(),
-            time = self.timeline.typ().format(time),
+            time = self.timeline.typ().format(time, false),
             "searching for primary & secondary cells…"
         );
 
@@ -736,7 +736,7 @@ impl IndexedBucket {
             %primary,
             ?components,
             timeline = %self.timeline.name(),
-            time = self.timeline.typ().format(time),
+            time = self.timeline.typ().format(time, false),
             %primary_row_nr,
             "found primary row number",
         );
@@ -750,7 +750,7 @@ impl IndexedBucket {
                     %primary,
                     ?components,
                     timeline = %self.timeline.name(),
-                    time = self.timeline.typ().format(time),
+                    time = self.timeline.typ().format(time, false),
                     %primary_row_nr,
                     "no secondary row number found",
                 );
@@ -764,7 +764,7 @@ impl IndexedBucket {
             %primary,
             ?components,
             timeline = %self.timeline.name(),
-            time = self.timeline.typ().format(time),
+            time = self.timeline.typ().format(time, false),
             %primary_row_nr, %secondary_row_nr,
             "found secondary row number",
         );
@@ -779,7 +779,7 @@ impl IndexedBucket {
                         %primary,
                         %component,
                         timeline = %self.timeline.name(),
-                        time = self.timeline.typ().format(time),
+                        time = self.timeline.typ().format(time, false),
                         %primary_row_nr, %secondary_row_nr,
                         "found cell",
                     );
@@ -836,10 +836,10 @@ impl IndexedBucket {
 
         trace!(
             kind = "range",
-            bucket_time_range = self.timeline.typ().format_range(bucket_time_range),
+            bucket_time_range = self.timeline.typ().format_range(bucket_time_range, false),
             ?components,
             timeline = %self.timeline.name(),
-            time_range = self.timeline.typ().format_range(time_range),
+            time_range = self.timeline.typ().format_range(time_range, false),
             "searching for time & component cell numbers…"
         );
 
@@ -847,10 +847,10 @@ impl IndexedBucket {
 
         trace!(
             kind = "range",
-            bucket_time_range = self.timeline.typ().format_range(bucket_time_range),
+            bucket_time_range = self.timeline.typ().format_range(bucket_time_range, false),
             ?components,
             timeline = %self.timeline.name(),
-            time_range = self.timeline.typ().format_range(time_range),
+            time_range = self.timeline.typ().format_range(time_range, false),
             %time_row_nr,
             "found time row number",
         );
@@ -896,10 +896,10 @@ impl IndexedBucket {
                 trace!(
                     kind = "range",
                     bucket_time_range =
-                        self.timeline.typ().format_range(bucket_time_range),
+                        self.timeline.typ().format_range(bucket_time_range, false),
                     ?components,
                     timeline = %self.timeline.name(),
-                    time_range = self.timeline.typ().format_range(time_range),
+                    time_range = self.timeline.typ().format_range(time_range, false),
                     %row_nr,
                     %row_id,
                     ?cells,

--- a/crates/re_arrow_store/src/store_sanity.rs
+++ b/crates/re_arrow_store/src/store_sanity.rs
@@ -100,9 +100,9 @@ impl IndexedTable {
                 if t1.max.as_i64() >= t2.min.as_i64() {
                     return Err(SanityError::OverlappingBuckets {
                         t1_max: t1.max.as_i64(),
-                        t1_max_formatted: self.timeline.typ().format(t1.max),
+                        t1_max_formatted: self.timeline.typ().format(t1.max, false),
                         t2_max: t2.max.as_i64(),
-                        t2_max_formatted: self.timeline.typ().format(t2.max),
+                        t2_max_formatted: self.timeline.typ().format(t2.max, false),
                     });
                 }
             }

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -128,7 +128,7 @@ impl DataStore {
             id = self.insert_id,
             cluster_key = %self.cluster_key,
             timelines = ?timepoint.iter()
-                .map(|(timeline, time)| (timeline.name(), timeline.typ().format(*time)))
+                .map(|(timeline, time)| (timeline.name(), timeline.typ().format(*time, false)))
                 .collect::<Vec<_>>(),
             entity = %ent_path,
             components = ?cells.iter().map(|cell| cell.component_name()).collect_vec(),
@@ -303,11 +303,11 @@ impl IndexedTable {
                 trace!(
                     kind = "insert",
                     timeline = %timeline.name(),
-                    time = timeline.typ().format(time),
+                    time = timeline.typ().format(time, false),
                     entity = %ent_path,
                     len_limit = config.indexed_bucket_num_rows,
                     len, len_overflow,
-                    new_time_bound = timeline.typ().format(min),
+                    new_time_bound = timeline.typ().format(min, false),
                     "splitting off indexed bucket following overflow"
                 );
 
@@ -353,11 +353,11 @@ impl IndexedTable {
                     debug!(
                         kind = "insert",
                         timeline = %timeline.name(),
-                        time = timeline.typ().format(time),
+                        time = timeline.typ().format(time, false),
                         entity = %ent_path,
                         len_limit = config.indexed_bucket_num_rows,
                         len, len_overflow,
-                        new_time_bound = timeline.typ().format(new_time_bound.into()),
+                        new_time_bound = timeline.typ().format(new_time_bound.into(), false),
                         "creating brand new indexed bucket following overflow"
                     );
 
@@ -388,7 +388,7 @@ impl IndexedTable {
 
                 re_log::debug_once!(
                     "Failed to split bucket on timeline {}",
-                    bucket.timeline.format_time_range(&bucket_time_range)
+                    bucket.timeline.format_time_range(&bucket_time_range, false)
                 );
 
                 if 1 < config.indexed_bucket_num_rows
@@ -398,7 +398,7 @@ impl IndexedTable {
                         "Found over {} rows with the same timepoint {:?}={} - perhaps you forgot to update or remove the timeline?",
                         config.indexed_bucket_num_rows,
                         bucket.timeline.name(),
-                        bucket.timeline.typ().format(bucket_time_range.min)
+                        bucket.timeline.typ().format(bucket_time_range.min, false)
                     );
                 }
             }
@@ -407,7 +407,7 @@ impl IndexedTable {
         trace!(
             kind = "insert",
             timeline = %timeline.name(),
-            time = timeline.typ().format(time),
+            time = timeline.typ().format(time, false),
             entity = %ent_path,
             ?components,
             "inserted into indexed tables"

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -85,6 +85,7 @@ pub fn export_env_vars() {
         );
     }
 
+    // TODO(paris): Determine if this needs to be updated if we're displaying in the local timezone.
     let time_format =
         time::format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z").unwrap();
     let date_time = time::OffsetDateTime::now_utc()

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -239,7 +239,12 @@ pub fn time_button(
 ) -> egui::Response {
     let is_selected = ctx.rec_cfg.time_ctrl.is_time_selected(timeline, value);
 
-    let response = ui.selectable_label(is_selected, timeline.typ().format(value));
+    let response = ui.selectable_label(
+        is_selected,
+        timeline
+            .typ()
+            .format(value, ctx.app_options.show_timestamps_in_local_timezone),
+    );
     if response.clicked() {
         ctx.rec_cfg
             .time_ctrl

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -49,7 +49,7 @@ impl DataUi for SetStoreInfo {
             ui.end_row();
 
             ui.monospace("started:");
-            ui.label(started.format());
+            ui.label(started.format(_ctx.app_options.show_timestamps_in_local_timezone));
             ui.end_row();
 
             ui.monospace("store_source:");

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -63,7 +63,7 @@ num-traits = "0.2"
 similar-asserts = "1.4.2"
 smallvec.workspace = true
 thiserror.workspace = true
-time = { workspace = true, features = ["formatting", "macros"] }
+time = { workspace = true, features = ["formatting", "macros", "local-offset"] }
 typenum = "1.15"
 uuid = { version = "1.1", features = ["serde", "v4", "js"] }
 web-time.workspace = true

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -546,7 +546,15 @@ impl std::fmt::Display for DataRow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Row #{} @ '{}'", self.row_id, self.entity_path)?;
         for (timeline, time) in &self.timepoint {
-            writeln!(f, "- {}: {}", timeline.name(), timeline.typ().format(*time))?;
+            // TODO(paris): Figure how to pass show_timestamps_in_local_timezone in to fmt(). We get:
+            // "method `fmt` has 3 parameters but the declaration in trait `std::fmt::Display::fmt` has 2"
+            // If we should be passing it, there are also a few other places to do so.
+            writeln!(
+                f,
+                "- {}: {}",
+                timeline.name(),
+                timeline.typ().format(*time, false)
+            )?;
         }
 
         re_format::arrow::format_table(

--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -1,5 +1,5 @@
 use std::ops::RangeInclusive;
-use time::OffsetDateTime;
+use time::{OffsetDateTime, UtcOffset};
 
 /// A date-time represented as nanoseconds since unix epoch
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -63,19 +63,23 @@ impl Time {
     }
 
     /// Human-readable formatting
-    pub fn format(&self) -> String {
+    pub fn format(&self, show_timestamps_in_local_timezone: bool) -> String {
         let nanos_since_epoch = self.nanos_since_epoch();
 
         if let Some(datetime) = self.to_datetime() {
+            let local_offset = UtcOffset::current_local_offset();
+            let will_show_timestamps_in_local_timezone =
+                show_timestamps_in_local_timezone && local_offset.is_ok();
+
             let is_whole_second = nanos_since_epoch % 1_000_000_000 == 0;
             let is_whole_millisecond = nanos_since_epoch % 1_000_000 == 0;
 
             let time_format = if is_whole_second {
-                "[hour]:[minute]:[second]Z"
+                "[hour]:[minute]:[second]"
             } else if is_whole_millisecond {
-                "[hour]:[minute]:[second].[subsecond digits:3]Z"
+                "[hour]:[minute]:[second].[subsecond digits:3]"
             } else {
-                "[hour]:[minute]:[second].[subsecond digits:6]Z"
+                "[hour]:[minute]:[second].[subsecond digits:6]"
             };
 
             let date_is_today = datetime.date() == OffsetDateTime::now_utc().date();
@@ -85,7 +89,17 @@ impl Time {
             } else {
                 time::format_description::parse(&date_format).unwrap()
             };
-            datetime.format(&parsed_format).unwrap()
+
+            // Return in the local timezone.
+            if will_show_timestamps_in_local_timezone {
+                let local_datetime = datetime.to_offset(local_offset.unwrap());
+                return local_datetime.format(&parsed_format).unwrap();
+            }
+
+            // Return in UTC.
+            let mut formatted_datetime = datetime.format(&parsed_format).unwrap();
+            formatted_datetime.push('Z');
+            formatted_datetime
         } else {
             // Relative time
             let secs = nanos_since_epoch as f64 * 1e-9;
@@ -104,12 +118,16 @@ impl Time {
     ///
     /// Shows dates when zoomed out, shows times when zoomed in,
     /// shows relative millisecond when really zoomed in.
-    pub fn format_time_compact(&self) -> String {
+    pub fn format_time_compact(&self, show_timestamps_in_local_timezone: bool) -> String {
         let ns = self.nanos_since_epoch();
         let relative_ns = ns % 1_000_000_000;
         let is_whole_second = relative_ns == 0;
         if is_whole_second {
             if let Some(datetime) = self.to_datetime() {
+                let local_offset = UtcOffset::current_local_offset();
+                let will_show_timestamps_in_local_timezone =
+                    show_timestamps_in_local_timezone && local_offset.is_ok();
+
                 let is_whole_minute = ns % 60_000_000_000 == 0;
                 let time_format = if self.is_exactly_midnight() {
                     "[year]-[month]-[day]Z"
@@ -119,7 +137,18 @@ impl Time {
                     "[hour]:[minute]:[second]Z"
                 };
                 let parsed_format = time::format_description::parse(time_format).unwrap();
-                return datetime.format(&parsed_format).unwrap();
+
+                // Return in the local timezone.
+                if will_show_timestamps_in_local_timezone {
+                    let local_datetime = datetime.to_offset(local_offset.unwrap());
+                    let local_formatted_datetime = local_datetime.format(&parsed_format).unwrap();
+                    return local_formatted_datetime;
+                }
+
+                // Return in UTC.
+                let mut formatted_datetime = datetime.format(&parsed_format).unwrap();
+                formatted_datetime.push('Z');
+                return formatted_datetime;
             }
 
             crate::Duration::from_nanos(ns).to_string()
@@ -155,7 +184,7 @@ impl Time {
 
 impl std::fmt::Debug for Time {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.format().fmt(f)
+        self.format(false).fmt(f)
     }
 }
 
@@ -224,6 +253,7 @@ impl TryFrom<time::OffsetDateTime> for Time {
 
 // ---------------
 
+// TODO(paris): Add tests for show_timestamps_in_local_timezone.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,27 +261,27 @@ mod tests {
 
     #[test]
     fn test_formatting_short_times() {
-        assert_eq!(&Time::from_us_since_epoch(42_000_000).format(), "+42s");
-        assert_eq!(&Time::from_us_since_epoch(69_000).format(), "+0.069s");
-        assert_eq!(&Time::from_us_since_epoch(69_900).format(), "+0.070s");
+        assert_eq!(&Time::from_us_since_epoch(42_000_000).format(false), "+42s");
+        assert_eq!(&Time::from_us_since_epoch(69_000).format(false), "+0.069s");
+        assert_eq!(&Time::from_us_since_epoch(69_900).format(false), "+0.070s");
     }
 
     #[test]
     fn test_formatting_whole_second_for_datetime() {
         let datetime = Time::try_from(datetime!(2022-02-28 22:35:42 UTC)).unwrap();
-        assert_eq!(&datetime.format(), "2022-02-28 22:35:42Z");
+        assert_eq!(&datetime.format(false), "2022-02-28 22:35:42Z");
     }
 
     #[test]
     fn test_formatting_whole_millisecond_for_datetime() {
         let datetime = Time::try_from(datetime!(2022-02-28 22:35:42.069 UTC)).unwrap();
-        assert_eq!(&datetime.format(), "2022-02-28 22:35:42.069Z");
+        assert_eq!(&datetime.format(false), "2022-02-28 22:35:42.069Z");
     }
 
     #[test]
     fn test_formatting_many_digits_for_datetime() {
         let datetime = Time::try_from(datetime!(2022-02-28 22:35:42.069_042_7 UTC)).unwrap();
-        assert_eq!(&datetime.format(), "2022-02-28 22:35:42.069042Z"); // format function is not rounding
+        assert_eq!(&datetime.format(false), "2022-02-28 22:35:42.069042Z"); // format function is not rounding
     }
 
     /// Check that formatting today times doesn't display the date.
@@ -261,7 +291,7 @@ mod tests {
     fn test_formatting_today_omit_date() {
         let today = OffsetDateTime::now_utc().replace_time(time!(22:35:42));
         let datetime = Time::try_from(today).unwrap();
-        assert_eq!(&datetime.format(), "22:35:42Z");
+        assert_eq!(&datetime.format(false), "22:35:42Z");
     }
 }
 

--- a/crates/re_log_types/src/time_point/mod.rs
+++ b/crates/re_log_types/src/time_point/mod.rs
@@ -128,24 +128,28 @@ impl TimeType {
         }
     }
 
-    pub fn format(&self, time_int: TimeInt) -> String {
+    pub fn format(&self, time_int: TimeInt, show_timestamps_in_local_timezone: bool) -> String {
         if time_int <= TimeInt::BEGINNING {
             "-∞".into()
         } else if time_int >= TimeInt::MAX {
             "+∞".into()
         } else {
             match self {
-                Self::Time => Time::from(time_int).format(),
+                Self::Time => Time::from(time_int).format(show_timestamps_in_local_timezone),
                 Self::Sequence => format!("#{}", time_int.0),
             }
         }
     }
 
-    pub fn format_range(&self, time_range: TimeRange) -> String {
+    pub fn format_range(
+        &self,
+        time_range: TimeRange,
+        show_timestamps_in_local_timezone: bool,
+    ) -> String {
         format!(
             "{}..={}",
-            self.format(time_range.min),
-            self.format(time_range.max)
+            self.format(time_range.min, show_timestamps_in_local_timezone),
+            self.format(time_range.max, show_timestamps_in_local_timezone)
         )
     }
 }

--- a/crates/re_log_types/src/time_point/timeline.rs
+++ b/crates/re_log_types/src/time_point/timeline.rs
@@ -93,12 +93,18 @@ impl Timeline {
 
     /// Returns a formatted string of `time_range` on this `Timeline`.
     #[inline]
-    pub fn format_time_range(&self, time_range: &TimeRange) -> String {
+    pub fn format_time_range(
+        &self,
+        time_range: &TimeRange,
+        show_timestamps_in_local_timezone: bool,
+    ) -> String {
         format!(
             "    - {}: from {} to {} (all inclusive)",
             self.name,
-            self.typ.format(time_range.min),
-            self.typ.format(time_range.max),
+            self.typ
+                .format(time_range.min, show_timestamps_in_local_timezone),
+            self.typ
+                .format(time_range.max, show_timestamps_in_local_timezone),
         )
     }
 

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -278,6 +278,7 @@ impl TimePanel {
             &time_area_painter,
             timeline_rect.top()..=timeline_rect.bottom(),
             ctx.rec_cfg.time_ctrl.time_type(),
+            ctx.app_options.show_timestamps_in_local_timezone,
         );
         paint_time_ranges_gaps(
             &self.time_ranges_ui,
@@ -799,7 +800,9 @@ fn current_time_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
         let timeline = ctx.rec_cfg.time_ctrl.timeline();
         if is_time_safe_to_show(ctx.store_db, timeline, time_int.into()) {
             let time_type = ctx.rec_cfg.time_ctrl.time_type();
-            ui.monospace(time_type.format(time_int));
+            ui.monospace(
+                time_type.format(time_int, ctx.app_options.show_timestamps_in_local_timezone),
+            );
         }
     }
 }

--- a/crates/re_time_panel/src/paint_ticks.rs
+++ b/crates/re_time_panel/src/paint_ticks.rs
@@ -13,6 +13,7 @@ pub fn paint_time_ranges_and_ticks(
     time_area_painter: &egui::Painter,
     line_y_range: RangeInclusive<f32>,
     time_type: TimeType,
+    show_timestamps_in_local_timezone: bool,
 ) {
     let clip_rect = ui.clip_rect();
     let clip_left = clip_rect.left() as f64;
@@ -46,7 +47,13 @@ pub fn paint_time_ranges_and_ticks(
         let rect = Rect::from_x_y_ranges(x_range, line_y_range.clone());
         time_area_painter
             .with_clip_rect(rect)
-            .extend(paint_time_range_ticks(ui, &rect, time_type, &time_range));
+            .extend(paint_time_range_ticks(
+                ui,
+                &rect,
+                time_type,
+                &time_range,
+                show_timestamps_in_local_timezone,
+            ));
     }
 }
 
@@ -55,6 +62,7 @@ fn paint_time_range_ticks(
     rect: &Rect,
     time_type: TimeType,
     time_range: &TimeRangeF,
+    _show_timestamps_in_local_timezone: bool,
 ) -> Vec<Shape> {
     let font_id = egui::TextStyle::Small.resolve(ui.style());
 
@@ -68,7 +76,8 @@ fn paint_time_range_ticks(
                 &ui.clip_rect(),
                 time_range, // ns
                 next_grid_tick_magnitude_ns,
-                |ns| Time::from_ns_since_epoch(ns).format_time_compact(),
+                // TODO(paris): Fix 'closures can only be coerced to `fn` types if they do not capture any variables' error.
+                |ns| Time::from_ns_since_epoch(ns).format_time_compact(false),
             )
         }
         TimeType::Sequence => {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -4,7 +4,9 @@ use time::macros::format_description;
 
 use re_log_types::LogMsg;
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
-use re_viewer_context::{CommandSender, SystemCommand, SystemCommandSender, ViewerContext};
+use re_viewer_context::{
+    AppOptions, CommandSender, SystemCommand, SystemCommandSender, ViewerContext,
+};
 
 static TIME_FORMAT_DESCRIPTION: once_cell::sync::Lazy<
     &'static [time::format_description::FormatItem<'static>],
@@ -138,6 +140,7 @@ fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
         if store_dbs.len() == 1 {
             let store_db = store_dbs[0];
             if recording_ui(
+                ctx.app_options,
                 ctx.re_ui,
                 ui,
                 store_db,
@@ -158,6 +161,7 @@ fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
                 |_, ui| {
                     for store_db in store_dbs {
                         if recording_ui(
+                            ctx.app_options,
                             ctx.re_ui,
                             ui,
                             store_db,
@@ -184,6 +188,7 @@ fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
 ///
 /// If an `app_id_label` is provided, it will be shown in front of the recording time.
 fn recording_ui(
+    app_options: &AppOptions,
     re_ui: &re_ui::ReUi,
     ui: &mut egui::Ui,
     store_db: &re_data_store::StoreDb,
@@ -202,6 +207,7 @@ fn recording_ui(
         .and_then(|info| {
             info.started
                 .to_datetime()
+                // TODO(paris): Update this formatting based on whether in UTC or not.
                 .and_then(|dt| dt.format(&TIME_FORMAT_DESCRIPTION).ok())
         })
         .unwrap_or("<unknown time>".to_owned());
@@ -231,11 +237,16 @@ fn recording_ui(
         .show(ui);
 
     response.on_hover_ui(|ui| {
-        recording_hover_ui(re_ui, ui, store_db);
+        recording_hover_ui(app_options, re_ui, ui, store_db);
     })
 }
 
-fn recording_hover_ui(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, store_db: &re_data_store::StoreDb) {
+fn recording_hover_ui(
+    app_options: &AppOptions,
+    re_ui: &re_ui::ReUi,
+    ui: &mut egui::Ui,
+    store_db: &re_data_store::StoreDb,
+) {
     egui::Grid::new("recording_hover_ui")
         .num_columns(2)
         .show(ui, |ui| {
@@ -264,7 +275,7 @@ fn recording_hover_ui(re_ui: &re_ui::ReUi, ui: &mut egui::Ui, store_db: &re_data
                 ui.end_row();
 
                 re_ui.grid_left_hand_label(ui, "Recording started");
-                ui.label(started.format());
+                ui.label(started.format(app_options.show_timestamps_in_local_timezone));
                 ui.end_row();
 
                 re_ui.grid_left_hand_label(ui, "Source");

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -164,6 +164,19 @@ impl App {
             ui.close_menu();
         }
 
+        if self
+            .re_ui
+            .checkbox(
+                ui,
+                &mut self.state.app_options.show_timestamps_in_local_timezone,
+                "Show timestamps in local timezone",
+            )
+            .on_hover_text("Convert timestamps from UTC to the local timezone")
+            .clicked()
+        {
+            ui.close_menu();
+        }
+
         #[cfg(not(target_arch = "wasm32"))]
         {
             if self.re_ui

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -1,5 +1,6 @@
 use egui::NumExt as _;
 use re_format::format_number;
+use re_log_types::Time;
 use re_renderer::WgpuResourcePoolStatistics;
 use re_ui::UICommand;
 use re_viewer_context::StoreContext;
@@ -81,6 +82,7 @@ fn top_bar_ui(
         frame_time_label_ui(ui, app);
         memory_use_label_ui(ui, gpu_resource_stats);
         input_latency_label_ui(ui, app);
+        paris_debug_ui(ui);
     }
 
     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -197,6 +199,18 @@ fn frame_time_label_ui(ui: &mut egui::Ui, app: &App) {
         ui.label(egui::RichText::new(text).monospace().color(color))
             .on_hover_text("CPU time used by Rerun Viewer each frame. Lower is better.");
     }
+}
+
+// TODO(paris): Just for testing, remove before going from draft to live.
+fn paris_debug_ui(ui: &mut egui::Ui) {
+    let visuals = ui.visuals();
+    let color = visuals.weak_text_color();
+
+    let t = Time::now();
+    let local = t.format(true);
+    let utc = t.format(false);
+    let text = format!("Local Time: {local} - UTC Time: {utc}");
+    ui.label(egui::RichText::new(text).monospace().color(color));
 }
 
 fn memory_use_label_ui(ui: &mut egui::Ui, gpu_resource_stats: &WgpuResourcePoolStatistics) {

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -23,6 +23,9 @@ pub struct AppOptions {
 
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
+
+    /// If true, show timestamps in the local timezone.
+    pub show_timestamps_in_local_timezone: bool,
 }
 
 impl Default for AppOptions {
@@ -40,6 +43,8 @@ impl Default for AppOptions {
             experimental_space_view_screenshots: false,
 
             show_picking_debug_overlay: false,
+
+            show_timestamps_in_local_timezone: false,
         }
     }
 }


### PR DESCRIPTION
### What
Adds the option to display timestamps in the local system timezone, addressing https://github.com/rerun-io/rerun/issues/1714.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)