### PR TITLE
New decorator/context manager to catch exceptions when not in strict mode.

### DIFF
--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -147,6 +147,12 @@ impl MemorySinkStorage {
         self.msgs.read()
     }
 
+    /// How many messages are currently written to this memory sink
+    #[inline]
+    pub fn num_msgs(&self) -> usize {
+        self.read().len()
+    }
+
     /// Consumes and returns the inner array of [`LogMsg`].
     ///
     /// This automatically takes care of flushing the underlying [`crate::RecordingStream`].

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -323,6 +323,7 @@ impl PythonCodeGenerator {
             import numpy.typing as npt
             import pyarrow as pa
             import uuid
+            from ..error_utils import catch_and_log_exceptions
 
             from {rerun_path}_baseclasses import (
                 Archetype,
@@ -1656,8 +1657,15 @@ fn quote_init_method(obj: &Object, ext_class: &ExtensionClass, objects: &Objects
         format!("self.__attrs_init__({})", attribute_init.join(", "))
     };
 
+    // Make sure Archetypes catch and log exceptions as a fallback
+    let decorator = if obj.kind == ObjectKind::Archetype {
+        "@catch_and_log_exceptions()\n"
+    } else {
+        ""
+    };
+
     format!(
-        "{head}\n{}",
+        "{decorator}{head}\n{}",
         indent::indent_all_by(
             4,
             format!("{doc_block}\n\n{custom_init_hint}\n{forwarding_call}"),

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -1663,18 +1663,14 @@ fn quote_init_method(obj: &Object, ext_class: &ExtensionClass, objects: &Objects
 
     // Make sure Archetypes catch and log exceptions as a fallback
     let forwarding_call = if obj.kind == ObjectKind::Archetype {
-        let required_param_nones = obj
-            .fields
-            .iter()
-            .map(|field| format!("{} = None,", field.name))
-            .join("\n");
-        [
-            "with catch_and_log_exceptions(context=self.__class__.__name__):".to_owned(),
-            indent::indent_all_by(4, forwarding_call),
-            indent::indent_all_by(4, "return"),
-            format!("self.__attrs_init__({required_param_nones})"),
-        ]
-        .join("\n")
+        unindent::unindent(&format!(
+            r#"
+            with catch_and_log_exceptions(context=self.__class__.__name__):
+                {forwarding_call}
+                return
+            self.__attrs_clear__()
+            "#
+        ))
     } else {
         forwarding_call
     };

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -1659,11 +1659,16 @@ fn quote_init_method(obj: &Object, ext_class: &ExtensionClass, objects: &Objects
 
     // Make sure Archetypes catch and log exceptions as a fallback
     let forwarding_call = if obj.kind == ObjectKind::Archetype {
+        let required_param_nones = obj
+            .fields
+            .iter()
+            .map(|field| format!("{} = None,", field.name))
+            .join("\n");
         [
             "with catch_and_log_exceptions(context=self.__class__.__name__):".to_owned(),
             indent::indent_all_by(4, forwarding_call),
             indent::indent_all_by(4, "return"),
-            "self.__attrs_init__()".to_owned(),
+            format!("self.__attrs_init__({required_param_nones})"),
         ]
         .join("\n")
     } else {

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -1660,7 +1660,7 @@ fn quote_init_method(obj: &Object, ext_class: &ExtensionClass, objects: &Objects
     // Make sure Archetypes catch and log exceptions as a fallback
     let forwarding_call = if obj.kind == ObjectKind::Archetype {
         [
-            format!("with catch_and_log_exceptions(\"{}\"):", obj.name),
+            "with catch_and_log_exceptions(context=self.__class__.__name__):".to_owned(),
             indent::indent_all_by(4, forwarding_call),
             indent::indent_all_by(4, "return"),
             "self.__attrs_init__()".to_owned(),

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -142,6 +142,7 @@ from .archetypes import (
 )
 from .components import MediaType
 from .datatypes import Quaternion, RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D
+from .error_utils import set_strict_mode
 from .log_deprecated.annotation import AnnotationInfo, ClassDescription, log_annotation_context
 from .log_deprecated.arrow import log_arrow
 from .log_deprecated.bounding_box import log_obb, log_obbs
@@ -195,7 +196,6 @@ __all__ += [
     "unregister_shutdown",
     "cleanup_if_forked_child",
     "shutdown_at_exit",
-    "strict_mode",
     "set_strict_mode",
     "start_web_viewer_server",
 ]
@@ -218,11 +218,6 @@ def _init_recording_stream() -> None:
 
 
 _init_recording_stream()
-
-
-# If `True`, we raise exceptions on use error (wrong parameter types, etc.).
-# If `False` we catch all errors and log a warning instead.
-_strict_mode = False
 
 
 def init(
@@ -294,8 +289,7 @@ def init(
         random.seed(0)
         np.random.seed(0)
 
-    global _strict_mode
-    _strict_mode = strict
+    set_strict_mode(strict)
 
     # Always check whether we are a forked child when calling init.  This should have happened
     # via `_register_on_fork` but it's worth being conservative.
@@ -500,35 +494,6 @@ def shutdown_at_exit(func: _TFunc) -> _TFunc:
 
 
 # ---
-
-
-def strict_mode() -> bool:
-    """
-    Strict mode enabled.
-
-    In strict mode, incorrect use of the Rerun API (wrong parameter types etc.)
-    will result in exception being raised.
-    When strict mode is on, such problems are instead logged as warnings.
-
-    The default is OFF.
-    """
-
-    return _strict_mode
-
-
-def set_strict_mode(mode: bool) -> None:
-    """
-    Turn strict mode on/off.
-
-    In strict mode, incorrect use of the Rerun API (wrong parameter types etc.)
-    will result in exception being raised.
-    When strict mode is off, such problems are instead logged as warnings.
-
-    The default is OFF.
-    """
-    global _strict_mode
-
-    _strict_mode = mode
 
 
 def start_web_viewer_server(port: int = 0) -> None:

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -152,10 +152,9 @@ class BaseBatch(Generic[T]):
     _ARROW_TYPE: BaseExtensionType = None  # type: ignore[assignment]
     """The pyarrow type of this batch."""
 
-    @catch_and_log_exceptions()
     def __init__(self, data: T | None) -> None:
         """
-        Primary method for creating Arrow arrays for required components.
+        Construct a new batch.
 
         This method must flexibly accept native data (which comply with type `T`). Subclasses must provide a type
         parameter specifying the type of the native data (this is automatically handled by the code generator).
@@ -190,6 +189,15 @@ class BaseBatch(Generic[T]):
 
         # If we didn't return above, default to the empty array
         self.pa_array = _empty_pa_array(self._ARROW_TYPE)
+
+    @classmethod
+    def _required(cls, data: T | None) -> BaseBatch[T]:
+        """
+        Primary method for creating Arrow arrays for optional components.
+
+        Just calls through to __init__, but with clearer type annotations.
+        """
+        return cls(data)
 
     @classmethod
     def _optional(cls, data: T | None) -> BaseBatch[T] | None:
@@ -272,6 +280,7 @@ class ComponentBatchMixin(ComponentBatchLike):
         return self._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
 
 
+@catch_and_log_exceptions(context="creating empty array")
 def _empty_pa_array(type: pa.DataType) -> pa.Array:
     if isinstance(type, pa.ExtensionType):
         return type.wrap_array(_empty_pa_array(type.storage_type))

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -5,6 +5,8 @@ from typing import Any, Generic, Iterable, Protocol, TypeVar
 import pyarrow as pa
 from attrs import define, fields
 
+from .error_utils import catch_and_log_exceptions
+
 T = TypeVar("T")
 
 
@@ -150,6 +152,7 @@ class BaseBatch(Generic[T]):
     _ARROW_TYPE: BaseExtensionType = None  # type: ignore[assignment]
     """The pyarrow type of this batch."""
 
+    @catch_and_log_exceptions()
     def __init__(self, data: T | None) -> None:
         """
         Primary method for creating Arrow arrays for required components.
@@ -172,22 +175,21 @@ class BaseBatch(Generic[T]):
         -------
         The Arrow array encapsulating the data.
         """
-
-        # If data is already an arrow array, use it
-        if isinstance(data, pa.Array):
-            if data.type == self._ARROW_TYPE:
-                self.pa_array = data
+        if data is not None:
+            with catch_and_log_exceptions(self.__class__.__name__):
+                # If data is already an arrow array, use it
+                if isinstance(data, pa.Array) and data.type == self._ARROW_TYPE:
+                    self.pa_array = data
+                elif isinstance(data, pa.Array) and data.type == self._ARROW_TYPE.storage_type:
+                    self.pa_array = self._ARROW_TYPE.wrap_array(data)
+                else:
+                    self.pa_array = self._ARROW_TYPE.wrap_array(
+                        self._native_to_pa_array(data, self._ARROW_TYPE.storage_type)
+                    )
                 return
-            elif data.type == self._ARROW_TYPE.storage_type:
-                self.pa_array = self._ARROW_TYPE.wrap_array(data)
-                return
 
-        if data is None:
-            pa_array = _empty_pa_array(self._ARROW_TYPE.storage_type)
-        else:
-            pa_array = self._native_to_pa_array(data, self._ARROW_TYPE.storage_type)
-
-        self.pa_array = self._ARROW_TYPE.wrap_array(pa_array)
+        # If we didn't return above, default to the empty array
+        self.pa_array = _empty_pa_array(self._ARROW_TYPE)
 
     @classmethod
     def _optional(cls, data: T | None) -> BaseBatch[T] | None:
@@ -272,7 +274,7 @@ class ComponentBatchMixin(ComponentBatchLike):
 
 def _empty_pa_array(type: pa.DataType) -> pa.Array:
     if isinstance(type, pa.ExtensionType):
-        return _empty_pa_array(type.storage_type)
+        return type.wrap_array(_empty_pa_array(type.storage_type))
 
     # Creation of empty arrays of dense unions aren't implemented in pyarrow yet.
     if isinstance(type, pa.UnionType):

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -214,6 +214,11 @@ def log_components(
         num_instances = max(len(arr) for arr in arrow_arrays)
 
     for name, array in zip(names, arrow_arrays):
+        # Array could be None if there was an error producing the empty array
+        # Nothing we can do at this point other than ignore it. Some form of error
+        # should have been logged.
+        if array is None:
+            pass
         # Strip off the ExtensionArray if it's present. We will always log via component_name.
         # TODO(jleibs): Maybe warn if there is a name mismatch here.
         if isinstance(array, pa.ExtensionArray):

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -144,7 +144,7 @@ def log(
     if hasattr(entity, "as_component_batches"):
         components = entity.as_component_batches()
     else:
-        components = entity
+        components = list(entity)
 
     if hasattr(entity, "num_instances"):
         num_instances = entity.num_instances()

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -9,7 +9,7 @@ import rerun_bindings as bindings
 
 from . import components as cmp
 from ._baseclasses import AsComponents, ComponentBatchLike
-from .error_utils import _send_warning
+from .error_utils import _send_warning, catch_and_log_exceptions
 from .recording_stream import RecordingStream
 
 __all__ = ["log", "IndicatorComponentBatch", "AsComponents"]
@@ -102,6 +102,7 @@ def _splat() -> cmp.InstanceKeyBatch:
     return pa.array([_MAX_U64], type=cmp.InstanceKeyType().storage_type)  # type: ignore[no-any-return]
 
 
+@catch_and_log_exceptions()
 def log(
     entity_path: str,
     entity: AsComponents | Iterable[ComponentBatchLike],
@@ -109,6 +110,7 @@ def log(
     ext: dict[str, Any] | None = None,
     timeless: bool = False,
     recording: RecordingStream | None = None,
+    strict: bool | None = None,
 ) -> None:
     """
     Log an entity.
@@ -127,7 +129,10 @@ def log(
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
-
+    strict:
+        If True, raise exceptions on non-loggable data.
+        If False, warn on non-loggable data.
+        if None, use the global default from `rerun.strict_mode()`
     """
     # TODO(jleibs): Profile is_instance with runtime_checkable vs has_attr
     # Note from: https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -156,6 +161,7 @@ def log(
     )
 
 
+@catch_and_log_exceptions()
 def log_components(
     entity_path: str,
     components: Iterable[ComponentBatchLike],
@@ -164,6 +170,7 @@ def log_components(
     ext: dict[str, Any] | None = None,
     timeless: bool = False,
     recording: RecordingStream | None = None,
+    strict: bool | None = None,
 ) -> None:
     """
     Log an entity from a collection of `ComponentBatchLike` objects.
@@ -190,7 +197,10 @@ def log_components(
         Specifies the [`rerun.RecordingStream`][] to use. If left unspecified,
         defaults to the current active data recording, if there is one. See
         also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
-
+    strict:
+        If True, raise exceptions on non-loggable data.
+        If False, warn on non-loggable data.
+        if None, use the global default from `rerun.strict_mode()`
     """
     instanced: dict[str, pa.Array] = {}
     splats: dict[str, pa.Array] = {}

--- a/rerun_py/rerun_sdk/rerun/_validators.py
+++ b/rerun_py/rerun_sdk/rerun/_validators.py
@@ -62,7 +62,7 @@ def flat_np_float_array_from_array_like(data: Any, dimension: int) -> npt.NDArra
 
     if not valid:
         raise ValueError(
-            f"Expected either a flat array with a length a of {dimension} elements, or an array with shape (`num_elements`, {dimension}). Shape of passed array was {array.shape}."
+            f"Expected either a flat array with a length multiple of {dimension} elements, or an array with shape (`num_elements`, {dimension}). Shape of passed array was {array.shape}."
         )
 
     return array.reshape((-1,))

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -136,6 +136,13 @@ class AnnotationContext(Archetype):
             context=None,
         )
 
+    @classmethod
+    def _clear(cls) -> AnnotationContext:
+        """Produce an empty AnnotationContext."""
+        return cls(
+            context=None,  # type: ignore[arg-type]
+        )
+
     context: components.AnnotationContextBatch = field(
         metadata={"component": "required"},
         converter=components.AnnotationContextBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AnnotationContext"]
 
@@ -124,6 +125,7 @@ class AnnotationContext(Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, context: components.AnnotationContextLike):
         """Create a new instance of the AnnotationContext archetype."""
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -132,7 +132,9 @@ class AnnotationContext(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(context=context)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            context=None,
+        )
 
     context: components.AnnotationContextBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -129,7 +129,7 @@ class AnnotationContext(Archetype):
         """Create a new instance of the AnnotationContext archetype."""
 
         # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py
-        with catch_and_log_exceptions("AnnotationContext"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(context=context)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -132,9 +132,7 @@ class AnnotationContext(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(context=context)
             return
-        self.__attrs_init__(
-            context=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -136,12 +136,18 @@ class AnnotationContext(Archetype):
             context=None,
         )
 
-    @classmethod
-    def _clear(cls) -> AnnotationContext:
-        """Produce an empty AnnotationContext."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             context=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> AnnotationContext:
+        """Produce an empty AnnotationContext, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     context: components.AnnotationContextBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -125,16 +125,18 @@ class AnnotationContext(Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, context: components.AnnotationContextLike):
         """Create a new instance of the AnnotationContext archetype."""
 
         # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py
-        self.__attrs_init__(context=context)
+        with catch_and_log_exceptions("AnnotationContext"):
+            self.__attrs_init__(context=context)
+            return
+        self.__attrs_init__()
 
     context: components.AnnotationContextBatch = field(
         metadata={"component": "required"},
-        converter=components.AnnotationContextBatch,  # type: ignore[misc]
+        converter=components.AnnotationContextBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -48,10 +48,9 @@ class Arrows3D(Arrows3DExt, Archetype):
 
     # __init__ can be found in arrows3d_ext.py
 
-    @classmethod
-    def _clear(cls) -> Arrows3D:
-        """Produce an empty Arrows3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             vectors=None,  # type: ignore[arg-type]
             origins=None,  # type: ignore[arg-type]
             radii=None,  # type: ignore[arg-type]
@@ -60,6 +59,13 @@ class Arrows3D(Arrows3DExt, Archetype):
             class_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Arrows3D:
+        """Produce an empty Arrows3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     vectors: components.Vector3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -48,6 +48,19 @@ class Arrows3D(Arrows3DExt, Archetype):
 
     # __init__ can be found in arrows3d_ext.py
 
+    @classmethod
+    def _clear(cls) -> Arrows3D:
+        """Produce an empty Arrows3D."""
+        return cls(
+            vectors=None,  # type: ignore[arg-type]
+            origins=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     vectors: components.Vector3DBatch = field(
         metadata={"component": "required"},
         converter=components.Vector3DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -50,7 +50,7 @@ class Arrows3D(Arrows3DExt, Archetype):
 
     vectors: components.Vector3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Vector3DBatch,  # type: ignore[misc]
+        converter=components.Vector3DBatch._required,  # type: ignore[misc]
     )
     """
     All the vectors for each arrow in the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
@@ -59,4 +59,12 @@ class Arrows3DExt:
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            vectors=None,
+            origins=None,
+            radii=None,
+            colors=None,
+            labels=None,
+            class_ids=None,
+            instance_keys=None,
+        )

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .. import components, datatypes
+from ..error_utils import catch_and_log_exceptions
 
 
 class Arrows3DExt:
@@ -47,12 +48,15 @@ class Arrows3DExt:
 
         # Custom constructor to remove positional arguments and force use of keyword arguments
         # while still making vectors required.
-        self.__attrs_init__(
-            vectors=vectors,
-            origins=origins,
-            radii=radii,
-            colors=colors,
-            labels=labels,
-            class_ids=class_ids,
-            instance_keys=instance_keys,
-        )
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            self.__attrs_init__(
+                vectors=vectors,
+                origins=origins,
+                radii=radii,
+                colors=colors,
+                labels=labels,
+                class_ids=class_ids,
+                instance_keys=instance_keys,
+            )
+            return
+        self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
@@ -59,12 +59,4 @@ class Arrows3DExt:
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__(
-            vectors=None,
-            origins=None,
-            radii=None,
-            colors=None,
-            labels=None,
-            class_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .asset3d_ext import Asset3DExt
 
 __all__ = ["Asset3D"]
@@ -73,6 +74,7 @@ class Asset3D(Asset3DExt, Archetype):
     ```
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         blob: components.BlobLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -74,7 +74,6 @@ class Asset3D(Asset3DExt, Archetype):
     ```
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         blob: components.BlobLike,
@@ -105,11 +104,14 @@ class Asset3D(Asset3DExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of Asset3DExt in asset3d_ext.py
-        self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
+        with catch_and_log_exceptions("Asset3D"):
+            self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
+            return
+        self.__attrs_init__()
 
     blob: components.BlobBatch = field(
         metadata={"component": "required"},
-        converter=components.BlobBatch,  # type: ignore[misc]
+        converter=components.BlobBatch._required,  # type: ignore[misc]
     )
     """
     The asset's bytes.

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -104,7 +104,7 @@ class Asset3D(Asset3DExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of Asset3DExt in asset3d_ext.py
-        with catch_and_log_exceptions("Asset3D"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -113,14 +113,20 @@ class Asset3D(Asset3DExt, Archetype):
             transform=None,
         )
 
-    @classmethod
-    def _clear(cls) -> Asset3D:
-        """Produce an empty Asset3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             blob=None,  # type: ignore[arg-type]
             media_type=None,  # type: ignore[arg-type]
             transform=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Asset3D:
+        """Produce an empty Asset3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     blob: components.BlobBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -113,6 +113,15 @@ class Asset3D(Asset3DExt, Archetype):
             transform=None,
         )
 
+    @classmethod
+    def _clear(cls) -> Asset3D:
+        """Produce an empty Asset3D."""
+        return cls(
+            blob=None,  # type: ignore[arg-type]
+            media_type=None,  # type: ignore[arg-type]
+            transform=None,  # type: ignore[arg-type]
+        )
+
     blob: components.BlobBatch = field(
         metadata={"component": "required"},
         converter=components.BlobBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -107,11 +107,7 @@ class Asset3D(Asset3DExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
             return
-        self.__attrs_init__(
-            blob=None,
-            media_type=None,
-            transform=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -107,7 +107,11 @@ class Asset3D(Asset3DExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            blob=None,
+            media_type=None,
+            transform=None,
+        )
 
     blob: components.BlobBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..error_utils import catch_and_log_exceptions
+
 if TYPE_CHECKING:
     from ..components import MediaType
     from . import Asset3D
@@ -36,8 +38,10 @@ class Asset3DExt:
         """
         from . import Asset3D
 
-        with open(path, "rb") as file:
-            return Asset3D.from_bytes(file.read(), guess_media_type(path))
+        with catch_and_log_exceptions(context="Asset3D.from_file"):
+            with open(path, "rb") as file:
+                return Asset3D.from_bytes(file.read(), guess_media_type(path))
+        return Asset3D._clear()
 
     @staticmethod
     def from_bytes(blob: bytes, media_type: MediaType | None) -> Asset3D:
@@ -50,4 +54,6 @@ class Asset3DExt:
         from . import Asset3D
 
         # TODO(cmc): we could try and guess using magic bytes here, like rust does.
-        return Asset3D(blob=blob, media_type=media_type)
+        with catch_and_log_exceptions(context="Asset3D.from_file"):
+            return Asset3D(blob=blob, media_type=media_type)
+        return Asset3D._clear()

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -49,7 +49,9 @@ class BarChart(BarChartExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(values=values)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            values=None,
+        )
 
     values: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .bar_chart_ext import BarChartExt
 
 __all__ = ["BarChart"]
@@ -34,6 +35,7 @@ class BarChart(BarChartExt, Archetype):
     ```
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, values: datatypes.TensorDataLike):
         """
         Create a new instance of the BarChart archetype.

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -53,6 +53,13 @@ class BarChart(BarChartExt, Archetype):
             values=None,
         )
 
+    @classmethod
+    def _clear(cls) -> BarChart:
+        """Produce an empty BarChart."""
+        return cls(
+            values=None,  # type: ignore[arg-type]
+        )
+
     values: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=BarChartExt.values__field_converter_override,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -53,12 +53,18 @@ class BarChart(BarChartExt, Archetype):
             values=None,
         )
 
-    @classmethod
-    def _clear(cls) -> BarChart:
-        """Produce an empty BarChart."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             values=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> BarChart:
+        """Produce an empty BarChart, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     values: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -35,7 +35,6 @@ class BarChart(BarChartExt, Archetype):
     ```
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, values: datatypes.TensorDataLike):
         """
         Create a new instance of the BarChart archetype.
@@ -47,7 +46,10 @@ class BarChart(BarChartExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of BarChartExt in bar_chart_ext.py
-        self.__attrs_init__(values=values)
+        with catch_and_log_exceptions("BarChart"):
+            self.__attrs_init__(values=values)
+            return
+        self.__attrs_init__()
 
     values: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -49,9 +49,7 @@ class BarChart(BarChartExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(values=values)
             return
-        self.__attrs_init__(
-            values=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -46,7 +46,7 @@ class BarChart(BarChartExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of BarChartExt in bar_chart_ext.py
-        with catch_and_log_exceptions("BarChart"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(values=values)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from rerun.error_utils import _send_warning
+from ..error_utils import _send_warning, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 class BarChartExt:
     @staticmethod
+    @catch_and_log_exceptions("BarChart converter")
     def values__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
         from ..components import TensorDataBatch
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -36,10 +36,9 @@ class Boxes2D(Boxes2DExt, Archetype):
 
     # __init__ can be found in boxes2d_ext.py
 
-    @classmethod
-    def _clear(cls) -> Boxes2D:
-        """Produce an empty Boxes2D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             half_sizes=None,  # type: ignore[arg-type]
             centers=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
@@ -49,6 +48,13 @@ class Boxes2D(Boxes2DExt, Archetype):
             class_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Boxes2D:
+        """Produce an empty Boxes2D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     half_sizes: components.HalfSizes2DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -38,7 +38,7 @@ class Boxes2D(Boxes2DExt, Archetype):
 
     half_sizes: components.HalfSizes2DBatch = field(
         metadata={"component": "required"},
-        converter=components.HalfSizes2DBatch,  # type: ignore[misc]
+        converter=components.HalfSizes2DBatch._required,  # type: ignore[misc]
     )
     """
     All half-extents that make up the batch of boxes.

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -36,6 +36,20 @@ class Boxes2D(Boxes2DExt, Archetype):
 
     # __init__ can be found in boxes2d_ext.py
 
+    @classmethod
+    def _clear(cls) -> Boxes2D:
+        """Produce an empty Boxes2D."""
+        return cls(
+            half_sizes=None,  # type: ignore[arg-type]
+            centers=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     half_sizes: components.HalfSizes2DBatch = field(
         metadata={"component": "required"},
         converter=components.HalfSizes2DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
@@ -4,9 +4,8 @@ from typing import Any
 
 import numpy as np
 
-from rerun.error_utils import _send_warning
-
 from .. import components, datatypes
+from ..error_utils import _send_warning, catch_and_log_exceptions
 
 
 class Boxes2DExt:
@@ -58,33 +57,46 @@ class Boxes2DExt:
             Unique identifiers for each individual boxes in the batch.
         """
 
-        if sizes is not None:
-            if half_sizes is not None:
-                _send_warning("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            if sizes is not None:
+                if half_sizes is not None:
+                    _send_warning("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
 
-            sizes = np.asarray(sizes, dtype=np.float32)
-            half_sizes = sizes / 2.0
+                sizes = np.asarray(sizes, dtype=np.float32)
+                half_sizes = sizes / 2.0
 
-        if mins is not None:
-            if centers is not None:
-                _send_warning("Cannot specify both `mins` and `centers` at the same time.", 1)
+            if mins is not None:
+                if centers is not None:
+                    _send_warning("Cannot specify both `mins` and `centers` at the same time.", 1)
 
-            # already converted `sizes` to `half_sizes`
-            if half_sizes is None:
-                _send_warning("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
-                half_sizes = np.asarray([1, 1], dtype=np.float32)
+                # already converted `sizes` to `half_sizes`
+                if half_sizes is None:
+                    _send_warning("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
+                    half_sizes = np.asarray([1, 1], dtype=np.float32)
 
-            mins = np.asarray(mins, dtype=np.float32)
-            half_sizes = np.asarray(half_sizes, dtype=np.float32)
-            centers = mins + half_sizes
+                mins = np.asarray(mins, dtype=np.float32)
+                half_sizes = np.asarray(half_sizes, dtype=np.float32)
+                centers = mins + half_sizes
+
+            self.__attrs_init__(
+                half_sizes=half_sizes,
+                centers=centers,
+                radii=radii,
+                colors=colors,
+                labels=labels,
+                draw_order=draw_order,
+                class_ids=class_ids,
+                instance_keys=instance_keys,
+            )
+            return
 
         self.__attrs_init__(
-            half_sizes=half_sizes,
-            centers=centers,
-            radii=radii,
-            colors=colors,
-            labels=labels,
-            draw_order=draw_order,
-            class_ids=class_ids,
-            instance_keys=instance_keys,
+            half_sizes=None,
+            centers=None,
+            radii=None,
+            colors=None,
+            labels=None,
+            draw_order=None,
+            class_ids=None,
+            instance_keys=None,
         )

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
@@ -166,13 +166,4 @@ class Boxes2DExt:
             )
             return
 
-        self.__attrs_init__(
-            half_sizes=None,
-            centers=None,
-            radii=None,
-            colors=None,
-            labels=None,
-            draw_order=None,
-            class_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -71,10 +71,9 @@ class Boxes3D(Boxes3DExt, Archetype):
 
     # __init__ can be found in boxes3d_ext.py
 
-    @classmethod
-    def _clear(cls) -> Boxes3D:
-        """Produce an empty Boxes3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             half_sizes=None,  # type: ignore[arg-type]
             centers=None,  # type: ignore[arg-type]
             rotations=None,  # type: ignore[arg-type]
@@ -84,6 +83,13 @@ class Boxes3D(Boxes3DExt, Archetype):
             class_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Boxes3D:
+        """Produce an empty Boxes3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     half_sizes: components.HalfSizes3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -71,6 +71,20 @@ class Boxes3D(Boxes3DExt, Archetype):
 
     # __init__ can be found in boxes3d_ext.py
 
+    @classmethod
+    def _clear(cls) -> Boxes3D:
+        """Produce an empty Boxes3D."""
+        return cls(
+            half_sizes=None,  # type: ignore[arg-type]
+            centers=None,  # type: ignore[arg-type]
+            rotations=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     half_sizes: components.HalfSizes3DBatch = field(
         metadata={"component": "required"},
         converter=components.HalfSizes3DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -73,7 +73,7 @@ class Boxes3D(Boxes3DExt, Archetype):
 
     half_sizes: components.HalfSizes3DBatch = field(
         metadata={"component": "required"},
-        converter=components.HalfSizes3DBatch,  # type: ignore[misc]
+        converter=components.HalfSizes3DBatch._required,  # type: ignore[misc]
     )
     """
     All half-extents that make up the batch of boxes.

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
@@ -87,13 +87,4 @@ class Boxes3DExt:
             )
             return
 
-        self.__attrs_init__(
-            half_sizes=None,
-            centers=None,
-            rotations=None,
-            colors=None,
-            radii=None,
-            labels=None,
-            class_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
@@ -4,9 +4,8 @@ from typing import Any
 
 import numpy as np
 
-from rerun.error_utils import _send_warning
-
 from .. import components, datatypes
+from ..error_utils import _send_warning, catch_and_log_exceptions
 
 
 class Boxes3DExt:
@@ -55,33 +54,46 @@ class Boxes3DExt:
             Unique identifiers for each individual boxes in the batch.
         """
 
-        if sizes is not None:
-            if half_sizes is not None:
-                _send_warning("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            if sizes is not None:
+                if half_sizes is not None:
+                    _send_warning("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
 
-            sizes = np.asarray(sizes, dtype=np.float32)
-            half_sizes = sizes / 2.0
+                sizes = np.asarray(sizes, dtype=np.float32)
+                half_sizes = sizes / 2.0
 
-        if mins is not None:
-            if centers is not None:
-                _send_warning("Cannot specify both `mins` and `centers` at the same time.", 1)
+            if mins is not None:
+                if centers is not None:
+                    _send_warning("Cannot specify both `mins` and `centers` at the same time.", 1)
 
-            # already converted `sizes` to `half_sizes`
-            if half_sizes is None:
-                _send_warning("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
-                half_sizes = np.asarray([1, 1, 1], dtype=np.float32)
+                # already converted `sizes` to `half_sizes`
+                if half_sizes is None:
+                    _send_warning("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
+                    half_sizes = np.asarray([1, 1, 1], dtype=np.float32)
 
-            mins = np.asarray(mins, dtype=np.float32)
-            half_sizes = np.asarray(half_sizes, dtype=np.float32)
-            centers = mins + half_sizes
+                mins = np.asarray(mins, dtype=np.float32)
+                half_sizes = np.asarray(half_sizes, dtype=np.float32)
+                centers = mins + half_sizes
+
+            self.__attrs_init__(
+                half_sizes=half_sizes,
+                centers=centers,
+                rotations=rotations,
+                colors=colors,
+                radii=radii,
+                labels=labels,
+                class_ids=class_ids,
+                instance_keys=instance_keys,
+            )
+            return
 
         self.__attrs_init__(
-            half_sizes=half_sizes,
-            centers=centers,
-            rotations=rotations,
-            colors=colors,
-            radii=radii,
-            labels=labels,
-            class_ids=class_ids,
-            instance_keys=instance_keys,
+            half_sizes=None,
+            centers=None,
+            rotations=None,
+            colors=None,
+            radii=None,
+            labels=None,
+            class_ids=None,
+            instance_keys=None,
         )

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -63,6 +63,13 @@ class Clear(ClearExt, Archetype):
 
     # __init__ can be found in clear_ext.py
 
+    @classmethod
+    def _clear(cls) -> Clear:
+        """Produce an empty Clear."""
+        return cls(
+            recursive=None,  # type: ignore[arg-type]
+        )
+
     recursive: components.ClearIsRecursiveBatch = field(
         metadata={"component": "required"},
         converter=components.ClearIsRecursiveBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -65,7 +65,7 @@ class Clear(ClearExt, Archetype):
 
     recursive: components.ClearIsRecursiveBatch = field(
         metadata={"component": "required"},
-        converter=components.ClearIsRecursiveBatch,  # type: ignore[misc]
+        converter=components.ClearIsRecursiveBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -63,12 +63,18 @@ class Clear(ClearExt, Archetype):
 
     # __init__ can be found in clear_ext.py
 
-    @classmethod
-    def _clear(cls) -> Clear:
-        """Produce an empty Clear."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             recursive=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Clear:
+        """Produce an empty Clear, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     recursive: components.ClearIsRecursiveBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -88,7 +88,6 @@ class DepthImage(DepthImageExt, Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         data: datatypes.TensorDataLike,
@@ -114,7 +113,10 @@ class DepthImage(DepthImageExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of DepthImageExt in depth_image_ext.py
-        self.__attrs_init__(data=data, meter=meter, draw_order=draw_order)
+        with catch_and_log_exceptions("DepthImage"):
+            self.__attrs_init__(data=data, meter=meter, draw_order=draw_order)
+            return
+        self.__attrs_init__()
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -116,7 +116,11 @@ class DepthImage(DepthImageExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, meter=meter, draw_order=draw_order)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            data=None,
+            meter=None,
+            draw_order=None,
+        )
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -113,7 +113,7 @@ class DepthImage(DepthImageExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of DepthImageExt in depth_image_ext.py
-        with catch_and_log_exceptions("DepthImage"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, meter=meter, draw_order=draw_order)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .depth_image_ext import DepthImageExt
 
 __all__ = ["DepthImage"]
@@ -87,6 +88,7 @@ class DepthImage(DepthImageExt, Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         data: datatypes.TensorDataLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -122,6 +122,15 @@ class DepthImage(DepthImageExt, Archetype):
             draw_order=None,
         )
 
+    @classmethod
+    def _clear(cls) -> DepthImage:
+        """Produce an empty DepthImage."""
+        return cls(
+            data=None,  # type: ignore[arg-type]
+            meter=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
+        )
+
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=DepthImageExt.data__field_converter_override,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -122,14 +122,20 @@ class DepthImage(DepthImageExt, Archetype):
             draw_order=None,
         )
 
-    @classmethod
-    def _clear(cls) -> DepthImage:
-        """Produce an empty DepthImage."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             data=None,  # type: ignore[arg-type]
             meter=None,  # type: ignore[arg-type]
             draw_order=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> DepthImage:
+        """Produce an empty DepthImage, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -116,11 +116,7 @@ class DepthImage(DepthImageExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, meter=meter, draw_order=draw_order)
             return
-        self.__attrs_init__(
-            data=None,
-            meter=None,
-            draw_order=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pyarrow as pa
 
-from rerun.error_utils import _send_warning
-
 from .._validators import find_non_empty_dim_indices
+from ..error_utils import _send_warning, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
 
 class DepthImageExt:
     @staticmethod
+    @catch_and_log_exceptions("DepthImage converter")
     def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
         from ..components import TensorDataBatch
         from ..datatypes import TensorDataType, TensorDimensionType

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -54,6 +54,13 @@ class DisconnectedSpace(Archetype):
             disconnected_space=None,
         )
 
+    @classmethod
+    def _clear(cls) -> DisconnectedSpace:
+        """Produce an empty DisconnectedSpace."""
+        return cls(
+            disconnected_space=None,  # type: ignore[arg-type]
+        )
+
     disconnected_space: components.DisconnectedSpaceBatch = field(
         metadata={"component": "required"},
         converter=components.DisconnectedSpaceBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -47,7 +47,7 @@ class DisconnectedSpace(Archetype):
         """Create a new instance of the DisconnectedSpace archetype."""
 
         # You can define your own __init__ function as a member of DisconnectedSpaceExt in disconnected_space_ext.py
-        with catch_and_log_exceptions("DisconnectedSpace"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(disconnected_space=disconnected_space)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -50,7 +50,9 @@ class DisconnectedSpace(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(disconnected_space=disconnected_space)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            disconnected_space=None,
+        )
 
     disconnected_space: components.DisconnectedSpaceBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -43,16 +43,18 @@ class DisconnectedSpace(Archetype):
     ```
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, disconnected_space: components.DisconnectedSpaceLike):
         """Create a new instance of the DisconnectedSpace archetype."""
 
         # You can define your own __init__ function as a member of DisconnectedSpaceExt in disconnected_space_ext.py
-        self.__attrs_init__(disconnected_space=disconnected_space)
+        with catch_and_log_exceptions("DisconnectedSpace"):
+            self.__attrs_init__(disconnected_space=disconnected_space)
+            return
+        self.__attrs_init__()
 
     disconnected_space: components.DisconnectedSpaceBatch = field(
         metadata={"component": "required"},
-        converter=components.DisconnectedSpaceBatch,  # type: ignore[misc]
+        converter=components.DisconnectedSpaceBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -50,9 +50,7 @@ class DisconnectedSpace(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(disconnected_space=disconnected_space)
             return
-        self.__attrs_init__(
-            disconnected_space=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -54,12 +54,18 @@ class DisconnectedSpace(Archetype):
             disconnected_space=None,
         )
 
-    @classmethod
-    def _clear(cls) -> DisconnectedSpace:
-        """Produce an empty DisconnectedSpace."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             disconnected_space=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> DisconnectedSpace:
+        """Produce an empty DisconnectedSpace, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     disconnected_space: components.DisconnectedSpaceBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["DisconnectedSpace"]
 
@@ -42,6 +43,7 @@ class DisconnectedSpace(Archetype):
     ```
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, disconnected_space: components.DisconnectedSpaceLike):
         """Create a new instance of the DisconnectedSpace archetype."""
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -72,7 +72,10 @@ class Image(ImageExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, draw_order=draw_order)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            data=None,
+            draw_order=None,
+        )
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .image_ext import ImageExt
 
 __all__ = ["Image"]
@@ -54,6 +55,7 @@ class Image(ImageExt, Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, data: datatypes.TensorDataLike, *, draw_order: components.DrawOrderLike | None = None):
         """
         Create a new instance of the Image archetype.

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -72,10 +72,7 @@ class Image(ImageExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, draw_order=draw_order)
             return
-        self.__attrs_init__(
-            data=None,
-            draw_order=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -77,13 +77,19 @@ class Image(ImageExt, Archetype):
             draw_order=None,
         )
 
-    @classmethod
-    def _clear(cls) -> Image:
-        """Produce an empty Image."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             data=None,  # type: ignore[arg-type]
             draw_order=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Image:
+        """Produce an empty Image, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -77,6 +77,14 @@ class Image(ImageExt, Archetype):
             draw_order=None,
         )
 
+    @classmethod
+    def _clear(cls) -> Image:
+        """Produce an empty Image."""
+        return cls(
+            data=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
+        )
+
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=ImageExt.data__field_converter_override,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -55,7 +55,6 @@ class Image(ImageExt, Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, data: datatypes.TensorDataLike, *, draw_order: components.DrawOrderLike | None = None):
         """
         Create a new instance of the Image archetype.
@@ -70,7 +69,10 @@ class Image(ImageExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of ImageExt in image_ext.py
-        self.__attrs_init__(data=data, draw_order=draw_order)
+        with catch_and_log_exceptions("Image"):
+            self.__attrs_init__(data=data, draw_order=draw_order)
+            return
+        self.__attrs_init__()
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -69,7 +69,7 @@ class Image(ImageExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of ImageExt in image_ext.py
-        with catch_and_log_exceptions("Image"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, draw_order=draw_order)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pyarrow as pa
 
-from rerun.error_utils import _send_warning
-
 from .._validators import find_non_empty_dim_indices
+from ..error_utils import _send_warning, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
 
 class ImageExt:
     @staticmethod
+    @catch_and_log_exceptions("Image converter")
     def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
         from ..components import TensorDataBatch
         from ..datatypes import TensorDataType, TensorDimensionType

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -143,7 +143,15 @@ class LineStrips2D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            strips=None,
+            radii=None,
+            colors=None,
+            labels=None,
+            draw_order=None,
+            class_ids=None,
+            instance_keys=None,
+        )
 
     strips: components.LineStrip2DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -132,7 +132,7 @@ class LineStrips2D(Archetype):
         """
 
         # You can define your own __init__ function as a member of LineStrips2DExt in line_strips2d_ext.py
-        with catch_and_log_exceptions("LineStrips2D"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 strips=strips,
                 radii=radii,

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -153,6 +153,19 @@ class LineStrips2D(Archetype):
             instance_keys=None,
         )
 
+    @classmethod
+    def _clear(cls) -> LineStrips2D:
+        """Produce an empty LineStrips2D."""
+        return cls(
+            strips=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     strips: components.LineStrip2DBatch = field(
         metadata={"component": "required"},
         converter=components.LineStrip2DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -153,10 +153,9 @@ class LineStrips2D(Archetype):
             instance_keys=None,
         )
 
-    @classmethod
-    def _clear(cls) -> LineStrips2D:
-        """Produce an empty LineStrips2D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             strips=None,  # type: ignore[arg-type]
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
@@ -165,6 +164,13 @@ class LineStrips2D(Archetype):
             class_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> LineStrips2D:
+        """Produce an empty LineStrips2D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     strips: components.LineStrip2DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -96,7 +96,6 @@ class LineStrips2D(Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         strips: components.LineStrip2DArrayLike,
@@ -133,19 +132,22 @@ class LineStrips2D(Archetype):
         """
 
         # You can define your own __init__ function as a member of LineStrips2DExt in line_strips2d_ext.py
-        self.__attrs_init__(
-            strips=strips,
-            radii=radii,
-            colors=colors,
-            labels=labels,
-            draw_order=draw_order,
-            class_ids=class_ids,
-            instance_keys=instance_keys,
-        )
+        with catch_and_log_exceptions("LineStrips2D"):
+            self.__attrs_init__(
+                strips=strips,
+                radii=radii,
+                colors=colors,
+                labels=labels,
+                draw_order=draw_order,
+                class_ids=class_ids,
+                instance_keys=instance_keys,
+            )
+            return
+        self.__attrs_init__()
 
     strips: components.LineStrip2DBatch = field(
         metadata={"component": "required"},
-        converter=components.LineStrip2DBatch,  # type: ignore[misc]
+        converter=components.LineStrip2DBatch._required,  # type: ignore[misc]
     )
     """
     All the actual 2D line strips that make up the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["LineStrips2D"]
 
@@ -95,6 +96,7 @@ class LineStrips2D(Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         strips: components.LineStrip2DArrayLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -143,15 +143,7 @@ class LineStrips2D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__(
-            strips=None,
-            radii=None,
-            colors=None,
-            labels=None,
-            draw_order=None,
-            class_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -164,14 +164,7 @@ class LineStrips3D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__(
-            strips=None,
-            radii=None,
-            colors=None,
-            labels=None,
-            class_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -164,7 +164,14 @@ class LineStrips3D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            strips=None,
+            radii=None,
+            colors=None,
+            labels=None,
+            class_ids=None,
+            instance_keys=None,
+        )
 
     strips: components.LineStrip3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -122,7 +122,6 @@ class LineStrips3D(Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         strips: components.LineStrip3DArrayLike,
@@ -155,13 +154,21 @@ class LineStrips3D(Archetype):
         """
 
         # You can define your own __init__ function as a member of LineStrips3DExt in line_strips3d_ext.py
-        self.__attrs_init__(
-            strips=strips, radii=radii, colors=colors, labels=labels, class_ids=class_ids, instance_keys=instance_keys
-        )
+        with catch_and_log_exceptions("LineStrips3D"):
+            self.__attrs_init__(
+                strips=strips,
+                radii=radii,
+                colors=colors,
+                labels=labels,
+                class_ids=class_ids,
+                instance_keys=instance_keys,
+            )
+            return
+        self.__attrs_init__()
 
     strips: components.LineStrip3DBatch = field(
         metadata={"component": "required"},
-        converter=components.LineStrip3DBatch,  # type: ignore[misc]
+        converter=components.LineStrip3DBatch._required,  # type: ignore[misc]
     )
     """
     All the actual 3D line strips that make up the batch.

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["LineStrips3D"]
 
@@ -121,6 +122,7 @@ class LineStrips3D(Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         strips: components.LineStrip3DArrayLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -154,7 +154,7 @@ class LineStrips3D(Archetype):
         """
 
         # You can define your own __init__ function as a member of LineStrips3DExt in line_strips3d_ext.py
-        with catch_and_log_exceptions("LineStrips3D"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 strips=strips,
                 radii=radii,

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -173,10 +173,9 @@ class LineStrips3D(Archetype):
             instance_keys=None,
         )
 
-    @classmethod
-    def _clear(cls) -> LineStrips3D:
-        """Produce an empty LineStrips3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             strips=None,  # type: ignore[arg-type]
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
@@ -184,6 +183,13 @@ class LineStrips3D(Archetype):
             class_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> LineStrips3D:
+        """Produce an empty LineStrips3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     strips: components.LineStrip3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -173,6 +173,18 @@ class LineStrips3D(Archetype):
             instance_keys=None,
         )
 
+    @classmethod
+    def _clear(cls) -> LineStrips3D:
+        """Produce an empty LineStrips3D."""
+        return cls(
+            strips=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     strips: components.LineStrip3DBatch = field(
         metadata={"component": "required"},
         converter=components.LineStrip3DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -73,7 +73,7 @@ class Mesh3D(Mesh3DExt, Archetype):
 
     vertex_positions: components.Position3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Position3DBatch,  # type: ignore[misc]
+        converter=components.Position3DBatch._required,  # type: ignore[misc]
     )
     """
     The positions of each vertex.

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -71,10 +71,9 @@ class Mesh3D(Mesh3DExt, Archetype):
 
     # __init__ can be found in mesh3d_ext.py
 
-    @classmethod
-    def _clear(cls) -> Mesh3D:
-        """Produce an empty Mesh3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             vertex_positions=None,  # type: ignore[arg-type]
             mesh_properties=None,  # type: ignore[arg-type]
             vertex_normals=None,  # type: ignore[arg-type]
@@ -83,6 +82,13 @@ class Mesh3D(Mesh3DExt, Archetype):
             class_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Mesh3D:
+        """Produce an empty Mesh3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     vertex_positions: components.Position3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -71,6 +71,19 @@ class Mesh3D(Mesh3DExt, Archetype):
 
     # __init__ can be found in mesh3d_ext.py
 
+    @classmethod
+    def _clear(cls) -> Mesh3D:
+        """Produce an empty Mesh3D."""
+        return cls(
+            vertex_positions=None,  # type: ignore[arg-type]
+            mesh_properties=None,  # type: ignore[arg-type]
+            vertex_normals=None,  # type: ignore[arg-type]
+            vertex_colors=None,  # type: ignore[arg-type]
+            mesh_material=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     vertex_positions: components.Position3DBatch = field(
         metadata={"component": "required"},
         converter=components.Position3DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
@@ -67,12 +67,4 @@ class Mesh3DExt:
             )
             return
 
-        self.__attrs_init__(
-            vertex_positions=None,
-            mesh_properties=None,
-            vertex_normals=None,
-            vertex_colors=None,
-            mesh_material=None,
-            class_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy.typing as npt
 
 from .. import components, datatypes
+from ..error_utils import catch_and_log_exceptions
 
 
 class Mesh3DExt:
@@ -48,18 +49,30 @@ class Mesh3DExt:
         instance_keys:
             Unique identifiers for each individual vertex in the mesh.
         """
-        if indices is not None:
-            if mesh_properties is not None:
-                raise ValueError("indices and mesh_properties are mutually exclusive")
-            mesh_properties = datatypes.MeshProperties(indices=indices)
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            if indices is not None:
+                if mesh_properties is not None:
+                    raise ValueError("indices and mesh_properties are mutually exclusive")
+                mesh_properties = datatypes.MeshProperties(indices=indices)
 
-        # You can define your own __init__ function as a member of Mesh3DExt in mesh3d_ext.py
+            # You can define your own __init__ function as a member of Mesh3DExt in mesh3d_ext.py
+            self.__attrs_init__(
+                vertex_positions=vertex_positions,
+                mesh_properties=mesh_properties,
+                vertex_normals=vertex_normals,
+                vertex_colors=vertex_colors,
+                mesh_material=mesh_material,
+                class_ids=class_ids,
+                instance_keys=instance_keys,
+            )
+            return
+
         self.__attrs_init__(
-            vertex_positions=vertex_positions,
-            mesh_properties=mesh_properties,
-            vertex_normals=vertex_normals,
-            vertex_colors=vertex_colors,
-            mesh_material=mesh_material,
-            class_ids=class_ids,
-            instance_keys=instance_keys,
+            vertex_positions=None,
+            mesh_properties=None,
+            vertex_normals=None,
+            vertex_colors=None,
+            mesh_material=None,
+            class_ids=None,
+            instance_keys=None,
         )

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -43,6 +43,15 @@ class Pinhole(PinholeExt, Archetype):
 
     # __init__ can be found in pinhole_ext.py
 
+    @classmethod
+    def _clear(cls) -> Pinhole:
+        """Produce an empty Pinhole."""
+        return cls(
+            image_from_camera=None,  # type: ignore[arg-type]
+            resolution=None,  # type: ignore[arg-type]
+            camera_xyz=None,  # type: ignore[arg-type]
+        )
+
     image_from_camera: components.PinholeProjectionBatch = field(
         metadata={"component": "required"},
         converter=components.PinholeProjectionBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -45,7 +45,7 @@ class Pinhole(PinholeExt, Archetype):
 
     image_from_camera: components.PinholeProjectionBatch = field(
         metadata={"component": "required"},
-        converter=components.PinholeProjectionBatch,  # type: ignore[misc]
+        converter=components.PinholeProjectionBatch._required,  # type: ignore[misc]
     )
     """
     Camera projection, from image coordinates to view coordinates.

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -43,14 +43,20 @@ class Pinhole(PinholeExt, Archetype):
 
     # __init__ can be found in pinhole_ext.py
 
-    @classmethod
-    def _clear(cls) -> Pinhole:
-        """Produce an empty Pinhole."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             image_from_camera=None,  # type: ignore[arg-type]
             resolution=None,  # type: ignore[arg-type]
             camera_xyz=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Pinhole:
+        """Produce an empty Pinhole, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     image_from_camera: components.PinholeProjectionBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole_ext.py
@@ -129,4 +129,4 @@ class PinholeExt:
             self.__attrs_init__(image_from_camera=image_from_camera, resolution=resolution, camera_xyz=camera_xyz)
             return
 
-        self.__attrs_init__(image_from_camera=None, resolution=None, camera_xyz=None)
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -138,10 +138,9 @@ class Points2D(Archetype):
             instance_keys=None,
         )
 
-    @classmethod
-    def _clear(cls) -> Points2D:
-        """Produce an empty Points2D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             positions=None,  # type: ignore[arg-type]
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
@@ -151,6 +150,13 @@ class Points2D(Archetype):
             keypoint_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Points2D:
+        """Produce an empty Points2D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     positions: components.Position2DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -138,6 +138,20 @@ class Points2D(Archetype):
             instance_keys=None,
         )
 
+    @classmethod
+    def _clear(cls) -> Points2D:
+        """Produce an empty Points2D."""
+        return cls(
+            positions=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            keypoint_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     positions: components.Position2DBatch = field(
         metadata={"component": "required"},
         converter=components.Position2DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -127,7 +127,16 @@ class Points2D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            positions=None,
+            radii=None,
+            colors=None,
+            labels=None,
+            draw_order=None,
+            class_ids=None,
+            keypoint_ids=None,
+            instance_keys=None,
+        )
 
     positions: components.Position2DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -115,7 +115,7 @@ class Points2D(Archetype):
         """
 
         # You can define your own __init__ function as a member of Points2DExt in points2d_ext.py
-        with catch_and_log_exceptions("Points2D"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 positions=positions,
                 radii=radii,

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -66,7 +66,6 @@ class Points2D(Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         positions: datatypes.Vec2DArrayLike,
@@ -116,20 +115,23 @@ class Points2D(Archetype):
         """
 
         # You can define your own __init__ function as a member of Points2DExt in points2d_ext.py
-        self.__attrs_init__(
-            positions=positions,
-            radii=radii,
-            colors=colors,
-            labels=labels,
-            draw_order=draw_order,
-            class_ids=class_ids,
-            keypoint_ids=keypoint_ids,
-            instance_keys=instance_keys,
-        )
+        with catch_and_log_exceptions("Points2D"):
+            self.__attrs_init__(
+                positions=positions,
+                radii=radii,
+                colors=colors,
+                labels=labels,
+                draw_order=draw_order,
+                class_ids=class_ids,
+                keypoint_ids=keypoint_ids,
+                instance_keys=instance_keys,
+            )
+            return
+        self.__attrs_init__()
 
     positions: components.Position2DBatch = field(
         metadata={"component": "required"},
-        converter=components.Position2DBatch,  # type: ignore[misc]
+        converter=components.Position2DBatch._required,  # type: ignore[misc]
     )
     """
     All the 2D positions at which the point cloud shows points.

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -127,16 +127,7 @@ class Points2D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__(
-            positions=None,
-            radii=None,
-            colors=None,
-            labels=None,
-            draw_order=None,
-            class_ids=None,
-            keypoint_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["Points2D"]
 
@@ -65,6 +66,7 @@ class Points2D(Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         positions: datatypes.Vec2DArrayLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -126,6 +126,19 @@ class Points3D(Archetype):
             instance_keys=None,
         )
 
+    @classmethod
+    def _clear(cls) -> Points3D:
+        """Produce an empty Points3D."""
+        return cls(
+            positions=None,  # type: ignore[arg-type]
+            radii=None,  # type: ignore[arg-type]
+            colors=None,  # type: ignore[arg-type]
+            labels=None,  # type: ignore[arg-type]
+            class_ids=None,  # type: ignore[arg-type]
+            keypoint_ids=None,  # type: ignore[arg-type]
+            instance_keys=None,  # type: ignore[arg-type]
+        )
+
     positions: components.Position3DBatch = field(
         metadata={"component": "required"},
         converter=components.Position3DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -60,7 +60,6 @@ class Points3D(Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         positions: datatypes.Vec3DArrayLike,
@@ -106,19 +105,22 @@ class Points3D(Archetype):
         """
 
         # You can define your own __init__ function as a member of Points3DExt in points3d_ext.py
-        self.__attrs_init__(
-            positions=positions,
-            radii=radii,
-            colors=colors,
-            labels=labels,
-            class_ids=class_ids,
-            keypoint_ids=keypoint_ids,
-            instance_keys=instance_keys,
-        )
+        with catch_and_log_exceptions("Points3D"):
+            self.__attrs_init__(
+                positions=positions,
+                radii=radii,
+                colors=colors,
+                labels=labels,
+                class_ids=class_ids,
+                keypoint_ids=keypoint_ids,
+                instance_keys=instance_keys,
+            )
+            return
+        self.__attrs_init__()
 
     positions: components.Position3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Position3DBatch,  # type: ignore[misc]
+        converter=components.Position3DBatch._required,  # type: ignore[misc]
     )
     """
     All the 3D positions at which the point cloud shows points.

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -105,7 +105,7 @@ class Points3D(Archetype):
         """
 
         # You can define your own __init__ function as a member of Points3DExt in points3d_ext.py
-        with catch_and_log_exceptions("Points3D"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 positions=positions,
                 radii=radii,

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -126,10 +126,9 @@ class Points3D(Archetype):
             instance_keys=None,
         )
 
-    @classmethod
-    def _clear(cls) -> Points3D:
-        """Produce an empty Points3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             positions=None,  # type: ignore[arg-type]
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
@@ -138,6 +137,13 @@ class Points3D(Archetype):
             keypoint_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Points3D:
+        """Produce an empty Points3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     positions: components.Position3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -116,7 +116,15 @@ class Points3D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            positions=None,
+            radii=None,
+            colors=None,
+            labels=None,
+            class_ids=None,
+            keypoint_ids=None,
+            instance_keys=None,
+        )
 
     positions: components.Position3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -116,15 +116,7 @@ class Points3D(Archetype):
                 instance_keys=instance_keys,
             )
             return
-        self.__attrs_init__(
-            positions=None,
-            radii=None,
-            colors=None,
-            labels=None,
-            class_ids=None,
-            keypoint_ids=None,
-            instance_keys=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["Points3D"]
 
@@ -59,6 +60,7 @@ class Points3D(Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         positions: datatypes.Vec3DArrayLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -78,13 +78,19 @@ class SegmentationImage(SegmentationImageExt, Archetype):
             draw_order=None,
         )
 
-    @classmethod
-    def _clear(cls) -> SegmentationImage:
-        """Produce an empty SegmentationImage."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             data=None,  # type: ignore[arg-type]
             draw_order=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> SegmentationImage:
+        """Produce an empty SegmentationImage, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -56,7 +56,6 @@ class SegmentationImage(SegmentationImageExt, Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, data: datatypes.TensorDataLike, *, draw_order: components.DrawOrderLike | None = None):
         """
         Create a new instance of the SegmentationImage archetype.
@@ -71,7 +70,10 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of SegmentationImageExt in segmentation_image_ext.py
-        self.__attrs_init__(data=data, draw_order=draw_order)
+        with catch_and_log_exceptions("SegmentationImage"):
+            self.__attrs_init__(data=data, draw_order=draw_order)
+            return
+        self.__attrs_init__()
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .segmentation_image_ext import SegmentationImageExt
 
 __all__ = ["SegmentationImage"]
@@ -55,6 +56,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, data: datatypes.TensorDataLike, *, draw_order: components.DrawOrderLike | None = None):
         """
         Create a new instance of the SegmentationImage archetype.

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -73,10 +73,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, draw_order=draw_order)
             return
-        self.__attrs_init__(
-            data=None,
-            draw_order=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -78,6 +78,14 @@ class SegmentationImage(SegmentationImageExt, Archetype):
             draw_order=None,
         )
 
+    @classmethod
+    def _clear(cls) -> SegmentationImage:
+        """Produce an empty SegmentationImage."""
+        return cls(
+            data=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
+        )
+
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=SegmentationImageExt.data__field_converter_override,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -70,7 +70,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         """
 
         # You can define your own __init__ function as a member of SegmentationImageExt in segmentation_image_ext.py
-        with catch_and_log_exceptions("SegmentationImage"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, draw_order=draw_order)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -73,7 +73,10 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(data=data, draw_order=draw_order)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            data=None,
+            draw_order=None,
+        )
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image_ext.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pyarrow as pa
 
-from rerun.error_utils import _send_warning
-
 from .._validators import find_non_empty_dim_indices
+from ..error_utils import _send_warning, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
 
 class SegmentationImageExt:
     @staticmethod
+    @catch_and_log_exceptions("SegmentationImage converter")
     def data__field_converter_override(data: TensorDataArrayLike) -> TensorDataBatch:
         from ..components import TensorDataBatch
         from ..datatypes import TensorDataType, TensorDimensionType

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -72,7 +72,7 @@ class Tensor(TensorExt, Archetype):
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},
-        converter=components.TensorDataBatch,  # type: ignore[misc]
+        converter=components.TensorDataBatch._required,  # type: ignore[misc]
     )
     """
     The tensor data

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -70,12 +70,18 @@ class Tensor(TensorExt, Archetype):
 
     # __init__ can be found in tensor_ext.py
 
-    @classmethod
-    def _clear(cls) -> Tensor:
-        """Produce an empty Tensor."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             data=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Tensor:
+        """Produce an empty Tensor, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -70,6 +70,13 @@ class Tensor(TensorExt, Archetype):
 
     # __init__ can be found in tensor_ext.py
 
+    @classmethod
+    def _clear(cls) -> Tensor:
+        """Produce an empty Tensor."""
+        return cls(
+            data=None,  # type: ignore[arg-type]
+        )
+
     data: components.TensorDataBatch = field(
         metadata={"component": "required"},
         converter=components.TensorDataBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor_ext.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Sequence
 
+from ..error_utils import catch_and_log_exceptions
+
 if TYPE_CHECKING:
     from ..datatypes import TensorDataLike
     from ..datatypes.tensor_data_ext import TensorLike
@@ -36,9 +38,13 @@ class TensorExt:
         """
         from ..datatypes import TensorData
 
-        if not isinstance(data, TensorData):
-            data = TensorData(array=data, dim_names=dim_names)
-        elif dim_names is not None:
-            data = TensorData(buffer=data.buffer, dim_names=dim_names)
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            if not isinstance(data, TensorData):
+                data = TensorData(array=data, dim_names=dim_names)
+            elif dim_names is not None:
+                data = TensorData(buffer=data.buffer, dim_names=dim_names)
 
-        self.__attrs_init__(data=data)
+            self.__attrs_init__(data=data)
+            return
+
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -42,10 +42,7 @@ class TextDocument(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(text=text, media_type=media_type)
             return
-        self.__attrs_init__(
-            text=None,
-            media_type=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -47,6 +47,14 @@ class TextDocument(Archetype):
             media_type=None,
         )
 
+    @classmethod
+    def _clear(cls) -> TextDocument:
+        """Produce an empty TextDocument."""
+        return cls(
+            text=None,  # type: ignore[arg-type]
+            media_type=None,  # type: ignore[arg-type]
+        )
+
     text: components.TextBatch = field(
         metadata={"component": "required"},
         converter=components.TextBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -39,7 +39,7 @@ class TextDocument(Archetype):
         """
 
         # You can define your own __init__ function as a member of TextDocumentExt in text_document_ext.py
-        with catch_and_log_exceptions("TextDocument"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(text=text, media_type=media_type)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -20,7 +20,6 @@ __all__ = ["TextDocument"]
 class TextDocument(Archetype):
     """A text element intended to be displayed in its own text-box."""
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, text: datatypes.Utf8Like, *, media_type: datatypes.Utf8Like | None = None):
         """
         Create a new instance of the TextDocument archetype.
@@ -40,11 +39,14 @@ class TextDocument(Archetype):
         """
 
         # You can define your own __init__ function as a member of TextDocumentExt in text_document_ext.py
-        self.__attrs_init__(text=text, media_type=media_type)
+        with catch_and_log_exceptions("TextDocument"):
+            self.__attrs_init__(text=text, media_type=media_type)
+            return
+        self.__attrs_init__()
 
     text: components.TextBatch = field(
         metadata={"component": "required"},
-        converter=components.TextBatch,  # type: ignore[misc]
+        converter=components.TextBatch._required,  # type: ignore[misc]
     )
     """
     Contents of the text document.

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -42,7 +42,10 @@ class TextDocument(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(text=text, media_type=media_type)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            text=None,
+            media_type=None,
+        )
 
     text: components.TextBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["TextDocument"]
 
@@ -19,6 +20,7 @@ __all__ = ["TextDocument"]
 class TextDocument(Archetype):
     """A text element intended to be displayed in its own text-box."""
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, text: datatypes.Utf8Like, *, media_type: datatypes.Utf8Like | None = None):
         """
         Create a new instance of the TextDocument archetype.

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -47,13 +47,19 @@ class TextDocument(Archetype):
             media_type=None,
         )
 
-    @classmethod
-    def _clear(cls) -> TextDocument:
-        """Produce an empty TextDocument."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             text=None,  # type: ignore[arg-type]
             media_type=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> TextDocument:
+        """Produce an empty TextDocument, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     text: components.TextBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -30,7 +30,7 @@ class TextLog(Archetype):
         """Create a new instance of the TextLog archetype."""
 
         # You can define your own __init__ function as a member of TextLogExt in text_log_ext.py
-        with catch_and_log_exceptions("TextLog"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(text=text, level=level, color=color)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -66,14 +66,20 @@ class TextLog(Archetype):
             color=None,
         )
 
-    @classmethod
-    def _clear(cls) -> TextLog:
-        """Produce an empty TextLog."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             text=None,  # type: ignore[arg-type]
             level=None,  # type: ignore[arg-type]
             color=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> TextLog:
+        """Produce an empty TextLog, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     text: components.TextBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -20,7 +20,6 @@ __all__ = ["TextLog"]
 class TextLog(Archetype):
     """A log entry in a text log, comprised of a text body and its log level."""
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         text: datatypes.Utf8Like,
@@ -31,11 +30,14 @@ class TextLog(Archetype):
         """Create a new instance of the TextLog archetype."""
 
         # You can define your own __init__ function as a member of TextLogExt in text_log_ext.py
-        self.__attrs_init__(text=text, level=level, color=color)
+        with catch_and_log_exceptions("TextLog"):
+            self.__attrs_init__(text=text, level=level, color=color)
+            return
+        self.__attrs_init__()
 
     text: components.TextBatch = field(
         metadata={"component": "required"},
-        converter=components.TextBatch,  # type: ignore[misc]
+        converter=components.TextBatch._required,  # type: ignore[misc]
     )
     level: components.TextLogLevelBatch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -39,6 +39,15 @@ class TextLog(Archetype):
             color=None,
         )
 
+    @classmethod
+    def _clear(cls) -> TextLog:
+        """Produce an empty TextLog."""
+        return cls(
+            text=None,  # type: ignore[arg-type]
+            level=None,  # type: ignore[arg-type]
+            color=None,  # type: ignore[arg-type]
+        )
+
     text: components.TextBatch = field(
         metadata={"component": "required"},
         converter=components.TextBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -33,7 +33,11 @@ class TextLog(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(text=text, level=level, color=color)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            text=None,
+            level=None,
+            color=None,
+        )
 
     text: components.TextBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["TextLog"]
 
@@ -19,6 +20,7 @@ __all__ = ["TextLog"]
 class TextLog(Archetype):
     """A log entry in a text log, comprised of a text body and its log level."""
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         text: datatypes.Utf8Like,

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -60,11 +60,7 @@ class TextLog(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(text=text, level=level, color=color)
             return
-        self.__attrs_init__(
-            text=None,
-            level=None,
-            color=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -129,6 +129,17 @@ class TimeSeriesScalar(Archetype):
             scattered=None,
         )
 
+    @classmethod
+    def _clear(cls) -> TimeSeriesScalar:
+        """Produce an empty TimeSeriesScalar."""
+        return cls(
+            scalar=None,  # type: ignore[arg-type]
+            radius=None,  # type: ignore[arg-type]
+            color=None,  # type: ignore[arg-type]
+            label=None,  # type: ignore[arg-type]
+            scattered=None,  # type: ignore[arg-type]
+        )
+
     scalar: components.ScalarBatch = field(
         metadata={"component": "required"},
         converter=components.ScalarBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -118,7 +118,7 @@ class TimeSeriesScalar(Archetype):
         """
 
         # You can define your own __init__ function as a member of TimeSeriesScalarExt in time_series_scalar_ext.py
-        with catch_and_log_exceptions("TimeSeriesScalar"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(scalar=scalar, radius=radius, color=color, label=label, scattered=scattered)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["TimeSeriesScalar"]
 
@@ -60,6 +61,7 @@ class TimeSeriesScalar(Archetype):
     ```
     """
 
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         scalar: components.ScalarLike,

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -129,16 +129,22 @@ class TimeSeriesScalar(Archetype):
             scattered=None,
         )
 
-    @classmethod
-    def _clear(cls) -> TimeSeriesScalar:
-        """Produce an empty TimeSeriesScalar."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             scalar=None,  # type: ignore[arg-type]
             radius=None,  # type: ignore[arg-type]
             color=None,  # type: ignore[arg-type]
             label=None,  # type: ignore[arg-type]
             scattered=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> TimeSeriesScalar:
+        """Produce an empty TimeSeriesScalar, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     scalar: components.ScalarBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -121,7 +121,13 @@ class TimeSeriesScalar(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(scalar=scalar, radius=radius, color=color, label=label, scattered=scattered)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            scalar=None,
+            radius=None,
+            color=None,
+            label=None,
+            scattered=None,
+        )
 
     scalar: components.ScalarBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -121,13 +121,7 @@ class TimeSeriesScalar(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(scalar=scalar, radius=radius, color=color, label=label, scattered=scattered)
             return
-        self.__attrs_init__(
-            scalar=None,
-            radius=None,
-            color=None,
-            label=None,
-            scattered=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -61,7 +61,6 @@ class TimeSeriesScalar(Archetype):
     ```
     """
 
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         scalar: components.ScalarLike,
@@ -119,11 +118,14 @@ class TimeSeriesScalar(Archetype):
         """
 
         # You can define your own __init__ function as a member of TimeSeriesScalarExt in time_series_scalar_ext.py
-        self.__attrs_init__(scalar=scalar, radius=radius, color=color, label=label, scattered=scattered)
+        with catch_and_log_exceptions("TimeSeriesScalar"):
+            self.__attrs_init__(scalar=scalar, radius=radius, color=color, label=label, scattered=scattered)
+            return
+        self.__attrs_init__()
 
     scalar: components.ScalarBatch = field(
         metadata={"component": "required"},
-        converter=components.ScalarBatch,  # type: ignore[misc]
+        converter=components.ScalarBatch._required,  # type: ignore[misc]
     )
     """
     The scalar value to log.

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -72,12 +72,18 @@ class Transform3D(Archetype):
             transform=None,
         )
 
-    @classmethod
-    def _clear(cls) -> Transform3D:
-        """Produce an empty Transform3D."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             transform=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> Transform3D:
+        """Produce an empty Transform3D, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     transform: components.Transform3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -54,7 +54,6 @@ class Transform3D(Archetype):
     </picture>
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, transform: datatypes.Transform3DLike):
         """
         Create a new instance of the Transform3D archetype.
@@ -66,11 +65,14 @@ class Transform3D(Archetype):
         """
 
         # You can define your own __init__ function as a member of Transform3DExt in transform3d_ext.py
-        self.__attrs_init__(transform=transform)
+        with catch_and_log_exceptions("Transform3D"):
+            self.__attrs_init__(transform=transform)
+            return
+        self.__attrs_init__()
 
     transform: components.Transform3DBatch = field(
         metadata={"component": "required"},
-        converter=components.Transform3DBatch,  # type: ignore[misc]
+        converter=components.Transform3DBatch._required,  # type: ignore[misc]
     )
     """
     The transform

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["Transform3D"]
 
@@ -53,6 +54,7 @@ class Transform3D(Archetype):
     </picture>
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, transform: datatypes.Transform3DLike):
         """
         Create a new instance of the Transform3D archetype.

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -72,6 +72,13 @@ class Transform3D(Archetype):
             transform=None,
         )
 
+    @classmethod
+    def _clear(cls) -> Transform3D:
+        """Produce an empty Transform3D."""
+        return cls(
+            transform=None,  # type: ignore[arg-type]
+        )
+
     transform: components.Transform3DBatch = field(
         metadata={"component": "required"},
         converter=components.Transform3DBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -68,7 +68,9 @@ class Transform3D(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(transform=transform)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            transform=None,
+        )
 
     transform: components.Transform3DBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -68,9 +68,7 @@ class Transform3D(Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(transform=transform)
             return
-        self.__attrs_init__(
-            transform=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -65,7 +65,7 @@ class Transform3D(Archetype):
         """
 
         # You can define your own __init__ function as a member of Transform3DExt in transform3d_ext.py
-        with catch_and_log_exceptions("Transform3D"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(transform=transform)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -11,6 +11,7 @@ from attrs import define, field
 
 from .. import components
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .view_coordinates_ext import ViewCoordinatesExt
 
 __all__ = ["ViewCoordinates"]
@@ -47,6 +48,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
     ```
     """
 
+    @catch_and_log_exceptions()
     def __init__(self: Any, xyz: components.ViewCoordinatesLike):
         """Create a new instance of the ViewCoordinates archetype."""
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -52,7 +52,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         """Create a new instance of the ViewCoordinates archetype."""
 
         # You can define your own __init__ function as a member of ViewCoordinatesExt in view_coordinates_ext.py
-        with catch_and_log_exceptions("ViewCoordinates"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(xyz=xyz)
             return
         self.__attrs_init__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -55,7 +55,9 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(xyz=xyz)
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            xyz=None,
+        )
 
     xyz: components.ViewCoordinatesBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -59,12 +59,18 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
             xyz=None,
         )
 
-    @classmethod
-    def _clear(cls) -> ViewCoordinates:
-        """Produce an empty ViewCoordinates."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             xyz=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> ViewCoordinates:
+        """Produce an empty ViewCoordinates, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     xyz: components.ViewCoordinatesBatch = field(
         metadata={"component": "required"},

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -55,9 +55,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(xyz=xyz)
             return
-        self.__attrs_init__(
-            xyz=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -48,16 +48,18 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
     ```
     """
 
-    @catch_and_log_exceptions()
     def __init__(self: Any, xyz: components.ViewCoordinatesLike):
         """Create a new instance of the ViewCoordinates archetype."""
 
         # You can define your own __init__ function as a member of ViewCoordinatesExt in view_coordinates_ext.py
-        self.__attrs_init__(xyz=xyz)
+        with catch_and_log_exceptions("ViewCoordinates"):
+            self.__attrs_init__(xyz=xyz)
+            return
+        self.__attrs_init__()
 
     xyz: components.ViewCoordinatesBatch = field(
         metadata={"component": "required"},
-        converter=components.ViewCoordinatesBatch,  # type: ignore[misc]
+        converter=components.ViewCoordinatesBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -59,6 +59,13 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
             xyz=None,
         )
 
+    @classmethod
+    def _clear(cls) -> ViewCoordinates:
+        """Produce an empty ViewCoordinates."""
+        return cls(
+            xyz=None,  # type: ignore[arg-type]
+        )
+
     xyz: components.ViewCoordinatesBatch = field(
         metadata={"component": "required"},
         converter=components.ViewCoordinatesBatch._required,  # type: ignore[misc]

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -115,10 +115,23 @@ class catch_and_log_exceptions:
 
     For functions, this decorator checks for a strict kwarg and uses it to
     override the global strict mode if provided.
+
+    Parameters
+    ----------
+    context:
+        A string describing the context of the exception.
+        If not provided, the function name will be used.
+    depth_to_user_code:
+        The number of frames to skip when building the warning context.
+        This should be the number of frames between the user code and the
+        context manager.
+    exception_return_value:
+        If an exception is caught, this value will be returned instead of
+        the function's return value.
     """
 
     def __init__(
-        self, context: str | None = None, depth_to_user_code: int = 0, exception_return_value: Any = None
+        self, context: str | None = None, depth_to_user_code: int = 1, exception_return_value: Any = None
     ) -> None:
         self.depth_to_user_code = depth_to_user_code
         self.context = context
@@ -136,8 +149,6 @@ class catch_and_log_exceptions:
         return self
 
     def __call__(self, func: _TFunc) -> _TFunc:
-        self.depth_to_user_code += 1
-
         if self.context is None:
             self.context = func.__qualname__
 

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -117,9 +117,12 @@ class catch_and_log_exceptions:
     override the global strict mode if provided.
     """
 
-    def __init__(self, context: str | None = None, depth_to_user_code: int = 0) -> None:
+    def __init__(
+        self, context: str | None = None, depth_to_user_code: int = 0, exception_return_value: Any = None
+    ) -> None:
         self.depth_to_user_code = depth_to_user_code
         self.context = context
+        self.exception_return_value = exception_return_value
 
     def __enter__(self) -> catch_and_log_exceptions:
         # Track the original strict_mode setting in case it's being
@@ -144,6 +147,9 @@ class catch_and_log_exceptions:
                 if "strict" in kwargs:
                     _rerun_exception_ctx.strict_mode = kwargs["strict"]
                 return func(*args, **kwargs)
+
+            # If there was an exception before returning from func
+            return self.exception_return_value
 
         return cast(_TFunc, wrapper)
 

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import threading
 import warnings
+from types import TracebackType
 from typing import Any, Callable, TypeVar, cast
 
 from .recording_stream import RecordingStream
@@ -92,11 +93,11 @@ def _send_warning(
     warnings.warn(message, category=RerunWarning, stacklevel=depth_to_user_code + 1)
 
 
-def catch_and_log_exceptions(func: _TFunc) -> _TFunc:
+class catch_and_log_exceptions:
     """
     A decorator we add to any function we want to catch exceptions if we're not in strict mode.
 
-    This function checks for a strict kwarg and uses it to override the global strict mode
+    This decorator checks for a strict kwarg and uses it to override the global strict mode
     if provided. Additionally it tracks the depth of the call stack to the user code -- the
     highest point in the stack where the user called a decorated function.
 
@@ -104,26 +105,57 @@ def catch_and_log_exceptions(func: _TFunc) -> _TFunc:
     just because they misused the Rerun API (or because we have a bug!).
     """
 
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def __init__(self, bare_context: bool = True) -> None:
+        self.bare_context = bare_context
+
+    def __enter__(self) -> catch_and_log_exceptions:
+        # Track the original strict_mode setting in case it's being
+        # overridden locally in this stack
+        self.original_strict = _rerun_exception_ctx.strict_mode
+        self.added_depth = 0
+
+        # Functions add a depth of 2
+        # Bare context helpers don't add a depth
+        if not self.bare_context:
+            self.added_depth = 2
+            _rerun_exception_ctx.depth += self.added_depth
+
+        return self
+
+    @classmethod
+    def __call__(cls, func: _TFunc) -> _TFunc:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with cls(bare_context=False):
+                if "strict" in kwargs:
+                    _rerun_exception_ctx.strict_mode = kwargs["strict"]
+
+                func(*args, **kwargs)
+
+        return cast(_TFunc, wrapper)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
         try:
-            original_strict = _rerun_exception_ctx.strict_mode
-            _rerun_exception_ctx.depth += 2
-            if "strict" in kwargs:
-                _rerun_exception_ctx.strict_mode = kwargs["strict"]
+            if exc_type is not None and not check_strict_mode():
+                warning = f"{exc_type.__name__}: {exc_val}"
 
-            if check_strict_mode():
-                # Pass on any exceptions to the caller
-                return func(*args, **kwargs)
+                # If the raise comes directly from a bare context, we need
+                # to add 1 extra layer of depth.
+                if self.bare_context:
+                    extra_depth = 2
+                else:
+                    extra_depth = 1
+                _send_warning(warning, depth_to_user_code=_rerun_exception_ctx.depth + extra_depth)
+                return True
             else:
-                try:
-                    return func(*args, **kwargs)
-                except Exception as e:
-                    warning = f"{type(e).__name__}: {e}"
-
-                    _send_warning(warning, depth_to_user_code=_rerun_exception_ctx.depth)
+                return False
         finally:
-            _rerun_exception_ctx.strict_mode = original_strict
-            _rerun_exception_ctx.depth -= 2
-
-    return cast(_TFunc, wrapper)
+            # Return the local context to the prior value
+            _rerun_exception_ctx.strict_mode = self.original_strict
+            _rerun_exception_ctx.depth -= self.added_depth
+        return False

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -22,7 +22,7 @@ _strict_mode = False
 _rerun_exception_ctx = threading.local()
 
 
-def check_strict_mode() -> bool:
+def strict_mode() -> bool:
     """
     Strict mode enabled.
 
@@ -81,7 +81,7 @@ def _send_warning(
     from rerun._log import log
     from rerun.archetypes import TextLog
 
-    if check_strict_mode():
+    if strict_mode():
         raise TypeError(message)
 
     # Send the warning to the user first
@@ -171,7 +171,7 @@ class catch_and_log_exceptions:
         exc_tb: TracebackType | None,
     ) -> bool:
         try:
-            if exc_type is not None and not check_strict_mode():
+            if exc_type is not None and not strict_mode():
                 if getattr(_rerun_exception_ctx, "pending_warnings", None) is None:
                     _rerun_exception_ctx.pending_warnings = []
 

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -94,7 +94,7 @@ def _send_warning(
         # TODO(jleibs): Context/stack should be its own component.
         context_descriptor = _build_warning_context_string(skip_first=depth_to_user_code + 1)
 
-        log("rerun", TextLog(body=f"{message}\n{context_descriptor}", level="WARN"), recording=recording)
+        log("rerun", TextLog(text=f"{message}\n{context_descriptor}", level="WARN"), recording=recording)
         _rerun_exception_ctx.sending_warning = False
     else:
         warnings.warn(

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -1,14 +1,64 @@
 from __future__ import annotations
 
+import functools
 import inspect
-import logging
+import threading
+import warnings
+from typing import Any, Callable, TypeVar, cast
 
-import rerun
-from rerun.recording_stream import RecordingStream
+from .recording_stream import RecordingStream
 
 __all__ = [
     "_send_warning",
 ]
+
+_TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
+
+# If `True`, we raise exceptions on use error (wrong parameter types, etc.).
+# If `False` we catch all errors and log a warning instead.
+_strict_mode = False
+
+_rerun_exception_ctx = threading.local()
+_rerun_exception_ctx.strict_mode = None
+_rerun_exception_ctx.depth = 0
+
+
+def check_strict_mode() -> bool:
+    """
+    Strict mode enabled.
+
+    In strict mode, incorrect use of the Rerun API (wrong parameter types etc.)
+    will result in exception being raised.
+    When strict mode is on, such problems are instead logged as warnings.
+
+    The default is OFF.
+    """
+    # If strict was set explicitly, we are in struct mode
+    if _rerun_exception_ctx.strict_mode is not None:
+        return _rerun_exception_ctx.strict_mode  # type: ignore[no-any-return]
+    else:
+        return _strict_mode
+
+
+def set_strict_mode(mode: bool) -> None:
+    """
+    Turn strict mode on/off.
+
+    In strict mode, incorrect use of the Rerun API (wrong parameter types etc.)
+    will result in exception being raised.
+    When strict mode is off, such problems are instead logged as warnings.
+
+    The default is OFF.
+    """
+    global _strict_mode
+
+    _strict_mode = mode
+
+
+class RerunWarning(Warning):
+    """A custom warning class that we use to identify warnings that are emitted by the Rerun SDK itself."""
+
+    pass
 
 
 def _build_warning_context_string(skip_first: int) -> str:
@@ -32,11 +82,48 @@ def _send_warning(
     from rerun._log import log
     from rerun.archetypes import TextLog
 
-    if rerun.strict_mode():
+    if check_strict_mode():
         raise TypeError(message)
 
-    context_descriptor = _build_warning_context_string(skip_first=depth_to_user_code + 2)
-    warning = f"{message}\n{context_descriptor}"
+    context_descriptor = _build_warning_context_string(skip_first=depth_to_user_code + 1)
 
-    log("rerun", TextLog(warning, level="WARN"), recording=recording)
-    logging.warning(warning)
+    # TODO(jleibs): Context/stack should be its component.
+    log("rerun", TextLog(body=f"{message}\n{context_descriptor}", level="WARN"), recording=recording)
+    warnings.warn(message, category=RerunWarning, stacklevel=depth_to_user_code + 1)
+
+
+def catch_and_log_exceptions(func: _TFunc) -> _TFunc:
+    """
+    A decorator we add to any function we want to catch exceptions if we're not in strict mode.
+
+    This function checks for a strict kwarg and uses it to override the global strict mode
+    if provided. Additionally it tracks the depth of the call stack to the user code -- the
+    highest point in the stack where the user called a decorated function.
+
+    This is important in order not to crash the users application
+    just because they misused the Rerun API (or because we have a bug!).
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            original_strict = _rerun_exception_ctx.strict_mode
+            _rerun_exception_ctx.depth += 2
+            if "strict" in kwargs:
+                _rerun_exception_ctx.strict_mode = kwargs["strict"]
+
+            if check_strict_mode():
+                # Pass on any exceptions to the caller
+                return func(*args, **kwargs)
+            else:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    warning = f"{type(e).__name__}: {e}"
+
+                    _send_warning(warning, depth_to_user_code=_rerun_exception_ctx.depth)
+        finally:
+            _rerun_exception_ctx.strict_mode = original_strict
+            _rerun_exception_ctx.depth -= 2
+
+    return cast(_TFunc, wrapper)

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -130,7 +130,7 @@ class catch_and_log_exceptions:
                 if "strict" in kwargs:
                     _rerun_exception_ctx.strict_mode = kwargs["strict"]
 
-                func(*args, **kwargs)
+                return func(*args, **kwargs)
 
         return cast(_TFunc, wrapper)
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/log_decorator.py
@@ -5,11 +5,12 @@ import traceback
 import warnings
 from typing import Any, Callable, TypeVar, cast
 
-import rerun
 from rerun import bindings
 from rerun._log import log
 from rerun.archetypes import TextLog
 from rerun.recording_stream import RecordingStream
+
+from ..error_utils import check_strict_mode
 
 _TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
 
@@ -44,7 +45,7 @@ def log_decorator(func: _TFunc) -> _TFunc:
             )
             return
 
-        if rerun.strict_mode():
+        if check_strict_mode():
             # Pass on any exceptions to the caller
             return func(*args, **kwargs)
         else:

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/log_decorator.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/log_decorator.py
@@ -10,7 +10,7 @@ from rerun._log import log
 from rerun.archetypes import TextLog
 from rerun.recording_stream import RecordingStream
 
-from ..error_utils import check_strict_mode
+from ..error_utils import strict_mode
 
 _TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
 
@@ -45,7 +45,7 @@ def log_decorator(func: _TFunc) -> _TFunc:
             )
             return
 
-        if check_strict_mode():
+        if strict_mode():
             # Pass on any exceptions to the caller
             return func(*args, **kwargs)
         else:

--- a/rerun_py/rerun_sdk/rerun/recording.py
+++ b/rerun_py/rerun_sdk/rerun/recording.py
@@ -32,7 +32,7 @@ class MemoryRecording:
 
         Note: counting the messages will flush the batcher in order to get a deterministic count.
         """
-        return self.storage.num_msgs()
+        return self.storage.num_msgs()  # type: ignore[no-any-return]
 
     def as_html(
         self,

--- a/rerun_py/rerun_sdk/rerun/recording.py
+++ b/rerun_py/rerun_sdk/rerun/recording.py
@@ -26,6 +26,14 @@ class MemoryRecording:
         """Reset the blueprint in the MemoryRecording."""
         self.storage.reset_blueprint(add_to_app_default_blueprint)
 
+    def num_msgs(self) -> int:
+        """
+        The number of pending messages in the MemoryRecording.
+
+        Note: counting the messages will flush the batcher in order to get a deterministic count.
+        """
+        return self.storage.num_msgs()
+
     def as_html(
         self,
         *,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -531,7 +531,9 @@ struct PyMemorySinkStorage {
 
 #[pymethods]
 impl PyMemorySinkStorage {
-    /// This will do a blocking flush before returning!
+    /// Concatenate the contents of the [`MemorySinkStorage`] as byes.
+    ///
+    /// Note: This will do a blocking flush before returning!
     fn concat_as_bytes<'p>(
         &self,
         concat: Option<&PyMemorySinkStorage>,
@@ -551,6 +553,18 @@ impl PyMemorySinkStorage {
         )
         .map(|bytes| PyBytes::new(py, bytes.as_slice()))
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))
+    }
+
+    /// Count the number of pending messages in the [`MemorySinkStorage`].
+    ///
+    /// This will do a blocking flush before returning!
+    fn num_msgs(&self, py: Python<'_>) -> usize {
+        // Release the GIL in case any flushing behavior needs to cleanup a python object.
+        py.allow_threads(|| {
+            self.rec.flush_blocking();
+        });
+
+        self.inner.num_msgs()
     }
 }
 

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -70,29 +70,7 @@ class AffixFuzzer1(Archetype):
                 fuzz1021=fuzz1021,
             )
             return
-        self.__attrs_init__(
-            fuzz1001=None,
-            fuzz1002=None,
-            fuzz1003=None,
-            fuzz1004=None,
-            fuzz1005=None,
-            fuzz1006=None,
-            fuzz1007=None,
-            fuzz1008=None,
-            fuzz1009=None,
-            fuzz1010=None,
-            fuzz1011=None,
-            fuzz1012=None,
-            fuzz1013=None,
-            fuzz1014=None,
-            fuzz1015=None,
-            fuzz1016=None,
-            fuzz1017=None,
-            fuzz1018=None,
-            fuzz1019=None,
-            fuzz1020=None,
-            fuzz1021=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -11,12 +11,14 @@ from attrs import define, field
 from rerun._baseclasses import Archetype
 
 from .. import components, datatypes
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer1"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer1(Archetype):
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         fuzz1001: datatypes.AffixFuzzer1Like,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -94,6 +94,33 @@ class AffixFuzzer1(Archetype):
             fuzz1021=None,
         )
 
+    @classmethod
+    def _clear(cls) -> AffixFuzzer1:
+        """Produce an empty AffixFuzzer1."""
+        return cls(
+            fuzz1001=None,  # type: ignore[arg-type]
+            fuzz1002=None,  # type: ignore[arg-type]
+            fuzz1003=None,  # type: ignore[arg-type]
+            fuzz1004=None,  # type: ignore[arg-type]
+            fuzz1005=None,  # type: ignore[arg-type]
+            fuzz1006=None,  # type: ignore[arg-type]
+            fuzz1007=None,  # type: ignore[arg-type]
+            fuzz1008=None,  # type: ignore[arg-type]
+            fuzz1009=None,  # type: ignore[arg-type]
+            fuzz1010=None,  # type: ignore[arg-type]
+            fuzz1011=None,  # type: ignore[arg-type]
+            fuzz1012=None,  # type: ignore[arg-type]
+            fuzz1013=None,  # type: ignore[arg-type]
+            fuzz1014=None,  # type: ignore[arg-type]
+            fuzz1015=None,  # type: ignore[arg-type]
+            fuzz1016=None,  # type: ignore[arg-type]
+            fuzz1017=None,  # type: ignore[arg-type]
+            fuzz1018=None,  # type: ignore[arg-type]
+            fuzz1019=None,  # type: ignore[arg-type]
+            fuzz1020=None,  # type: ignore[arg-type]
+            fuzz1021=None,  # type: ignore[arg-type]
+        )
+
     fuzz1001: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},
         converter=components.AffixFuzzer1Batch._required,  # type: ignore[misc]

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -94,10 +94,9 @@ class AffixFuzzer1(Archetype):
             fuzz1021=None,
         )
 
-    @classmethod
-    def _clear(cls) -> AffixFuzzer1:
-        """Produce an empty AffixFuzzer1."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             fuzz1001=None,  # type: ignore[arg-type]
             fuzz1002=None,  # type: ignore[arg-type]
             fuzz1003=None,  # type: ignore[arg-type]
@@ -120,6 +119,13 @@ class AffixFuzzer1(Archetype):
             fuzz1020=None,  # type: ignore[arg-type]
             fuzz1021=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> AffixFuzzer1:
+        """Produce an empty AffixFuzzer1, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     fuzz1001: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -9,16 +9,15 @@ from typing import Any
 
 from attrs import define, field
 from rerun._baseclasses import Archetype
+from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes
-from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer1"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer1(Archetype):
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         fuzz1001: datatypes.AffixFuzzer1Like,
@@ -46,113 +45,116 @@ class AffixFuzzer1(Archetype):
         """Create a new instance of the AffixFuzzer1 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer1Ext in affix_fuzzer1_ext.py
-        self.__attrs_init__(
-            fuzz1001=fuzz1001,
-            fuzz1002=fuzz1002,
-            fuzz1003=fuzz1003,
-            fuzz1004=fuzz1004,
-            fuzz1005=fuzz1005,
-            fuzz1006=fuzz1006,
-            fuzz1007=fuzz1007,
-            fuzz1008=fuzz1008,
-            fuzz1009=fuzz1009,
-            fuzz1010=fuzz1010,
-            fuzz1011=fuzz1011,
-            fuzz1012=fuzz1012,
-            fuzz1013=fuzz1013,
-            fuzz1014=fuzz1014,
-            fuzz1015=fuzz1015,
-            fuzz1016=fuzz1016,
-            fuzz1017=fuzz1017,
-            fuzz1018=fuzz1018,
-            fuzz1019=fuzz1019,
-            fuzz1020=fuzz1020,
-            fuzz1021=fuzz1021,
-        )
+        with catch_and_log_exceptions("AffixFuzzer1"):
+            self.__attrs_init__(
+                fuzz1001=fuzz1001,
+                fuzz1002=fuzz1002,
+                fuzz1003=fuzz1003,
+                fuzz1004=fuzz1004,
+                fuzz1005=fuzz1005,
+                fuzz1006=fuzz1006,
+                fuzz1007=fuzz1007,
+                fuzz1008=fuzz1008,
+                fuzz1009=fuzz1009,
+                fuzz1010=fuzz1010,
+                fuzz1011=fuzz1011,
+                fuzz1012=fuzz1012,
+                fuzz1013=fuzz1013,
+                fuzz1014=fuzz1014,
+                fuzz1015=fuzz1015,
+                fuzz1016=fuzz1016,
+                fuzz1017=fuzz1017,
+                fuzz1018=fuzz1018,
+                fuzz1019=fuzz1019,
+                fuzz1020=fuzz1020,
+                fuzz1021=fuzz1021,
+            )
+            return
+        self.__attrs_init__()
 
     fuzz1001: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer1Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer1Batch._required,  # type: ignore[misc]
     )
     fuzz1002: components.AffixFuzzer2Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer2Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer2Batch._required,  # type: ignore[misc]
     )
     fuzz1003: components.AffixFuzzer3Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer3Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer3Batch._required,  # type: ignore[misc]
     )
     fuzz1004: components.AffixFuzzer4Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer4Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer4Batch._required,  # type: ignore[misc]
     )
     fuzz1005: components.AffixFuzzer5Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer5Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer5Batch._required,  # type: ignore[misc]
     )
     fuzz1006: components.AffixFuzzer6Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer6Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer6Batch._required,  # type: ignore[misc]
     )
     fuzz1007: components.AffixFuzzer7Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer7Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer7Batch._required,  # type: ignore[misc]
     )
     fuzz1008: components.AffixFuzzer8Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer8Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer8Batch._required,  # type: ignore[misc]
     )
     fuzz1009: components.AffixFuzzer9Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer9Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer9Batch._required,  # type: ignore[misc]
     )
     fuzz1010: components.AffixFuzzer10Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer10Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer10Batch._required,  # type: ignore[misc]
     )
     fuzz1011: components.AffixFuzzer11Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer11Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer11Batch._required,  # type: ignore[misc]
     )
     fuzz1012: components.AffixFuzzer12Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer12Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer12Batch._required,  # type: ignore[misc]
     )
     fuzz1013: components.AffixFuzzer13Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer13Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer13Batch._required,  # type: ignore[misc]
     )
     fuzz1014: components.AffixFuzzer14Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer14Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer14Batch._required,  # type: ignore[misc]
     )
     fuzz1015: components.AffixFuzzer15Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer15Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer15Batch._required,  # type: ignore[misc]
     )
     fuzz1016: components.AffixFuzzer16Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer16Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer16Batch._required,  # type: ignore[misc]
     )
     fuzz1017: components.AffixFuzzer17Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer17Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer17Batch._required,  # type: ignore[misc]
     )
     fuzz1018: components.AffixFuzzer18Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer18Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer18Batch._required,  # type: ignore[misc]
     )
     fuzz1019: components.AffixFuzzer19Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer19Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer19Batch._required,  # type: ignore[misc]
     )
     fuzz1020: components.AffixFuzzer20Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer20Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer20Batch._required,  # type: ignore[misc]
     )
     fuzz1021: components.AffixFuzzer21Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer21Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer21Batch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -70,7 +70,29 @@ class AffixFuzzer1(Archetype):
                 fuzz1021=fuzz1021,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            fuzz1001=None,
+            fuzz1002=None,
+            fuzz1003=None,
+            fuzz1004=None,
+            fuzz1005=None,
+            fuzz1006=None,
+            fuzz1007=None,
+            fuzz1008=None,
+            fuzz1009=None,
+            fuzz1010=None,
+            fuzz1011=None,
+            fuzz1012=None,
+            fuzz1013=None,
+            fuzz1014=None,
+            fuzz1015=None,
+            fuzz1016=None,
+            fuzz1017=None,
+            fuzz1018=None,
+            fuzz1019=None,
+            fuzz1020=None,
+            fuzz1021=None,
+        )
 
     fuzz1001: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -45,7 +45,7 @@ class AffixFuzzer1(Archetype):
         """Create a new instance of the AffixFuzzer1 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer1Ext in affix_fuzzer1_ext.py
-        with catch_and_log_exceptions("AffixFuzzer1"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 fuzz1001=fuzz1001,
                 fuzz1002=fuzz1002,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -64,26 +64,7 @@ class AffixFuzzer2(Archetype):
                 fuzz1118=fuzz1118,
             )
             return
-        self.__attrs_init__(
-            fuzz1101=None,
-            fuzz1102=None,
-            fuzz1103=None,
-            fuzz1104=None,
-            fuzz1105=None,
-            fuzz1106=None,
-            fuzz1107=None,
-            fuzz1108=None,
-            fuzz1109=None,
-            fuzz1110=None,
-            fuzz1111=None,
-            fuzz1112=None,
-            fuzz1113=None,
-            fuzz1114=None,
-            fuzz1115=None,
-            fuzz1116=None,
-            fuzz1117=None,
-            fuzz1118=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -9,16 +9,15 @@ from typing import Any
 
 from attrs import define, field
 from rerun._baseclasses import Archetype
+from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes
-from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer2"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer2(Archetype):
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         fuzz1101: datatypes.AffixFuzzer1ArrayLike,
@@ -43,98 +42,101 @@ class AffixFuzzer2(Archetype):
         """Create a new instance of the AffixFuzzer2 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer2Ext in affix_fuzzer2_ext.py
-        self.__attrs_init__(
-            fuzz1101=fuzz1101,
-            fuzz1102=fuzz1102,
-            fuzz1103=fuzz1103,
-            fuzz1104=fuzz1104,
-            fuzz1105=fuzz1105,
-            fuzz1106=fuzz1106,
-            fuzz1107=fuzz1107,
-            fuzz1108=fuzz1108,
-            fuzz1109=fuzz1109,
-            fuzz1110=fuzz1110,
-            fuzz1111=fuzz1111,
-            fuzz1112=fuzz1112,
-            fuzz1113=fuzz1113,
-            fuzz1114=fuzz1114,
-            fuzz1115=fuzz1115,
-            fuzz1116=fuzz1116,
-            fuzz1117=fuzz1117,
-            fuzz1118=fuzz1118,
-        )
+        with catch_and_log_exceptions("AffixFuzzer2"):
+            self.__attrs_init__(
+                fuzz1101=fuzz1101,
+                fuzz1102=fuzz1102,
+                fuzz1103=fuzz1103,
+                fuzz1104=fuzz1104,
+                fuzz1105=fuzz1105,
+                fuzz1106=fuzz1106,
+                fuzz1107=fuzz1107,
+                fuzz1108=fuzz1108,
+                fuzz1109=fuzz1109,
+                fuzz1110=fuzz1110,
+                fuzz1111=fuzz1111,
+                fuzz1112=fuzz1112,
+                fuzz1113=fuzz1113,
+                fuzz1114=fuzz1114,
+                fuzz1115=fuzz1115,
+                fuzz1116=fuzz1116,
+                fuzz1117=fuzz1117,
+                fuzz1118=fuzz1118,
+            )
+            return
+        self.__attrs_init__()
 
     fuzz1101: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer1Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer1Batch._required,  # type: ignore[misc]
     )
     fuzz1102: components.AffixFuzzer2Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer2Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer2Batch._required,  # type: ignore[misc]
     )
     fuzz1103: components.AffixFuzzer3Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer3Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer3Batch._required,  # type: ignore[misc]
     )
     fuzz1104: components.AffixFuzzer4Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer4Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer4Batch._required,  # type: ignore[misc]
     )
     fuzz1105: components.AffixFuzzer5Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer5Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer5Batch._required,  # type: ignore[misc]
     )
     fuzz1106: components.AffixFuzzer6Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer6Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer6Batch._required,  # type: ignore[misc]
     )
     fuzz1107: components.AffixFuzzer7Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer7Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer7Batch._required,  # type: ignore[misc]
     )
     fuzz1108: components.AffixFuzzer8Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer8Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer8Batch._required,  # type: ignore[misc]
     )
     fuzz1109: components.AffixFuzzer9Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer9Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer9Batch._required,  # type: ignore[misc]
     )
     fuzz1110: components.AffixFuzzer10Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer10Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer10Batch._required,  # type: ignore[misc]
     )
     fuzz1111: components.AffixFuzzer11Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer11Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer11Batch._required,  # type: ignore[misc]
     )
     fuzz1112: components.AffixFuzzer12Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer12Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer12Batch._required,  # type: ignore[misc]
     )
     fuzz1113: components.AffixFuzzer13Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer13Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer13Batch._required,  # type: ignore[misc]
     )
     fuzz1114: components.AffixFuzzer14Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer14Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer14Batch._required,  # type: ignore[misc]
     )
     fuzz1115: components.AffixFuzzer15Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer15Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer15Batch._required,  # type: ignore[misc]
     )
     fuzz1116: components.AffixFuzzer16Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer16Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer16Batch._required,  # type: ignore[misc]
     )
     fuzz1117: components.AffixFuzzer17Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer17Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer17Batch._required,  # type: ignore[misc]
     )
     fuzz1118: components.AffixFuzzer18Batch = field(
         metadata={"component": "required"},
-        converter=components.AffixFuzzer18Batch,  # type: ignore[misc]
+        converter=components.AffixFuzzer18Batch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -85,10 +85,9 @@ class AffixFuzzer2(Archetype):
             fuzz1118=None,
         )
 
