### PR TITLE
Add some profile scopes to the generated `re_types` arrow functions

### DIFF
--- a/crates/re_query/benches/query_benchmark.rs
+++ b/crates/re_query/benches/query_benchmark.rs
@@ -190,7 +190,7 @@ fn batch_strings(c: &mut Criterion) {
 
 // --- Helpers ---
 
-fn build_points_rows(paths: &[EntityPath], pts: usize) -> Vec<DataRow> {
+fn build_points_rows(paths: &[EntityPath], num_points: usize) -> Vec<DataRow> {
     (0..NUM_FRAMES_POINTS)
         .flat_map(move |frame_idx| {
             paths.iter().map(move |path| {
@@ -198,8 +198,11 @@ fn build_points_rows(paths: &[EntityPath], pts: usize) -> Vec<DataRow> {
                     RowId::ZERO,
                     path.clone(),
                     [build_frame_nr((frame_idx as i64).into())],
-                    pts as _,
-                    (build_some_point2d(pts), build_some_colors(pts)),
+                    num_points as _,
+                    (
+                        build_some_point2d(num_points),
+                        build_some_colors(num_points),
+                    ),
                 )
                 .unwrap();
                 // NOTE: Using unsized cells will crash in debug mode, and benchmarks are run for 1 iteration,

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -362,7 +362,6 @@ impl<A: Archetype> ArchetypeView<A> {
                 // Therefore there cannot be any null values, therefore we can go through the fast
                 // deserialization path.
                 let component_value_iter = {
-                    re_tracing::profile_scope!("try_from_arrow", C::name());
                     C::from_arrow(component.values.as_arrow_ref())?
                         .into_iter()
                         .map(Some)
@@ -373,10 +372,8 @@ impl<A: Archetype> ArchetypeView<A> {
                 )));
             }
 
-            let component_value_iter = {
-                re_tracing::profile_scope!("try_from_arrow_opt", C::name());
-                C::from_arrow_opt(component.values.as_arrow_ref())?.into_iter()
-            };
+            let component_value_iter =
+                { C::from_arrow_opt(component.values.as_arrow_ref())?.into_iter() };
 
             let primary_instance_key_iter = self.iter_instance_keys();
             let mut component_instance_key_iter = component.instance_keys().into_iter();
@@ -426,7 +423,6 @@ impl<A: Archetype> ArchetypeView<A> {
         let component = self.components.get(&C::name());
 
         if let Some(component) = component {
-            re_tracing::profile_scope!("try_from_arrow", C::name());
             return Ok(Some(
                 C::from_arrow(component.values.as_arrow_ref())?.into_iter(),
             ));

--- a/crates/re_types/definitions/rerun/archetypes/view_coordinates.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/view_coordinates.fbs
@@ -17,7 +17,8 @@ namespace rerun.archetypes;
 ///
 /// \example view_coordinates_simple
 table ViewCoordinates (
-  "attr.rust.derive": "Copy, PartialEq, Eq"
+  "attr.rust.derive": "Copy, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   xyz: rerun.components.ViewCoordinates ("attr.rerun.component_required", required, order: 1000);
 }

--- a/crates/re_types/definitions/rerun/components/class_id.fbs
+++ b/crates/re_types/definitions/rerun/components/class_id.fbs
@@ -15,7 +15,7 @@ table ClassId (
   "attr.arrow.transparent",
   "attr.python.aliases": "int",
   "attr.python.array_aliases": "int, npt.NDArray[np.uint8], npt.NDArray[np.uint16], npt.NDArray[np.uint32], npt.NDArray[np.uint64]",
-  "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash",
+  "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",
   "attr.rust.custom_clause":
     'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'

--- a/crates/re_types/definitions/rerun/components/depth_meter.fbs
+++ b/crates/re_types/definitions/rerun/components/depth_meter.fbs
@@ -13,7 +13,8 @@ namespace rerun.components;
 struct DepthMeter (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float32]",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   value: float (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/keypoint_id.fbs
+++ b/crates/re_types/definitions/rerun/components/keypoint_id.fbs
@@ -22,7 +22,8 @@ struct KeypointId (
   "attr.arrow.transparent",
   "attr.python.aliases": "int",
   "attr.python.array_aliases": "int, npt.NDArray[np.uint8], npt.NDArray[np.uint16], npt.NDArray[np.uint32], npt.NDArray[np.uint64]",
-  "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash",
+  "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent",
   "attr.rust.custom_clause":
     'cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))'
 ) {

--- a/crates/re_types/definitions/rerun/components/origin2d.fbs
+++ b/crates/re_types/definitions/rerun/components/origin2d.fbs
@@ -11,7 +11,8 @@ namespace rerun.components;
 
 /// A point of origin in 2D space.
 struct Origin2D (
-  "attr.rust.derive": "Copy, PartialEq"
+  "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   origin: rerun.datatypes.Vec2D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/origin3d.fbs
+++ b/crates/re_types/definitions/rerun/components/origin3d.fbs
@@ -11,7 +11,8 @@ namespace rerun.components;
 
 /// A point of origin in 3D space.
 struct Origin3D (
-  "attr.rust.derive": "Copy, PartialEq"
+  "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   origin: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/radius.fbs
+++ b/crates/re_types/definitions/rerun/components/radius.fbs
@@ -13,7 +13,8 @@ namespace rerun.components;
 struct Radius (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.ArrayLike",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   value: float (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/scalar.fbs
+++ b/crates/re_types/definitions/rerun/components/scalar.fbs
@@ -15,7 +15,8 @@ namespace rerun.components;
 struct Scalar (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float64]",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd"
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   value: double (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/vector3d.fbs
+++ b/crates/re_types/definitions/rerun/components/vector3d.fbs
@@ -11,7 +11,8 @@ namespace rerun.components;
 
 /// A vector in 3D space.
 struct Vector3D (
-  "attr.rust.derive": "Copy, PartialEq"
+  "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   vector: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/re_types/definitions/rerun/components/view_coordinates.fbs
+++ b/crates/re_types/definitions/rerun/components/view_coordinates.fbs
@@ -38,7 +38,8 @@ enum ViewDir: byte {
 struct ViewCoordinates (
   "attr.python.aliases": "npt.ArrayLike",
   "attr.python.array_aliases": "npt.ArrayLike",
-  "attr.rust.derive": "Copy, PartialEq, Eq"
+  "attr.rust.derive": "Copy, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   /// The directions of the [x, y, z] axes.
   coordinates: [ubyte: 3] (order: 100);

--- a/crates/re_types/definitions/rerun/datatypes/class_id.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_id.fbs
@@ -15,7 +15,7 @@ struct ClassId (
   "attr.arrow.transparent",
   "attr.python.aliases": "int",
   "attr.python.array_aliases": "int, npt.ArrayLike",
-  "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash",
+  "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct",
   "attr.rust.custom_clause":

--- a/crates/re_types/definitions/rerun/datatypes/keypoint_id.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/keypoint_id.fbs
@@ -22,7 +22,7 @@ struct KeypointId (
   "attr.arrow.transparent",
   "attr.python.aliases": "int",
   "attr.python.array_aliases": "int, npt.ArrayLike",
-  "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash",
+  "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct",
   "attr.rust.custom_clause":

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -235,6 +235,7 @@ impl crate::Archetype for AnnotationContext {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -259,6 +260,7 @@ impl crate::Archetype for AnnotationContext {
 
 impl crate::AsComponents for AnnotationContext {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -177,6 +177,7 @@ impl crate::Archetype for Arrows3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -281,6 +282,7 @@ impl crate::Archetype for Arrows3D {
 
 impl crate::AsComponents for Arrows3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -190,6 +190,7 @@ impl crate::Archetype for Asset3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -245,6 +246,7 @@ impl crate::Archetype for Asset3D {
 
 impl crate::AsComponents for Asset3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -108,6 +108,7 @@ impl crate::Archetype for BarChart {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -132,6 +133,7 @@ impl crate::Archetype for BarChart {
 
 impl crate::AsComponents for BarChart {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -156,6 +156,7 @@ impl crate::Archetype for Boxes2D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -274,6 +275,7 @@ impl crate::Archetype for Boxes2D {
 
 impl crate::AsComponents for Boxes2D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -197,6 +197,7 @@ impl crate::Archetype for Boxes3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -314,6 +315,7 @@ impl crate::Archetype for Boxes3D {
 
 impl crate::AsComponents for Boxes3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/clear.rs
+++ b/crates/re_types/src/archetypes/clear.rs
@@ -167,6 +167,7 @@ impl crate::Archetype for Clear {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -191,6 +192,7 @@ impl crate::Archetype for Clear {
 
 impl crate::AsComponents for Clear {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -181,6 +181,7 @@ impl crate::Archetype for DepthImage {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -235,6 +236,7 @@ impl crate::Archetype for DepthImage {
 
 impl crate::AsComponents for DepthImage {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -117,6 +117,7 @@ impl crate::Archetype for DisconnectedSpace {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -141,6 +142,7 @@ impl crate::Archetype for DisconnectedSpace {
 
 impl crate::AsComponents for DisconnectedSpace {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -134,6 +134,7 @@ impl crate::Archetype for Image {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -171,6 +172,7 @@ impl crate::Archetype for Image {
 
 impl crate::AsComponents for Image {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -231,6 +231,7 @@ impl crate::Archetype for LineStrips2D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -336,6 +337,7 @@ impl crate::Archetype for LineStrips2D {
 
 impl crate::AsComponents for LineStrips2D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -227,6 +227,7 @@ impl crate::Archetype for LineStrips3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -318,6 +319,7 @@ impl crate::Archetype for LineStrips3D {
 
 impl crate::AsComponents for LineStrips3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -196,6 +196,7 @@ impl crate::Archetype for Mesh3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -303,6 +304,7 @@ impl crate::Archetype for Mesh3D {
 
 impl crate::AsComponents for Mesh3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -172,6 +172,7 @@ impl crate::Archetype for Pinhole {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -227,6 +228,7 @@ impl crate::Archetype for Pinhole {
 
 impl crate::AsComponents for Pinhole {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -206,6 +206,7 @@ impl crate::Archetype for Points2D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -324,6 +325,7 @@ impl crate::Archetype for Points2D {
 
 impl crate::AsComponents for Points2D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -187,6 +187,7 @@ impl crate::Archetype for Points3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -291,6 +292,7 @@ impl crate::Archetype for Points3D {
 
 impl crate::AsComponents for Points3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -146,6 +146,7 @@ impl crate::Archetype for SegmentationImage {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -183,6 +184,7 @@ impl crate::Archetype for SegmentationImage {
 
 impl crate::AsComponents for SegmentationImage {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -146,6 +146,7 @@ impl crate::Archetype for Tensor {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -170,6 +171,7 @@ impl crate::Archetype for Tensor {
 
 impl crate::AsComponents for Tensor {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -101,6 +101,7 @@ impl crate::Archetype for TextDocument {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -138,6 +139,7 @@ impl crate::Archetype for TextDocument {
 
 impl crate::AsComponents for TextDocument {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -93,6 +93,7 @@ impl crate::Archetype for TextLog {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -143,6 +144,7 @@ impl crate::Archetype for TextLog {
 
 impl crate::AsComponents for TextLog {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -210,6 +210,7 @@ impl crate::Archetype for TimeSeriesScalar {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -293,6 +294,7 @@ impl crate::Archetype for TimeSeriesScalar {
 
 impl crate::AsComponents for TimeSeriesScalar {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -144,6 +144,7 @@ impl crate::Archetype for Transform3D {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -168,6 +169,7 @@ impl crate::Archetype for Transform3D {
 
 impl crate::AsComponents for Transform3D {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -118,6 +118,7 @@ impl crate::Archetype for ViewCoordinates {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -142,6 +143,7 @@ impl crate::Archetype for ViewCoordinates {
 
 impl crate::AsComponents for ViewCoordinates {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -48,7 +48,8 @@
 ///     Ok(())
 /// }
 /// ```
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct ViewCoordinates {
     pub xyz: crate::components::ViewCoordinates,
 }

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for AnnotationContext {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -129,6 +130,7 @@ impl crate::Loggable for AnnotationContext {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for Blob {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -128,6 +129,7 @@ impl crate::Loggable for Blob {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -17,7 +17,9 @@
 /// A 16-bit ID representing a type of semantic class.
 ///
 /// Used to look up a [`crate::datatypes::ClassDescription`] within the [`crate::components::AnnotationContext`].
-#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable,
+)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ClassId(pub crate::datatypes::ClassId);

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -80,6 +80,7 @@ impl crate::Loggable for ClassId {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -124,6 +125,7 @@ impl crate::Loggable for ClassId {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -154,6 +156,7 @@ impl crate::Loggable for ClassId {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/clear_is_recursive.rs
+++ b/crates/re_types/src/components/clear_is_recursive.rs
@@ -71,6 +71,7 @@ impl crate::Loggable for ClearIsRecursive {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -105,6 +106,7 @@ impl crate::Loggable for ClearIsRecursive {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -80,6 +80,7 @@ impl crate::Loggable for Color {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -124,6 +125,7 @@ impl crate::Loggable for Color {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -154,6 +156,7 @@ impl crate::Loggable for Color {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -15,7 +15,8 @@
 #![allow(clippy::unnecessary_cast)]
 
 /// A component indicating how long a meter is, expressed in native units.
-#[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct DepthMeter(pub f32);
 
 impl From<f32> for DepthMeter {

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -68,6 +68,7 @@ impl crate::Loggable for DepthMeter {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -102,6 +103,7 @@ impl crate::Loggable for DepthMeter {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -131,6 +133,7 @@ impl crate::Loggable for DepthMeter {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for DisconnectedSpace {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -106,6 +107,7 @@ impl crate::Loggable for DisconnectedSpace {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -148,21 +148,25 @@ impl crate::Loggable for DrawOrder {
                 return Err(crate::DeserializationError::missing_data());
             }
         }
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                crate::DeserializationError::datatype_mismatch(
-                    DataType::Float32,
-                    arrow_data.data_type().clone(),
-                )
-            })
-            .with_context("rerun.components.DrawOrder#value")?
-            .values()
-            .as_slice()
-            .iter()
-            .copied()
-            .map(|v| Self(v))
-            .collect::<Vec<_>>())
+        Ok({
+            let iterator = arrow_data
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| {
+                    crate::DeserializationError::datatype_mismatch(
+                        DataType::Float32,
+                        arrow_data.data_type().clone(),
+                    )
+                })
+                .with_context("rerun.components.DrawOrder#value")?
+                .values()
+                .as_slice()
+                .iter()
+                .copied();
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -75,6 +75,7 @@ impl crate::Loggable for DrawOrder {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -109,6 +110,7 @@ impl crate::Loggable for DrawOrder {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -138,6 +140,7 @@ impl crate::Loggable for DrawOrder {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -87,6 +87,7 @@ impl crate::Loggable for HalfSizes2D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -154,6 +155,7 @@ impl crate::Loggable for HalfSizes2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -242,6 +244,7 @@ impl crate::Loggable for HalfSizes2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -253,44 +253,46 @@ impl crate::Loggable for HalfSizes2D {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            2usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.HalfSizes2D#xy")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 2usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                2usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.HalfSizes2D#xy")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec2D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.HalfSizes2D#xy")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 2usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.HalfSizes2D#xy")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec2D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -87,6 +87,7 @@ impl crate::Loggable for HalfSizes3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -154,6 +155,7 @@ impl crate::Loggable for HalfSizes3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -242,6 +244,7 @@ impl crate::Loggable for HalfSizes3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -253,44 +253,46 @@ impl crate::Loggable for HalfSizes3D {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            3usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.HalfSizes3D#xyz")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 3usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                3usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.HalfSizes3D#xyz")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec3D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.HalfSizes3D#xyz")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.HalfSizes3D#xyz")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec3D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -69,6 +69,7 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -103,6 +104,7 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -132,6 +134,7 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -142,21 +142,25 @@ impl crate::Loggable for InstanceKey {
                 return Err(crate::DeserializationError::missing_data());
             }
         }
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .ok_or_else(|| {
-                crate::DeserializationError::datatype_mismatch(
-                    DataType::UInt64,
-                    arrow_data.data_type().clone(),
-                )
-            })
-            .with_context("rerun.components.InstanceKey#value")?
-            .values()
-            .as_slice()
-            .iter()
-            .copied()
-            .map(|v| Self(v))
-            .collect::<Vec<_>>())
+        Ok({
+            let iterator = arrow_data
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    crate::DeserializationError::datatype_mismatch(
+                        DataType::UInt64,
+                        arrow_data.data_type().clone(),
+                    )
+                })
+                .with_context("rerun.components.InstanceKey#value")?
+                .values()
+                .as_slice()
+                .iter()
+                .copied();
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -81,6 +81,7 @@ impl crate::Loggable for KeypointId {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -125,6 +126,7 @@ impl crate::Loggable for KeypointId {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -155,6 +157,7 @@ impl crate::Loggable for KeypointId {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -165,22 +165,26 @@ impl crate::Loggable for KeypointId {
                 return Err(crate::DeserializationError::missing_data());
             }
         }
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<UInt16Array>()
-            .ok_or_else(|| {
-                crate::DeserializationError::datatype_mismatch(
-                    DataType::UInt16,
-                    arrow_data.data_type().clone(),
-                )
-            })
-            .with_context("rerun.components.KeypointId#id")?
-            .values()
-            .as_slice()
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::KeypointId(v))
-            .map(|v| Self(v))
-            .collect::<Vec<_>>())
+        Ok({
+            let iterator = arrow_data
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .ok_or_else(|| {
+                    crate::DeserializationError::datatype_mismatch(
+                        DataType::UInt16,
+                        arrow_data.data_type().clone(),
+                    )
+                })
+                .with_context("rerun.components.KeypointId#id")?
+                .values()
+                .as_slice()
+                .iter()
+                .copied()
+                .map(|v| crate::datatypes::KeypointId(v));
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -19,7 +19,10 @@
 /// `KeypointId`s are only meaningful within the context of a `crate::components::ClassDescription`.
 ///
 /// Used to look up an `crate::components::AnnotationInfo` for a Keypoint within the `crate::components::AnnotationContext`.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::Pod, bytemuck::Zeroable,
+)]
+#[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct KeypointId(pub crate::datatypes::KeypointId);
 

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -76,6 +76,7 @@ impl crate::Loggable for LineStrip2D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -175,6 +176,7 @@ impl crate::Loggable for LineStrip2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -76,6 +76,7 @@ impl crate::Loggable for LineStrip3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -175,6 +176,7 @@ impl crate::Loggable for LineStrip3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -80,6 +80,7 @@ impl crate::Loggable for Material {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -112,6 +113,7 @@ impl crate::Loggable for Material {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Material::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -80,6 +80,7 @@ impl crate::Loggable for MediaType {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -140,6 +141,7 @@ impl crate::Loggable for MediaType {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/mesh_properties.rs
+++ b/crates/re_types/src/components/mesh_properties.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for MeshProperties {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -117,6 +118,7 @@ impl crate::Loggable for MeshProperties {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::MeshProperties::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/origin2d.rs
+++ b/crates/re_types/src/components/origin2d.rs
@@ -15,7 +15,8 @@
 #![allow(clippy::unnecessary_cast)]
 
 /// A point of origin in 2D space.
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct Origin2D(pub crate::datatypes::Vec2D);
 
 impl<T: Into<crate::datatypes::Vec2D>> From<T> for Origin2D {

--- a/crates/re_types/src/components/origin2d.rs
+++ b/crates/re_types/src/components/origin2d.rs
@@ -84,6 +84,7 @@ impl crate::Loggable for Origin2D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -151,6 +152,7 @@ impl crate::Loggable for Origin2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -239,6 +241,7 @@ impl crate::Loggable for Origin2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -15,7 +15,8 @@
 #![allow(clippy::unnecessary_cast)]
 
 /// A point of origin in 3D space.
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct Origin3D(pub crate::datatypes::Vec3D);
 
 impl<T: Into<crate::datatypes::Vec3D>> From<T> for Origin3D {

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -84,6 +84,7 @@ impl crate::Loggable for Origin3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -151,6 +152,7 @@ impl crate::Loggable for Origin3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -239,6 +241,7 @@ impl crate::Loggable for Origin3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/origin3d.rs
+++ b/crates/re_types/src/components/origin3d.rs
@@ -250,44 +250,46 @@ impl crate::Loggable for Origin3D {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            3usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.Origin3D#origin")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 3usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                3usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.Origin3D#origin")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec3D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.Origin3D#origin")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.Origin3D#origin")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec3D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -104,6 +104,7 @@ impl crate::Loggable for OutOfTreeTransform3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -136,6 +137,7 @@ impl crate::Loggable for OutOfTreeTransform3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Transform3D::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -94,6 +94,7 @@ impl crate::Loggable for PinholeProjection {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -161,6 +162,7 @@ impl crate::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -249,6 +251,7 @@ impl crate::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -251,44 +251,46 @@ impl crate::Loggable for Position2D {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            2usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.Position2D#xy")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 2usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                2usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.Position2D#xy")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec2D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.Position2D#xy")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 2usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.Position2D#xy")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec2D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for Position2D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -152,6 +153,7 @@ impl crate::Loggable for Position2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -240,6 +242,7 @@ impl crate::Loggable for Position2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for Position3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -152,6 +153,7 @@ impl crate::Loggable for Position3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -240,6 +242,7 @@ impl crate::Loggable for Position3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -251,44 +251,46 @@ impl crate::Loggable for Position3D {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            3usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.Position3D#xyz")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 3usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                3usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.Position3D#xyz")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec3D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.Position3D#xyz")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.Position3D#xyz")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec3D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -68,6 +68,7 @@ impl crate::Loggable for Radius {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -102,6 +103,7 @@ impl crate::Loggable for Radius {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -131,6 +133,7 @@ impl crate::Loggable for Radius {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -15,7 +15,8 @@
 #![allow(clippy::unnecessary_cast)]
 
 /// A Radius component.
-#[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct Radius(pub f32);
 
 impl From<f32> for Radius {

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -141,21 +141,25 @@ impl crate::Loggable for Radius {
                 return Err(crate::DeserializationError::missing_data());
             }
         }
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                crate::DeserializationError::datatype_mismatch(
-                    DataType::Float32,
-                    arrow_data.data_type().clone(),
-                )
-            })
-            .with_context("rerun.components.Radius#value")?
-            .values()
-            .as_slice()
-            .iter()
-            .copied()
-            .map(|v| Self(v))
-            .collect::<Vec<_>>())
+        Ok({
+            let iterator = arrow_data
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| {
+                    crate::DeserializationError::datatype_mismatch(
+                        DataType::Float32,
+                        arrow_data.data_type().clone(),
+                    )
+                })
+                .with_context("rerun.components.Radius#value")?
+                .values()
+                .as_slice()
+                .iter()
+                .copied();
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -86,6 +86,7 @@ impl crate::Loggable for Resolution {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -153,6 +154,7 @@ impl crate::Loggable for Resolution {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -241,6 +243,7 @@ impl crate::Loggable for Resolution {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -252,44 +252,46 @@ impl crate::Loggable for Resolution {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            2usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.Resolution#resolution")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 2usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                2usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.Resolution#resolution")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec2D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.Resolution#resolution")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 2usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.Resolution#resolution")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec2D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -102,6 +102,7 @@ impl crate::Loggable for Rotation3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -134,6 +135,7 @@ impl crate::Loggable for Rotation3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Rotation3D::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/scalar.rs
+++ b/crates/re_types/src/components/scalar.rs
@@ -17,7 +17,8 @@
 /// A double-precision scalar.
 ///
 /// Used for time series plots.
-#[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct Scalar(pub f64);
 
 impl From<f64> for Scalar {

--- a/crates/re_types/src/components/scalar.rs
+++ b/crates/re_types/src/components/scalar.rs
@@ -143,21 +143,25 @@ impl crate::Loggable for Scalar {
                 return Err(crate::DeserializationError::missing_data());
             }
         }
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .ok_or_else(|| {
-                crate::DeserializationError::datatype_mismatch(
-                    DataType::Float64,
-                    arrow_data.data_type().clone(),
-                )
-            })
-            .with_context("rerun.components.Scalar#value")?
-            .values()
-            .as_slice()
-            .iter()
-            .copied()
-            .map(|v| Self(v))
-            .collect::<Vec<_>>())
+        Ok({
+            let iterator = arrow_data
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| {
+                    crate::DeserializationError::datatype_mismatch(
+                        DataType::Float64,
+                        arrow_data.data_type().clone(),
+                    )
+                })
+                .with_context("rerun.components.Scalar#value")?
+                .values()
+                .as_slice()
+                .iter()
+                .copied();
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/scalar.rs
+++ b/crates/re_types/src/components/scalar.rs
@@ -70,6 +70,7 @@ impl crate::Loggable for Scalar {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -104,6 +105,7 @@ impl crate::Loggable for Scalar {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -133,6 +135,7 @@ impl crate::Loggable for Scalar {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/scalar_scattering.rs
+++ b/crates/re_types/src/components/scalar_scattering.rs
@@ -68,6 +68,7 @@ impl crate::Loggable for ScalarScattering {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -102,6 +103,7 @@ impl crate::Loggable for ScalarScattering {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -94,6 +94,7 @@ impl crate::Loggable for TensorData {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -126,6 +127,7 @@ impl crate::Loggable for TensorData {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::TensorData::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for Text {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,6 +138,7 @@ impl crate::Loggable for Text {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for TextLogLevel {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -145,6 +146,7 @@ impl crate::Loggable for TextLogLevel {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -102,6 +102,7 @@ impl crate::Loggable for Transform3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -134,6 +135,7 @@ impl crate::Loggable for Transform3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Transform3D::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -250,44 +250,46 @@ impl crate::Loggable for Vector3D {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::Float32,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            3usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.Vector3D#vector")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 3usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::Float32,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::Float32,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                3usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.Vector3D#vector")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-            .map(|v| crate::datatypes::Vec3D(v))
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.Vector3D#vector")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::Float32,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.Vector3D#vector")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied().map(|v| crate::datatypes::Vec3D(v))
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -84,6 +84,7 @@ impl crate::Loggable for Vector3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -151,6 +152,7 @@ impl crate::Loggable for Vector3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -239,6 +241,7 @@ impl crate::Loggable for Vector3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -15,7 +15,8 @@
 #![allow(clippy::unnecessary_cast)]
 
 /// A vector in 3D space.
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct Vector3D(pub crate::datatypes::Vec3D);
 
 impl<T: Into<crate::datatypes::Vec3D>> From<T> for Vector3D {

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -30,7 +30,8 @@
 ///  Left = 4
 ///  Forward = 5
 ///  Back = 6
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct ViewCoordinates(
     /// The directions of the [x, y, z] axes.
     pub [u8; 3usize],

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -251,43 +251,46 @@ impl crate::Loggable for ViewCoordinates {
             }
         }
         Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<::arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    crate::DeserializationError::datatype_mismatch(
-                        DataType::FixedSizeList(
-                            Box::new(Field {
-                                name: "item".to_owned(),
-                                data_type: DataType::UInt8,
-                                is_nullable: false,
-                                metadata: [].into(),
-                            }),
-                            3usize,
-                        ),
-                        arrow_data.data_type().clone(),
-                    )
-                })
-                .with_context("rerun.components.ViewCoordinates#coordinates")?;
-            let arrow_data_inner = &**arrow_data.values();
-            bytemuck::cast_slice::<_, [_; 3usize]>(
-                arrow_data_inner
+            let iterator = {
+                let arrow_data = arrow_data
                     .as_any()
-                    .downcast_ref::<UInt8Array>()
+                    .downcast_ref::<::arrow2::array::FixedSizeListArray>()
                     .ok_or_else(|| {
                         crate::DeserializationError::datatype_mismatch(
-                            DataType::UInt8,
-                            arrow_data_inner.data_type().clone(),
+                            DataType::FixedSizeList(
+                                Box::new(Field {
+                                    name: "item".to_owned(),
+                                    data_type: DataType::UInt8,
+                                    is_nullable: false,
+                                    metadata: [].into(),
+                                }),
+                                3usize,
+                            ),
+                            arrow_data.data_type().clone(),
                         )
                     })
-                    .with_context("rerun.components.ViewCoordinates#coordinates")?
-                    .values()
-                    .as_slice(),
-            )
-            .iter()
-            .copied()
-        }
-        .map(|v| Self(v))
-        .collect::<Vec<_>>())
+                    .with_context("rerun.components.ViewCoordinates#coordinates")?;
+                let arrow_data_inner = &**arrow_data.values();
+                let slice = bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<UInt8Array>()
+                        .ok_or_else(|| {
+                            crate::DeserializationError::datatype_mismatch(
+                                DataType::UInt8,
+                                arrow_data_inner.data_type().clone(),
+                            )
+                        })
+                        .with_context("rerun.components.ViewCoordinates#coordinates")?
+                        .values()
+                        .as_slice(),
+                );
+                slice.iter().copied()
+            };
+            {
+                re_tracing::profile_scope!("collect");
+                iterator.map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
     }
 }

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -94,6 +94,7 @@ impl crate::Loggable for ViewCoordinates {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -155,6 +156,7 @@ impl crate::Loggable for ViewCoordinates {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -240,6 +242,7 @@ impl crate::Loggable for ViewCoordinates {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -80,6 +80,7 @@ impl crate::Loggable for Angle {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -185,6 +186,7 @@ impl crate::Loggable for Angle {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for AnnotationInfo {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -225,6 +226,7 @@ impl crate::Loggable for AnnotationInfo {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -105,6 +105,7 @@ impl crate::Loggable for ClassDescription {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -268,6 +269,7 @@ impl crate::Loggable for ClassDescription {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -157,6 +158,7 @@ impl crate::Loggable for ClassDescriptionMapElem {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -17,7 +17,19 @@
 /// A 16-bit ID representing a type of semantic class.
 ///
 /// Used to look up a [`crate::datatypes::ClassDescription`] within the [`crate::components::AnnotationContext`].
-#[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone,
+    Debug,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ClassId(pub u16);

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for ClassId {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -106,6 +107,7 @@ impl crate::Loggable for ClassId {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/color.rs
+++ b/crates/re_types/src/datatypes/color.rs
@@ -74,6 +74,7 @@ impl crate::Loggable for Color {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -108,6 +109,7 @@ impl crate::Loggable for Color {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/float32.rs
+++ b/crates/re_types/src/datatypes/float32.rs
@@ -67,6 +67,7 @@ impl crate::Loggable for Float32 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -101,6 +102,7 @@ impl crate::Loggable for Float32 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -19,7 +19,19 @@
 /// `KeypointId`s are only meaningful within the context of a `crate::components::ClassDescription`.
 ///
 /// Used to look up an `crate::components::AnnotationInfo` for a Keypoint within the `crate::components::AnnotationContext`.
-#[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone,
+    Debug,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    bytemuck::Pod,
+    bytemuck::Zeroable,
+)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct KeypointId(pub u16);

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -74,6 +74,7 @@ impl crate::Loggable for KeypointId {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -108,6 +109,7 @@ impl crate::Loggable for KeypointId {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -70,6 +70,7 @@ impl crate::Loggable for KeypointPair {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -165,6 +166,7 @@ impl crate::Loggable for KeypointPair {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for Mat3x3 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -146,6 +147,7 @@ impl crate::Loggable for Mat3x3 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -86,6 +86,7 @@ impl crate::Loggable for Mat4x4 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -147,6 +148,7 @@ impl crate::Loggable for Mat4x4 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/material.rs
+++ b/crates/re_types/src/datatypes/material.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for Material {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -149,6 +150,7 @@ impl crate::Loggable for Material {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/mesh_properties.rs
+++ b/crates/re_types/src/datatypes/mesh_properties.rs
@@ -81,6 +81,7 @@ impl crate::Loggable for MeshProperties {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -166,6 +167,7 @@ impl crate::Loggable for MeshProperties {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -79,6 +79,7 @@ impl crate::Loggable for Quaternion {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -140,6 +141,7 @@ impl crate::Loggable for Quaternion {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -83,6 +83,7 @@ impl crate::Loggable for Rotation3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -231,6 +232,7 @@ impl crate::Loggable for Rotation3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for RotationAxisAngle {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -191,6 +192,7 @@ impl crate::Loggable for RotationAxisAngle {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -83,6 +83,7 @@ impl crate::Loggable for Scale3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -229,6 +230,7 @@ impl crate::Loggable for Scale3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -214,6 +214,7 @@ impl crate::Loggable for TensorBuffer {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -987,6 +988,7 @@ impl crate::Loggable for TensorBuffer {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -82,6 +82,7 @@ impl crate::Loggable for TensorData {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -185,6 +186,7 @@ impl crate::Loggable for TensorData {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -70,6 +70,7 @@ impl crate::Loggable for TensorDimension {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -163,6 +164,7 @@ impl crate::Loggable for TensorDimension {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -83,6 +83,7 @@ impl crate::Loggable for Transform3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -200,6 +201,7 @@ impl crate::Loggable for Transform3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -85,6 +85,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -273,6 +274,7 @@ impl crate::Loggable for TranslationAndMat3x3 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -94,6 +94,7 @@ impl crate::Loggable for TranslationRotationScale3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -262,6 +263,7 @@ impl crate::Loggable for TranslationRotationScale3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/utf8.rs
+++ b/crates/re_types/src/datatypes/utf8.rs
@@ -69,6 +69,7 @@ impl crate::Loggable for Utf8 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -119,6 +120,7 @@ impl crate::Loggable for Utf8 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for UVec2D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -138,6 +139,7 @@ impl crate::Loggable for UVec2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for UVec3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -138,6 +139,7 @@ impl crate::Loggable for UVec3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for UVec4D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -138,6 +139,7 @@ impl crate::Loggable for UVec4D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for Vec2D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -138,6 +139,7 @@ impl crate::Loggable for Vec2D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for Vec3D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -138,6 +139,7 @@ impl crate::Loggable for Vec3D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -77,6 +77,7 @@ impl crate::Loggable for Vec4D {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -138,6 +139,7 @@ impl crate::Loggable for Vec4D {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/loggable.rs
+++ b/crates/re_types/src/loggable.rs
@@ -84,6 +84,7 @@ pub trait Loggable: Clone + Sized {
     where
         Self: 'a,
     {
+        re_tracing::profile_function!();
         Self::to_arrow_opt(data.into_iter().map(Some))
     }
 
@@ -95,6 +96,7 @@ pub trait Loggable: Clone + Sized {
     /// [`Loggable::arrow_field`].
     #[inline]
     fn from_arrow(data: &dyn ::arrow2::array::Array) -> DeserializationResult<Vec<Self>> {
+        re_tracing::profile_function!();
         Self::from_arrow_opt(data)?
             .into_iter()
             .map(|opt| {

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -148,6 +148,7 @@ impl crate::Archetype for AffixFuzzer1 {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -454,6 +455,7 @@ impl crate::Archetype for AffixFuzzer1 {
 
 impl crate::AsComponents for AffixFuzzer1 {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -139,6 +139,7 @@ impl crate::Archetype for AffixFuzzer2 {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -385,6 +386,7 @@ impl crate::Archetype for AffixFuzzer2 {
 
 impl crate::AsComponents for AffixFuzzer2 {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -140,6 +140,7 @@ impl crate::Archetype for AffixFuzzer3 {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -422,6 +423,7 @@ impl crate::Archetype for AffixFuzzer3 {
 
 impl crate::AsComponents for AffixFuzzer3 {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -140,6 +140,7 @@ impl crate::Archetype for AffixFuzzer4 {
             Item = (::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>),
         >,
     ) -> crate::DeserializationResult<Self> {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
             .into_iter()
@@ -404,6 +405,7 @@ impl crate::Archetype for AffixFuzzer4 {
 
 impl crate::AsComponents for AffixFuzzer4 {
     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+        re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -145,6 +145,7 @@ impl crate::Loggable for AffixFuzzer1 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -177,6 +178,7 @@ impl crate::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -67,6 +67,7 @@ impl crate::Loggable for AffixFuzzer10 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -119,6 +120,7 @@ impl crate::Loggable for AffixFuzzer10 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for AffixFuzzer11 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -129,6 +130,7 @@ impl crate::Loggable for AffixFuzzer11 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for AffixFuzzer12 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -149,6 +150,7 @@ impl crate::Loggable for AffixFuzzer12 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for AffixFuzzer13 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -151,6 +152,7 @@ impl crate::Loggable for AffixFuzzer13 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -123,6 +123,7 @@ impl crate::Loggable for AffixFuzzer14 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -155,6 +156,7 @@ impl crate::Loggable for AffixFuzzer14 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer15.rs
@@ -123,6 +123,7 @@ impl crate::Loggable for AffixFuzzer15 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -157,6 +158,7 @@ impl crate::Loggable for AffixFuzzer15 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -66,6 +66,7 @@ impl crate::Loggable for AffixFuzzer16 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -122,6 +123,7 @@ impl crate::Loggable for AffixFuzzer16 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -66,6 +66,7 @@ impl crate::Loggable for AffixFuzzer17 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -124,6 +125,7 @@ impl crate::Loggable for AffixFuzzer17 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -66,6 +66,7 @@ impl crate::Loggable for AffixFuzzer18 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -124,6 +125,7 @@ impl crate::Loggable for AffixFuzzer18 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -80,6 +80,7 @@ impl crate::Loggable for AffixFuzzer19 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -112,6 +113,7 @@ impl crate::Loggable for AffixFuzzer19 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -145,6 +145,7 @@ impl crate::Loggable for AffixFuzzer2 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -177,6 +178,7 @@ impl crate::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -88,6 +88,7 @@ impl crate::Loggable for AffixFuzzer20 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,6 +121,7 @@ impl crate::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -93,6 +93,7 @@ impl crate::Loggable for AffixFuzzer21 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -125,6 +126,7 @@ impl crate::Loggable for AffixFuzzer21 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -145,6 +145,7 @@ impl crate::Loggable for AffixFuzzer3 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -177,6 +178,7 @@ impl crate::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer4.rs
@@ -145,6 +145,7 @@ impl crate::Loggable for AffixFuzzer4 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -179,6 +180,7 @@ impl crate::Loggable for AffixFuzzer4 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer5.rs
@@ -145,6 +145,7 @@ impl crate::Loggable for AffixFuzzer5 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -179,6 +180,7 @@ impl crate::Loggable for AffixFuzzer5 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer6.rs
@@ -145,6 +145,7 @@ impl crate::Loggable for AffixFuzzer6 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -179,6 +180,7 @@ impl crate::Loggable for AffixFuzzer6 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -66,6 +66,7 @@ impl crate::Loggable for AffixFuzzer7 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -124,6 +125,7 @@ impl crate::Loggable for AffixFuzzer7 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer8.rs
@@ -67,6 +67,7 @@ impl crate::Loggable for AffixFuzzer8 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -103,6 +104,7 @@ impl crate::Loggable for AffixFuzzer8 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -67,6 +67,7 @@ impl crate::Loggable for AffixFuzzer9 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -117,6 +118,7 @@ impl crate::Loggable for AffixFuzzer9 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -133,6 +133,7 @@ impl crate::Loggable for AffixFuzzer1 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -584,6 +585,7 @@ impl crate::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -67,6 +67,7 @@ impl crate::Loggable for AffixFuzzer2 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -103,6 +104,7 @@ impl crate::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -69,6 +69,7 @@ impl crate::Loggable for AffixFuzzer20 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -183,6 +184,7 @@ impl crate::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -74,6 +74,7 @@ impl crate::Loggable for AffixFuzzer21 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -183,6 +184,7 @@ impl crate::Loggable for AffixFuzzer21 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -106,6 +106,7 @@ impl crate::Loggable for AffixFuzzer3 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -349,6 +350,7 @@ impl crate::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -96,6 +96,7 @@ impl crate::Loggable for AffixFuzzer4 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -296,6 +297,7 @@ impl crate::Loggable for AffixFuzzer4 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -84,6 +84,7 @@ impl crate::Loggable for AffixFuzzer5 {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -141,6 +142,7 @@ impl crate::Loggable for AffixFuzzer5 {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -74,6 +74,7 @@ impl crate::Loggable for FlattenedScalar {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -125,6 +126,7 @@ impl crate::Loggable for FlattenedScalar {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/re_types/src/testing/datatypes/primitive_component.rs
@@ -68,6 +68,7 @@ impl crate::Loggable for PrimitiveComponent {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -102,6 +103,7 @@ impl crate::Loggable for PrimitiveComponent {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -68,6 +68,7 @@ impl crate::Loggable for StringComponent {
     where
         Self: Clone + 'a,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, datatypes::*};
         Ok({
@@ -118,6 +119,7 @@ impl crate::Loggable for StringComponent {
     where
         Self: Sized,
     {
+        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use ::arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -703,12 +703,15 @@ fn quote_trait_impls_from_obj(
             let quoted_from_arrow = if optimize_for_buffer_slice {
                 let quoted_deserializer =
                     quote_arrow_deserializer_buffer_slice(arrow_registry, objects, obj);
+
                 quote! {
                     #[allow(unused_imports, clippy::wildcard_imports)]
                     #[inline]
                     fn from_arrow(arrow_data: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>>
                     where
                         Self: Sized {
+                        re_tracing::profile_function!();
+
                         use ::arrow2::{datatypes::*, array::*, buffer::*};
                         use crate::{Loggable as _, ResultExt as _};
 
@@ -753,8 +756,11 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Clone + 'a
                     {
+                        re_tracing::profile_function!();
+
                         use ::arrow2::{datatypes::*, array::*};
                         use crate::{Loggable as _, ResultExt as _};
+
                         Ok(#quoted_serializer)
                     }
 
@@ -764,8 +770,11 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Sized
                     {
+                        re_tracing::profile_function!();
+
                         use ::arrow2::{datatypes::*, array::*, buffer::*};
                         use crate::{Loggable as _, ResultExt as _};
+
                         Ok(#quoted_deserializer)
                     }
 
@@ -978,6 +987,8 @@ fn quote_trait_impls_from_obj(
                     fn from_arrow(
                         arrow_data: impl IntoIterator<Item = (::arrow2::datatypes::Field, Box<dyn::arrow2::array::Array>)>,
                     ) -> crate::DeserializationResult<Self> {
+                        re_tracing::profile_function!();
+
                         use crate::{Loggable as _, ResultExt as _};
 
                         let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
@@ -994,7 +1005,10 @@ fn quote_trait_impls_from_obj(
 
                 impl crate::AsComponents for #name {
                     fn as_component_batches(&self) -> Vec<crate::MaybeOwnedComponentBatch<'_>> {
+                        re_tracing::profile_function!();
+
                         use crate::Archetype as _;
+
                         [#(#all_component_batches,)*].into_iter().flatten().collect()
                     }
 


### PR DESCRIPTION
### What
I discovered some small improvements that could be made

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ x I have tested [demo.rerun.io](https://demo.rerun.io/pr/3532) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3532)
- [Docs preview](https://rerun.io/preview/c89b93b841f5fc1dff092b81e8a75e9b71130a75/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c89b93b841f5fc1dff092b81e8a75e9b71130a75/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)