### PR TITLE
Replace `Result<T, anyhow::Error>` with `anyhow::Result<T>`

### DIFF
--- a/crates/re_data_source/src/load_file_contents.rs
+++ b/crates/re_data_source/src/load_file_contents.rs
@@ -102,7 +102,7 @@ fn log_msg_from_file_contents(
     Ok(LogMsg::ArrowMsg(store_id, arrow_msg))
 }
 
-fn load_rrd_sync(file_contents: &FileContents, tx: &Sender<LogMsg>) -> Result<(), anyhow::Error> {
+fn load_rrd_sync(file_contents: &FileContents, tx: &Sender<LogMsg>) -> anyhow::Result<()> {
     re_tracing::profile_function!(file_contents.name.as_str());
 
     let bytes: &[u8] = &file_contents.bytes;

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -28,7 +28,7 @@
 ///     RecordingStreamBuilder,
 /// };
 ///
-/// fn main() -> Result<(), anyhow::Error> {
+/// fn main() -> anyhow::Result<()> {
 ///     let args = std::env::args().collect::<Vec<_>>();
 ///     let Some(path) = args.get(1) else {
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
@@ -57,7 +57,7 @@
 ///     RecordingStreamBuilder,
 /// };
 ///
-/// fn main() -> Result<(), anyhow::Error> {
+/// fn main() -> anyhow::Result<()> {
 ///     let args = std::env::args().collect::<Vec<_>>();
 ///     let Some(path) = args.get(1) else {
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);

--- a/crates/re_types/src/archetypes/asset3d_ext.rs
+++ b/crates/re_types/src/archetypes/asset3d_ext.rs
@@ -12,7 +12,7 @@ impl Asset3D {
     /// from the data at render-time. If it can't, rendering will fail with an error.
     #[cfg(not(target_arch = "wasm32"))]
     #[inline]
-    pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self, anyhow::Error> {
+    pub fn from_file(path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
         use anyhow::Context as _;
         let path = path.as_ref();
         let data = std::fs::read(path)

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -9,7 +9,7 @@ use rerun::{
     RecordingStreamBuilder,
 };
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
     let Some(path) = args.get(1) else {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -6,7 +6,7 @@ use rerun::{
     RecordingStreamBuilder,
 };
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
     let Some(path) = args.get(1) else {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);

--- a/docs/content/reference/data_types/datatypes/translation_and_mat3x3.md
+++ b/docs/content/reference/data_types/datatypes/translation_and_mat3x3.md
@@ -9,7 +9,7 @@ First applies the matrix, then the translation.
 ## Fields
 
 * translation: [`Vec3D`](../datatypes/vec3d.md)
-* matrix: [`Mat3x3`](../datatypes/mat3x3.md)
+* mat3x3: [`Mat3x3`](../datatypes/mat3x3.md)
 
 
 ## Used by

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -33,6 +33,8 @@ legal_todo_inner_pattern = re.compile(
     r"TODO\(((?:[a-zA-Z\-_/]+)?#\d+|[a-zA-Z]+)(?:,\s*((?:[a-zA-Z\-_/]+)?#\d+|[a-zA-Z]+))*\)"
 )
 
+anyhow_result = re.compile(r"Result<.*, anyhow::Error>")
+
 
 def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if line == "":
@@ -75,6 +77,9 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
 
     if "from attr import dataclass" in line:
         return "Avoid 'from attr import dataclass'; prefer 'from dataclasses import dataclass'"
+
+    if anyhow_result.search(line):
+        return "Prefer using anyhow::Result<>"
 
     m = re.search(error_map_err_name, line) or re.search(error_match_name, line)
     if m:
@@ -142,6 +147,7 @@ def test_lint_line() -> None:
         "let Some(foo) = bar else { return; };",
         "{foo:?}",
         "rec",
+        "anyhow::Result<()>",
     ]
 
     should_error = [
@@ -172,6 +178,7 @@ def test_lint_line() -> None:
         "trailing whitespace ",
         "rr_stream",
         "rec_stream",
+        "Result<(), anyhow::Error>",
     ]
 
     for line in should_pass:


### PR DESCRIPTION
### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3595) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3595)
- [Docs preview](https://rerun.io/preview/21f01ad9407077e1e8b955ef133144f0bbd44566/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/21f01ad9407077e1e8b955ef133144f0bbd44566/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)