-    @classmethod
-    def _clear(cls) -> AffixFuzzer2:
-        """Produce an empty AffixFuzzer2."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             fuzz1101=None,  # type: ignore[arg-type]
             fuzz1102=None,  # type: ignore[arg-type]
             fuzz1103=None,  # type: ignore[arg-type]
@@ -108,6 +107,13 @@ class AffixFuzzer2(Archetype):
             fuzz1117=None,  # type: ignore[arg-type]
             fuzz1118=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> AffixFuzzer2:
+        """Produce an empty AffixFuzzer2, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     fuzz1101: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -85,6 +85,30 @@ class AffixFuzzer2(Archetype):
             fuzz1118=None,
         )
 
+    @classmethod
+    def _clear(cls) -> AffixFuzzer2:
+        """Produce an empty AffixFuzzer2."""
+        return cls(
+            fuzz1101=None,  # type: ignore[arg-type]
+            fuzz1102=None,  # type: ignore[arg-type]
+            fuzz1103=None,  # type: ignore[arg-type]
+            fuzz1104=None,  # type: ignore[arg-type]
+            fuzz1105=None,  # type: ignore[arg-type]
+            fuzz1106=None,  # type: ignore[arg-type]
+            fuzz1107=None,  # type: ignore[arg-type]
+            fuzz1108=None,  # type: ignore[arg-type]
+            fuzz1109=None,  # type: ignore[arg-type]
+            fuzz1110=None,  # type: ignore[arg-type]
+            fuzz1111=None,  # type: ignore[arg-type]
+            fuzz1112=None,  # type: ignore[arg-type]
+            fuzz1113=None,  # type: ignore[arg-type]
+            fuzz1114=None,  # type: ignore[arg-type]
+            fuzz1115=None,  # type: ignore[arg-type]
+            fuzz1116=None,  # type: ignore[arg-type]
+            fuzz1117=None,  # type: ignore[arg-type]
+            fuzz1118=None,  # type: ignore[arg-type]
+        )
+
     fuzz1101: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},
         converter=components.AffixFuzzer1Batch._required,  # type: ignore[misc]

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -42,7 +42,7 @@ class AffixFuzzer2(Archetype):
         """Create a new instance of the AffixFuzzer2 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer2Ext in affix_fuzzer2_ext.py
-        with catch_and_log_exceptions("AffixFuzzer2"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 fuzz1101=fuzz1101,
                 fuzz1102=fuzz1102,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -11,12 +11,14 @@ from attrs import define, field
 from rerun._baseclasses import Archetype
 
 from .. import components, datatypes
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer2"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer2(Archetype):
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         fuzz1101: datatypes.AffixFuzzer1ArrayLike,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -64,7 +64,26 @@ class AffixFuzzer2(Archetype):
                 fuzz1118=fuzz1118,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            fuzz1101=None,
+            fuzz1102=None,
+            fuzz1103=None,
+            fuzz1104=None,
+            fuzz1105=None,
+            fuzz1106=None,
+            fuzz1107=None,
+            fuzz1108=None,
+            fuzz1109=None,
+            fuzz1110=None,
+            fuzz1111=None,
+            fuzz1112=None,
+            fuzz1113=None,
+            fuzz1114=None,
+            fuzz1115=None,
+            fuzz1116=None,
+            fuzz1117=None,
+            fuzz1118=None,
+        )
 
     fuzz1101: components.AffixFuzzer1Batch = field(
         metadata={"component": "required"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -65,7 +65,26 @@ class AffixFuzzer3(Archetype):
                 fuzz2018=fuzz2018,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            fuzz2001=None,
+            fuzz2002=None,
+            fuzz2003=None,
+            fuzz2004=None,
+            fuzz2005=None,
+            fuzz2006=None,
+            fuzz2007=None,
+            fuzz2008=None,
+            fuzz2009=None,
+            fuzz2010=None,
+            fuzz2011=None,
+            fuzz2012=None,
+            fuzz2013=None,
+            fuzz2014=None,
+            fuzz2015=None,
+            fuzz2016=None,
+            fuzz2017=None,
+            fuzz2018=None,
+        )
 
     fuzz2001: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -11,12 +11,14 @@ from attrs import define, field
 from rerun._baseclasses import Archetype
 
 from .. import components, datatypes
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer3"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer3(Archetype):
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         *,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -9,16 +9,15 @@ from typing import Any
 
 from attrs import define, field
 from rerun._baseclasses import Archetype
+from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes
-from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer3"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer3(Archetype):
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         *,
@@ -44,26 +43,29 @@ class AffixFuzzer3(Archetype):
         """Create a new instance of the AffixFuzzer3 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer3Ext in affix_fuzzer3_ext.py
