### PR TITLE
Rust SDK: Import archetypes and other select types into `mod rerun`

### DIFF
--- a/crates/re_log_types/src/time_point/timeline.rs
+++ b/crates/re_log_types/src/time_point/timeline.rs
@@ -37,14 +37,7 @@ impl Default for Timeline {
 }
 
 impl Timeline {
-    #[inline]
-    pub fn new(name: impl Into<TimelineName>, typ: TimeType) -> Self {
-        Self {
-            name: name.into(),
-            typ,
-        }
-    }
-
+    /// For absolute or relative time.
     #[inline]
     pub fn new_temporal(name: impl Into<TimelineName>) -> Self {
         Self {
@@ -53,11 +46,20 @@ impl Timeline {
         }
     }
 
+    /// For things like camera frames or iteration count.
     #[inline]
     pub fn new_sequence(name: impl Into<TimelineName>) -> Self {
         Self {
             name: name.into(),
             typ: TimeType::Sequence,
+        }
+    }
+
+    #[inline]
+    pub fn new(name: impl Into<TimelineName>, typ: TimeType) -> Self {
+        Self {
+            name: name.into(),
+            typ,
         }
     }
 

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -98,31 +98,7 @@ pub use re_types::{
 mod prelude {
     // Import all archetypes into the global namespace to minimize
     // the amount of typing for our users.
-    // We explicitly select archetypes with no name clashes.
-    pub use super::archetypes::{
-        AnnotationContext,
-        Arrows3D,
-        Asset3D,
-        BarChart,
-        Boxes2D,
-        Boxes3D,
-        Clear,
-        DepthImage,
-        DisconnectedSpace,
-        Image,
-        LineStrips2D,
-        LineStrips3D,
-        Mesh3D,
-        Pinhole,
-        Points2D,
-        Points3D,
-        SegmentationImage,
-        Tensor,
-        TextDocument,
-        TextLog,
-        TimeSeriesScalar,
-        ViewCoordinates, // Has a conflict with `re_types::components::ViewCoordinates`, but this is the one you mostly want
-    };
+    pub use super::archetypes::*;
 
     // Also import some select, often-used, datatypes and components:
     pub use super::components::{

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -126,11 +126,12 @@ mod prelude {
 
     // Also import some select, often-used, datatypes and components:
     pub use super::components::{
-        Color, HalfSizes2D, HalfSizes3D, InstanceKey, MediaType, Position3D, TextLogLevel,
+        Color, HalfSizes2D, HalfSizes3D, InstanceKey, Material, MediaType, MeshProperties,
+        Origin3D, OutOfTreeTransform3D, Position3D, Radius, TextLogLevel, Vector3D,
     };
     pub use super::datatypes::{
-        Angle, Mat3x3, Quaternion, Rotation3D, RotationAxisAngle, Scale3D, TranslationAndMat3x3,
-        TranslationRotationScale3D,
+        Angle, ClassDescription, Float32, KeypointPair, Mat3x3, Quaternion, Rotation3D,
+        RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D,
     };
 
     pub use super::time::{Time, TimePoint, Timeline};

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -95,6 +95,48 @@ pub use re_types::{
     NamedIndicatorComponent,
 };
 
+mod prelude {
+    // Import all archetypes into the global namespace to minimize
+    // the amount of typing for our users.
+    // We explicitly select archetypes with no name clashes.
+    pub use super::archetypes::{
+        AnnotationContext,
+        Arrows3D,
+        Asset3D,
+        BarChart,
+        Boxes2D,
+        Boxes3D,
+        Clear,
+        DepthImage,
+        DisconnectedSpace,
+        Image,
+        LineStrips2D,
+        LineStrips3D,
+        Mesh3D,
+        Pinhole,
+        Points2D,
+        Points3D,
+        SegmentationImage,
+        Tensor,
+        TextDocument,
+        TextLog,
+        TimeSeriesScalar,
+        ViewCoordinates, // Has a conflict with `re_types::components::ViewCoordinates`, but this is the one you mostly want
+    };
+
+    // Also import some select, often-used, datatypes and components:
+    pub use super::components::{
+        Color, HalfSizes2D, HalfSizes3D, InstanceKey, MediaType, Position3D, TextLogLevel,
+    };
+    pub use super::datatypes::{
+        Angle, Mat3x3, Quaternion, Rotation3D, RotationAxisAngle, Scale3D, TranslationAndMat3x3,
+        TranslationRotationScale3D,
+    };
+
+    pub use super::time::{Time, TimePoint, Timeline};
+}
+pub use prelude::*;
+
 #[cfg(feature = "log")]
 pub use self::log_integration::Logger;
 #[cfg(feature = "log")]

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -70,18 +70,18 @@
 /// //! Log a segmentation image with annotations.
 ///
 /// use ndarray::{s, Array, ShapeBuilder};
-/// use rerun::{datatypes::Color, AnnotationContext, RecordingStreamBuilder, SegmentationImage};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
+///             .memory()?;
 ///
 ///     // create an annotation context to describe the classes
 ///     rec.log(
 ///         "segmentation",
-///         &AnnotationContext::new([
-///             (1, "red", Color::from(0xFF0000FF)),
-///             (2, "green", Color::from(0x00FF00FF)),
+///         &rerun::AnnotationContext::new([
+///             (1, "red", rerun::datatypes::Color::from(0xFF0000FF)),
+///             (2, "green", rerun::datatypes::Color::from(0x00FF00FF)),
 ///         ]),
 ///     )?;
 ///
@@ -90,7 +90,10 @@
 ///     data.slice_mut(s![0..4, 0..6]).fill(1);
 ///     data.slice_mut(s![4..8, 6..12]).fill(2);
 ///
-///     rec.log("segmentation/image", &SegmentationImage::try_from(data)?)?;
+///     rec.log(
+///         "segmentation/image",
+///         &rerun::SegmentationImage::try_from(data)?,
+///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -108,21 +111,19 @@
 /// ```ignore
 /// //! Log some very simple points.
 ///
-/// use rerun::{
-///     datatypes::{ClassDescription, Color, KeypointPair},
-///     AnnotationContext, Points3D, RecordingStreamBuilder,
-/// };
+/// use rerun::datatypes::Color;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_annotation_context_connections").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
+///             .memory()?;
 ///
 ///     // Log an annotation context to assign a label and color to each class
 ///     // Create a class description with labels and color for each keypoint ID as well as some
 ///     // connections between keypoints.
 ///     rec.log(
 ///         "/",
-///         &AnnotationContext::new([ClassDescription {
+///         &rerun::AnnotationContext::new([rerun::ClassDescription {
 ///             info: 0.into(),
 ///             keypoint_annotations: vec![
 ///                 (0, "zero", Color::from(0xFF0000FF)).into(),
@@ -130,14 +131,14 @@
 ///                 (2, "two", Color::from(0x0000FFFF)).into(),
 ///                 (3, "three", Color::from(0xFFFF00FF)).into(),
 ///             ],
-///             keypoint_connections: KeypointPair::vec_from([(0, 2), (1, 2), (2, 3)]),
+///             keypoint_connections: rerun::KeypointPair::vec_from([(0, 2), (1, 2), (2, 3)]),
 ///         }]),
 ///     )?;
 ///
 ///     // Log some points with different keypoint IDs
 ///     rec.log(
 ///         "points",
-///         &Points3D::new([
+///         &rerun::Points3D::new([
 ///             [0., 0., 0.],
 ///             [50., 0., 20.],
 ///             [100., 100., 30.],

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -28,20 +28,16 @@
 /// ```ignore
 /// //! Log rectangles with different colors and labels using annotation context
 ///
-/// use rerun::{
-///     archetypes::{AnnotationContext, Boxes2D},
-///     datatypes::Color,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::datatypes::Color;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_annotation_context_rects").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").memory()?;
 ///
 ///     // Log an annotation context to assign a label and color to each class
 ///     rec.log(
 ///         "/",
-///         &AnnotationContext::new([
+///         &rerun::AnnotationContext::new([
 ///             (1, "red", Color::from(0xFF0000FF)),
 ///             (2, "green", Color::from(0x00FF00FF)),
 ///         ]),
@@ -50,12 +46,12 @@
 ///     // Log a batch of 2 rectangles with different class IDs
 ///     rec.log(
 ///         "detections",
-///         &Boxes2D::from_mins_and_sizes([(-2., -2.), (0., 0.)], [(3., 3.), (2., 2.)])
+///         &rerun::Boxes2D::from_mins_and_sizes([(-2., -2.), (0., 0.)], [(3., 3.), (2., 2.)])
 ///             .with_class_ids([1, 2]),
 ///     )?;
 ///
 ///     // Log an extra rect to set the view bounds
-///     rec.log("bounds", &Boxes2D::from_half_sizes([(2.5, 2.5)]))?;
+///     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(2.5, 2.5)]))?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -74,11 +70,7 @@
 /// //! Log a segmentation image with annotations.
 ///
 /// use ndarray::{s, Array, ShapeBuilder};
-/// use rerun::{
-///     archetypes::{AnnotationContext, SegmentationImage},
-///     datatypes::Color,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::{datatypes::Color, AnnotationContext, RecordingStreamBuilder, SegmentationImage};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
@@ -116,9 +108,10 @@
 /// ```ignore
 /// //! Log some very simple points.
 ///
-/// use rerun::archetypes::{AnnotationContext, Points3D};
-/// use rerun::datatypes::{ClassDescription, Color, KeypointPair};
-/// use rerun::RecordingStreamBuilder;
+/// use rerun::{
+///     datatypes::{ClassDescription, Color, KeypointPair},
+///     AnnotationContext, Points3D, RecordingStreamBuilder,
+/// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -23,30 +23,25 @@
 ///
 /// use std::f32::consts::TAU;
 ///
-/// use rerun::{
-///     components::{Color, Origin3D, Vector3D},
-///     Arrows3D, RecordingStreamBuilder,
-/// };
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_arrow3d").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").memory()?;
 ///
-///     let origins = vec![Origin3D::ZERO; 100];
+///     let origins = vec![rerun::Origin3D::ZERO; 100];
 ///     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)
 ///         .map(|i| {
 ///             let angle = TAU * i as f32 * 0.01;
 ///             let length = ((i + 1) as f32).log2();
 ///             let c = (angle / TAU * 255.0).round() as u8;
 ///             (
-///                 Vector3D::from([(length * angle.sin()), 0.0, (length * angle.cos())]),
-///                 Color::from_unmultiplied_rgba(255 - c, c, 128, 128),
+///                 rerun::Vector3D::from([(length * angle.sin()), 0.0, (length * angle.cos())]),
+///                 rerun::Color::from_unmultiplied_rgba(255 - c, c, 128, 128),
 ///             )
 ///         })
 ///         .unzip();
 ///
 ///     rec.log(
 ///         "arrows",
-///         &Arrows3D::from_vectors(vectors)
+///         &rerun::Arrows3D::from_vectors(vectors)
 ///             .with_origins(origins)
 ///             .with_colors(colors),
 ///     )?;

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -24,9 +24,8 @@
 /// use std::f32::consts::TAU;
 ///
 /// use rerun::{
-///     archetypes::Arrows3D,
 ///     components::{Color, Origin3D, Vector3D},
-///     RecordingStreamBuilder,
+///     Arrows3D, RecordingStreamBuilder,
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -46,10 +46,8 @@
 /// //! Log a simple 3D asset with an out-of-tree transform which will not affect its children.
 ///
 /// use rerun::{
-///     components::OutOfTreeTransform3D,
 ///     demo_util::grid,
 ///     external::{anyhow, glam},
-///     Asset3D, Points3D, RecordingStreamBuilder, TranslationRotationScale3D, ViewCoordinates,
 /// };
 ///
 /// fn main() -> anyhow::Result<()> {
@@ -59,27 +57,28 @@
 ///     };
 ///
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
 ///
-///     rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///
 ///     rec.set_time_sequence("frame", 0);
-///     rec.log("world/asset", &Asset3D::from_file(path)?)?;
+///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 ///     // Those points will not be affected by their parent's out-of-tree transform!
 ///     rec.log(
 ///         "world/asset/points",
-///         &Points3D::new(grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10)),
+///         &rerun::Points3D::new(grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10)),
 ///     )?;
 ///
 ///     for i in 1..20 {
 ///         rec.set_time_sequence("frame", i);
 ///
 ///         // Modify the asset's out-of-tree transform: this will not affect its children (i.e. the points)!
-///         let translation = TranslationRotationScale3D::translation([0.0, 0.0, i as f32 - 10.0]);
+///         let translation =
+///             rerun::TranslationRotationScale3D::translation([0.0, 0.0, i as f32 - 10.0]);
 ///         rec.log_component_batches(
 ///             "world/asset",
 ///             false,
-///             [&OutOfTreeTransform3D::from(translation) as _],
+///             [&rerun::OutOfTreeTransform3D::from(translation) as _],
 ///         )?;
 ///     }
 ///

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -22,11 +22,7 @@
 /// ```ignore
 /// //! Log a simple 3D asset.
 ///
-/// use rerun::{
-///     archetypes::{Asset3D, ViewCoordinates},
-///     external::anyhow,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::external::anyhow;
 ///
 /// fn main() -> anyhow::Result<()> {
 ///     let args = std::env::args().collect::<Vec<_>>();
@@ -34,10 +30,11 @@
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
 ///     };
 ///
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
 ///
-///     rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
-///     rec.log("world/asset", &Asset3D::from_file(path)?)?;
+///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -49,12 +46,10 @@
 /// //! Log a simple 3D asset with an out-of-tree transform which will not affect its children.
 ///
 /// use rerun::{
-///     archetypes::{Asset3D, Points3D, ViewCoordinates},
 ///     components::OutOfTreeTransform3D,
-///     datatypes::TranslationRotationScale3D,
 ///     demo_util::grid,
 ///     external::{anyhow, glam},
-///     RecordingStreamBuilder,
+///     Asset3D, Points3D, RecordingStreamBuilder, TranslationRotationScale3D, ViewCoordinates,
 /// };
 ///
 /// fn main() -> anyhow::Result<()> {

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -23,14 +23,12 @@
 /// ```ignore
 /// //! Create and log a bar chart
 ///
-/// use rerun::{archetypes::BarChart, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_bar_chart").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").memory()?;
 ///
 ///     rec.log(
 ///         "bar_chart",
-///         &BarChart::new(vec![8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0]),
+///         &rerun::BarChart::new(vec![8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0]),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -22,18 +22,16 @@
 /// ```ignore
 /// //! Log some very simple 2D boxes.
 ///
-/// use rerun::{archetypes::Boxes2D, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box2d").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box2d").memory()?;
 ///
 ///     rec.log(
 ///         "simple",
-///         &Boxes2D::from_mins_and_sizes([(-1., -1.)], [(2., 2.)]),
+///         &rerun::Boxes2D::from_mins_and_sizes([(-1., -1.)], [(2., 2.)]),
 ///     )?;
 ///
 ///     // Log an extra rect to set the view bounds
-///     rec.log("bounds", &Boxes2D::from_sizes([(4., 3.)]))?;
+///     rec.log("bounds", &rerun::Boxes2D::from_sizes([(4., 3.)]))?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -45,30 +45,26 @@
 /// ### Batch of 3D boxes
 /// ```ignore
 /// //! Log a batch of oriented bounding boxes.
-/// use rerun::{
-///     components::Color, Angle, Boxes3D, Quaternion, RecordingStreamBuilder, Rotation3D,
-///     RotationAxisAngle,
-/// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
 ///
 ///     rec.log(
 ///         "batch",
-///         &Boxes3D::from_centers_and_half_sizes(
+///         &rerun::Boxes3D::from_centers_and_half_sizes(
 ///             [(2.0, 0.0, 0.0), (-2.0, 0.0, 0.0), (0.0, 0.0, 2.0)],
 ///             [(2.0, 2.0, 1.0), (1.0, 1.0, 0.5), (2.0, 0.5, 1.0)],
 ///         )
 ///         .with_rotations([
-///             Rotation3D::IDENTITY,
-///             Quaternion::from_xyzw([0.0, 0.0, 0.382683, 0.923880]).into(), // 45 degrees around Z
-///             RotationAxisAngle::new((0.0, 1.0, 0.0), Angle::Degrees(30.0)).into(),
+///             rerun::Rotation3D::IDENTITY,
+///             rerun::Quaternion::from_xyzw([0.0, 0.0, 0.382683, 0.923880]).into(), // 45 degrees around Z
+///             rerun::RotationAxisAngle::new((0.0, 1.0, 0.0), rerun::Angle::Degrees(30.0)).into(),
 ///         ])
 ///         .with_radii([0.025])
 ///         .with_colors([
-///             Color::from_rgb(255, 0, 0),
-///             Color::from_rgb(0, 255, 0),
-///             Color::from_rgb(0, 0, 255),
+///             rerun::Color::from_rgb(255, 0, 0),
+///             rerun::Color::from_rgb(0, 255, 0),
+///             rerun::Color::from_rgb(0, 0, 255),
 ///         ])
 ///         .with_labels(["red", "green", "blue"]),
 ///     )?;

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -21,13 +21,14 @@
 /// ### Simple 3D boxes
 /// ```ignore
 /// //! Log a single 3D box.
-/// use rerun::archetypes::Boxes3D;
-/// use rerun::RecordingStreamBuilder;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
 ///
-///     rec.log("simple", &Boxes3D::from_half_sizes([(2.0, 2.0, 1.0)]))?;
+///     rec.log(
+///         "simple",
+///         &rerun::Boxes3D::from_half_sizes([(2.0, 2.0, 1.0)]),
+///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -45,10 +46,8 @@
 /// ```ignore
 /// //! Log a batch of oriented bounding boxes.
 /// use rerun::{
-///     archetypes::Boxes3D,
-///     components::Color,
-///     datatypes::{Angle, Quaternion, Rotation3D, RotationAxisAngle},
-///     RecordingStreamBuilder,
+///     components::Color, Angle, Boxes3D, Quaternion, RecordingStreamBuilder, Rotation3D,
+///     RotationAxisAngle,
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -47,7 +47,8 @@
 /// //! Log a batch of oriented bounding boxes.
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
 ///
 ///     rec.log(
 ///         "batch",

--- a/crates/re_types/src/archetypes/clear.rs
+++ b/crates/re_types/src/archetypes/clear.rs
@@ -22,15 +22,11 @@
 /// ```ignore
 /// //! Log a batch of 3D arrows.
 ///
-/// use rerun::{
-///     archetypes::{Arrows3D, Clear},
-///     components::Color,
-///     external::glam,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_clear_simple").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").memory()?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (
@@ -43,15 +39,15 @@
 ///     for (i, ((vector, origin), color)) in vectors.into_iter().zip(origins).zip(colors).enumerate() {
 ///         rec.log(
 ///             format!("arrows/{i}"),
-///             &Arrows3D::from_vectors([vector])
+///             &rerun::Arrows3D::from_vectors([vector])
 ///                 .with_origins([origin])
-///                 .with_colors([Color::from_rgb(color.0, color.1, color.2)]),
+///                 .with_colors([rerun::Color::from_rgb(color.0, color.1, color.2)]),
 ///         )?;
 ///     }
 ///
 ///     // Now clear them, one by one on each tick.
 ///     for i in 0..vectors.len() {
-///         rec.log(format!("arrows/{i}"), &Clear::flat())?;
+///         rec.log(format!("arrows/{i}"), &rerun::Clear::flat())?;
 ///     }
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -63,15 +59,11 @@
 /// ```ignore
 /// //! Log a batch of 3D arrows.
 ///
-/// use rerun::{
-///     archetypes::{Arrows3D, Clear},
-///     components::Color,
-///     external::glam,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_clear_recursive").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").memory()?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (
@@ -84,14 +76,14 @@
 ///     for (i, ((vector, origin), color)) in vectors.into_iter().zip(origins).zip(colors).enumerate() {
 ///         rec.log(
 ///             format!("arrows/{i}"),
-///             &Arrows3D::from_vectors([vector])
+///             &rerun::Arrows3D::from_vectors([vector])
 ///                 .with_origins([origin])
-///                 .with_colors([Color::from_rgb(color.0, color.1, color.2)]),
+///                 .with_colors([rerun::Color::from_rgb(color.0, color.1, color.2)]),
 ///         )?;
 ///     }
 ///
 ///     // Now clear all of them at once.
-///     rec.log("arrows", &Clear::recursive())?;
+///     rec.log("arrows", &rerun::Clear::recursive())?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -26,16 +26,16 @@
 /// //! Create and log a depth image.
 ///
 /// use ndarray::{s, Array, ShapeBuilder};
-/// use rerun::{archetypes::DepthImage, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
 ///
 ///     let mut image = Array::<u16, _>::from_elem((8, 12).f(), 65535);
 ///     image.slice_mut(s![0..4, 0..6]).fill(20000);
 ///     image.slice_mut(s![4..8, 6..12]).fill(45000);
 ///
-///     let depth_image = DepthImage::try_from(image)?.with_meter(10_000.0);
+///     let depth_image = rerun::DepthImage::try_from(image)?.with_meter(10_000.0);
 ///
 ///     rec.log("depth", &depth_image)?;
 ///
@@ -55,25 +55,22 @@
 /// ```ignore
 /// //! Create and log a depth image.
 /// use ndarray::{s, Array, ShapeBuilder};
-/// use rerun::{
-///     archetypes::{DepthImage, Pinhole},
-///     RecordingStreamBuilder,
-/// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
 ///
 ///     // Create a dummy depth image
 ///     let mut image = Array::<u16, _>::from_elem((8, 12).f(), 65535);
 ///     image.slice_mut(s![0..4, 0..6]).fill(20000);
 ///     image.slice_mut(s![4..8, 6..12]).fill(45000);
 ///
-///     let depth_image = DepthImage::try_from(image.clone())?.with_meter(10000.0);
+///     let depth_image = rerun::DepthImage::try_from(image.clone())?.with_meter(10000.0);
 ///
 ///     // If we log a pinhole camera model, the depth gets automatically back-projected to 3D
 ///     rec.log(
 ///         "world/camera",
-///         &Pinhole::from_focal_length_and_resolution(
+///         &rerun::Pinhole::from_focal_length_and_resolution(
 ///             [20.0, 20.0],
 ///             [image.shape()[1] as f32, image.shape()[0] as f32],
 ///         ),

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -26,19 +26,26 @@
 /// ```ignore
 /// //! Disconnect two spaces.
 ///
-/// use rerun::{DisconnectedSpace, Points3D, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_disconnected_space").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").memory()?;
 ///
 ///     // These two points can be projected into the same space..
-///     rec.log("world/room1/point", &Points3D::new([(0.0, 0.0, 0.0)]))?;
-///     rec.log("world/room2/point", &Points3D::new([(1.0, 1.0, 1.0)]))?;
+///     rec.log(
+///         "world/room1/point",
+///         &rerun::Points3D::new([(0.0, 0.0, 0.0)]),
+///     )?;
+///     rec.log(
+///         "world/room2/point",
+///         &rerun::Points3D::new([(1.0, 1.0, 1.0)]),
+///     )?;
 ///
 ///     // ..but this one lives in a completely separate space!
-///     rec.log("world/wormhole", &DisconnectedSpace::new(true))?;
-///     rec.log("world/wormhole/point", &Points3D::new([(2.0, 2.0, 2.0)]))?;
+///     rec.log("world/wormhole", &rerun::DisconnectedSpace::new(true))?;
+///     rec.log(
+///         "world/wormhole/point",
+///         &rerun::Points3D::new([(2.0, 2.0, 2.0)]),
+///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -26,10 +26,7 @@
 /// ```ignore
 /// //! Disconnect two spaces.
 ///
-/// use rerun::{
-///     archetypes::{DisconnectedSpace, Points3D},
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::{DisconnectedSpace, Points3D, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -30,17 +30,17 @@
 /// //! Create and log an image
 ///
 /// use ndarray::{s, Array, ShapeBuilder};
-/// use rerun::{archetypes::Image, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_image_simple").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_image_simple").memory()?;
 ///
 ///     let mut image = Array::<u8, _>::zeros((8, 12, 3).f());
 ///     image.slice_mut(s![.., .., 0]).fill(255);
 ///     image.slice_mut(s![0..4, 0..6, 0]).fill(0);
 ///     image.slice_mut(s![0..4, 0..6, 1]).fill(255);
 ///
-///     rec.log("image", &Image::try_from(image)?)?;
+///     rec.log("image", &rerun::Image::try_from(image)?)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -21,21 +21,17 @@
 /// ```ignore
 /// //! Log a simple line strip.
 ///
-/// use rerun::{
-///     archetypes::{Boxes2D, LineStrips2D},
-///     RecordingStreamBuilder,
-/// };
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
 ///
 ///     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
-///     rec.log("strip", &LineStrips2D::new([points]))?;
+///     rec.log("strip", &rerun::LineStrips2D::new([points]))?;
 ///
 ///     // Log an extra rect to set the view bounds
 ///     rec.log(
 ///         "bounds",
-///         &Boxes2D::from_centers_and_sizes([(3., 0.)], [(8., 6.)]),
+///         &rerun::Boxes2D::from_centers_and_sizes([(3., 0.)], [(8., 6.)]),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -53,21 +49,17 @@
 /// ```ignore
 /// //! Log a couple 2D line segments using 2D line strips.
 ///
-/// use rerun::{
-///     archetypes::{Boxes2D, LineStrips2D},
-///     RecordingStreamBuilder,
-/// };
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_segments2d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").memory()?;
 ///
 ///     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
-///     rec.log("segments", &LineStrips2D::new(points.chunks(2)))?;
+///     rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;
 ///
 ///     // Log an extra rect to set the view bounds
 ///     rec.log(
 ///         "bounds",
-///         &Boxes2D::from_centers_and_sizes([(3.0, 0.0)], [(8.0, 6.0)]),
+///         &rerun::Boxes2D::from_centers_and_sizes([(3.0, 0.0)], [(8.0, 6.0)]),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -85,20 +77,16 @@
 /// ```ignore
 /// //! Log a batch of 2d line strips.
 ///
-/// use rerun::{
-///     archetypes::{Boxes2D, LineStrips2D},
-///     RecordingStreamBuilder,
-/// };
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
 ///
 ///     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 ///     #[rustfmt::skip]
 ///     let strip2 = [[0., 3.], [1., 4.], [2., 2.], [3., 4.], [4., 2.], [5., 4.], [6., 3.]];
 ///     rec.log(
 ///         "strips",
-///         &LineStrips2D::new([strip1.to_vec(), strip2.to_vec()])
+///         &rerun::LineStrips2D::new([strip1.to_vec(), strip2.to_vec()])
 ///             .with_colors([0xFF0000FF, 0x00FF00FF])
 ///             .with_radii([0.025, 0.005])
 ///             .with_labels(["one strip here", "and one strip there"]),
@@ -107,7 +95,7 @@
 ///     // Log an extra rect to set the view bounds
 ///     rec.log(
 ///         "bounds",
-///         &Boxes2D::from_centers_and_sizes([(3.0, 1.5)], [(8.0, 9.0)]),
+///         &rerun::Boxes2D::from_centers_and_sizes([(3.0, 1.5)], [(8.0, 9.0)]),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -22,10 +22,9 @@
 /// ```ignore
 /// //! Log a simple line strip.
 ///
-/// use rerun::{archetypes::LineStrips3D, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
 ///
 ///     let points = [
 ///         [0., 0., 0.],
@@ -37,7 +36,7 @@
 ///         [0., 1., 0.],
 ///         [0., 1., 1.],
 ///     ];
-///     rec.log("strip", &LineStrips3D::new([points]))?;
+///     rec.log("strip", &rerun::LineStrips3D::new([points]))?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -55,10 +54,9 @@
 /// ```ignore
 /// //! Log a simple set of line segments.
 ///
-/// use rerun::{archetypes::LineStrips3D, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_segments3d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").memory()?;
 ///
 ///     let points = [
 ///         [0., 0., 0.],
@@ -70,7 +68,7 @@
 ///         [0., 1., 0.],
 ///         [0., 1., 1.],
 ///     ];
-///     rec.log("segments", &LineStrips3D::new(points.chunks(2)))?;
+///     rec.log("segments", &rerun::LineStrips3D::new(points.chunks(2)))?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -88,10 +86,9 @@
 /// ```ignore
 /// //! Log a batch of 2d line strips.
 ///
-/// use rerun::{archetypes::LineStrips3D, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
 ///
 ///     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
 ///     let strip2 = [
@@ -106,7 +103,7 @@
 ///     ];
 ///     rec.log(
 ///         "strips",
-///         &LineStrips3D::new([strip1.to_vec(), strip2.to_vec()])
+///         &rerun::LineStrips3D::new([strip1.to_vec(), strip2.to_vec()])
 ///             .with_colors([0xFF0000FF, 0x00FF00FF])
 ///             .with_radii([0.025, 0.005])
 ///             .with_labels(["one strip here", "and one strip there"]),

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -23,9 +23,8 @@
 /// //! Log a simple colored triangle with indexed drawing.
 ///
 /// use rerun::{
-///     archetypes::Mesh3D,
 ///     components::{Material, MeshProperties},
-///     RecordingStreamBuilder,
+///     Mesh3D, RecordingStreamBuilder,
 /// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -49,7 +48,7 @@
 /// ```ignore
 /// //! Log a simple colored triangle, then update its vertices' positions each frame.
 ///
-/// use rerun::{archetypes::Mesh3D, components::Position3D, external::glam, RecordingStreamBuilder};
+/// use rerun::{components::Position3D, external::glam, Mesh3D, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -22,21 +22,17 @@
 /// ```ignore
 /// //! Log a simple colored triangle with indexed drawing.
 ///
-/// use rerun::{
-///     components::{Material, MeshProperties},
-///     Mesh3D, RecordingStreamBuilder,
-/// };
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").memory()?;
 ///
 ///     rec.log(
 ///         "triangle",
-///         &Mesh3D::new([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+///         &rerun::Mesh3D::new([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 ///             .with_vertex_normals([[0.0, 0.0, 1.0]])
 ///             .with_vertex_colors([0x0000FFFF, 0x00FF00FF, 0xFF0000FF])
-///             .with_mesh_properties(MeshProperties::from_triangle_indices([[2, 1, 0]]))
-///             .with_mesh_material(Material::from_albedo_factor(0xCC00CCFF)),
+///             .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
+///             .with_mesh_material(rerun::Material::from_albedo_factor(0xCC00CCFF)),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -48,11 +44,11 @@
 /// ```ignore
 /// //! Log a simple colored triangle, then update its vertices' positions each frame.
 ///
-/// use rerun::{components::Position3D, external::glam, Mesh3D, RecordingStreamBuilder};
+/// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").memory()?;
 ///
 ///     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 ///
@@ -60,7 +56,7 @@
 ///     rec.set_time_sequence("frame", 0);
 ///     rec.log(
 ///         "triangle",
-///         &Mesh3D::new(vertex_positions)
+///         &rerun::Mesh3D::new(vertex_positions)
 ///             .with_vertex_normals([[0.0, 0.0, 1.0]])
 ///             .with_vertex_colors([0xFF0000FF, 0x00FF00FF, 0x0000FFFF]),
 ///     )?;
@@ -70,7 +66,7 @@
 ///         rec.set_time_sequence("frame", i);
 ///
 ///         let factor = (i as f32 * 0.04).sin().abs();
-///         let vertex_positions: [Position3D; 3] = [
+///         let vertex_positions: [rerun::Position3D; 3] = [
 ///             (glam::Vec3::from(vertex_positions[0]) * factor).into(),
 ///             (glam::Vec3::from(vertex_positions[1]) * factor).into(),
 ///             (glam::Vec3::from(vertex_positions[2]) * factor).into(),

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -22,22 +22,18 @@
 /// //! Log a pinhole and a random image.
 ///
 /// use ndarray::{Array, ShapeBuilder};
-/// use rerun::{
-///     archetypes::{Image, Pinhole},
-///     RecordingStreamBuilder,
-/// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_pinhole").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").memory()?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
 ///     image.map_inplace(|x| *x = rand::random());
 ///
 ///     rec.log(
 ///         "world/image",
-///         &Pinhole::from_focal_length_and_resolution([3., 3.], [3., 3.]),
+///         &rerun::Pinhole::from_focal_length_and_resolution([3., 3.], [3., 3.]),
 ///     )?;
-///     rec.log("world/image", &Image::try_from(image)?)?;
+///     rec.log("world/image", &rerun::Image::try_from(image)?)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -45,23 +45,22 @@
 /// //! Log some random points with color and radii.
 ///
 /// use rand::{distributions::Uniform, Rng as _};
-/// use rerun::{Boxes2D, Color, Points2D, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-3., 3.);
 ///
 ///     rec.log(
 ///         "random",
-///         &Points2D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist))))
-///             .with_colors((0..10).map(|_| Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
+///         &rerun::Points2D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist))))
+///             .with_colors((0..10).map(|_| rerun::Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
 ///             .with_radii((0..10).map(|_| rng.gen::<f32>())),
 ///     )?;
 ///
 ///     // Log an extra rect to set the view bounds
-///     rec.log("bounds", &Boxes2D::from_half_sizes([(4., 3.)]))?;
+///     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(4., 3.)]))?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -21,18 +21,13 @@
 /// ```ignore
 /// //! Log some very simple points.
 ///
-/// use rerun::{
-///     archetypes::{Boxes2D, Points2D},
-///     RecordingStreamBuilder,
-/// };
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
 ///
-///     rec.log("points", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
+///     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 ///
 ///     // Log an extra rect to set the view bounds
-///     rec.log("bounds", &Boxes2D::from_half_sizes([(2.0, 1.5)]))?;
+///     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(2.0, 1.5)]))?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -50,11 +45,7 @@
 /// //! Log some random points with color and radii.
 ///
 /// use rand::{distributions::Uniform, Rng as _};
-/// use rerun::{
-///     archetypes::{Boxes2D, Points2D},
-///     components::Color,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::{Boxes2D, Color, Points2D, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points2d").memory()?;

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -21,12 +21,14 @@
 /// ```ignore
 /// //! Log some very simple points.
 ///
-/// use rerun::{archetypes::Points3D, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points3d_simple").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").memory()?;
 ///
-///     rec.log("points", &Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]))?;
+///     rec.log(
+///         "points",
+///         &rerun::Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]),
+///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
@@ -44,7 +46,7 @@
 /// //! Log some random points with color and radii.
 ///
 /// use rand::{distributions::Uniform, Rng as _};
-/// use rerun::{archetypes::Points3D, components::Color, RecordingStreamBuilder};
+/// use rerun::{Color, Points3D, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -46,19 +46,21 @@
 /// //! Log some random points with color and radii.
 ///
 /// use rand::{distributions::Uniform, Rng as _};
-/// use rerun::{Color, Points3D, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-5., 5.);
 ///
 ///     rec.log(
 ///         "random",
-///         &Points3D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist), rng.sample(dist))))
-///             .with_colors((0..10).map(|_| Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
-///             .with_radii((0..10).map(|_| rng.gen::<f32>())),
+///         &rerun::Points3D::new(
+///             (0..10).map(|_| (rng.sample(dist), rng.sample(dist), rng.sample(dist))),
+///         )
+///         .with_colors((0..10).map(|_| rerun::Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
+///         .with_radii((0..10).map(|_| rng.gen::<f32>())),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -28,15 +28,11 @@
 /// //! Create and log a segmentation image.
 ///
 /// use ndarray::{s, Array, ShapeBuilder};
-/// use rerun::{
-///     archetypes::{AnnotationContext, SegmentationImage},
-///     datatypes::Color,
-///     RecordingStreamBuilder,
-/// };
+/// use rerun::datatypes::Color;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_segmentation_image").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").memory()?;
 ///
 ///     // create a segmentation image
 ///     let mut image = Array::<u8, _>::zeros((8, 12).f());
@@ -44,7 +40,7 @@
 ///     image.slice_mut(s![4..8, 6..12]).fill(2);
 ///
 ///     // create an annotation context to describe the classes
-///     let annotation = AnnotationContext::new([
+///     let annotation = rerun::AnnotationContext::new([
 ///         (1, "red", Color::from(0xFF0000FF)),
 ///         (2, "green", Color::from(0x00FF00FF)),
 ///     ]);
@@ -52,7 +48,7 @@
 ///     // log the annotation and the image
 ///     rec.log("/", &annotation)?;
 ///
-///     rec.log("image", &SegmentationImage::try_from(image)?)?;
+///     rec.log("image", &rerun::SegmentationImage::try_from(image)?)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -22,15 +22,15 @@
 /// //! Create and log a tensor.
 ///
 /// use ndarray::{Array, ShapeBuilder};
-/// use rerun::{archetypes::Tensor, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_tensor_simple").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").memory()?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
 ///     data.map_inplace(|x| *x = rand::random());
 ///
-///     let tensor = Tensor::try_from(data)?.with_names(["batch", "channel", "height", "width"]);
+///     let tensor = rerun::Tensor::try_from(data)?.with_names(["batch", "channel", "height", "width"]);
 ///     rec.log("tensor", &tensor)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -51,17 +51,16 @@
 /// use ndarray::{Array, ShapeBuilder};
 /// use rand::{thread_rng, Rng};
 /// use rand_distr::StandardNormal;
-/// use rerun::{archetypes::Tensor, RecordingStreamBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_tensors").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_tensors").memory()?;
 ///
 ///     let mut data = Array::<f64, _>::default((100).f());
 ///     data.map_inplace(|x| *x = thread_rng().sample(StandardNormal));
 ///
 ///     rec.log(
 ///         "tensor",
-///         &Tensor::try_from(data.as_standard_layout().view())?,
+///         &rerun::Tensor::try_from(data.as_standard_layout().view())?,
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -21,16 +21,17 @@
 /// ```ignore
 /// //! Shows integration of Rerun's `TextLog` with the native logging interface.
 ///
-/// use rerun::{archetypes::TextLog, components::TextLogLevel, external::log, RecordingStreamBuilder};
+/// use rerun::external::log;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_text_log_integration").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").memory()?;
 ///
 ///     // Log a text entry directly:
 ///     rec.log(
 ///         "logs",
-///         &TextLog::new("this entry has loglevel TRACE").with_level(TextLogLevel::TRACE),
+///         &rerun::TextLog::new("this entry has loglevel TRACE")
+///             .with_level(rerun::TextLogLevel::TRACE),
 ///     )?;
 ///
 ///     // Or log via a logging handler:

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -43,11 +43,9 @@
 /// ```ignore
 /// //! Log a scalar over time.
 ///
-/// use rerun::{RecordingStreamBuilder, TimeSeriesScalar};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =
-///         RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").memory()?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").memory()?;
 ///     let mut lcg_state = 0_i64;
 ///
 ///     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
@@ -56,13 +54,13 @@
 ///         // Log two time series under a shared root so that they show in the same plot by default.
 ///         rec.log(
 ///             "trig/sin",
-///             &TimeSeriesScalar::new((t as f64 / 100.0).sin())
+///             &rerun::TimeSeriesScalar::new((t as f64 / 100.0).sin())
 ///                 .with_label("sin(0.01t)")
 ///                 .with_color([255, 0, 0]),
 ///         )?;
 ///         rec.log(
 ///             "trig/cos",
-///             &TimeSeriesScalar::new((t as f64 / 100.0).cos())
+///             &rerun::TimeSeriesScalar::new((t as f64 / 100.0).cos())
 ///                 .with_label("cos(0.01t)")
 ///                 .with_color([0, 255, 0]),
 ///         )?;
@@ -74,7 +72,7 @@
 ///             % 16777216; // simple linear congruency generator
 ///         rec.log(
 ///             "scatter/lcg",
-///             &TimeSeriesScalar::new(lcg_state as f64).with_scattered(true),
+///             &rerun::TimeSeriesScalar::new(lcg_state as f64).with_scattered(true),
 ///         )?;
 ///     }
 ///

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -24,14 +24,15 @@
 /// ```ignore
 /// //! Log a scalar over time.
 ///
-/// use rerun::{archetypes::TimeSeriesScalar, RecordingStreamBuilder};
-///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_scalar").memory()?;
+///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_scalar").memory()?;
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log("scalar", &TimeSeriesScalar::new((step as f64 / 10.0).sin()))?;
+///         rec.log(
+///             "scalar",
+///             &rerun::TimeSeriesScalar::new((step as f64 / 10.0).sin()),
+///         )?;
 ///     }
 ///
 ///     rerun::native_viewer::show(storage.take())?;
@@ -42,7 +43,7 @@
 /// ```ignore
 /// //! Log a scalar over time.
 ///
-/// use rerun::{archetypes::TimeSeriesScalar, RecordingStreamBuilder};
+/// use rerun::{RecordingStreamBuilder, TimeSeriesScalar};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) =

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -22,11 +22,10 @@
 /// //! Log some transforms.
 ///
 /// use rerun::{
-///     archetypes::{Arrows3D, Transform3D},
-///     datatypes::{Angle, RotationAxisAngle, Scale3D, TranslationRotationScale3D},
-///     RecordingStreamBuilder,
+///     archetypes::Transform3D, Angle, Arrows3D, RecordingStreamBuilder, RotationAxisAngle, Scale3D,
+///     TranslationRotationScale3D,
 /// };
-/// use std::f32::consts::PI;
+/// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
@@ -49,7 +48,9 @@
 ///     rec.log(
 ///         "base/rotated_scaled",
 ///         &Transform3D::new(TranslationRotationScale3D {
-///             rotation: Some(RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(PI / 4.)).into()),
+///             rotation: Some(
+///                 RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(TAU / 8.0)).into(),
+///             ),
 ///             scale: Some(Scale3D::from(2.0)),
 ///             ..Default::default()
 ///         }),

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -21,44 +21,44 @@
 /// ```ignore
 /// //! Log some transforms.
 ///
-/// use rerun::{
-///     archetypes::Transform3D, Angle, Arrows3D, RecordingStreamBuilder, RotationAxisAngle, Scale3D,
-///     TranslationRotationScale3D,
-/// };
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
 ///
 ///     rec.log(
 ///         "base",
-///         &Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
+///         &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
 ///     )?;
 ///
 ///     rec.log(
 ///         "base/translated",
-///         &Transform3D::new(TranslationRotationScale3D::translation([1.0, 0.0, 0.0])),
+///         &rerun::Transform3D::new(rerun::TranslationRotationScale3D::translation([
+///             1.0, 0.0, 0.0,
+///         ])),
 ///     )?;
 ///
 ///     rec.log(
 ///         "base/translated",
-///         &Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
+///         &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
 ///     )?;
 ///
 ///     rec.log(
 ///         "base/rotated_scaled",
-///         &Transform3D::new(TranslationRotationScale3D {
+///         &rerun::Transform3D::new(rerun::TranslationRotationScale3D {
 ///             rotation: Some(
-///                 RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(TAU / 8.0)).into(),
+///                 rerun::RotationAxisAngle::new([0.0, 0.0, 1.0], rerun::Angle::Radians(TAU / 8.0))
+///                     .into(),
 ///             ),
-///             scale: Some(Scale3D::from(2.0)),
+///             scale: Some(rerun::Scale3D::from(2.0)),
 ///             ..Default::default()
 ///         }),
 ///     )?;
 ///
 ///     rec.log(
 ///         "base/rotated_scaled",
-///         &Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
+///         &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -27,18 +27,15 @@
 ///
 /// ```ignore
 /// //! Change the view coordinates for the scene.
-/// use rerun::{
-///     archetypes::{Arrows3D, ViewCoordinates},
-///     RecordingStreamBuilder,
-/// };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
+///     let (rec, storage) =
+///         rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
 ///
-///     rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(
 ///         "world/xyz",
-///         &Arrows3D::from_vectors(
+///         &rerun::Arrows3D::from_vectors(
 ///             [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], //
 ///         )
 ///         .with_colors([[255, 0, 0], [0, 255, 0], [0, 0, 255]]),

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -172,7 +172,7 @@
 //! Then the url you should use is `https://static.rerun.io/my_screenshot/9066060e59ee9d2d7d98b214b8db0b8f2e8ab4b8/1024w.png`.
 //!
 //! It works this way because `upload_image.py` does not upscale screenshots, it only downscales them.
-//! We need to know what the maximum width we can use is, becuase we can't just provide all the widths all the time.
+//! We need to know what the maximum width we can use is, because we can't just provide all the widths all the time.
 //! If the currently-used `max-width` source fails to load, it will show the blank image icon.
 //! There is no way to provide a fallback in `<picture>` if a specific `max-width` source fails to load.
 //! Browsers will not automatically try to load the other sources!

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -1,8 +1,9 @@
 //! Log some very simple points.
 
-use rerun::archetypes::{AnnotationContext, Points3D};
-use rerun::datatypes::{ClassDescription, Color, KeypointPair};
-use rerun::RecordingStreamBuilder;
+use rerun::{
+    datatypes::{ClassDescription, Color, KeypointPair},
+    AnnotationContext, Points3D, RecordingStreamBuilder,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -1,20 +1,18 @@
 //! Log some very simple points.
 
-use rerun::{
-    datatypes::{ClassDescription, Color, KeypointPair},
-    AnnotationContext, Points3D, RecordingStreamBuilder,
-};
+use rerun::datatypes::Color;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_annotation_context_connections").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
+            .memory()?;
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some
     // connections between keypoints.
     rec.log(
         "/",
-        &AnnotationContext::new([ClassDescription {
+        &rerun::AnnotationContext::new([rerun::ClassDescription {
             info: 0.into(),
             keypoint_annotations: vec![
                 (0, "zero", Color::from(0xFF0000FF)).into(),
@@ -22,14 +20,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 (2, "two", Color::from(0x0000FFFF)).into(),
                 (3, "three", Color::from(0xFFFF00FF)).into(),
             ],
-            keypoint_connections: KeypointPair::vec_from([(0, 2), (1, 2), (2, 3)]),
+            keypoint_connections: rerun::KeypointPair::vec_from([(0, 2), (1, 2), (2, 3)]),
         }]),
     )?;
 
     // Log some points with different keypoint IDs
     rec.log(
         "points",
-        &Points3D::new([
+        &rerun::Points3D::new([
             [0., 0., 0.],
             [50., 0., 20.],
             [100., 100., 30.],

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -1,19 +1,15 @@
 //! Log rectangles with different colors and labels using annotation context
 
-use rerun::{
-    archetypes::{AnnotationContext, Boxes2D},
-    datatypes::Color,
-    RecordingStreamBuilder,
-};
+use rerun::datatypes::Color;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_annotation_context_rects").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").memory()?;
 
     // Log an annotation context to assign a label and color to each class
     rec.log(
         "/",
-        &AnnotationContext::new([
+        &rerun::AnnotationContext::new([
             (1, "red", Color::from(0xFF0000FF)),
             (2, "green", Color::from(0x00FF00FF)),
         ]),
@@ -22,12 +18,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log a batch of 2 rectangles with different class IDs
     rec.log(
         "detections",
-        &Boxes2D::from_mins_and_sizes([(-2., -2.), (0., 0.)], [(3., 3.), (2., 2.)])
+        &rerun::Boxes2D::from_mins_and_sizes([(-2., -2.), (0., 0.)], [(3., 3.), (2., 2.)])
             .with_class_ids([1, 2]),
     )?;
 
     // Log an extra rect to set the view bounds
-    rec.log("bounds", &Boxes2D::from_half_sizes([(2.5, 2.5)]))?;
+    rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(2.5, 2.5)]))?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -1,11 +1,7 @@
 //! Log a segmentation image with annotations.
 
 use ndarray::{s, Array, ShapeBuilder};
-use rerun::{
-    archetypes::{AnnotationContext, SegmentationImage},
-    datatypes::Color,
-    RecordingStreamBuilder,
-};
+use rerun::{datatypes::Color, AnnotationContext, RecordingStreamBuilder, SegmentationImage};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -1,18 +1,18 @@
 //! Log a segmentation image with annotations.
 
 use ndarray::{s, Array, ShapeBuilder};
-use rerun::{datatypes::Color, AnnotationContext, RecordingStreamBuilder, SegmentationImage};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
+            .memory()?;
 
     // create an annotation context to describe the classes
     rec.log(
         "segmentation",
-        &AnnotationContext::new([
-            (1, "red", Color::from(0xFF0000FF)),
-            (2, "green", Color::from(0x00FF00FF)),
+        &rerun::AnnotationContext::new([
+            (1, "red", rerun::datatypes::Color::from(0xFF0000FF)),
+            (2, "green", rerun::datatypes::Color::from(0x00FF00FF)),
         ]),
     )?;
 
@@ -21,7 +21,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     data.slice_mut(s![0..4, 0..6]).fill(1);
     data.slice_mut(s![4..8, 6..12]).fill(2);
 
-    rec.log("segmentation/image", &SegmentationImage::try_from(data)?)?;
+    rec.log(
+        "segmentation/image",
+        &rerun::SegmentationImage::try_from(data)?,
+    )?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -2,30 +2,25 @@
 
 use std::f32::consts::TAU;
 
-use rerun::{
-    components::{Color, Origin3D, Vector3D},
-    Arrows3D, RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_arrow3d").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").memory()?;
 
-    let origins = vec![Origin3D::ZERO; 100];
+    let origins = vec![rerun::Origin3D::ZERO; 100];
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)
         .map(|i| {
             let angle = TAU * i as f32 * 0.01;
             let length = ((i + 1) as f32).log2();
             let c = (angle / TAU * 255.0).round() as u8;
             (
-                Vector3D::from([(length * angle.sin()), 0.0, (length * angle.cos())]),
-                Color::from_unmultiplied_rgba(255 - c, c, 128, 128),
+                rerun::Vector3D::from([(length * angle.sin()), 0.0, (length * angle.cos())]),
+                rerun::Color::from_unmultiplied_rgba(255 - c, c, 128, 128),
             )
         })
         .unzip();
 
     rec.log(
         "arrows",
-        &Arrows3D::from_vectors(vectors)
+        &rerun::Arrows3D::from_vectors(vectors)
             .with_origins(origins)
             .with_colors(colors),
     )?;

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -3,9 +3,8 @@
 use std::f32::consts::TAU;
 
 use rerun::{
-    archetypes::Arrows3D,
     components::{Color, Origin3D, Vector3D},
-    RecordingStreamBuilder,
+    Arrows3D, RecordingStreamBuilder,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -1,10 +1,8 @@
 //! Log a simple 3D asset with an out-of-tree transform which will not affect its children.
 
 use rerun::{
-    components::OutOfTreeTransform3D,
     demo_util::grid,
     external::{anyhow, glam},
-    Asset3D, Points3D, RecordingStreamBuilder, TranslationRotationScale3D, ViewCoordinates,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -14,27 +12,28 @@ fn main() -> anyhow::Result<()> {
     };
 
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
 
-    rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 
     rec.set_time_sequence("frame", 0);
-    rec.log("world/asset", &Asset3D::from_file(path)?)?;
+    rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
     // Those points will not be affected by their parent's out-of-tree transform!
     rec.log(
         "world/asset/points",
-        &Points3D::new(grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10)),
+        &rerun::Points3D::new(grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10)),
     )?;
 
     for i in 1..20 {
         rec.set_time_sequence("frame", i);
 
         // Modify the asset's out-of-tree transform: this will not affect its children (i.e. the points)!
-        let translation = TranslationRotationScale3D::translation([0.0, 0.0, i as f32 - 10.0]);
+        let translation =
+            rerun::TranslationRotationScale3D::translation([0.0, 0.0, i as f32 - 10.0]);
         rec.log_component_batches(
             "world/asset",
             false,
-            [&OutOfTreeTransform3D::from(translation) as _],
+            [&rerun::OutOfTreeTransform3D::from(translation) as _],
         )?;
     }
 

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -1,12 +1,10 @@
 //! Log a simple 3D asset with an out-of-tree transform which will not affect its children.
 
 use rerun::{
-    archetypes::{Asset3D, Points3D, ViewCoordinates},
     components::OutOfTreeTransform3D,
-    datatypes::TranslationRotationScale3D,
     demo_util::grid,
     external::{anyhow, glam},
-    RecordingStreamBuilder,
+    Asset3D, Points3D, RecordingStreamBuilder, TranslationRotationScale3D, ViewCoordinates,
 };
 
 fn main() -> anyhow::Result<()> {

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -1,10 +1,6 @@
 //! Log a simple 3D asset.
 
-use rerun::{
-    archetypes::{Asset3D, ViewCoordinates},
-    external::anyhow,
-    RecordingStreamBuilder,
-};
+use rerun::external::anyhow;
 
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
@@ -12,10 +8,11 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
     };
 
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
 
-    rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
-    rec.log("world/asset", &Asset3D::from_file(path)?)?;
+    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -1,13 +1,11 @@
 //! Create and log a bar chart
 
-use rerun::{archetypes::BarChart, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_bar_chart").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").memory()?;
 
     rec.log(
         "bar_chart",
-        &BarChart::new(vec![8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0]),
+        &rerun::BarChart::new(vec![8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0]),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/box2d_simple.rs
+++ b/docs/code-examples/box2d_simple.rs
@@ -1,17 +1,15 @@
 //! Log some very simple 2D boxes.
 
-use rerun::{archetypes::Boxes2D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box2d").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box2d").memory()?;
 
     rec.log(
         "simple",
-        &Boxes2D::from_mins_and_sizes([(-1., -1.)], [(2., 2.)]),
+        &rerun::Boxes2D::from_mins_and_sizes([(-1., -1.)], [(2., 2.)]),
     )?;
 
     // Log an extra rect to set the view bounds
-    rec.log("bounds", &Boxes2D::from_sizes([(4., 3.)]))?;
+    rec.log("bounds", &rerun::Boxes2D::from_sizes([(4., 3.)]))?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,9 +1,7 @@
 //! Log a batch of oriented bounding boxes.
 use rerun::{
-    archetypes::Boxes3D,
-    components::Color,
-    datatypes::{Angle, Quaternion, Rotation3D, RotationAxisAngle},
-    RecordingStreamBuilder,
+    components::Color, Angle, Boxes3D, Quaternion, RecordingStreamBuilder, Rotation3D,
+    RotationAxisAngle,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,28 +1,24 @@
 //! Log a batch of oriented bounding boxes.
-use rerun::{
-    components::Color, Angle, Boxes3D, Quaternion, RecordingStreamBuilder, Rotation3D,
-    RotationAxisAngle,
-};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
 
     rec.log(
         "batch",
-        &Boxes3D::from_centers_and_half_sizes(
+        &rerun::Boxes3D::from_centers_and_half_sizes(
             [(2.0, 0.0, 0.0), (-2.0, 0.0, 0.0), (0.0, 0.0, 2.0)],
             [(2.0, 2.0, 1.0), (1.0, 1.0, 0.5), (2.0, 0.5, 1.0)],
         )
         .with_rotations([
-            Rotation3D::IDENTITY,
-            Quaternion::from_xyzw([0.0, 0.0, 0.382683, 0.923880]).into(), // 45 degrees around Z
-            RotationAxisAngle::new((0.0, 1.0, 0.0), Angle::Degrees(30.0)).into(),
+            rerun::Rotation3D::IDENTITY,
+            rerun::Quaternion::from_xyzw([0.0, 0.0, 0.382683, 0.923880]).into(), // 45 degrees around Z
+            rerun::RotationAxisAngle::new((0.0, 1.0, 0.0), rerun::Angle::Degrees(30.0)).into(),
         ])
         .with_radii([0.025])
         .with_colors([
-            Color::from_rgb(255, 0, 0),
-            Color::from_rgb(0, 255, 0),
-            Color::from_rgb(0, 0, 255),
+            rerun::Color::from_rgb(255, 0, 0),
+            rerun::Color::from_rgb(0, 255, 0),
+            rerun::Color::from_rgb(0, 0, 255),
         ])
         .with_labels(["red", "green", "blue"]),
     )?;

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,7 +1,8 @@
 //! Log a batch of oriented bounding boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
 
     rec.log(
         "batch",

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -1,11 +1,12 @@
 //! Log a single 3D box.
-use rerun::archetypes::Boxes3D;
-use rerun::RecordingStreamBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
 
-    rec.log("simple", &Boxes3D::from_half_sizes([(2.0, 2.0, 1.0)]))?;
+    rec.log(
+        "simple",
+        &rerun::Boxes3D::from_half_sizes([(2.0, 2.0, 1.0)]),
+    )?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -1,14 +1,10 @@
 //! Log a batch of 3D arrows.
 
-use rerun::{
-    archetypes::{Arrows3D, Clear},
-    components::Color,
-    external::glam,
-    RecordingStreamBuilder,
-};
+use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_clear_recursive").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").memory()?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (
@@ -21,14 +17,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (i, ((vector, origin), color)) in vectors.into_iter().zip(origins).zip(colors).enumerate() {
         rec.log(
             format!("arrows/{i}"),
-            &Arrows3D::from_vectors([vector])
+            &rerun::Arrows3D::from_vectors([vector])
                 .with_origins([origin])
-                .with_colors([Color::from_rgb(color.0, color.1, color.2)]),
+                .with_colors([rerun::Color::from_rgb(color.0, color.1, color.2)]),
         )?;
     }
 
     // Now clear all of them at once.
-    rec.log("arrows", &Clear::recursive())?;
+    rec.log("arrows", &rerun::Clear::recursive())?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -1,14 +1,10 @@
 //! Log a batch of 3D arrows.
 
-use rerun::{
-    archetypes::{Arrows3D, Clear},
-    components::Color,
-    external::glam,
-    RecordingStreamBuilder,
-};
+use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_clear_simple").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").memory()?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (
@@ -21,15 +17,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (i, ((vector, origin), color)) in vectors.into_iter().zip(origins).zip(colors).enumerate() {
         rec.log(
             format!("arrows/{i}"),
-            &Arrows3D::from_vectors([vector])
+            &rerun::Arrows3D::from_vectors([vector])
                 .with_origins([origin])
-                .with_colors([Color::from_rgb(color.0, color.1, color.2)]),
+                .with_colors([rerun::Color::from_rgb(color.0, color.1, color.2)]),
         )?;
     }
 
     // Now clear them, one by one on each tick.
     for i in 0..vectors.len() {
-        rec.log(format!("arrows/{i}"), &Clear::flat())?;
+        rec.log(format!("arrows/{i}"), &rerun::Clear::flat())?;
     }
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -7,7 +7,7 @@ use rerun::{
 
 // ---
 
-/// A custom [component bundle] that extends Rerun's builtin [`Points3D`] archetype with extra
+/// A custom [component bundle] that extends Rerun's builtin [`rerun::Points3D`] archetype with extra
 /// [`rerun::Component`]s.
 ///
 /// [component bundle]: [`AsComponents`]
@@ -38,7 +38,7 @@ impl rerun::AsComponents for CustomPoints3D {
 
 // ---
 
-/// A custom [`rerun::Component`] that is backed by a builtin [`Float32`] scalar [`rerun::Datatype`].
+/// A custom [`rerun::Component`] that is backed by a builtin [`rerun::Float32`] scalar [`rerun::Datatype`].
 #[derive(Debug, Clone, Copy)]
 struct Confidence(rerun::Float32);
 

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -1,24 +1,21 @@
 //! Create and log a depth image.
 use ndarray::{s, Array, ShapeBuilder};
-use rerun::{
-    archetypes::{DepthImage, Pinhole},
-    RecordingStreamBuilder,
-};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
 
     // Create a dummy depth image
     let mut image = Array::<u16, _>::from_elem((8, 12).f(), 65535);
     image.slice_mut(s![0..4, 0..6]).fill(20000);
     image.slice_mut(s![4..8, 6..12]).fill(45000);
 
-    let depth_image = DepthImage::try_from(image.clone())?.with_meter(10000.0);
+    let depth_image = rerun::DepthImage::try_from(image.clone())?.with_meter(10000.0);
 
     // If we log a pinhole camera model, the depth gets automatically back-projected to 3D
     rec.log(
         "world/camera",
-        &Pinhole::from_focal_length_and_resolution(
+        &rerun::Pinhole::from_focal_length_and_resolution(
             [20.0, 20.0],
             [image.shape()[1] as f32, image.shape()[0] as f32],
         ),

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -1,16 +1,16 @@
 //! Create and log a depth image.
 
 use ndarray::{s, Array, ShapeBuilder};
-use rerun::{archetypes::DepthImage, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
 
     let mut image = Array::<u16, _>::from_elem((8, 12).f(), 65535);
     image.slice_mut(s![0..4, 0..6]).fill(20000);
     image.slice_mut(s![4..8, 6..12]).fill(45000);
 
-    let depth_image = DepthImage::try_from(image)?.with_meter(10_000.0);
+    let depth_image = rerun::DepthImage::try_from(image)?.with_meter(10_000.0);
 
     rec.log("depth", &depth_image)?;
 

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,18 +1,25 @@
 //! Disconnect two spaces.
 
-use rerun::{DisconnectedSpace, Points3D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_disconnected_space").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").memory()?;
 
     // These two points can be projected into the same space..
-    rec.log("world/room1/point", &Points3D::new([(0.0, 0.0, 0.0)]))?;
-    rec.log("world/room2/point", &Points3D::new([(1.0, 1.0, 1.0)]))?;
+    rec.log(
+        "world/room1/point",
+        &rerun::Points3D::new([(0.0, 0.0, 0.0)]),
+    )?;
+    rec.log(
+        "world/room2/point",
+        &rerun::Points3D::new([(1.0, 1.0, 1.0)]),
+    )?;
 
     // ..but this one lives in a completely separate space!
-    rec.log("world/wormhole", &DisconnectedSpace::new(true))?;
-    rec.log("world/wormhole/point", &Points3D::new([(2.0, 2.0, 2.0)]))?;
+    rec.log("world/wormhole", &rerun::DisconnectedSpace::new(true))?;
+    rec.log(
+        "world/wormhole/point",
+        &rerun::Points3D::new([(2.0, 2.0, 2.0)]),
+    )?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,9 +1,6 @@
 //! Disconnect two spaces.
 
-use rerun::{
-    archetypes::{DisconnectedSpace, Points3D},
-    RecordingStreamBuilder,
-};
+use rerun::{DisconnectedSpace, Points3D, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -1,17 +1,17 @@
 //! Create and log an image
 
 use ndarray::{s, Array, ShapeBuilder};
-use rerun::{archetypes::Image, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_image_simple").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_image_simple").memory()?;
 
     let mut image = Array::<u8, _>::zeros((8, 12, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);
     image.slice_mut(s![0..4, 0..6, 0]).fill(0);
     image.slice_mut(s![0..4, 0..6, 1]).fill(255);
 
-    rec.log("image", &Image::try_from(image)?)?;
+    rec.log("image", &rerun::Image::try_from(image)?)?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -1,20 +1,16 @@
 //! Log a couple 2D line segments using 2D line strips.
 
-use rerun::{
-    archetypes::{Boxes2D, LineStrips2D},
-    RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_segments2d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").memory()?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
-    rec.log("segments", &LineStrips2D::new(points.chunks(2)))?;
+    rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;
 
     // Log an extra rect to set the view bounds
     rec.log(
         "bounds",
-        &Boxes2D::from_centers_and_sizes([(3.0, 0.0)], [(8.0, 6.0)]),
+        &rerun::Boxes2D::from_centers_and_sizes([(3.0, 0.0)], [(8.0, 6.0)]),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -1,9 +1,8 @@
 //! Log a simple set of line segments.
 
-use rerun::{archetypes::LineStrips3D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_segments3d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").memory()?;
 
     let points = [
         [0., 0., 0.],
@@ -15,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         [0., 1., 0.],
         [0., 1., 1.],
     ];
-    rec.log("segments", &LineStrips3D::new(points.chunks(2)))?;
+    rec.log("segments", &rerun::LineStrips3D::new(points.chunks(2)))?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -1,19 +1,15 @@
 //! Log a batch of 2d line strips.
 
-use rerun::{
-    archetypes::{Boxes2D, LineStrips2D},
-    RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
 
     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     #[rustfmt::skip]
     let strip2 = [[0., 3.], [1., 4.], [2., 2.], [3., 4.], [4., 2.], [5., 4.], [6., 3.]];
     rec.log(
         "strips",
-        &LineStrips2D::new([strip1.to_vec(), strip2.to_vec()])
+        &rerun::LineStrips2D::new([strip1.to_vec(), strip2.to_vec()])
             .with_colors([0xFF0000FF, 0x00FF00FF])
             .with_radii([0.025, 0.005])
             .with_labels(["one strip here", "and one strip there"]),
@@ -22,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log an extra rect to set the view bounds
     rec.log(
         "bounds",
-        &Boxes2D::from_centers_and_sizes([(3.0, 1.5)], [(8.0, 9.0)]),
+        &rerun::Boxes2D::from_centers_and_sizes([(3.0, 1.5)], [(8.0, 9.0)]),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -1,20 +1,16 @@
 //! Log a simple line strip.
 
-use rerun::{
-    archetypes::{Boxes2D, LineStrips2D},
-    RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
-    rec.log("strip", &LineStrips2D::new([points]))?;
+    rec.log("strip", &rerun::LineStrips2D::new([points]))?;
 
     // Log an extra rect to set the view bounds
     rec.log(
         "bounds",
-        &Boxes2D::from_centers_and_sizes([(3., 0.)], [(8., 6.)]),
+        &rerun::Boxes2D::from_centers_and_sizes([(3., 0.)], [(8., 6.)]),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/line_strip3d_batch.rs
+++ b/docs/code-examples/line_strip3d_batch.rs
@@ -1,9 +1,8 @@
 //! Log a batch of 2d line strips.
 
-use rerun::{archetypes::LineStrips3D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
 
     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
     let strip2 = [
@@ -18,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     rec.log(
         "strips",
-        &LineStrips3D::new([strip1.to_vec(), strip2.to_vec()])
+        &rerun::LineStrips3D::new([strip1.to_vec(), strip2.to_vec()])
             .with_colors([0xFF0000FF, 0x00FF00FF])
             .with_radii([0.025, 0.005])
             .with_labels(["one strip here", "and one strip there"]),

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -1,9 +1,8 @@
 //! Log a simple line strip.
 
-use rerun::{archetypes::LineStrips3D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
 
     let points = [
         [0., 0., 0.],
@@ -15,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         [0., 1., 0.],
         [0., 1., 1.],
     ];
-    rec.log("strip", &LineStrips3D::new([points]))?;
+    rec.log("strip", &rerun::LineStrips3D::new([points]))?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -1,9 +1,8 @@
 //! Shows how to manually associate one or more indicator components with arbitrary data.
 
 use rerun::{
-    archetypes::{Mesh3D, Points3D},
     components::{Color, Position3D, Radius},
-    Archetype, ComponentBatch, RecordingStreamBuilder,
+    Archetype, ComponentBatch, Mesh3D, Points3D, RecordingStreamBuilder,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -1,12 +1,10 @@
 //! Shows how to manually associate one or more indicator components with arbitrary data.
 
-use rerun::{
-    components::{Color, Position3D, Radius},
-    Archetype, ComponentBatch, Mesh3D, Points3D, RecordingStreamBuilder,
-};
+use rerun::Archetype as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_manual_indicator").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").memory()?;
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.
@@ -14,11 +12,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "points_and_mesh",
         false,
         [
-            Points3D::indicator().as_ref() as &dyn ComponentBatch,
-            Mesh3D::indicator().as_ref(),
-            &[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]].map(Position3D::from),
-            &[[255, 0, 0], [0, 255, 0], [0, 0, 255]].map(|[r, g, b]| Color::from_rgb(r, g, b)),
-            &[1.0].map(Radius::from),
+            rerun::Points3D::indicator().as_ref() as &dyn rerun::ComponentBatch,
+            rerun::Mesh3D::indicator().as_ref(),
+            &[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]].map(rerun::Position3D::from),
+            &[[255, 0, 0], [0, 255, 0], [0, 0, 255]]
+                .map(|[r, g, b]| rerun::Color::from_rgb(r, g, b)),
+            &[1.0].map(rerun::Radius::from),
         ],
     )?;
 

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,20 +1,16 @@
 //! Log a simple colored triangle with indexed drawing.
 
-use rerun::{
-    components::{Material, MeshProperties},
-    Mesh3D, RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").memory()?;
 
     rec.log(
         "triangle",
-        &Mesh3D::new([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        &rerun::Mesh3D::new([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
             .with_vertex_normals([[0.0, 0.0, 1.0]])
             .with_vertex_colors([0x0000FFFF, 0x00FF00FF, 0xFF0000FF])
-            .with_mesh_properties(MeshProperties::from_triangle_indices([[2, 1, 0]]))
-            .with_mesh_material(Material::from_albedo_factor(0xCC00CCFF)),
+            .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
+            .with_mesh_material(rerun::Material::from_albedo_factor(0xCC00CCFF)),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,9 +1,8 @@
 //! Log a simple colored triangle with indexed drawing.
 
 use rerun::{
-    archetypes::Mesh3D,
     components::{Material, MeshProperties},
-    RecordingStreamBuilder,
+    Mesh3D, RecordingStreamBuilder,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -1,6 +1,6 @@
 //! Log a simple colored triangle, then update its vertices' positions each frame.
 
-use rerun::{archetypes::Mesh3D, components::Position3D, external::glam, RecordingStreamBuilder};
+use rerun::{components::Position3D, external::glam, Mesh3D, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -1,10 +1,10 @@
 //! Log a simple colored triangle, then update its vertices' positions each frame.
 
-use rerun::{components::Position3D, external::glam, Mesh3D, RecordingStreamBuilder};
+use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").memory()?;
 
     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.set_time_sequence("frame", 0);
     rec.log(
         "triangle",
-        &Mesh3D::new(vertex_positions)
+        &rerun::Mesh3D::new(vertex_positions)
             .with_vertex_normals([[0.0, 0.0, 1.0]])
             .with_vertex_colors([0xFF0000FF, 0x00FF00FF, 0x0000FFFF]),
     )?;
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.set_time_sequence("frame", i);
 
         let factor = (i as f32 * 0.04).sin().abs();
-        let vertex_positions: [Position3D; 3] = [
+        let vertex_positions: [rerun::Position3D; 3] = [
             (glam::Vec3::from(vertex_positions[0]) * factor).into(),
             (glam::Vec3::from(vertex_positions[1]) * factor).into(),
             (glam::Vec3::from(vertex_positions[2]) * factor).into(),

--- a/docs/code-examples/mesh3d_simple.rs
+++ b/docs/code-examples/mesh3d_simple.rs
@@ -1,13 +1,12 @@
 //! Log a simple colored triangle.
 
-use rerun::{archetypes::Mesh3D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_mesh3d_simple").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").memory()?;
 
     rec.log(
         "triangle",
-        &Mesh3D::new([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        &rerun::Mesh3D::new([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
             .with_vertex_normals([[0.0, 0.0, 1.0]])
             .with_vertex_colors([0xFF0000FF, 0x00FF00FF, 0x0000FFFF]),
     )?;

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -1,22 +1,18 @@
 //! Log a pinhole and a random image.
 
 use ndarray::{Array, ShapeBuilder};
-use rerun::{
-    archetypes::{Image, Pinhole},
-    RecordingStreamBuilder,
-};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_pinhole").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").memory()?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());
 
     rec.log(
         "world/image",
-        &Pinhole::from_focal_length_and_resolution([3., 3.], [3., 3.]),
+        &rerun::Pinhole::from_focal_length_and_resolution([3., 3.], [3., 3.]),
     )?;
-    rec.log("world/image", &Image::try_from(image)?)?;
+    rec.log("world/image", &rerun::Image::try_from(image)?)?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -1,11 +1,7 @@
 //! Log some random points with color and radii.
 
 use rand::{distributions::Uniform, Rng as _};
-use rerun::{
-    archetypes::{Boxes2D, Points2D},
-    components::Color,
-    RecordingStreamBuilder,
-};
+use rerun::{Boxes2D, Color, Points2D, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points2d").memory()?;

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -1,23 +1,22 @@
 //! Log some random points with color and radii.
 
 use rand::{distributions::Uniform, Rng as _};
-use rerun::{Boxes2D, Color, Points2D, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);
 
     rec.log(
         "random",
-        &Points2D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist))))
-            .with_colors((0..10).map(|_| Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
+        &rerun::Points2D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist))))
+            .with_colors((0..10).map(|_| rerun::Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
             .with_radii((0..10).map(|_| rng.gen::<f32>())),
     )?;
 
     // Log an extra rect to set the view bounds
-    rec.log("bounds", &Boxes2D::from_half_sizes([(4., 3.)]))?;
+    rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(4., 3.)]))?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -1,17 +1,12 @@
 //! Log some very simple points.
 
-use rerun::{
-    archetypes::{Boxes2D, Points2D},
-    RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
 
-    rec.log("points", &Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
+    rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 
     // Log an extra rect to set the view bounds
-    rec.log("bounds", &Boxes2D::from_half_sizes([(2.0, 1.5)]))?;
+    rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(2.0, 1.5)]))?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -1,7 +1,7 @@
 //! Log some random points with color and radii.
 
 use rand::{distributions::Uniform, Rng as _};
-use rerun::{archetypes::Points3D, components::Color, RecordingStreamBuilder};
+use rerun::{Color, Points3D, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -1,19 +1,21 @@
 //! Log some random points with color and radii.
 
 use rand::{distributions::Uniform, Rng as _};
-use rerun::{Color, Points3D, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);
 
     rec.log(
         "random",
-        &Points3D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist), rng.sample(dist))))
-            .with_colors((0..10).map(|_| Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
-            .with_radii((0..10).map(|_| rng.gen::<f32>())),
+        &rerun::Points3D::new(
+            (0..10).map(|_| (rng.sample(dist), rng.sample(dist), rng.sample(dist))),
+        )
+        .with_colors((0..10).map(|_| rerun::Color::from_rgb(rng.gen(), rng.gen(), rng.gen())))
+        .with_radii((0..10).map(|_| rng.gen::<f32>())),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -1,11 +1,13 @@
 //! Log some very simple points.
 
-use rerun::{archetypes::Points3D, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_points3d_simple").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").memory()?;
 
-    rec.log("points", &Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]))?;
+    rec.log(
+        "points",
+        &rerun::Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]),
+    )?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -1,6 +1,6 @@
 //! Log a scalar over time.
 
-use rerun::{archetypes::TimeSeriesScalar, RecordingStreamBuilder};
+use rerun::{RecordingStreamBuilder, TimeSeriesScalar};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -1,10 +1,8 @@
 //! Log a scalar over time.
 
-use rerun::{RecordingStreamBuilder, TimeSeriesScalar};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").memory()?;
     let mut lcg_state = 0_i64;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
@@ -13,13 +11,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Log two time series under a shared root so that they show in the same plot by default.
         rec.log(
             "trig/sin",
-            &TimeSeriesScalar::new((t as f64 / 100.0).sin())
+            &rerun::TimeSeriesScalar::new((t as f64 / 100.0).sin())
                 .with_label("sin(0.01t)")
                 .with_color([255, 0, 0]),
         )?;
         rec.log(
             "trig/cos",
-            &TimeSeriesScalar::new((t as f64 / 100.0).cos())
+            &rerun::TimeSeriesScalar::new((t as f64 / 100.0).cos())
                 .with_label("cos(0.01t)")
                 .with_color([0, 255, 0]),
         )?;
@@ -31,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             % 16777216; // simple linear congruency generator
         rec.log(
             "scatter/lcg",
-            &TimeSeriesScalar::new(lcg_state as f64).with_scattered(true),
+            &rerun::TimeSeriesScalar::new(lcg_state as f64).with_scattered(true),
         )?;
     }
 

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -1,13 +1,14 @@
 //! Log a scalar over time.
 
-use rerun::{archetypes::TimeSeriesScalar, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_scalar").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_scalar").memory()?;
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log("scalar", &TimeSeriesScalar::new((step as f64 / 10.0).sin()))?;
+        rec.log(
+            "scalar",
+            &rerun::TimeSeriesScalar::new((step as f64 / 10.0).sin()),
+        )?;
     }
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -1,15 +1,11 @@
 //! Create and log a segmentation image.
 
 use ndarray::{s, Array, ShapeBuilder};
-use rerun::{
-    archetypes::{AnnotationContext, SegmentationImage},
-    datatypes::Color,
-    RecordingStreamBuilder,
-};
+use rerun::datatypes::Color;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_segmentation_image").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").memory()?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((8, 12).f());
@@ -17,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     image.slice_mut(s![4..8, 6..12]).fill(2);
 
     // create an annotation context to describe the classes
-    let annotation = AnnotationContext::new([
+    let annotation = rerun::AnnotationContext::new([
         (1, "red", Color::from(0xFF0000FF)),
         (2, "green", Color::from(0x00FF00FF)),
     ]);
@@ -25,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // log the annotation and the image
     rec.log("/", &annotation)?;
 
-    rec.log("image", &SegmentationImage::try_from(image)?)?;
+    rec.log("image", &rerun::SegmentationImage::try_from(image)?)?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/tensor_one_dim.rs
+++ b/docs/code-examples/tensor_one_dim.rs
@@ -3,17 +3,16 @@
 use ndarray::{Array, ShapeBuilder};
 use rand::{thread_rng, Rng};
 use rand_distr::StandardNormal;
-use rerun::{archetypes::Tensor, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_tensors").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_tensors").memory()?;
 
     let mut data = Array::<f64, _>::default((100).f());
     data.map_inplace(|x| *x = thread_rng().sample(StandardNormal));
 
     rec.log(
         "tensor",
-        &Tensor::try_from(data.as_standard_layout().view())?,
+        &rerun::Tensor::try_from(data.as_standard_layout().view())?,
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -1,15 +1,15 @@
 //! Create and log a tensor.
 
 use ndarray::{Array, ShapeBuilder};
-use rerun::{archetypes::Tensor, RecordingStreamBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_tensor_simple").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").memory()?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());
 
-    let tensor = Tensor::try_from(data)?.with_names(["batch", "channel", "height", "width"]);
+    let tensor = rerun::Tensor::try_from(data)?.with_names(["batch", "channel", "height", "width"]);
     rec.log("tensor", &tensor)?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -1,17 +1,17 @@
 //! Log a `TextDocument`
 
-use rerun::{
-    archetypes::TextDocument, external::re_types::components::MediaType, RecordingStreamBuilder,
-};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_text_document").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_text_document").memory()?;
 
-    rec.log("text_document", &TextDocument::new("Hello, TextDocument!"))?;
+    rec.log(
+        "text_document",
+        &rerun::TextDocument::new("Hello, TextDocument!"),
+    )?;
 
     rec.log(
         "markdown",
-        &TextDocument::new(
+        &rerun::TextDocument::new(
             r#"
 # Hello Markdown!
 [Click here to see the raw text](recording://markdown.Text).
@@ -55,7 +55,7 @@ Of course you can also have [normal https links](https://github.com/rerun-io/rer
 ![A random image](https://picsum.photos/640/480)
 "#.trim(),
         )
-        .with_media_type(MediaType::markdown()),
+        .with_media_type(rerun::MediaType::markdown()),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/text_log.rs
+++ b/docs/code-examples/text_log.rs
@@ -1,13 +1,11 @@
 //! Log a `TextLog`
 
-use rerun::{archetypes::TextLog, RecordingStreamBuilder};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_text_log").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_text_log").memory()?;
 
     rec.log(
         "log",
-        &TextLog::new("Application started.").with_level("INFO"),
+        &rerun::TextLog::new("Application started.").with_level("INFO"),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -1,15 +1,16 @@
 //! Shows integration of Rerun's `TextLog` with the native logging interface.
 
-use rerun::{archetypes::TextLog, components::TextLogLevel, external::log, RecordingStreamBuilder};
+use rerun::external::log;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
-        RecordingStreamBuilder::new("rerun_example_text_log_integration").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").memory()?;
 
     // Log a text entry directly:
     rec.log(
         "logs",
-        &TextLog::new("this entry has loglevel TRACE").with_level(TextLogLevel::TRACE),
+        &rerun::TextLog::new("this entry has loglevel TRACE")
+            .with_level(rerun::TextLogLevel::TRACE),
     )?;
 
     // Or log via a logging handler:

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -1,11 +1,10 @@
 //! Log some transforms.
 
 use rerun::{
-    archetypes::{Arrows3D, Transform3D},
-    datatypes::{Angle, RotationAxisAngle, Scale3D, TranslationRotationScale3D},
-    RecordingStreamBuilder,
+    archetypes::Transform3D, Angle, Arrows3D, RecordingStreamBuilder, RotationAxisAngle, Scale3D,
+    TranslationRotationScale3D,
 };
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) = RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
@@ -28,7 +27,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.log(
         "base/rotated_scaled",
         &Transform3D::new(TranslationRotationScale3D {
-            rotation: Some(RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(PI / 4.)).into()),
+            rotation: Some(
+                RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(TAU / 8.0)).into(),
+            ),
             scale: Some(Scale3D::from(2.0)),
             ..Default::default()
         }),

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -1,43 +1,43 @@
 //! Log some transforms.
 
-use rerun::{
-    archetypes::Transform3D, Angle, Arrows3D, RecordingStreamBuilder, RotationAxisAngle, Scale3D,
-    TranslationRotationScale3D,
-};
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
 
     rec.log(
         "base",
-        &Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
+        &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
     )?;
 
     rec.log(
         "base/translated",
-        &Transform3D::new(TranslationRotationScale3D::translation([1.0, 0.0, 0.0])),
+        &rerun::Transform3D::new(rerun::TranslationRotationScale3D::translation([
+            1.0, 0.0, 0.0,
+        ])),
     )?;
 
     rec.log(
         "base/translated",
-        &Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
+        &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
     )?;
 
     rec.log(
         "base/rotated_scaled",
-        &Transform3D::new(TranslationRotationScale3D {
+        &rerun::Transform3D::new(rerun::TranslationRotationScale3D {
             rotation: Some(
-                RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(TAU / 8.0)).into(),
+                rerun::RotationAxisAngle::new([0.0, 0.0, 1.0], rerun::Angle::Radians(TAU / 8.0))
+                    .into(),
             ),
-            scale: Some(Scale3D::from(2.0)),
+            scale: Some(rerun::Scale3D::from(2.0)),
             ..Default::default()
         }),
     )?;
 
     rec.log(
         "base/rotated_scaled",
-        &Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
+        &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -1,16 +1,13 @@
 //! Change the view coordinates for the scene.
-use rerun::{
-    archetypes::{Arrows3D, ViewCoordinates},
-    RecordingStreamBuilder,
-};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
 
-    rec.log_timeless("world", &ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(
         "world/xyz",
-        &Arrows3D::from_vectors(
+        &rerun::Arrows3D::from_vectors(
             [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], //
         )
         .with_colors([[255, 0, 0], [0, 255, 0], [0, 0, 255]]),

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -5,11 +5,8 @@ use std::f32::consts::TAU;
 use itertools::Itertools as _;
 
 use rerun::{
-    archetypes::{LineStrips3D, Points3D, Transform3D},
-    components::{Color, Position3D},
     demo_util::{bounce_lerp, color_spiral},
     external::glam,
-    RecordingStream, RecordingStreamResult,
 };
 
 const NUM_POINTS: usize = 100;
@@ -22,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn run(rec: &RecordingStream) -> RecordingStreamResult<()> {
+fn run(rec: &rerun::RecordingStream) -> rerun::RecordingStreamResult<()> {
     let (points1, colors1) = color_spiral(NUM_POINTS, 2.0, 0.02, 0.0, 0.1);
     let (points2, colors2) = color_spiral(NUM_POINTS, 2.0, 0.02, TAU * 0.5, 0.1);
 
@@ -30,13 +27,13 @@ fn run(rec: &RecordingStream) -> RecordingStreamResult<()> {
 
     rec.log(
         "dna/structure/left",
-        &Points3D::new(points1.iter().copied())
+        &rerun::Points3D::new(points1.iter().copied())
             .with_colors(colors1)
             .with_radii([0.08]),
     )?;
     rec.log(
         "dna/structure/right",
-        &Points3D::new(points2.iter().copied())
+        &rerun::Points3D::new(points2.iter().copied())
             .with_colors(colors2)
             .with_radii([0.08]),
     )?;
@@ -51,8 +48,8 @@ fn run(rec: &RecordingStream) -> RecordingStreamResult<()> {
 
     rec.log(
         "dna/structure/scaffolding",
-        &LineStrips3D::new(points_interleaved.iter().cloned())
-            .with_colors([Color::from([128, 128, 128, 255])]),
+        &rerun::LineStrips3D::new(points_interleaved.iter().cloned())
+            .with_colors([rerun::Color::from([128, 128, 128, 255])]),
     )?;
 
     use rand::Rng as _;
@@ -71,22 +68,24 @@ fn run(rec: &RecordingStream) -> RecordingStreamResult<()> {
             .map(|(n, &[p1, p2])| {
                 let c = bounce_lerp(80.0, 230.0, times[n] * 2.0) as u8;
                 (
-                    Position3D::from(bounce_lerp(p1, p2, times[n])),
-                    Color::from_rgb(c, c, c),
+                    rerun::Position3D::from(bounce_lerp(p1, p2, times[n])),
+                    rerun::Color::from_rgb(c, c, c),
                 )
             })
             .unzip();
 
         rec.log(
             "dna/structure/scaffolding/beads",
-            &Points3D::new(beads).with_colors(colors).with_radii([0.06]),
+            &rerun::Points3D::new(beads)
+                .with_colors(colors)
+                .with_radii([0.06]),
         )?;
 
         rec.log(
             "dna/structure",
-            &Transform3D::new(rerun::transform::RotationAxisAngle::new(
+            &rerun::archetypes::Transform3D::new(rerun::RotationAxisAngle::new(
                 glam::Vec3::Z,
-                rerun::transform::Angle::Radians(time / 4.0 * TAU),
+                rerun::Angle::Radians(time / 4.0 * TAU),
             )),
         )?;
     }

--- a/examples/rust/minimal/src/main.rs
+++ b/examples/rust/minimal/src/main.rs
@@ -1,20 +1,19 @@
 //! Demonstrates the most barebone usage of the Rerun SDK.
 
-use rerun::{
-    archetypes::Points3D, components::Color, demo_util::grid, external::glam,
-    RecordingStreamBuilder,
-};
+use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_minimal_rs").memory()?;
+    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").memory()?;
 
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);
     let colors = grid(glam::Vec3::ZERO, glam::Vec3::splat(255.0), 10)
-        .map(|v| Color::from_rgb(v.x as u8, v.y as u8, v.z as u8));
+        .map(|v| rerun::Color::from_rgb(v.x as u8, v.y as u8, v.z as u8));
 
     rec.log(
         "my_points",
-        &Points3D::new(points).with_colors(colors).with_radii([0.5]),
+        &rerun::Points3D::new(points)
+            .with_colors(colors)
+            .with_radii([0.5]),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/examples/rust/minimal_options/src/main.rs
+++ b/examples/rust/minimal_options/src/main.rs
@@ -5,9 +5,7 @@
 //!  cargo run -p minimal_options -- --help
 //! ```
 
-use rerun::archetypes::Points3D;
-use rerun::components::Color;
-use rerun::{external::re_log, RecordingStream};
+use rerun::external::re_log;
 
 use rerun::demo_util::grid;
 
@@ -24,28 +22,6 @@ struct Args {
     radius: f32,
 }
 
-fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
-    let points = grid(
-        glam::Vec3::splat(-args.radius),
-        glam::Vec3::splat(args.radius),
-        args.num_points_per_axis,
-    );
-    let colors = grid(
-        glam::Vec3::ZERO,
-        glam::Vec3::splat(255.0),
-        args.num_points_per_axis,
-    )
-    .map(|v| Color::from_rgb(v.x as u8, v.y as u8, v.z as u8));
-
-    rec.set_time_sequence("keyframe", 0);
-    rec.log(
-        "my_points",
-        &Points3D::new(points).with_colors(colors).with_radii([0.5]),
-    )?;
-
-    Ok(())
-}
-
 fn main() -> anyhow::Result<()> {
     re_log::setup_native_logging();
 
@@ -60,4 +36,28 @@ fn main() -> anyhow::Result<()> {
             run(&rec, &args).unwrap();
         },
     )
+}
+
+fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
+    let points = grid(
+        glam::Vec3::splat(-args.radius),
+        glam::Vec3::splat(args.radius),
+        args.num_points_per_axis,
+    );
+    let colors = grid(
+        glam::Vec3::ZERO,
+        glam::Vec3::splat(255.0),
+        args.num_points_per_axis,
+    )
+    .map(|v| rerun::Color::from_rgb(v.x as u8, v.y as u8, v.z as u8));
+
+    rec.set_time_sequence("keyframe", 0);
+    rec.log(
+        "my_points",
+        &rerun::Points3D::new(points)
+            .with_colors(colors)
+            .with_radii([0.5]),
+    )?;
+
+    Ok(())
 }

--- a/examples/rust/minimal_serve/src/main.rs
+++ b/examples/rust/minimal_serve/src/main.rs
@@ -1,29 +1,29 @@
 //! Demonstrates the most barebone usage of the Rerun SDK.
 
-use rerun::{
-    archetypes::Points3D, components::Color, demo_util::grid, external::glam,
-    RecordingStreamBuilder,
-};
+use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `serve()` requires to have a running Tokio runtime in the current context.
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
     let _guard = rt.enter();
 
-    let rec = RecordingStreamBuilder::new("rerun_example_minimal_serve_rs").serve(
+    let open_browser = true;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_serve_rs").serve(
         "0.0.0.0",
         Default::default(),
         Default::default(),
-        true,
+        open_browser,
     )?;
 
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);
     let colors = grid(glam::Vec3::ZERO, glam::Vec3::splat(255.0), 10)
-        .map(|v| Color::from_rgb(v.x as u8, v.y as u8, v.z as u8));
+        .map(|v| rerun::Color::from_rgb(v.x as u8, v.y as u8, v.z as u8));
 
     rec.log(
         "my_points",
-        &Points3D::new(points).with_colors(colors).with_radii([0.5]),
+        &rerun::Points3D::new(points)
+            .with_colors(colors)
+            .with_radii([0.5]),
     )?;
 
     eprintln!("Check your browser!");

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -18,16 +18,7 @@ use std::{
 
 use anyhow::Context as _;
 
-use rerun::{
-    archetypes::{
-        Boxes3D, Image, LineStrips2D, Pinhole, Points2D, Points3D, Transform3D, ViewCoordinates,
-    },
-    components::HalfSizes3D,
-    datatypes::TranslationRotationScale3D,
-    external::re_log,
-    time::{Time, TimePoint, TimeType, Timeline},
-    RecordingStream,
-};
+use rerun::external::re_log;
 
 // --- Rerun logging ---
 
@@ -35,14 +26,14 @@ struct ArFrame {
     dir: PathBuf,
     data: objectron::ArFrame,
     index: usize,
-    timepoint: TimePoint,
+    timepoint: rerun::TimePoint,
 }
 
 impl ArFrame {
     fn from_raw(
         dir: PathBuf,
         index: usize,
-        timepoint: TimePoint,
+        timepoint: rerun::TimePoint,
         ar_frame: objectron::ArFrame,
     ) -> Self {
         Self {
@@ -54,10 +45,10 @@ impl ArFrame {
     }
 }
 
-fn timepoint(index: usize, time: f64) -> TimePoint {
-    let timeline_time = Timeline::new("time", TimeType::Time);
-    let timeline_frame = Timeline::new("frame", TimeType::Sequence);
-    let time = Time::from_seconds_since_epoch(time);
+fn timepoint(index: usize, time: f64) -> rerun::TimePoint {
+    let timeline_time = rerun::Timeline::new_temporal("time");
+    let timeline_frame = rerun::Timeline::new_sequence("frame");
+    let time = rerun::Time::from_seconds_since_epoch(time);
     [
         (timeline_time, time.into()),
         (timeline_frame, (index as i64).into()),
@@ -78,7 +69,7 @@ impl<'a> From<&'a [objectron::FrameAnnotation]> for AnnotationsPerFrame<'a> {
 }
 
 fn log_ar_frame(
-    rec: &RecordingStream,
+    rec: &rerun::RecordingStream,
     annotations: &AnnotationsPerFrame<'_>,
     ar_frame: &ArFrame,
 ) -> anyhow::Result<()> {
@@ -100,11 +91,9 @@ fn log_ar_frame(
 }
 
 fn log_baseline_objects(
-    rec: &RecordingStream,
+    rec: &rerun::RecordingStream,
     objects: &[objectron::Object],
 ) -> anyhow::Result<()> {
-    use rerun::{components::Color, transform::TranslationAndMat3x3};
-
     let boxes = objects.iter().filter_map(|object| {
         Some({
             if object.r#type != objectron::object::Type::BoundingBox as i32 {
@@ -112,12 +101,13 @@ fn log_baseline_objects(
                 return None;
             }
 
-            let box_half_size: HalfSizes3D = (glam::Vec3::from_slice(&object.scale) * 0.5).into();
+            let box_half_size: rerun::HalfSizes3D =
+                (glam::Vec3::from_slice(&object.scale) * 0.5).into();
             let transform = {
                 let translation = glam::Vec3::from_slice(&object.translation);
                 // NOTE: the dataset is all row-major, transpose those matrices!
                 let rotation = glam::Mat3::from_cols_slice(&object.rotation).transpose();
-                TranslationAndMat3x3::new(translation, rotation)
+                rerun::TranslationAndMat3x3::new(translation, rotation)
             };
             let label = object.category.as_str();
 
@@ -129,28 +119,28 @@ fn log_baseline_objects(
         let path = format!("world/annotations/box-{id}");
         rec.log_timeless(
             path.clone(),
-            &Boxes3D::from_half_sizes([bbox_half_size])
+            &rerun::Boxes3D::from_half_sizes([bbox_half_size])
                 .with_labels([label])
-                .with_colors([Color::from_rgb(160, 230, 130)]),
+                .with_colors([rerun::Color::from_rgb(160, 230, 130)]),
         )?;
-        rec.log_timeless(path, &Transform3D::new(transform))?;
+        rec.log_timeless(path, &rerun::archetypes::Transform3D::new(transform))?;
     }
 
     Ok(())
 }
 
-fn log_video_frame(rec: &RecordingStream, ar_frame: &ArFrame) -> anyhow::Result<()> {
+fn log_video_frame(rec: &rerun::RecordingStream, ar_frame: &ArFrame) -> anyhow::Result<()> {
     let image_path = ar_frame.dir.join(format!("video/{}.jpg", ar_frame.index));
     let img = rerun::datatypes::TensorData::from_jpeg_file(&image_path)?;
 
     rec.set_timepoint(ar_frame.timepoint.clone());
-    rec.log("world/camera", &Image::new(img))
+    rec.log("world/camera", &rerun::Image::new(img))
         .map_err(Into::into)
 }
 
 fn log_ar_camera(
-    rec: &RecordingStream,
-    timepoint: TimePoint,
+    rec: &rerun::RecordingStream,
+    timepoint: rerun::TimePoint,
     ar_camera: &objectron::ArCamera,
 ) -> anyhow::Result<()> {
     // NOTE: the dataset is all row-major, transpose those matrices!
@@ -180,51 +170,53 @@ fn log_ar_camera(
 
     rec.log(
         "world/camera",
-        &Transform3D::new(TranslationRotationScale3D::rigid(translation, rot)),
+        &rerun::archetypes::Transform3D::new(rerun::TranslationRotationScale3D::rigid(
+            translation,
+            rot,
+        )),
     )?;
 
     rec.log(
         "world/camera",
-        &Pinhole::new(intrinsics).with_resolution(resolution),
+        &rerun::Pinhole::new(intrinsics)
+            // See https://github.com/google-research-datasets/Objectron/issues/39 for coordinate systems
+            .with_camera_xyz(rerun::components::ViewCoordinates::RDF)
+            .with_resolution(resolution),
     )?;
 
     Ok(())
 }
 
 fn log_feature_points(
-    rec: &RecordingStream,
-    timepoint: TimePoint,
+    rec: &rerun::RecordingStream,
+    timepoint: rerun::TimePoint,
     points: &objectron::ArPointCloud,
 ) -> anyhow::Result<()> {
-    use rerun::components::{Color, InstanceKey};
-
     let ids = points.identifier.iter();
     let points = points.point.iter();
 
     rec.set_timepoint(timepoint);
     rec.log(
         "world/points",
-        &Points3D::new(points.map(|p| {
+        &rerun::Points3D::new(points.map(|p| {
             (
                 p.x.unwrap_or_default(),
                 p.y.unwrap_or_default(),
                 p.z.unwrap_or_default(),
             )
         }))
-        .with_instance_keys(ids.map(|id| InstanceKey(*id as _)))
-        .with_colors([Color::from_rgb(255, 255, 255)]),
+        .with_instance_keys(ids.map(|id| rerun::InstanceKey(*id as _)))
+        .with_colors([rerun::Color::from_rgb(255, 255, 255)]),
     )?;
 
     Ok(())
 }
 
 fn log_frame_annotations(
-    rec: &RecordingStream,
-    timepoint: &TimePoint,
+    rec: &rerun::RecordingStream,
+    timepoint: &rerun::TimePoint,
     annotations: &objectron::FrameAnnotation,
 ) -> anyhow::Result<()> {
-    use rerun::components::{Color, InstanceKey};
-
     for ann in &annotations.annotations {
         // TODO(cmc): we shouldn't be using those preprojected 2D points to begin with, Rerun is
         // capable of projecting the actual 3D points in real time now.
@@ -234,7 +226,7 @@ fn log_frame_annotations(
             .filter_map(|kp| {
                 kp.point_2d
                     .as_ref()
-                    .map(|p| (InstanceKey(kp.id as _), [p.x * 1440.0, p.y * 1920.0]))
+                    .map(|p| (rerun::InstanceKey(kp.id as _), [p.x * 1440.0, p.y * 1920.0]))
             })
             .unzip();
 
@@ -274,15 +266,15 @@ fn log_frame_annotations(
             }
             rec.log(
                 ent_path,
-                &LineStrips2D::new(linestrips(&points))
-                    .with_colors([Color::from_rgb(130, 160, 250)]),
+                &rerun::LineStrips2D::new(linestrips(&points))
+                    .with_colors([rerun::Color::from_rgb(130, 160, 250)]),
             )?;
         } else {
             rec.log(
                 ent_path,
-                &Points2D::new(points)
+                &rerun::Points2D::new(points)
                     .with_instance_keys(ids)
-                    .with_colors([Color::from_rgb(130, 160, 250)]),
+                    .with_colors([rerun::Color::from_rgb(130, 160, 250)]),
             )?;
         }
     }
@@ -338,7 +330,7 @@ fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseFloat
     Ok(std::time::Duration::from_secs_f64(seconds))
 }
 
-fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
+fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     // Parse protobuf dataset
     let store_info = args.recording.info().with_context(|| {
         use clap::ValueEnum as _;
@@ -351,9 +343,8 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
     })?;
     let annotations = read_annotations(&store_info.path_annotations)?;
 
-    // See https://github.com/google-research-datasets/Objectron/issues/39
-    rec.log_timeless("world", &ViewCoordinates::RUB)?;
-    rec.log_timeless("world/camera", &ViewCoordinates::RDF)?;
+    // See https://github.com/google-research-datasets/Objectron/issues/39 for coordinate systems
+    rec.log_timeless("world", &rerun::ViewCoordinates::RUB)?;
 
     log_baseline_objects(rec, &annotations.objects)?;
 

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -12,11 +12,9 @@ use std::path::PathBuf;
 
 use bytes::Bytes;
 use rerun::{
-    archetypes::{Mesh3D, ViewCoordinates},
-    components::{Color, MeshProperties, Transform3D},
+    components::{MeshProperties, Transform3D},
     external::{ecolor, re_log, re_memory::AccountingAllocator},
-    transform::TranslationRotationScale3D,
-    RecordingStream,
+    Color, Mesh3D, RecordingStream, TranslationRotationScale3D,
 };
 
 // TODO(cmc): This example needs to support animations to showcase Rerun's time capabilities.
@@ -169,7 +167,7 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
     // Log raw glTF nodes and their transforms with Rerun
     for root in nodes {
         re_log::info!(scene = root.name, "logging glTF scene");
-        rec.log_timeless(root.name.as_str(), &ViewCoordinates::RIGHT_HAND_Y_UP)?;
+        rec.log_timeless(root.name.as_str(), &rerun::ViewCoordinates::RIGHT_HAND_Y_UP)?;
         log_node(rec, root)?;
     }
 

--- a/examples/rust/template/src/main.rs
+++ b/examples/rust/template/src/main.rs
@@ -1,9 +1,8 @@
 //! Example template.
 
-use rerun::RecordingStreamBuilder;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = RecordingStreamBuilder::new("rerun_example_my_example_name").memory()?;
+    let (rec, storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").memory()?;
 
     let _ = rec;
 


### PR DESCRIPTION
### What
* Requires https://github.com/rerun-io/rerun/pull/3542 to be merged first

Import selected types into the `re_sdk` and `rerun` modules to reduce the typing in user code.

In a lot of examples i opted for putting `rerun::` in the code, to make it super-clear to the reader what types are rerun types, and which isn't.

There are a few annoying name-clashes:

* `archetypes::Viewport` and `components::Viewport` (the latter is used by `Pinhole::camera_xyz`)
* `datatype::Color` and `components::Color` (TODO: rename the former to `Rgba`)
* `datatypes::Transform3D`, `components::Transform3D` and `datatypes::Transform3D`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3589) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3589)
- [Docs preview](https://rerun.io/preview/3edd7d6f07ac78a46d83232d91c70ebf3872179e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3edd7d6f07ac78a46d83232d91c70ebf3872179e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)