### PR TITLE
Alpha release workflow

### DIFF
--- a/.github/workflows/auto_release_crates.yml
+++ b/.github/workflows/auto_release_crates.yml
@@ -1,4 +1,4 @@
-name: Weekly release
+name: Automated crates release
 
 on:
   workflow_dispatch:
@@ -29,17 +29,18 @@ jobs:
           python3 scripts/ci/crates.py version --bump prerelease
 
       - name: Get bumped version
+        id: versioning
         run: |
-          CRATE_VERSION=$(python3 scripts/ci/crates.py get-version)
-          echo "CRATE_VERSION=$CRATE_VERSION" >> "$GITHUB_ENV"
+          crate_version=$(python3 scripts/ci/crates.py get-version)
+          echo "crate_version=$crate_version" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5.0.2
         with:
           token: ${{ secrets.RERUN_BOT_TOKEN }}
-          branch: "weekly-release-${{ env.CRATE_VERSION }}"
-          commit-message: "[weekly-release] ${{ env.CRATE_VERSION }}"
-          title: "Release ${{ env.CRATE_VERSION }}"
+          branch: "weekly-release-${{ steps.versioning.outputs.crate_version }}"
+          commit-message: "[weekly-release] ${{ steps.versioning.outputs.crate_version }}"
+          title: "Release ${{ steps.versioning.outputs.crate_version }}"
           labels: |
             ⛴ release
             exclude from changelog
@@ -48,7 +49,7 @@ jobs:
           body: |
             ### What
 
-            - [x] Bump all crate versions to `${{ env.CRATE_VERSION }}`
+            - [x] Bump all crate versions to `${{ steps.versioning.outputs.crate_version }}`
 
             The release process will begin once this pull request is merged.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,11 @@ jobs:
 
             ### Next steps
             - [Test the release](#testing)
-            - For any added commits, run the release workflow in `prerelease` mode again
-            - After testing, run the release workflow in `release` mode
-            - Once the final release workflow finishes, [create a GitHub release](https://github.com/rerun-io/rerun/releases/new)
+            - If this is an `alpha` release, you can just merge the pull request.
+            - Otherwise:
+              - For any added commits, run the release workflow in `rc` mode again
+              - After testing, run the release workflow in `release` mode
+              - Once the final release workflow finishes, [create a GitHub release](https://github.com/rerun-io/rerun/releases/new)
 
             ### Testing
             - [ ] Docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,8 @@ jobs:
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
       CONCURRENCY: ${{ github.ref_name }}
-      PY_DOCS_VERSION_NAME: ${{ inputs.release-type != 'final' && 'prerelease' || needs.version.outputs.final }}
-      RS_DOCS_VERSION_NAME: ${{ inputs.release-type != 'final' && 'prerelease' || 'head' }}
+      PY_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'prerelease' }}
+      RS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'head' || 'prerelease' }}
       UPDATE_LATEST: ${{ inputs.release-type == 'final' }}
       RELEASE_COMMIT: ${{ needs.version.outputs.release-commit }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       release-type:
-        description: "Is this a pre-release or a final release?"
+        description: "What kind of release is this?"
         type: choice
         options:
-          - prerelease
-          - release
+          - alpha
+          - rc
+          - final
         required: true
 
 concurrency:
@@ -60,8 +61,8 @@ jobs:
         run: |
 
           # parse the release version from the branch name
-          #   `release-0.8.1` -> `0.8.1`
-          release_version=$(echo ${{ github.ref_name }} | grep -oP '^release-\K\d+\.\d+\.\d+$')
+          #   `release-0.8.1-meta.N` -> `0.8.1`
+          release_version=$(python3 scripts/ci/crates.py get-version --from-git --finalize)
 
           # store version before the update, so we can later detect if it changed
           previous=$(python3 scripts/ci/crates.py get-version)
@@ -72,10 +73,15 @@ jobs:
             python3 scripts/ci/crates.py version --exact $release_version
           fi
 
-          # if this is a prerelease, additionally set add `-rc.N`
+          # if this is an `rc`, additionally set add `-rc.N`
           # this will also bump the `N` if `-rc.N` is already set
-          if [ ${{ inputs.release-type }} = "prerelease" ]; then
+          if [ ${{ inputs.release-type }} = "rc" ]; then
             python3 scripts/ci/crates.py version --bump prerelease --pre-id=rc
+          fi
+
+          # if this is an `alpha`, set the version to whatever is in the git branch name.
+          if [ ${{ inputs.release-type }} = "alpha" ]; then
+            python3 scripts/ci/crates.py version --exact $(python3 scripts/ci/crates.py get-version --from-git)
           fi
 
           # store version after the update, and the expected "final" release version
@@ -158,9 +164,9 @@ jobs:
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
       CONCURRENCY: ${{ github.ref_name }}
-      PY_DOCS_VERSION_NAME: ${{ inputs.release-type == 'prerelease' && 'prerelease' || needs.version.outputs.final }}
-      RS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'prerelease' && 'prerelease' || 'head' }}
-      UPDATE_LATEST: ${{ inputs.release-type == 'release' }}
+      PY_DOCS_VERSION_NAME: ${{ inputs.release-type != 'final' && 'prerelease' || needs.version.outputs.final }}
+      RS_DOCS_VERSION_NAME: ${{ inputs.release-type != 'final' && 'prerelease' || 'head' }}
+      UPDATE_LATEST: ${{ inputs.release-type == 'final' }}
       RELEASE_COMMIT: ${{ needs.version.outputs.release-commit }}
     secrets: inherit
 
