### PR TITLE
Hide indicator components from hover-ui

### DIFF
--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -18,7 +18,7 @@ impl DataUi for ComponentPath {
 
         let store = &ctx.store_db.entity_db.data_store;
 
-        if let Some(archetype_name) = crate::indicator_component_archetype(component_name) {
+        if let Some(archetype_name) = component_name.indicator_component_archetype() {
             ui.label(format!(
                 "Indicator component for the {archetype_name} archetype"
             ));

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -21,7 +21,7 @@ impl DataUi for InstancePath {
 
         let store = &ctx.store_db.entity_db.data_store;
 
-        let Some(mut components) = store.all_components(&query.timeline, entity_path) else {
+        let Some(components) = store.all_components(&query.timeline, entity_path) else {
             if ctx.store_db.entity_db.knows_of_entity(entity_path) {
                 ui.label(format!(
                     "No components in entity {:?} on timeline {:?}",
@@ -36,7 +36,6 @@ impl DataUi for InstancePath {
             }
             return;
         };
-        components.sort();
 
         egui::Grid::new("entity_instance")
             .num_columns(2)

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -55,9 +55,7 @@ impl DataUi for InstancePath {
                         );
                     });
 
-                    if let Some(archetype_name) =
-                        crate::indicator_component_archetype(&component_name)
-                    {
+                    if let Some(archetype_name) = component_name.indicator_component_archetype() {
                         ui.weak(format!(
                             "Indicator component for the {archetype_name} archetype"
                         ));

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -11,7 +11,7 @@ impl DataUi for InstancePath {
         &self,
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
         let Self {
@@ -37,10 +37,20 @@ impl DataUi for InstancePath {
             return;
         };
 
+        let all_are_indicators = components.iter().all(|c| c.is_indicator_component());
+
         egui::Grid::new("entity_instance")
             .num_columns(2)
             .show(ui, |ui| {
                 for &component_name in crate::ui_visible_components(&components) {
+                    if verbosity != UiVerbosity::All
+                        && component_name.is_indicator_component()
+                        && !all_are_indicators
+                    {
+                        // Skip indicator components in hover ui (unless there are no other types of components).
+                        continue;
+                    }
+
                     let Some((_, component_data)) =
                         get_component_with_instances(store, query, entity_path, component_name)
                     else {

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -42,7 +42,7 @@ pub fn ui_visible_components<'a>(
         .collect();
 
     // Put indicator components first:
-    components.sort_by_key(|c| !is_indicator_component(c));
+    components.sort_by_key(|c| (!is_indicator_component(c), c.full_name()));
 
     components.into_iter()
 }

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -42,7 +42,7 @@ pub fn ui_visible_components<'a>(
         .collect();
 
     // Put indicator components first:
-    components.sort_by_key(|c| (!is_indicator_component(c), c.full_name()));
+    components.sort_by_key(|c| (!c.is_indicator_component(), c.full_name()));
 
     components.into_iter()
 }
@@ -53,21 +53,6 @@ fn is_component_visible_in_ui(component_name: &ComponentName) -> bool {
     !HIDDEN_COMPONENTS.contains(&component_name.as_ref())
 }
 
-/// Is this an indicator component for an archetype?
-pub fn is_indicator_component(component_name: &ComponentName) -> bool {
-    component_name.starts_with("rerun.components.") && component_name.ends_with("Indicator")
-}
-
-/// If this is an indicator component, for which archetype?
-pub fn indicator_component_archetype(component_name: &ComponentName) -> Option<String> {
-    if let Some(name) = component_name.strip_prefix("rerun.components.") {
-        if let Some(name) = name.strip_suffix("Indicator") {
-            return Some(name.to_owned());
-        }
-    }
-    None
-}
-
 pub fn temporary_style_ui_for_component<R>(
     ui: &mut egui::Ui,
     component_name: &ComponentName,
@@ -75,7 +60,7 @@ pub fn temporary_style_ui_for_component<R>(
 ) -> R {
     let old_style: egui::Style = (**ui.style()).clone();
 
-    if crate::is_indicator_component(component_name) {
+    if component_name.is_indicator_component() {
         // Make indicator components stand out by making them slightly fainter:
 
         let inactive = &mut ui.style_mut().visuals.widgets.inactive;

--- a/crates/re_types/src/archetypes/pinhole_ext.rs
+++ b/crates/re_types/src/archetypes/pinhole_ext.rs
@@ -34,31 +34,6 @@ impl Pinhole {
             .map(|resolution| 2.0 * (0.5 * resolution[1] / self.image_from_camera.col(1)[1]).atan())
     }
 
-    /// X & Y focal length in pixels.
-    ///
-    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
-    #[inline]
-    pub fn focal_length_in_pixels(&self) -> Vec2D {
-        [
-            self.image_from_camera.col(0)[0],
-            self.image_from_camera.col(1)[1],
-        ]
-        .into()
-    }
-
-    /// Principal point of the pinhole camera,
-    /// i.e. the intersection of the optical axis and the image plane.
-    ///
-    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
-    #[cfg(feature = "glam")]
-    #[inline]
-    pub fn principal_point(&self) -> glam::Vec2 {
-        glam::vec2(
-            self.image_from_camera.col(2)[0],
-            self.image_from_camera.col(2)[1],
-        )
-    }
-
     #[inline]
     #[cfg(feature = "glam")]
     pub fn resolution(&self) -> Option<glam::Vec2> {
@@ -70,14 +45,33 @@ impl Pinhole {
         self.resolution.map(|r| r[0] / r[1])
     }
 
+    // ------------------------------------------------------------------------
+    // Forwarding calls to `PinholeProjection`:
+
+    /// X & Y focal length in pixels.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[inline]
+    pub fn focal_length_in_pixels(&self) -> Vec2D {
+        self.image_from_camera.focal_length_in_pixels()
+    }
+
+    /// Principal point of the pinhole camera,
+    /// i.e. the intersection of the optical axis and the image plane.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn principal_point(&self) -> glam::Vec2 {
+        self.image_from_camera.principal_point()
+    }
+
     /// Project camera-space coordinates into pixel coordinates,
     /// returning the same z/depth.
     #[cfg(feature = "glam")]
     #[inline]
     pub fn project(&self, pixel: glam::Vec3) -> glam::Vec3 {
-        ((pixel.truncate() * glam::Vec2::from(self.focal_length_in_pixels())) / pixel.z
-            + self.principal_point())
-        .extend(pixel.z)
+        self.image_from_camera.project(pixel)
     }
 
     /// Given pixel coordinates and a world-space depth,
@@ -87,8 +81,6 @@ impl Pinhole {
     #[cfg(feature = "glam")]
     #[inline]
     pub fn unproject(&self, pixel: glam::Vec3) -> glam::Vec3 {
-        ((pixel.truncate() - self.principal_point()) * pixel.z
-            / glam::Vec2::from(self.focal_length_in_pixels()))
-        .extend(pixel.z)
+        self.image_from_camera.unproject(pixel)
     }
 }

--- a/crates/re_types/src/components/mod.rs
+++ b/crates/re_types/src/components/mod.rs
@@ -38,6 +38,7 @@ mod origin3d;
 mod origin3d_ext;
 mod out_of_tree_transform3d;
 mod pinhole_projection;
+mod pinhole_projection_ext;
 mod position2d;
 mod position2d_ext;
 mod position3d;

--- a/crates/re_types/src/components/pinhole_projection_ext.rs
+++ b/crates/re_types/src/components/pinhole_projection_ext.rs
@@ -1,0 +1,45 @@
+use crate::datatypes::Vec2D;
+
+use super::PinholeProjection;
+
+impl PinholeProjection {
+    /// X & Y focal length in pixels.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[inline]
+    pub fn focal_length_in_pixels(&self) -> Vec2D {
+        [self.col(0)[0], self.col(1)[1]].into()
+    }
+
+    /// Principal point of the pinhole camera,
+    /// i.e. the intersection of the optical axis and the image plane.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn principal_point(&self) -> glam::Vec2 {
+        glam::vec2(self.col(2)[0], self.col(2)[1])
+    }
+
+    /// Project camera-space coordinates into pixel coordinates,
+    /// returning the same z/depth.
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn project(&self, pixel: glam::Vec3) -> glam::Vec3 {
+        ((pixel.truncate() * glam::Vec2::from(self.focal_length_in_pixels())) / pixel.z
+            + self.principal_point())
+        .extend(pixel.z)
+    }
+
+    /// Given pixel coordinates and a world-space depth,
+    /// return a position in the camera space.
+    ///
+    /// The returned z is the same as the input z (depth).
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn unproject(&self, pixel: glam::Vec3) -> glam::Vec3 {
+        ((pixel.truncate() - self.principal_point()) * pixel.z
+            / glam::Vec2::from(self.focal_length_in_pixels()))
+        .extend(pixel.z)
+    }
+}

--- a/crates/re_types/src/loggable.rs
+++ b/crates/re_types/src/loggable.rs
@@ -176,6 +176,21 @@ impl ComponentName {
             full_name
         }
     }
+
+    /// Is this an indicator component for an archetype?
+    pub fn is_indicator_component(&self) -> bool {
+        self.starts_with("rerun.components.") && self.ends_with("Indicator")
+    }
+
+    /// If this is an indicator component, for which archetype?
+    pub fn indicator_component_archetype(&self) -> Option<String> {
+        if let Some(name) = self.strip_prefix("rerun.components.") {
+            if let Some(name) = name.strip_suffix("Indicator") {
+                return Some(name.to_owned());
+            }
+        }
+        None
+    }
 }
 
 // ---

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -8,7 +8,7 @@ use re_types::{components::InstanceKey, ComponentName, Loggable as _};
 use crate::ViewerContext;
 
 /// Controls how mich space we use to show the data in a component ui.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UiVerbosity {
     /// Keep it small enough to fit on one row.
     Small,


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3548

It's still visible in the selection ui

![image](https://github.com/rerun-io/rerun/assets/1148717/3ae96dee-f679-4bb5-8997-c86dde5a0d8b)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3576) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3576)
- [Docs preview](https://rerun.io/preview/dcdd4a7996b7f953685e672ba6e6bbac06691533/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/dcdd4a7996b7f953685e672ba6e6bbac06691533/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)