### PR TITLE
Deprecate all of the legacy `log_` prefixed APIs.

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log_deprecated/annotation.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/annotation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
+
 from rerun._log import log
 from rerun.archetypes import AnnotationContext
 from rerun.datatypes import AnnotationInfo, ClassDescription, ClassDescriptionArrayLike
@@ -9,6 +11,10 @@ from rerun.recording_stream import RecordingStream
 __all__ = ["log_annotation_context", "AnnotationInfo", "ClassDescription", "ClassDescriptionArrayLike"]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.AnnotationContext(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_annotation_context(
     entity_path: str,
@@ -19,6 +25,11 @@ def log_annotation_context(
 ) -> None:
     """
     Log an annotation context made up of a collection of [ClassDescription][rerun.log_deprecated.annotation.ClassDescription]s.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.AnnotationContext][]
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Any entity needing to access the annotation context will find it by searching the
     path upward. If all entities share the same you can simply log it to the

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/arrow.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/arrow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import Arrows3D
@@ -15,6 +16,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Arrows3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_arrow(
     entity_path: str,
@@ -30,6 +35,11 @@ def log_arrow(
 ) -> None:
     """
     Log a 3D arrow.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Arrows3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     An arrow is defined with an `origin`, and a `vector`. This can also be considered as `start` and `end` positions
     for the arrow.

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
@@ -4,6 +4,7 @@ from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import Boxes3D
@@ -22,6 +23,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Boxes3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_obb(
     entity_path: str,
@@ -39,6 +44,11 @@ def log_obb(
 ) -> None:
     """
     Log a 3D Oriented Bounding Box, or OBB.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Boxes3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Example:
     --------
@@ -89,6 +99,10 @@ def log_obb(
     )
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Boxes3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_obbs(
     entity_path: str,
@@ -105,13 +119,12 @@ def log_obbs(
     recording: RecordingStream | None = None,
 ) -> None:
     """
-    Log a 3D Oriented Bounding Box, or OBB.
+    Log a collection of 3D Oriented Bounding Boxes, or OBB.
 
-    Example:
-    --------
-    ```
-    rr.log_obb("my_obb", half_size=[1.0, 2.0, 3.0], position=[0, 0, 0], rotation_q=[0, 0, 0, 1])
-    ```
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Boxes3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Parameters
     ----------

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/camera.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/camera.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import Pinhole
@@ -14,6 +15,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Pinhole(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_pinhole(
     entity_path: str,
@@ -29,6 +34,11 @@ def log_pinhole(
 ) -> None:
     """
     Log a perspective camera model.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Pinhole][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     This logs the pinhole model that projects points from the parent (camera) space to this space (image) such that:
     ```

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/clear.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/clear.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
+
 from rerun._log import log
 from rerun.archetypes import Clear
 from rerun.recording_stream import RecordingStream
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Clear(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 def log_cleared(
     entity_path: str,
     *,
@@ -13,6 +19,11 @@ def log_cleared(
 ) -> None:
     """
     Indicate that an entity at a given path should no longer be displayed.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Clear][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     If `recursive` is True this will also clear all sub-paths
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/extension_components.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/extension_components.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 import rerun.error_utils
 from rerun import bindings
@@ -73,6 +74,10 @@ def _add_extension_components(
             instanced[name] = pa_value
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.AnyValues(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_extension_components(
     entity_path: str,
@@ -84,6 +89,11 @@ def log_extension_components(
 ) -> None:
     """
     Log an arbitrary collection of extension components.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.AnyValues][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Each item in `ext` will be logged as a separate component.
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import Asset3D
@@ -37,6 +38,10 @@ class MeshFormat(Enum):
     """Wavefront .obj format."""
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Asset3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_mesh_file(
     entity_path: str,
@@ -50,6 +55,11 @@ def log_mesh_file(
 ) -> None:
     """
     Log the contents of a mesh file (.gltf, .glb, .obj, …).
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Asset3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     You must pass either `mesh_bytes` or `mesh_path`.
 
@@ -108,6 +118,10 @@ def log_mesh_file(
     return log(entity_path, asset3d, timeless=timeless, recording=recording)
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.ImageEncoded(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_image_file(
     entity_path: str,
@@ -120,6 +134,11 @@ def log_image_file(
 ) -> None:
     """
     Log an image file given its contents or path on disk.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.ImageEncoded][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     You must pass either `img_bytes` or `img_path`.
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import DepthImage, Image, SegmentationImage
@@ -19,6 +20,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Image(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_image(
     entity_path: str,
@@ -32,6 +37,11 @@ def log_image(
 ) -> None:
     """
     Log a gray or color image.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Image][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     The image should either have 1, 3 or 4 channels (gray, RGB or RGBA).
 
@@ -78,6 +88,10 @@ def log_image(
     log(entity_path, Image(tensor_data, draw_order=draw_order), ext=ext, timeless=timeless, recording=recording)
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.DepthImage(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_depth_image(
     entity_path: str,
@@ -91,6 +105,11 @@ def log_depth_image(
 ) -> None:
     """
     Log a depth image.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.DepthImage][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     The image must be a 2D array.
 
@@ -134,6 +153,10 @@ def log_depth_image(
     )
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.SegmentationImage(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_segmentation_image(
     entity_path: str,
@@ -146,6 +169,11 @@ def log_segmentation_image(
 ) -> None:
     """
     Log an image made up of integer class-ids.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.SegmentationImage][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     The image should have 1 channel, i.e. be either `H x W` or `H x W x 1`.
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, Sequence
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import LineStrips2D, LineStrips3D
@@ -20,6 +21,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.LineStrips2D(…)) or `rr.log(…, rr.LineStrips3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_line_strip(
     entity_path: str,
@@ -34,6 +39,11 @@ def log_line_strip(
 ) -> None:
     r"""
     Log a line strip through 2D or 3D space.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.LineStrips2D][] or [rerun.LineStrips3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     A line strip is a list of points connected by line segments. It can be used to draw approximations of smooth curves.
 
@@ -98,6 +108,10 @@ def log_line_strip(
         raise TypeError("Positions should be either Nx2 or Nx3")
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.LineStrips2D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_line_strips_2d(
     entity_path: str,
@@ -113,6 +127,11 @@ def log_line_strips_2d(
 ) -> None:
     r"""
     Log a batch of line strips through 2D space.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.LineStrips2D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Each line strip is a list of points connected by line segments. It can be used to draw
     approximations of smooth curves.
@@ -183,6 +202,10 @@ def log_line_strips_2d(
     return log(entity_path, arch, ext=ext, timeless=timeless, recording=recording)
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.LineStrips3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_line_strips_3d(
     entity_path: str,
@@ -197,6 +220,11 @@ def log_line_strips_3d(
 ) -> None:
     r"""
     Log a batch of line strips through 3D space.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.LineStrips3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Each line strip is a list of points connected by line segments. It can be used to draw approximations
     of smooth curves.
@@ -262,6 +290,10 @@ def log_line_strips_3d(
     return log(entity_path, arch, ext=ext, timeless=timeless, recording=recording)
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.LineStrips2D(…)) or `rr.log(…, rr.LineStrips3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_line_segments(
     entity_path: str,
@@ -276,6 +308,11 @@ def log_line_segments(
 ) -> None:
     r"""
     Log many 2D or 3D line segments.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.LineStrips2D][] or [rerun.LineStrips3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     The points will be connected in even-odd pairs, like so:
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/mesh.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/mesh.py
@@ -4,6 +4,7 @@ from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import Mesh3D
@@ -18,6 +19,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Mesh3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_mesh(
     entity_path: str,
@@ -32,6 +37,11 @@ def log_mesh(
 ) -> None:
     """
     Log a raw 3D mesh by specifying its vertex positions, and optionally indices, normals and albedo factor.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Mesh3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     You can also use [`rerun.log_mesh_file`] to log .gltf, .glb, .obj, etc.
 
@@ -107,6 +117,10 @@ def log_mesh(
     return log(entity_path, mesh3d, timeless=timeless, recording=recording)
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Mesh3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_meshes(
     entity_path: str,
@@ -121,6 +135,11 @@ def log_meshes(
 ) -> None:
     """
     Log multiple raw 3D meshes by specifying their different buffers and albedo factors.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Mesh3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     To learn more about how the data within these buffers is interpreted and laid out, refer
     to the documentation for [`rerun.log_mesh`].

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
@@ -24,6 +24,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Points2D(…))` or `rr.log(…, rr.Points3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_point(
     entity_path: str,
@@ -41,6 +45,11 @@ def log_point(
 ) -> None:
     """
     Log a 2D or 3D point, with a position and optional color, radii, label, etc.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.Points2D][] or [rerun.Points3D][]
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Logging again to the same `entity_path` will replace the previous point.
 
@@ -126,7 +135,7 @@ def log_point(
 
 
 @deprecated(
-    """Please migrate to `Points3D` or `Points2D`.
+    """Please migrate to `rr.log(…, rr.Points2D(…))` or `rr.log(…, rr.Points3D(…))`.
   See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
 )
 @log_decorator
@@ -149,7 +158,7 @@ def log_points(
     Log 2D or 3D points, with positions and optional colors, radii, labels, etc.
 
     !!! Warning "Deprecated"
-        Please migrate to [rerun.Points3D][] or [rerun.Points2D][]
+        Please migrate to [rerun.Points2D][] or [rerun.Points3D][]
 
         See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import Boxes2D
@@ -42,6 +43,10 @@ class RectFormat(Enum):
     """[x_center, y_center, width/2, height/2]."""
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Boxes2D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_rect(
     entity_path: str,
@@ -58,6 +63,11 @@ def log_rect(
 ) -> None:
     """
     Log a 2D rectangle.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Boxes2D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Parameters
     ----------
@@ -103,6 +113,10 @@ def log_rect(
     )
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Boxes2D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_rects(
     entity_path: str,
@@ -120,6 +134,11 @@ def log_rects(
 ) -> None:
     """
     Log multiple 2D rectangles.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Boxes2D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Logging again to the same `entity_path` will replace all the previous rectangles.
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/scalar.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
+
 from rerun._log import log
 from rerun.archetypes import TimeSeriesScalar
 from rerun.log_deprecated import Color, _normalize_colors
@@ -13,6 +15,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.TimeSeriesScalar(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_scalar(
     entity_path: str,
@@ -27,6 +33,11 @@ def log_scalar(
 ) -> None:
     """
     Log a double-precision scalar that will be visualized as a timeseries plot.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.TimeSeriesScalar][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     The current simulation time will be used for the time/X-axis, hence scalars
     cannot be timeless!

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Protocol, Sequence
 
 import numpy.typing as npt
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from rerun._log import log
 from rerun.archetypes import BarChart, Tensor
@@ -23,6 +24,10 @@ class TorchTensorLike(Protocol):
         ...
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Tensor(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_tensor(
     entity_path: str,
@@ -36,6 +41,11 @@ def log_tensor(
 ) -> None:
     """
     Log an n-dimensional tensor.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Tensor][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Parameters
     ----------

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/text.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/text.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
+
 from rerun._log import log
 from rerun.archetypes import TextLog
 from rerun.log_deprecated import Color, _normalize_colors
@@ -15,6 +17,10 @@ __all__ = [
 ]
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.TextLog(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_text_entry(
     entity_path: str,
@@ -28,6 +34,11 @@ def log_text_entry(
 ) -> None:
     """
     Log a text entry, with optional level.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.TextLog][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Parameters
     ----------

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/transform.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/transform.py
@@ -5,6 +5,8 @@ Learn more about transforms [in the manual](https://www.rerun.io/docs/concepts/s
 """
 from __future__ import annotations
 
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
+
 from rerun._log import log
 from rerun.archetypes import DisconnectedSpace, ViewCoordinates
 from rerun.datatypes import (
@@ -48,6 +50,10 @@ _up_attrs = {
 }
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.ViewCoordinates(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_view_coordinates(
     entity_path: str,
@@ -60,6 +66,11 @@ def log_view_coordinates(
 ) -> None:
     """
     Log the view coordinates for an entity.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.ViewCoordinates][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     Each entity defines its own coordinate system, called a space.
     By logging view coordinates you can give semantic meaning to the XYZ axes of the space.
@@ -150,6 +161,10 @@ def log_view_coordinates(
             raise ValueError("Invalid up value.")
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.DisconnectedSpace(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_disconnected_space(
     entity_path: str,
@@ -158,6 +173,11 @@ def log_disconnected_space(
 ) -> None:
     """
     Log that this entity is NOT in the same space as the parent.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.DisconnectedSpace][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     This is useful for specifying that a subgraph is independent of the rest of the scene.
     If a transform or pinhole is logged on the same path, this component will be ignored.
@@ -181,6 +201,10 @@ def log_disconnected_space(
     log(entity_path, DisconnectedSpace(True), timeless=timeless, recording=recording)
 
 
+@deprecated(
+    """Please migrate to `rr.log(…, rr.Transform3D(…))`.
+  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
+)
 @log_decorator
 def log_transform3d(
     entity_path: str,
@@ -200,6 +224,11 @@ def log_transform3d(
 ) -> None:
     """
     Log an (affine) 3D transform between this entity and the parent.
+
+    !!! Warning "Deprecated"
+        Please migrate to [rerun.log][] with [rerun.Transform3D][].
+
+        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
 
     If `from_parent` is set to `True`, the transformation is from the parent to the space of the entity_path,
     otherwise it is from the child to the parent.


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/3275
 - Follows the pattern from https://github.com/rerun-io/rerun/pull/3500

Changes the pattern slightly to:

Decorator
```
@deprecated(
    """Please migrate to `rr.log(…, rr.Arrows3D(…))`.
  See: https://www.rerun.io/docs/reference/migration-0-9 for more details."""
)
```

Docstring
```
    !!! Warning "Deprecated"
        Please migrate to [rerun.log][] with [rerun.Arrows3D][].

        See [the migration guide](https://www.rerun.io/docs/reference/migration-0-9) for more details.
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3564) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3564)
- [Docs preview](https://rerun.io/preview/c8edbef741ce60416de3915755e21ffabf133c14/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c8edbef741ce60416de3915755e21ffabf133c14/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)