@@ -195,12 +201,12 @@ jobs:
       concurrency: ${{ github.ref_name }}
       wheel-artifact-name: linux-wheel
       rrd-artifact-name: linux-rrd
-      update-latest: ${{ inputs.release-type == 'release' }}
+      update-latest: ${{ inputs.release-type == 'final' }}
     secrets: inherit
 
   update-latest-branch:
     name: "Update Latest Branch"
-    if: inputs.release-type == 'release'
+    if: inputs.release-type == 'final'
     needs: [version, update-docs, publish-crates, build-and-publish-wheels, build-and-publish-web]
     runs-on: ubuntu-latest
     steps:
@@ -217,7 +223,7 @@ jobs:
 
   post-release-version-bump:
     name: "Post-release Version Bump"
-    if: inputs.release-type == 'release'
+    if: inputs.release-type == 'final'
     needs: [version, update-docs, publish-crates, build-and-publish-wheels, build-and-publish-web]
     runs-on: ubuntu-latest
     steps:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -76,11 +76,8 @@ If we are doing a patch release, we do a branch off of the latest release tag (e
      - `alpha` if the branch name is `release-x.y.z-alpha.N`.
        This will create a one-off alpha release.
 
-     - `rc` if the branch is `release-x.y.z`.
+     - `rc` if the branch name is `release-x.y.z`.
        This will create a pull request for the release, and publish a release candidate.
-
-     - `final` if this is a final release.
-       This will perform a full release for the existing `release-x.y.z` pull request.
 
    ![Image showing the Run workflow UI. It can be found at https://github.com/rerun-io/rerun/actions/workflows/release.yml](https://github.com/rerun-io/rerun/assets/1665677/6cdc8e7e-c0fc-4cf1-99cb-0749957b8328)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -45,8 +45,10 @@ If we are doing a patch release, we do a branch off of the latest release tag (e
 
 2. ### Create a release branch.
 
-   Name it `release-0.x.y`, replacing `0.x.y` with the current version number you found in `Cargo.toml`.
-   The branch name _must_ match the `release-0.x.y` pattern, otherwise the CI can't infer the version from it.
+   The name should be:
+   - `release-0.x.y` for final releases.
+   - `release-0.x.y-alpha.N` where `N` is incremented from the previous alpha,
+     or defaulted to `1` if no previous alpha exists.
 
 ![Image showing the branch create UI. You can find the `new branch` button at https://github.com/rerun-io/rerun/branches](https://github.com/rerun-io/rerun/assets/1665677/becaad03-9262-4476-b811-c23d40305aec)
 
@@ -68,11 +70,20 @@ If we are doing a patch release, we do a branch off of the latest release tag (e
 
 5. ### Run the [release workflow](https://github.com/rerun-io/rerun/actions/workflows/release.yml).
 
-   Set `Use workflow from` to the new release branch, and choose `prerelease` in the drop-down menu.
+   In the UI:
+   - Set `Use workflow from` to the release branch you created in step (2).
+   - Then choose one of the following values in the dropdown:
+     - `alpha` if the branch name is `release-x.y.z-alpha.N`.
+       This will create a one-off alpha release.
+
+     - `rc` if the branch is `release-x.y.z`.
+       This will create a pull request for the release, and publish a release candidate.
+
+     - `final` if this is a final release.
+       This will perform a full release for the existing `release-x.y.z` pull request.
 
    ![Image showing the Run workflow UI. It can be found at https://github.com/rerun-io/rerun/actions/workflows/release.yml](https://github.com/rerun-io/rerun/assets/1665677/6cdc8e7e-c0fc-4cf1-99cb-0749957b8328)
 
 6. ### Wait for the workflow to finish
 
-   The workflow will create a pull request for the release.
    The PR description will contain next steps.

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from time import sleep, time
 from typing import Any, Generator
 
+import git
 import requests
 import tomlkit
 from colorama import Fore
@@ -360,14 +361,28 @@ def publish(dry_run: bool, token: str) -> None:
                 sleep(1 - elapsed_s)
 
 
-def get_version(finalize: bool) -> None:
-    root: dict[str, Any] = tomlkit.parse(Path("Cargo.toml").read_text())
-    current_version = VersionInfo.parse(root["workspace"]["package"]["version"])
+def get_version(finalize: bool, from_git: bool, pre_id: bool) -> None:
+    if not from_git:
+        root: dict[str, Any] = tomlkit.parse(Path("Cargo.toml").read_text())
+        current_version = VersionInfo.parse(root["workspace"]["package"]["version"])
+    else:
+        branch_name = git.Repo().active_branch.name.lstrip("release-")
+        try:
+            current_version = VersionInfo.parse(branch_name)  # ensures that it is a valid version
+        except ValueError:
+            print(f"the current branch `{branch_name}` does not specify a valid version.")
+            print("this script expects the format `release-x.y.z-meta.N`")
+            exit(1)
+
     if finalize:
         current_version = current_version.finalize_version()
 
-    sys.stdout.write(str(current_version))
-    sys.stdout.flush()
+    if pre_id:
+        sys.stdout.write(str(current_version.prerelease.split(".", 1)[0]))
+        sys.stdout.flush()
+    else:
+        sys.stdout.write(str(current_version))
+        sys.stdout.flush()
 
 
 def main() -> None:
@@ -403,10 +418,12 @@ def main() -> None:
     get_version_parser.add_argument(
         "--finalize", action="store_true", help="Return version finalized if it is a pre-release"
     )
+    get_version_parser.add_argument("--from-git", action="store_true", help="Get version from branch name")
+    get_version_parser.add_argument("--pre-id", action="store_true", help="Retrieve only the prerelease identifier")
     args = parser.parse_args()
 
     if args.cmd == "get-version":
-        get_version(args.finalize)
+        get_version(args.finalize, args.from_git, args.pre_id)
     if args.cmd == "version":
         if args.dev and args.pre_id != "alpha":
             parser.error("`--pre-id` must be set to `alpha` when `--dev` is set")

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -362,10 +362,7 @@ def publish(dry_run: bool, token: str) -> None:
 
 
 def get_version(finalize: bool, from_git: bool, pre_id: bool) -> None:
-    if not from_git:
-        root: dict[str, Any] = tomlkit.parse(Path("Cargo.toml").read_text())
-        current_version = VersionInfo.parse(root["workspace"]["package"]["version"])
-    else:
+    if from_git:
         branch_name = git.Repo().active_branch.name.lstrip("release-")
         try:
             current_version = VersionInfo.parse(branch_name)  # ensures that it is a valid version
@@ -373,6 +370,9 @@ def get_version(finalize: bool, from_git: bool, pre_id: bool) -> None:
             print(f"the current branch `{branch_name}` does not specify a valid version.")
             print("this script expects the format `release-x.y.z-meta.N`")
             exit(1)
+    else:
+        root: dict[str, Any] = tomlkit.parse(Path("Cargo.toml").read_text())
+        current_version = VersionInfo.parse(root["workspace"]["package"]["version"])
 
     if finalize:
         current_version = current_version.finalize_version()

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -6,7 +6,7 @@
 Jinja2==3.1.2
 Pillow==10.0.0
 PyGithub==1.59.0
-
+GitPython==3.1.37
 aiohttp==3.8.5
 colorama==0.4.6
 gitignore-parser==0.1.4


### PR DESCRIPTION
### What

The `release` workflow now supports the `alpha` release kind, which is the same as an `rc`, but it's just called `alpha`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3577) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3577)
- [Docs preview](https://rerun.io/preview/38773381a56e31ceed4d8df814849c992a20c5b4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/38773381a56e31ceed4d8df814849c992a20c5b4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)