### PR TITLE
Document annotation context archetype field.

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/annotation_context.fbs
@@ -20,5 +20,6 @@ namespace rerun.archetypes;
 table AnnotationContext (
   "attr.rust.derive": "Eq, PartialEq"
 ) {
+  /// List of class descriptions, mapping class indices to class names, colors etc.
   context: rerun.components.AnnotationContext ("attr.rerun.component_required", order: 1000);
 }

--- a/crates/re_types/definitions/rerun/components/annotation_context.fbs
+++ b/crates/re_types/definitions/rerun/components/annotation_context.fbs
@@ -20,5 +20,6 @@ table AnnotationContext (
   "attr.python.aliases": "datatypes.ClassDescriptionArrayLike, Sequence[datatypes.ClassDescriptionMapElemLike]",
   "attr.rust.derive": "Default, Eq, PartialEq"
 ) {
+  /// List of class descriptions, mapping class indices to class names, colors etc.
   class_map: [rerun.datatypes.ClassDescriptionMapElem] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat3x3.fbs
@@ -45,7 +45,6 @@ struct Mat3x3 (
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
   "attr.rust.tuple_struct"
 ) {
-  /// \py Flat list of matrix coefficients in column-major order.
-  /// \cpp Flat list of matrix coefficients in column-major order.
+  /// Flat list of matrix coefficients in column-major order.
   flat_columns: [float32: 9] (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/mat4x4.fbs
@@ -47,7 +47,6 @@ struct Mat4x4 (
   "attr.rust.derive": "Copy, PartialEq, PartialOrd",
   "attr.rust.tuple_struct"
 ) {
-  /// \py Flat list of matrix coefficients in column-major order.
-  /// \cpp Flat list of matrix coefficients in column-major order.
+  /// Flat list of matrix coefficients in column-major order.
   flat_columns: [float32: 16] (order: 100);
 }

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -167,6 +167,7 @@
 /// </picture>
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AnnotationContext {
+    /// List of class descriptions, mapping class indices to class names, colors etc.
     pub context: crate::components::AnnotationContext,
 }
 

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -22,7 +22,10 @@
 /// path-hierarchy when searching up through the ancestors of a given entity
 /// path.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct AnnotationContext(pub Vec<crate::datatypes::ClassDescriptionMapElem>);
+pub struct AnnotationContext(
+    /// List of class descriptions, mapping class indices to class names, colors etc.
+    pub Vec<crate::datatypes::ClassDescriptionMapElem>,
+);
 
 impl<I: Into<crate::datatypes::ClassDescriptionMapElem>, T: IntoIterator<Item = I>> From<T>
     for AnnotationContext

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -25,7 +25,10 @@
 /// row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 /// ```
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
-pub struct Mat3x3(pub [f32; 9usize]);
+pub struct Mat3x3(
+    /// Flat list of matrix coefficients in column-major order.
+    pub [f32; 9usize],
+);
 
 impl From<[f32; 9usize]> for Mat3x3 {
     #[inline]

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -26,7 +26,10 @@
 /// row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 /// ```
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
-pub struct Mat4x4(pub [f32; 16usize]);
+pub struct Mat4x4(
+    /// Flat list of matrix coefficients in column-major order.
+    pub [f32; 16usize],
+);
 
 impl From<[f32; 16usize]> for Mat4x4 {
     #[inline]

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -60,6 +60,7 @@ namespace rerun {
         /// }
         /// ```
         struct AnnotationContext {
+            /// List of class descriptions, mapping class indices to class names, colors etc.
             rerun::components::AnnotationContext context;
 
             /// Name of the indicator component, used to identify the archetype when converting to a

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -28,6 +28,7 @@ namespace rerun {
         /// path-hierarchy when searching up through the ancestors of a given entity
         /// path.
         struct AnnotationContext {
+            /// List of class descriptions, mapping class indices to class names, colors etc.
             std::vector<rerun::datatypes::ClassDescriptionMapElem> class_map;
 
             /// Name of the component, used for serialization.

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -125,7 +125,14 @@ class AnnotationContext(Archetype):
     """
 
     def __init__(self: Any, context: components.AnnotationContextLike):
-        """Create a new instance of the AnnotationContext archetype."""
+        """
+        Create a new instance of the AnnotationContext archetype.
+
+        Parameters
+        ----------
+        context:
+             List of class descriptions, mapping class indices to class names, colors etc.
+        """
 
         # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py
         self.__attrs_init__(context=context)
@@ -134,5 +141,9 @@ class AnnotationContext(Archetype):
         metadata={"component": "required"},
         converter=components.AnnotationContextBatch,  # type: ignore[misc]
     )
+    """
+    List of class descriptions, mapping class indices to class names, colors etc.
+    """
+
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -36,7 +36,14 @@ class AnnotationContext(AnnotationContextExt):
     """
 
     def __init__(self: Any, class_map: AnnotationContextLike):
-        """Create a new instance of the AnnotationContext component."""
+        """
+        Create a new instance of the AnnotationContext component.
+
+        Parameters
+        ----------
+        class_map:
+             List of class descriptions, mapping class indices to class names, colors etc.
+        """
 
         # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py
         self.__attrs_init__(class_map=class_map)
@@ -44,6 +51,9 @@ class AnnotationContext(AnnotationContextExt):
     class_map: list[datatypes.ClassDescriptionMapElem] = field(
         converter=AnnotationContextExt.class_map__field_converter_override,  # type: ignore[misc]
     )
+    """
+    List of class descriptions, mapping class indices to class names, colors etc.
+    """
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
### What

* Fixes #3529

Before:
![image (18)](https://github.com/rerun-io/rerun/assets/1220815/1d376a42-d42d-4e47-913f-5bc1e76f5a5f)

After:
![image (16)](https://github.com/rerun-io/rerun/assets/1220815/665aeb29-e0c9-4937-b8b6-b0b5bcf452da)


Stands to reason that the type annotation should be resolved for better visibility of what an annotationcontextlike object actually is. But I figure that's out of scope for now.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
