### PR TITLE
Remove ext= and allow logging extra component bundles

### DIFF
--- a/docs/code-examples/extra_values.py
+++ b/docs/code-examples/extra_values.py
@@ -1,0 +1,15 @@
+"""Log extra values with a Points2D."""
+import rerun as rr
+
+rr.init("rerun_example_extra_values", spawn=True)
+
+rr.log(
+    "extra_values",
+    rr.Points2D([[-1, -1], [-1, 1], [1, -1], [1, 1]]),
+    rr.AnyValues(
+        confidence=[0.3, 0.4, 0.5, 0.6],
+    ),
+)
+
+# Log an extra rect to set the view bounds
+rr.log("bounds", rr.Boxes2D(sizes=[3, 3]))

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -29,6 +29,7 @@ opt_out_entirely = {
     "custom_data": ["cpp"],
     "depth_image_3d": ["cpp"],
     "depth_image_simple": ["cpp"],
+    "extra_values": ["cpp", "rust"], # Only implemented for Python
     "image_advanced": ["cpp", "rust"], # Missing example for Rust
     "image_simple": ["cpp"],
     "mesh3d_partial_updates": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -143,7 +143,7 @@ class FaceDetectorLogger:
             rr.log(
                 f"video/detector/faces/{i}/bbox",
                 rr.Boxes2D(array=[bbox.origin_x, bbox.origin_y, bbox.width, bbox.height]),
-                ext={"index": index, "score": score},
+                rr.AnyValues(index=index, score=score),
             )
 
             # MediaPipe's keypoints are normalized to [0, 1], so we need to scale them to get pixel coordinates.

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -45,7 +45,7 @@ The colored 3D points were added to the scene by logging the
 [rr.Points3D archetype](https://www.rerun.io/docs/reference/data_types/points3d)
 to the [points entity](recording://points):
 ```python
-rr.log("points", rr.Points3D(points, colors=point_colors), ext={"error": point_errors})
+rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
 ```
 **Note:** we added some [custom per-point errors](recording://points.ext.error) that you can see when you
 hover over the points in the 3D view.
@@ -150,7 +150,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
 
         rr.log("plot/avg_reproj_err", rr.TimeSeriesScalar(np.mean(point_errors), color=[240, 45, 58]))
 
-        rr.log("points", rr.Points3D(points, colors=point_colors), ext={"error": point_errors})
+        rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
 
         # COLMAP's camera transform is "camera from world"
         rr.log(

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Iterable
 
-import numpy as np
-import numpy.typing as npt
 import pyarrow as pa
 import rerun_bindings as bindings
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/arrow.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/arrow.py
@@ -6,6 +6,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import Arrows3D
 from rerun.log_deprecated import Color
 from rerun.log_deprecated.log_decorator import log_decorator
@@ -78,4 +79,4 @@ def log_arrow(
         colors=color,
         labels=label,
     )
-    return log(entity_path, arrows3d, ext=ext, timeless=timeless, recording=recording)
+    return log(entity_path, arrows3d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import Boxes3D
 from rerun.datatypes import Quaternion
 from rerun.log_deprecated import (
@@ -191,4 +192,4 @@ def log_obbs(
         labels=labels,
         class_ids=class_ids,
     )
-    return log(entity_path, arch, ext=ext, timeless=timeless, recording=recording)
+    return log(entity_path, arch, AnyValues(**(ext or {})), timeless=timeless, recording=recording)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import DepthImage, Image, SegmentationImage
 from rerun.datatypes import TensorData
 from rerun.datatypes.tensor_data import TensorDataLike
@@ -85,7 +86,13 @@ def log_image(
 
     tensor_data = TensorData(array=image, jpeg_quality=jpeg_quality)
 
-    log(entity_path, Image(tensor_data, draw_order=draw_order), ext=ext, timeless=timeless, recording=recording)
+    log(
+        entity_path,
+        Image(tensor_data, draw_order=draw_order),
+        AnyValues(**(ext or {})),
+        timeless=timeless,
+        recording=recording,
+    )
 
 
 @deprecated(
@@ -147,7 +154,7 @@ def log_depth_image(
     log(
         entity_path,
         DepthImage(tensor_data, draw_order=draw_order, meter=meter),
-        ext=ext,
+        AnyValues(**(ext or {})),
         timeless=timeless,
         recording=recording,
     )
@@ -214,7 +221,7 @@ def log_segmentation_image(
     log(
         entity_path,
         SegmentationImage(tensor_data, draw_order=draw_order),
-        ext=ext,
+        AnyValues(**(ext or {})),
         timeless=timeless,
         recording=recording,
     )

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import LineStrips2D, LineStrips3D
 from rerun.error_utils import _send_warning
 from rerun.log_deprecated import Color, Colors, _normalize_radii
@@ -96,14 +97,14 @@ def log_line_strip(
             colors=color,
             draw_order=draw_order,
         )
-        return log(entity_path, strips2d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, strips2d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     elif positions.shape[1] == 3:
         strips3d = LineStrips3D(
             [positions],
             radii=radii,
             colors=color,
         )
-        return log(entity_path, strips3d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, strips3d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     else:
         raise TypeError("Positions should be either Nx2 or Nx3")
 
@@ -199,7 +200,7 @@ def log_line_strips_2d(
         draw_order=draw_order,
         instance_keys=identifiers_np,
     )
-    return log(entity_path, arch, ext=ext, timeless=timeless, recording=recording)
+    return log(entity_path, arch, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
 
 
 @deprecated(
@@ -287,7 +288,7 @@ def log_line_strips_3d(
         colors=colors,
         instance_keys=identifiers_np,
     )
-    return log(entity_path, arch, ext=ext, timeless=timeless, recording=recording)
+    return log(entity_path, arch, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
 
 
 @deprecated(
@@ -368,7 +369,7 @@ def log_line_segments(
             colors=color,
             draw_order=draw_order,
         )
-        return log(entity_path, strips2d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, strips2d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     elif positions.ndim > 1 and positions.shape[1] == 3:
         # Same as above but for 3d points
         positions = positions.reshape([len(positions) // 2, 2, 3])
@@ -377,6 +378,6 @@ def log_line_segments(
             radii=stroke_width * 0.5 if stroke_width is not None else None,
             colors=color,
         )
-        return log(entity_path, strips3d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, strips3d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     else:
         raise TypeError("Positions should be either Nx2 or Nx3")

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import Points2D, Points3D
 from rerun.error_utils import _send_warning
 from rerun.log_deprecated import (
@@ -117,7 +118,7 @@ def log_point(
             class_ids=class_id,
             keypoint_ids=keypoint_id,
         )
-        return log(entity_path, points2d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, points2d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     elif position.size == 3:
         if draw_order is not None:
             raise ValueError("`draw_order` is only supported for 3D points")
@@ -129,7 +130,7 @@ def log_point(
             class_ids=class_id,
             keypoint_ids=keypoint_id,
         )
-        return log(entity_path, points3d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, points3d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     else:
         raise TypeError("Position must have a total size of 2 or 3")
 
@@ -243,7 +244,7 @@ def log_points(
             keypoint_ids=keypoint_ids,
             instance_keys=identifiers_np,
         )
-        return log(entity_path, points2d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, points2d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     elif positions.shape[1] == 3:
         if draw_order is not None:
             raise ValueError("`draw_order` is only supported for 3D points")
@@ -257,6 +258,6 @@ def log_points(
             keypoint_ids=keypoint_ids,
             instance_keys=identifiers_np,
         )
-        return log(entity_path, points3d, ext=ext, timeless=timeless, recording=recording)
+        return log(entity_path, points3d, AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     else:
         raise TypeError("Positions should be Nx2 or Nx3")

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import Boxes2D
 from rerun.error_utils import _send_warning
 from rerun.log_deprecated import Color, Colors, OptionalClassIds
@@ -231,4 +232,4 @@ def log_rects(
         class_ids=class_ids,
         instance_keys=identifiers_np,
     )
-    return log(entity_path, arch, ext=ext, timeless=timeless, recording=recording)
+    return log(entity_path, arch, AnyValues(**(ext or {})), timeless=timeless, recording=recording)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/scalar.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import TimeSeriesScalar
 from rerun.log_deprecated import Color, _normalize_colors
 from rerun.log_deprecated.log_decorator import log_decorator
@@ -133,6 +134,6 @@ def log_scalar(
     return log(
         entity_path,
         TimeSeriesScalar(scalar=scalar, label=label, color=color, radius=radius, scattered=scattered),
-        ext=ext,
+        AnyValues(**(ext or {})),
         recording=recording,
     )

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
@@ -6,6 +6,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import BarChart, Tensor
 from rerun.datatypes.tensor_data import TensorData, TensorDataLike
 from rerun.error_utils import _send_warning
@@ -94,6 +95,6 @@ def _log_tensor(
 
     # Our legacy documentation is that 1D tensors were interpreted as barcharts
     if len(tensor_data.shape) == 1:
-        log(entity_path, BarChart(tensor_data), ext=ext, timeless=timeless, recording=recording)
+        log(entity_path, BarChart(tensor_data), AnyValues(**(ext or {})), timeless=timeless, recording=recording)
     else:
-        log(entity_path, Tensor(tensor_data), ext=ext, timeless=timeless, recording=recording)
+        log(entity_path, Tensor(tensor_data), AnyValues(**(ext or {})), timeless=timeless, recording=recording)

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/text.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/text.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
+from rerun.any_value import AnyValues
 from rerun.archetypes import TextLog
 from rerun.log_deprecated import Color, _normalize_colors
 from rerun.log_deprecated.log_decorator import log_decorator
@@ -67,4 +68,10 @@ def log_text_entry(
     if color is not None:
         color = _normalize_colors(color)
 
-    return log(entity_path, TextLog(text, level=level, color=color), ext=ext, timeless=timeless, recording=recording)
+    return log(
+        entity_path,
+        TextLog(text, level=level, color=color),
+        AnyValues(**(ext or {})),
+        timeless=timeless,
+        recording=recording,
+    )

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -398,21 +398,20 @@ def run_bounding_box(experimental_api: bool) -> None:
 def run_extension_component(experimental_api: bool) -> None:
     rr.set_time_seconds("sim_time", 0)
     # Hack to establish 2d view bounds
-    rr.log_rect("extension_components", [0, 0, 128, 128])
+    rr.log("extension_components", rr.Boxes2D(array=[0, 0, 128, 128], array_format=rr.Box2DFormat.XYWH))
 
     # Single point
-    rr.log_point("extension_components/point", np.array([64, 64]), color=(255, 0, 0))
+    rr.log("extension_components/point", rr.Points2D(np.array([64, 64]), colors=(255, 0, 0)))
     # Separate extension component
-    rr.log_extension_components("extension_components/point", {"confidence": 0.9})
+    rr.log("extension_components/point", rr.AnyValues(confidence=0.9))
 
     # Batch points with extension
     # Note: each extension component must either be length 1 (a splat) or the same length as the batch
     rr.set_time_seconds("sim_time", 1)
-    rr.log_points(
+    rr.log(
         "extension_components/points",
-        np.array([[32, 32], [32, 96], [96, 32], [96, 96]]),
-        colors=(0, 255, 0),
-        ext={"corner": ["upper left", "lower left", "upper right", "lower right"], "training": True},
+        rr.Points2D(np.array([[32, 32], [32, 96], [96, 32], [96, 96]]), colors=(0, 255, 0)),
+        rr.AnyValues(corner=["upper left", "lower left", "upper right", "lower right"], training=True),
     )
 
 


### PR DESCRIPTION
### What
- Builds on top of https://github.com/rerun-io/rerun/pull/3561

With `AnyValues` as a means of quickly creating arbitrary component bundles, it's nice to be able to log these on a single line.

I briefly looked into adding `+` to components, but making it guaranteed to play nicely with arbitrary user extension components introduced more risk than I think it gained in clarity.

This simply allows `log` to consume any additional unnamed args as extra sets of components which are merged into the logging set.

This replaces:
```
rr.log(
    "extra_values",
    rr.Points2D([[-1, -1], [-1, 1], [1, -1], [1, 1]]),
    ext={'confidence': [0.3, 0.4, 0.5, 0.6]}
)
```

With
```
rr.log(
    "extra_values",
    rr.Points2D([[-1, -1], [-1, 1], [1, -1], [1, 1]]),
    rr.AnyValues(
        confidence=[0.3, 0.4, 0.5, 0.6],
    ),
)
```

A bit more typing involved, but gets rid of special handling of an ext keyword in a way that paves a much clearer path to users adding their own custom components.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3562) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3562)
- [Docs preview](https://rerun.io/preview/0c41bf3abc4e9bfe1ea4af77a662bf2268e42162/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0c41bf3abc4e9bfe1ea4af77a662bf2268e42162/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)