### PR TITLE
Checkout `github.sha` in `documentation` workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
       - uses: streetsidesoftware/cspell-action@v2
         with:
           config: "docs/cspell.json"
@@ -26,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
       - uses: jprochazk/linkinator-action@main
         with:
           paths: "docs/**/*.md"


### PR DESCRIPTION
### What

Fix for https://github.com/rerun-io/rerun/actions/runs/6381692457/job/17319982732?pr=3530
- `linkinator` and `spell-check` jobs were trying to checkout a commit that doesn't exist on contributor PRs
- switched them to checkout the default ref (`github.sha`) instead, which is the merge commit for PRs

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3598) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3598)
- [Docs preview](https://rerun.io/preview/74bdec9cf1af4546ad8f62d5a166b9c6eaca3463/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/74bdec9cf1af4546ad8f62d5a166b9c6eaca3463/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)