-        self.__attrs_init__(
-            fuzz2001=fuzz2001,
-            fuzz2002=fuzz2002,
-            fuzz2003=fuzz2003,
-            fuzz2004=fuzz2004,
-            fuzz2005=fuzz2005,
-            fuzz2006=fuzz2006,
-            fuzz2007=fuzz2007,
-            fuzz2008=fuzz2008,
-            fuzz2009=fuzz2009,
-            fuzz2010=fuzz2010,
-            fuzz2011=fuzz2011,
-            fuzz2012=fuzz2012,
-            fuzz2013=fuzz2013,
-            fuzz2014=fuzz2014,
-            fuzz2015=fuzz2015,
-            fuzz2016=fuzz2016,
-            fuzz2017=fuzz2017,
-            fuzz2018=fuzz2018,
-        )
+        with catch_and_log_exceptions("AffixFuzzer3"):
+            self.__attrs_init__(
+                fuzz2001=fuzz2001,
+                fuzz2002=fuzz2002,
+                fuzz2003=fuzz2003,
+                fuzz2004=fuzz2004,
+                fuzz2005=fuzz2005,
+                fuzz2006=fuzz2006,
+                fuzz2007=fuzz2007,
+                fuzz2008=fuzz2008,
+                fuzz2009=fuzz2009,
+                fuzz2010=fuzz2010,
+                fuzz2011=fuzz2011,
+                fuzz2012=fuzz2012,
+                fuzz2013=fuzz2013,
+                fuzz2014=fuzz2014,
+                fuzz2015=fuzz2015,
+                fuzz2016=fuzz2016,
+                fuzz2017=fuzz2017,
+                fuzz2018=fuzz2018,
+            )
+            return
+        self.__attrs_init__()
 
     fuzz2001: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -86,6 +86,30 @@ class AffixFuzzer3(Archetype):
             fuzz2018=None,
         )
 
