### PR TITLE
Improve Asset3D and Blob APIs

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
@@ -7,7 +7,7 @@ namespace rerun.archetypes;
 
 // ---
 
-/// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc).
+/// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 ///
 /// \example asset3d_simple "Simple 3D asset"
 /// \example asset3d_out_of_tree "3D asset with out-of-tree transform"

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc).
+/// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 ///
 /// ## Examples
 ///

--- a/docs/code-examples/asset3d_out_of_tree.py
+++ b/docs/code-examples/asset3d_out_of_tree.py
@@ -15,16 +15,16 @@ rr.init("rerun_example_asset3d_out_of_tree", spawn=True)
 rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
 
 rr.set_time_sequence("frame", 0)
-rr.log("world/asset", rr.Asset3D.from_file(sys.argv[1]))
+rr.log("world/asset", rr.Asset3D(sys.argv[1]))
 # Those points will not be affected by their parent's out-of-tree transform!
 rr.log(
     "world/asset/points",
     rr.Points3D(np.vstack([xyz.ravel() for xyz in np.mgrid[3 * [slice(-10, 10, 10j)]]]).T),
 )
 
-asset = rr.Asset3D.from_file(sys.argv[1])
+asset = rr.Asset3D(sys.argv[1])
 for i in range(1, 20):
     rr.set_time_sequence("frame", i)
 
     translation = TranslationRotationScale3D(translation=[0, 0, i - 10.0])
-    rr.log_components("asset", [OutOfTreeTransform3DBatch(translation)])
+    rr.log_components("world/asset", [OutOfTreeTransform3DBatch(translation)])

--- a/docs/code-examples/asset3d_simple.py
+++ b/docs/code-examples/asset3d_simple.py
@@ -10,4 +10,4 @@ if len(sys.argv) < 2:
 rr.init("rerun_example_asset3d_simple", spawn=True)
 
 rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
-rr.log("world/asset", rr.Asset3D.from_file(sys.argv[1]))
+rr.log("world/asset", rr.Asset3D(sys.argv[1]))

--- a/docs/content/reference/data_types/archetypes/asset3d.md
+++ b/docs/content/reference/data_types/archetypes/asset3d.md
@@ -2,7 +2,7 @@
 title: "Asset3D"
 ---
 
-A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc).
+A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 
 ## Components
 

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -21,7 +21,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc).
+        /// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
         ///
         /// ## Example
         ///

--- a/rerun_py/rerun_sdk/rerun/_converters.py
+++ b/rerun_py/rerun_sdk/rerun/_converters.py
@@ -115,7 +115,7 @@ def to_np_uint8(data: npt.ArrayLike | bytes) -> npt.NDArray[np.uint8]:
     """
     Convert some data to a numpy uint8 array.
 
-    This function additionally supports bytes.
+    This function additionally supports `bytes`.
     """
 
     if isinstance(data, bytes):

--- a/rerun_py/rerun_sdk/rerun/_converters.py
+++ b/rerun_py/rerun_sdk/rerun/_converters.py
@@ -111,18 +111,26 @@ def str_or_none(data: str | None) -> str | None:
     return str(data)
 
 
-def to_np_uint8(data: npt.ArrayLike) -> npt.NDArray[np.uint8]:
-    """Convert some datat to a numpy uint8 array."""
-    return np.asarray(data, dtype=np.uint8)
+def to_np_uint8(data: npt.ArrayLike | bytes) -> npt.NDArray[np.uint8]:
+    """
+    Convert some data to a numpy uint8 array.
+
+    This function additionally supports bytes.
+    """
+
+    if isinstance(data, bytes):
+        return np.frombuffer(data, dtype=np.uint8)
+    else:
+        return np.asarray(data, dtype=np.uint8)
 
 
 def to_np_uint16(data: npt.ArrayLike) -> npt.NDArray[np.uint16]:
-    """Convert some datat to a numpy uint16 array."""
+    """Convert some data to a numpy uint16 array."""
     return np.asarray(data, dtype=np.uint16)
 
 
 def to_np_uint32(data: npt.ArrayLike | None) -> npt.NDArray[np.uint32] | None:
-    """Convert some datat to a numpy uint32 array."""
+    """Convert some data to a numpy uint32 array."""
     if data is not None:
         return np.asarray(data, dtype=np.uint32)
     else:
@@ -130,45 +138,45 @@ def to_np_uint32(data: npt.ArrayLike | None) -> npt.NDArray[np.uint32] | None:
 
 
 def to_np_uint64(data: npt.ArrayLike) -> npt.NDArray[np.uint64]:
-    """Convert some datat to a numpy uint64 array."""
+    """Convert some data to a numpy uint64 array."""
     return np.asarray(data, dtype=np.uint64)
 
 
 def to_np_int8(data: npt.ArrayLike) -> npt.NDArray[np.int8]:
-    """Convert some datat to a numpy int8 array."""
+    """Convert some data to a numpy int8 array."""
     return np.asarray(data, dtype=np.int8)
 
 
 def to_np_int16(data: npt.ArrayLike) -> npt.NDArray[np.int16]:
-    """Convert some datat to a numpy int16 array."""
+    """Convert some data to a numpy int16 array."""
     return np.asarray(data, dtype=np.int16)
 
 
 def to_np_int32(data: npt.ArrayLike) -> npt.NDArray[np.int32]:
-    """Convert some datat to a numpy int32 array."""
+    """Convert some data to a numpy int32 array."""
     return np.asarray(data, dtype=np.int32)
 
 
 def to_np_int64(data: npt.ArrayLike) -> npt.NDArray[np.int64]:
-    """Convert some datat to a numpy int64 array."""
+    """Convert some data to a numpy int64 array."""
     return np.asarray(data, dtype=np.int64)
 
 
 def to_np_bool(data: npt.ArrayLike) -> npt.NDArray[np.bool_]:
-    """Convert some datat to a numpy bool array."""
+    """Convert some data to a numpy bool array."""
     return np.asarray(data, dtype=np.bool_)
 
 
 def to_np_float16(data: npt.ArrayLike) -> npt.NDArray[np.float16]:
-    """Convert some datat to a numpy float16 array."""
+    """Convert some data to a numpy float16 array."""
     return np.asarray(data, dtype=np.float16)
 
 
 def to_np_float32(data: npt.ArrayLike) -> npt.NDArray[np.float32]:
-    """Convert some datat to a numpy float32 array."""
+    """Convert some data to a numpy float32 array."""
     return np.asarray(data, dtype=np.float32)
 
 
 def to_np_float64(data: npt.ArrayLike) -> npt.NDArray[np.float64]:
-    """Convert some datat to a numpy float64 array."""
+    """Convert some data to a numpy float64 array."""
     return np.asarray(data, dtype=np.float64)

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -67,7 +67,7 @@ class Asset3D(Asset3DExt, Archetype):
         rr.set_time_sequence("frame", i)
 
         translation = TranslationRotationScale3D(translation=[0, 0, i - 10.0])
-        rr.log_components("asset", [OutOfTreeTransform3DBatch(translation)])
+        rr.log_components("world/asset", [OutOfTreeTransform3DBatch(translation)])
     ```
     """
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -5,13 +5,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from attrs import define, field
 
-from .. import components, datatypes
+from .. import components
 from .._baseclasses import Archetype
-from ..error_utils import catch_and_log_exceptions
 from .asset3d_ext import Asset3DExt
 
 __all__ = ["Asset3D"]
@@ -20,7 +17,7 @@ __all__ = ["Asset3D"]
 @define(str=False, repr=False, init=False)
 class Asset3D(Asset3DExt, Archetype):
     """
-    A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc).
+    A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 
     Examples
     --------
@@ -37,7 +34,7 @@ class Asset3D(Asset3DExt, Archetype):
     rr.init("rerun_example_asset3d_simple", spawn=True)
 
     rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
-    rr.log("world/asset", rr.Asset3D.from_file(sys.argv[1]))
+    rr.log("world/asset", rr.Asset3D(sys.argv[1]))
     ```
 
     3D asset with out-of-tree transform:
@@ -58,14 +55,14 @@ class Asset3D(Asset3DExt, Archetype):
     rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
 
     rr.set_time_sequence("frame", 0)
-    rr.log("world/asset", rr.Asset3D.from_file(sys.argv[1]))
+    rr.log("world/asset", rr.Asset3D(sys.argv[1]))
     # Those points will not be affected by their parent's out-of-tree transform!
     rr.log(
         "world/asset/points",
         rr.Points3D(np.vstack([xyz.ravel() for xyz in np.mgrid[3 * [slice(-10, 10, 10j)]]]).T),
     )
 
-    asset = rr.Asset3D.from_file(sys.argv[1])
+    asset = rr.Asset3D(sys.argv[1])
     for i in range(1, 20):
         rr.set_time_sequence("frame", i)
 
@@ -74,40 +71,7 @@ class Asset3D(Asset3DExt, Archetype):
     ```
     """
 
-    def __init__(
-        self: Any,
-        blob: components.BlobLike,
-        *,
-        media_type: datatypes.Utf8Like | None = None,
-        transform: datatypes.Transform3DLike | None = None,
-    ):
-        """
-        Create a new instance of the Asset3D archetype.
-
-        Parameters
-        ----------
-        blob:
-             The asset's bytes.
-        media_type:
-             The Media Type of the asset.
-
-             For instance:
-             * `model/gltf-binary`
-             * `model/obj`
-
-             If omitted, the viewer will try to guess from the data blob.
-             If it cannot guess, it won't be able to render the asset.
-        transform:
-             An out-of-tree transform.
-
-             Applies a transformation to the asset itself without impacting its children.
-        """
-
-        # You can define your own __init__ function as a member of Asset3DExt in asset3d_ext.py
-        with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
-            return
-        self.__attrs_clear__()
+    # __init__ can be found in asset3d_ext.py
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pathlib
+from typing import TYPE_CHECKING, Any
 
+from .. import components, datatypes
 from ..error_utils import catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import MediaType
-    from . import Asset3D
 
 
 def guess_media_type(path: str) -> MediaType | None:
@@ -26,34 +27,47 @@ def guess_media_type(path: str) -> MediaType | None:
 
 
 class Asset3DExt:
-    @staticmethod
-    def from_file(path: str) -> Asset3D:
+    def __init__(
+        self: Any,
+        data: components.BlobLike | str | pathlib.Path,
+        *,
+        media_type: datatypes.Utf8Like | None = None,
+        transform: datatypes.Transform3DLike | None = None,
+    ):
         """
-        Creates a new [`Asset3D`] from the file contents at `path`.
+        Create a new instance of the Asset3D archetype.
 
-        The [`MediaType`] will be guessed from the file extension.
+        Parameters
+        ----------
+        data:
+             The asset's data (either a [`rerun.components.Blob`][] or compatible type, including `bytes`, or a file
+             path).
+        media_type:
+             The Media Type of the asset.
 
-        If no [`MediaType`] can be guessed at the moment, the Rerun Viewer will try to guess one
-        from the data at render-time. If it can't, rendering will fail with an error.
+             For instance:
+             * `model/gltf-binary`
+             * `model/obj`
+
+             If omitted, the viewer will try to guess from the data blob.
+             If it cannot guess, it won't be able to render the asset.
+        transform:
+             An out-of-tree transform.
+
+             Applies a transformation to the asset itself without impacting its children.
         """
-        from . import Asset3D
 
-        with catch_and_log_exceptions(context="Asset3D.from_file"):
-            with open(path, "rb") as file:
-                return Asset3D.from_bytes(file.read(), guess_media_type(path))
-        return Asset3D._clear()
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            if isinstance(data, (str, pathlib.Path)):
+                path = str(data)
+                with open(path, "rb") as file:
+                    blob: components.BlobLike = file.read()
+                if media_type is None:
+                    media_type = guess_media_type(path)
+            else:
+                blob = data
 
-    @staticmethod
-    def from_bytes(blob: bytes, media_type: MediaType | None) -> Asset3D:
-        """
-        Creates a new [`Asset3D`] from the given `bytes`.
+            self.__attrs_init__(blob=blob, media_type=media_type, transform=transform)
+            return
 
-        If no [`MediaType`] is specified, the Rerun Viewer will try to guess one from the data
-        at render-time. If it can't, rendering will fail with an error.
-        """
-        from . import Asset3D
-
-        # TODO(cmc): we could try and guess using magic bytes here, like rust does.
-        with catch_and_log_exceptions(context="Asset3D.from_file"):
-            return Asset3D(blob=blob, media_type=media_type)
-        return Asset3D._clear()
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/file.py
@@ -99,13 +99,13 @@ def log_mesh_file(
     recording = RecordingStream.to_native(recording)
 
     if mesh_path is not None:
-        asset3d = Asset3D.from_file(str(mesh_path))
+        asset3d = Asset3D(str(mesh_path))
     elif mesh_bytes is not None:
         if mesh_format == MeshFormat.GLB:
             media_type = MediaType.GLB
         else:
             media_type = MediaType.OBJ
-        asset3d = Asset3D.from_bytes(mesh_bytes, media_type)
+        asset3d = Asset3D(mesh_bytes, media_type=media_type)
     else:
         raise ValueError("must specify either `mesh_path` or `mesh_bytes`")
 

--- a/rerun_py/tests/unit/test_asset3d.py
+++ b/rerun_py/tests/unit/test_asset3d.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import rerun as rr
+
+CUBE_FILE = pathlib.Path(__file__).parent.parent.parent.parent / "docs" / "assets" / "cube.glb"
+assert CUBE_FILE.is_file()
+
+
+def test_asset3d() -> None:
+    blob_bytes = CUBE_FILE.read_bytes()
+    blob_comp = rr.components.Blob(blob_bytes)
+
+    all_input: list[tuple[rr.components.BlobLike | str | pathlib.Path, rr.components.MediaType | None]] = [
+        (CUBE_FILE, None),
+        (str(CUBE_FILE), None),
+        (blob_bytes, rr.components.MediaType.GLB),
+        (np.frombuffer(blob_bytes, dtype=np.uint8), rr.components.MediaType.GLB),
+        (blob_comp, rr.components.MediaType.GLB),
+    ]
+
+    rr.set_strict_mode(True)
+
+    assets = [rr.Asset3D(blob, media_type=typ) for blob, typ in all_input]
+
+    for asset in assets:
+        assert asset.blob.as_arrow_array() == rr.components.BlobBatch(blob_comp).as_arrow_array()
+        assert asset.media_type == rr.components.MediaTypeBatch(rr.components.MediaType.GLB)
+        assert asset.transform is None
+
+
+def test_asset3d_transform() -> None:
+    asset = rr.Asset3D(CUBE_FILE, transform=rr.datatypes.TranslationRotationScale3D(translation=[1, 2, 3]))
+
+    assert asset.transform is not None
+    assert (
+        asset.transform.as_arrow_array()
+        == rr.components.OutOfTreeTransform3DBatch(
+            rr.datatypes.TranslationRotationScale3D(translation=[1, 2, 3])
+        ).as_arrow_array()
+    )

--- a/rerun_py/tests/unit/test_blob.py
+++ b/rerun_py/tests/unit/test_blob.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import numpy as np
+import rerun as rr
+
+
+def test_blob() -> None:
+    """Blob should accept bytes input."""
+
+    bites = b"Hello world"
+    array = np.array([72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100], dtype=np.uint8)
+
+    assert rr.components.BlobBatch(bites).as_arrow_array() == rr.components.BlobBatch(array).as_arrow_array()


### PR DESCRIPTION
### What

This PR does the following:
- improve `Asset3D` API (fixes #3555)
- improve `Blob` API to accept `bytes`
- actually anything of type `np.array(dtype=np.uint8)` accepts `bytes` now
- added tests for both `Asset3D` and `Blob`
- fixed a bug in one of the `Asset3D` python code example

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3591) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3591)
- [Docs preview](https://rerun.io/preview/6837f14f6f6dadf1f5d17541646eb8412be75ce1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6837f14f6f6dadf1f5d17541646eb8412be75ce1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)