### PR TITLE
Fix egui ID clash warning on toast notifcations

### DIFF
--- a/crates/re_ui/src/toasts.rs
+++ b/crates/re_ui/src/toasts.rs
@@ -107,9 +107,7 @@ impl Toasts {
                 })
                 .response;
 
-            let response = response
-                .interact(egui::Sense::click())
-                .on_hover_text("Click to close and copy contents");
+            let response = response.on_hover_text("Click to close and copy contents");
 
             if !response.hovered() {
                 toast.options.ttl_sec -= dt;


### PR DESCRIPTION
### What
Something that snuck in with new egui update

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3597) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3597)
- [Docs preview](https://rerun.io/preview/69900eaacb6d71faf79e49dfeb84cf33ccc1f673/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/69900eaacb6d71faf79e49dfeb84cf33ccc1f673/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)