+    @classmethod
+    def _clear(cls) -> AffixFuzzer3:
+        """Produce an empty AffixFuzzer3."""
+        return cls(
+            fuzz2001=None,  # type: ignore[arg-type]
+            fuzz2002=None,  # type: ignore[arg-type]
+            fuzz2003=None,  # type: ignore[arg-type]
+            fuzz2004=None,  # type: ignore[arg-type]
+            fuzz2005=None,  # type: ignore[arg-type]
+            fuzz2006=None,  # type: ignore[arg-type]
+            fuzz2007=None,  # type: ignore[arg-type]
+            fuzz2008=None,  # type: ignore[arg-type]
+            fuzz2009=None,  # type: ignore[arg-type]
+            fuzz2010=None,  # type: ignore[arg-type]
+            fuzz2011=None,  # type: ignore[arg-type]
+            fuzz2012=None,  # type: ignore[arg-type]
+            fuzz2013=None,  # type: ignore[arg-type]
+            fuzz2014=None,  # type: ignore[arg-type]
+            fuzz2015=None,  # type: ignore[arg-type]
+            fuzz2016=None,  # type: ignore[arg-type]
+            fuzz2017=None,  # type: ignore[arg-type]
+            fuzz2018=None,  # type: ignore[arg-type]
+        )
+
     fuzz2001: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},
         default=None,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -86,10 +86,9 @@ class AffixFuzzer3(Archetype):
             fuzz2018=None,
         )
 
-    @classmethod
-    def _clear(cls) -> AffixFuzzer3:
-        """Produce an empty AffixFuzzer3."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             fuzz2001=None,  # type: ignore[arg-type]
             fuzz2002=None,  # type: ignore[arg-type]
             fuzz2003=None,  # type: ignore[arg-type]
@@ -109,6 +108,13 @@ class AffixFuzzer3(Archetype):
             fuzz2017=None,  # type: ignore[arg-type]
             fuzz2018=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> AffixFuzzer3:
+        """Produce an empty AffixFuzzer3, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     fuzz2001: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -65,26 +65,7 @@ class AffixFuzzer3(Archetype):
                 fuzz2018=fuzz2018,
             )
             return
-        self.__attrs_init__(
-            fuzz2001=None,
-            fuzz2002=None,
-            fuzz2003=None,
-            fuzz2004=None,
-            fuzz2005=None,
-            fuzz2006=None,
-            fuzz2007=None,
-            fuzz2008=None,
-            fuzz2009=None,
-            fuzz2010=None,
-            fuzz2011=None,
-            fuzz2012=None,
-            fuzz2013=None,
-            fuzz2014=None,
-            fuzz2015=None,
-            fuzz2016=None,
-            fuzz2017=None,
-            fuzz2018=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -43,7 +43,7 @@ class AffixFuzzer3(Archetype):
         """Create a new instance of the AffixFuzzer3 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer3Ext in affix_fuzzer3_ext.py
-        with catch_and_log_exceptions("AffixFuzzer3"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 fuzz2001=fuzz2001,
                 fuzz2002=fuzz2002,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -65,7 +65,26 @@ class AffixFuzzer4(Archetype):
                 fuzz2118=fuzz2118,
             )
             return
-        self.__attrs_init__()
+        self.__attrs_init__(
+            fuzz2101=None,
+            fuzz2102=None,
+            fuzz2103=None,
+            fuzz2104=None,
+            fuzz2105=None,
+            fuzz2106=None,
+            fuzz2107=None,
+            fuzz2108=None,
+            fuzz2109=None,
+            fuzz2110=None,
+            fuzz2111=None,
+            fuzz2112=None,
+            fuzz2113=None,
+            fuzz2114=None,
+            fuzz2115=None,
+            fuzz2116=None,
+            fuzz2117=None,
+            fuzz2118=None,
+        )
 
     fuzz2101: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -65,26 +65,7 @@ class AffixFuzzer4(Archetype):
                 fuzz2118=fuzz2118,
             )
             return
-        self.__attrs_init__(
-            fuzz2101=None,
-            fuzz2102=None,
-            fuzz2103=None,
-            fuzz2104=None,
-            fuzz2105=None,
-            fuzz2106=None,
-            fuzz2107=None,
-            fuzz2108=None,
-            fuzz2109=None,
-            fuzz2110=None,
-            fuzz2111=None,
-            fuzz2112=None,
-            fuzz2113=None,
-            fuzz2114=None,
-            fuzz2115=None,
-            fuzz2116=None,
-            fuzz2117=None,
-            fuzz2118=None,
-        )
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -86,10 +86,9 @@ class AffixFuzzer4(Archetype):
             fuzz2118=None,
         )
 
-    @classmethod
-    def _clear(cls) -> AffixFuzzer4:
-        """Produce an empty AffixFuzzer4."""
-        return cls(
+    def __attrs_clear__(self) -> None:
+        """Convenience method for calling `__attrs_init__` with all `None`s."""
+        self.__attrs_init__(
             fuzz2101=None,  # type: ignore[arg-type]
             fuzz2102=None,  # type: ignore[arg-type]
             fuzz2103=None,  # type: ignore[arg-type]
@@ -109,6 +108,13 @@ class AffixFuzzer4(Archetype):
             fuzz2117=None,  # type: ignore[arg-type]
             fuzz2118=None,  # type: ignore[arg-type]
         )
+
+    @classmethod
+    def _clear(cls) -> AffixFuzzer4:
+        """Produce an empty AffixFuzzer4, bypassing `__init__`."""
+        inst = cls.__new__(cls)
+        inst.__attrs_clear__()
+        return inst
 
     fuzz2101: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -9,16 +9,15 @@ from typing import Any
 
 from attrs import define, field
 from rerun._baseclasses import Archetype
+from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes
-from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer4"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer4(Archetype):
-    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         *,
@@ -44,26 +43,29 @@ class AffixFuzzer4(Archetype):
         """Create a new instance of the AffixFuzzer4 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer4Ext in affix_fuzzer4_ext.py
-        self.__attrs_init__(
-            fuzz2101=fuzz2101,
-            fuzz2102=fuzz2102,
-            fuzz2103=fuzz2103,
-            fuzz2104=fuzz2104,
-            fuzz2105=fuzz2105,
-            fuzz2106=fuzz2106,
-            fuzz2107=fuzz2107,
-            fuzz2108=fuzz2108,
-            fuzz2109=fuzz2109,
-            fuzz2110=fuzz2110,
-            fuzz2111=fuzz2111,
-            fuzz2112=fuzz2112,
-            fuzz2113=fuzz2113,
-            fuzz2114=fuzz2114,
-            fuzz2115=fuzz2115,
-            fuzz2116=fuzz2116,
-            fuzz2117=fuzz2117,
-            fuzz2118=fuzz2118,
-        )
+        with catch_and_log_exceptions("AffixFuzzer4"):
+            self.__attrs_init__(
+                fuzz2101=fuzz2101,
+                fuzz2102=fuzz2102,
+                fuzz2103=fuzz2103,
+                fuzz2104=fuzz2104,
+                fuzz2105=fuzz2105,
+                fuzz2106=fuzz2106,
+                fuzz2107=fuzz2107,
+                fuzz2108=fuzz2108,
+                fuzz2109=fuzz2109,
+                fuzz2110=fuzz2110,
+                fuzz2111=fuzz2111,
+                fuzz2112=fuzz2112,
+                fuzz2113=fuzz2113,
+                fuzz2114=fuzz2114,
+                fuzz2115=fuzz2115,
+                fuzz2116=fuzz2116,
+                fuzz2117=fuzz2117,
+                fuzz2118=fuzz2118,
+            )
+            return
+        self.__attrs_init__()
 
     fuzz2101: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -43,7 +43,7 @@ class AffixFuzzer4(Archetype):
         """Create a new instance of the AffixFuzzer4 archetype."""
 
         # You can define your own __init__ function as a member of AffixFuzzer4Ext in affix_fuzzer4_ext.py
-        with catch_and_log_exceptions("AffixFuzzer4"):
+        with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 fuzz2101=fuzz2101,
                 fuzz2102=fuzz2102,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -11,12 +11,14 @@ from attrs import define, field
 from rerun._baseclasses import Archetype
 
 from .. import components, datatypes
+from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AffixFuzzer4"]
 
 
 @define(str=False, repr=False, init=False)
 class AffixFuzzer4(Archetype):
+    @catch_and_log_exceptions()
     def __init__(
         self: Any,
         *,

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -86,6 +86,30 @@ class AffixFuzzer4(Archetype):
             fuzz2118=None,
         )
 
+    @classmethod
+    def _clear(cls) -> AffixFuzzer4:
+        """Produce an empty AffixFuzzer4."""
+        return cls(
+            fuzz2101=None,  # type: ignore[arg-type]
+            fuzz2102=None,  # type: ignore[arg-type]
+            fuzz2103=None,  # type: ignore[arg-type]
+            fuzz2104=None,  # type: ignore[arg-type]
+            fuzz2105=None,  # type: ignore[arg-type]
+            fuzz2106=None,  # type: ignore[arg-type]
+            fuzz2107=None,  # type: ignore[arg-type]
+            fuzz2108=None,  # type: ignore[arg-type]
+            fuzz2109=None,  # type: ignore[arg-type]
+            fuzz2110=None,  # type: ignore[arg-type]
+            fuzz2111=None,  # type: ignore[arg-type]
+            fuzz2112=None,  # type: ignore[arg-type]
+            fuzz2113=None,  # type: ignore[arg-type]
+            fuzz2114=None,  # type: ignore[arg-type]
+            fuzz2115=None,  # type: ignore[arg-type]
+            fuzz2116=None,  # type: ignore[arg-type]
+            fuzz2117=None,  # type: ignore[arg-type]
+            fuzz2118=None,  # type: ignore[arg-type]
+        )
+
     fuzz2101: components.AffixFuzzer1Batch | None = field(
         metadata={"component": "optional"},
         default=None,

--- a/rerun_py/tests/unit/test_exceptions.py
+++ b/rerun_py/tests/unit/test_exceptions.py
@@ -7,25 +7,35 @@ import rerun as rr
 from rerun.error_utils import RerunWarning, catch_and_log_exceptions
 
 
-@catch_and_log_exceptions
-def outer() -> None:
+@catch_and_log_exceptions()
+def outer(strict: bool | None = None) -> None:
+    """Calls an inner decorated function."""
     inner(3)
 
 
-@catch_and_log_exceptions
+@catch_and_log_exceptions()
 def inner(count: int) -> None:
+    """Calls itself recursively but ultimately raises an error."""
     if count < 0:
         raise ValueError("count must be positive")
     inner(count - 1)
 
 
+@catch_and_log_exceptions()
+def uses_context(strict: bool | None = None) -> None:
+    with catch_and_log_exceptions():
+        raise ValueError
+
+
 def get_line_number() -> int:
+    """Helper to get a line-number. Make sure our warnings point to the right place."""
     frame = inspect.currentframe().f_back  # type: ignore[union-attr]
     return frame.f_lineno  # type: ignore[union-attr]
 
 
-def test_enable_strict_mode() -> None:
+def test_stack_tracking() -> None:
     rr.init("test_enable_strict_mode", spawn=False)
+
     mem = rr.memory_recording()
     with pytest.warns(RerunWarning) as record:
         starting_msgs = mem.num_msgs()
@@ -35,6 +45,43 @@ def test_enable_strict_mode() -> None:
         assert "count must be positive" in str(record[0].message)
         assert mem.num_msgs() == starting_msgs + 1
 
+    mem = rr.memory_recording()
+    with pytest.warns(RerunWarning) as record:
+        starting_msgs = mem.num_msgs()
+        uses_context()
+        assert record[0].lineno == get_line_number() - 1
+        assert record[0].filename == __file__
+        assert mem.num_msgs() == starting_msgs + 1
+
+    mem = rr.memory_recording()
+    with pytest.warns(RerunWarning) as record:
+        starting_msgs = mem.num_msgs()
+        with catch_and_log_exceptions():
+            inner(count=2)
+        assert record[0].lineno == get_line_number() - 1
+        assert record[0].filename == __file__
+        assert "count must be positive" in str(record[0].message)
+        assert mem.num_msgs() == starting_msgs + 1
+
+    mem = rr.memory_recording()
+    with pytest.warns(RerunWarning) as record:
+        starting_msgs = mem.num_msgs()
+        with catch_and_log_exceptions():
+            raise ValueError
+        assert record[0].lineno == get_line_number() - 2
+        assert record[0].filename == __file__
+        assert mem.num_msgs() == starting_msgs + 1
+
+
+def test_strict_mode() -> None:
+    # We can disable strict on just this function
+    with pytest.raises(ValueError):
+        outer(strict=True)
+
+    with pytest.raises(ValueError):
+        uses_context(strict=True)
+
+    # We can disable strict mode globally
     rr.set_strict_mode(True)
     with pytest.raises(ValueError):
         outer()

--- a/rerun_py/tests/unit/test_exceptions.py
+++ b/rerun_py/tests/unit/test_exceptions.py
@@ -83,7 +83,7 @@ def test_stack_tracking() -> None:
     with pytest.warns(RerunWarning) as warnings:
         starting_msgs = mem.num_msgs()
 
-        with catch_and_log_exceptions():
+        with catch_and_log_exceptions(depth_to_user_code=0):
             uses_context()
 
         expected_warnings(warnings, mem, starting_msgs, 1, get_line_number() - 3)
@@ -92,7 +92,7 @@ def test_stack_tracking() -> None:
     with pytest.warns(RerunWarning) as warnings:
         starting_msgs = mem.num_msgs()
 
-        with catch_and_log_exceptions("some context"):
+        with catch_and_log_exceptions("some context", depth_to_user_code=0):
             raise ValueError("some value error")
 
         expected_warnings(warnings, mem, starting_msgs, 1, get_line_number() - 3)

--- a/rerun_py/tests/unit/test_exceptions.py
+++ b/rerun_py/tests/unit/test_exceptions.py
@@ -120,7 +120,7 @@ def test_bad_components() -> None:
         points = rr.Points3D(positions=[1, 2, 3], colors="RED")
         assert len(warnings) == 1
         assert len(points.positions) == 1
-        assert len(points.colors) == 0
+        assert len(points.colors) == 0  # type: ignore[arg-type]
 
     rr.set_strict_mode(True)
     with pytest.raises(ValueError):

--- a/rerun_py/tests/unit/test_exceptions.py
+++ b/rerun_py/tests/unit/test_exceptions.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+import rerun as rr
+from rerun.error_utils import RerunWarning, catch_and_log_exceptions
+
+
+@catch_and_log_exceptions
+def outer() -> None:
+    inner(3)
+
+
+@catch_and_log_exceptions
+def inner(count: int) -> None:
+    if count < 0:
+        raise ValueError("count must be positive")
+    inner(count - 1)
+
+
+def get_line_number() -> int:
+    frame = inspect.currentframe().f_back  # type: ignore[union-attr]
+    return frame.f_lineno  # type: ignore[union-attr]
+
+
+def test_enable_strict_mode() -> None:
+    rr.init("test_enable_strict_mode", spawn=False)
+    mem = rr.memory_recording()
+    with pytest.warns(RerunWarning) as record:
+        starting_msgs = mem.num_msgs()
+        outer()
+        assert record[0].lineno == get_line_number() - 1
+        assert record[0].filename == __file__
+        assert "count must be positive" in str(record[0].message)
+        assert mem.num_msgs() == starting_msgs + 1
+
+    rr.set_strict_mode(True)
+    with pytest.raises(ValueError):
+        outer()

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -5,15 +5,25 @@ import rerun as rr
 from rerun.error_utils import RerunWarning
 
 rr.init("exceptions", spawn=False)
+# Make sure strict mode isn't leaking in from another context
 mem = rr.memory_recording()
 
 
-def test_points_warnings() -> None:
+def test_expected_warnings() -> None:
+    # Always set strict mode to false in case it leaked from another test
+    rr.set_strict_mode(False)
     with pytest.warns(RerunWarning) as warnings:
-        rr.log("points", rr.Points3D([1, 2, 3, 4, 5]))
+        expected_warnings = [
+            (
+                rr.log("points", rr.Points3D([1, 2, 3, 4, 5])),
+                "Expected either a flat array with a length multiple of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,).",
+            ),
+            (
+                rr.log("points", rr.Points2D([1, 2, 3, 4, 5])),
+                "Expected either a flat array with a length multiple of 2 elements, or an array with shape (`num_elements`, 2). Shape of passed array was (5,).",
+            ),
+        ]
 
-        assert len(warnings) == 1
-        assert (
-            "Expected either a flat array with a length multiple of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,)."
-            in str(warnings[0].message)
-        )
+        assert len(warnings) == len(expected_warnings)
+        for warning, (_, expected) in zip(warnings, expected_warnings):
+            assert expected in str(warning)

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -14,6 +14,6 @@ def test_points_warnings() -> None:
 
         assert len(warnings) == 1
         assert (
-            "Expected either a flat array with a length multiple of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,).)"
+            "Expected either a flat array with a length multiple of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,)."
             in str(warnings[0].message)
         )

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+import rerun as rr
+from rerun.error_utils import RerunWarning
+
+rr.init("exceptions", spawn=False)
+mem = rr.memory_recording()
+
+
+def test_points_warnings() -> None:
+    with pytest.warns(RerunWarning) as warnings:
+        rr.log("points", rr.Points3D([1, 2, 3, 4, 5]))
+
+        assert len(warnings) == 1
+        assert (
+            "Expected either a flat array with a length a of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,).)"
+            in str(warnings[0].message)
+        )

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -13,6 +13,10 @@ def test_expected_warnings() -> None:
     # Always set strict mode to false in case it leaked from another test
     rr.set_strict_mode(False)
     with pytest.warns(RerunWarning) as warnings:
+        # Each of these calls will fail as they are executed and aggregate warnings into the single warnings recording.
+        # We then check that all the warnings were emitted in the expected order.
+        # If a log-call is expected to produce multiple warnings, add another tuple to the list that doesn't produce a warning,
+        # or else the offsets will get out of alignment.
         expected_warnings = [
             (
                 rr.log("points", rr.Points3D([1, 2, 3, 4, 5])),

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -14,6 +14,6 @@ def test_points_warnings() -> None:
 
         assert len(warnings) == 1
         assert (
-            "Expected either a flat array with a length a of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,).)"
+            "Expected either a flat array with a length multiple of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (5,).)"
             in str(warnings[0].message)
         )


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3513

The permutations and indirections in our new API style made this fairly involved.

In an effort to be as-forgiving-as-possible I wanted to be able to handle exceptions down multiple levels in the construction hierarchy. For example:
```
rr.log("points", rr.Points3D(positions, colors='RED'))
```

Should produce an error:
```
my_points3d.py:12: RerunWarning: ColorBatch: ValueError(expected sequence of length of 3 or 4, received 1)
```
But still successfully log positions; just not colors.

However, if something else goes wrong in that constructor, or the things using it, the next level up in the stack, for example `log` should catch the error instead. In this case no data will be sent, but we'll still get a warning and not crash the program.

To handle this I introduced a hybrid decorator / context manager: `catch_and_log_exceptions` which tries to behave as sanely as possible in the context of a situation where we might recursively call multiple levels of functions, any one of which might produce an exception we would like to handle.

The basic idea is that the deepest context manager to see the error will handle it and produce the message. This means we can add the `catch_and_log_exceptions` decorator or context manager anywhere we know that we can try to recover sanely. We'll get an error produced from that location, but the code higher up in the stack will still run.

To improve the user experience, errors are appended to a warning list as they are encountered, and finally we output them when exiting the top-most context manager. This means we get warning lines that point to the user call-site rather than some arbitrary location within the guts of rerun SDK.

One irritation I discovered is that decorating `__init__` methods causes two major issues. For one, it leaves the object in a potentially uninitialized state, just waiting to cascade into more exceptions in future. Additionally, it wreaks havoc on the type-checker. To accommodate this,`__init__` functions follow a pattern where they use the context-manager directly and then fallback on a hopefully safer code-path.

The Archetype constructors now generally call `__attr_clear__` which is a new helper function designed to call `__attrs_init__` with `None` for all the known params.

I also code-gen a `_clear` helper to use as a similar fallback path in builder functions.

Recommend reviewing with:
![image](https://github.com/rerun-io/rerun/assets/3312232/6f05d3b8-8c5c-48ff-a227-c515a92735ea)

Since a number of big snippets got indented when adding the context managers.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3531) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3531)
- [Docs preview](https://rerun.io/preview/41f3a7dae887503cf098e063121e54bcdeb7378d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/41f3a7dae887503cf098e063121e54bcdeb7378d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)