### PR TITLE
Make `array_format` on `Box2D` required if `array` was specified

### DIFF
--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -172,7 +172,7 @@
 //! Then the url you should use is `https://static.rerun.io/my_screenshot/9066060e59ee9d2d7d98b214b8db0b8f2e8ab4b8/1024w.png`.
 //!
 //! It works this way because `upload_image.py` does not upscale screenshots, it only downscales them.
-//! We need to know what the maximum width we can use is, becuase we can't just provide all the widths all the time.
+//! We need to know what the maximum width we can use is, because we can't just provide all the widths all the time.
 //! If the currently-used `max-width` source fails to load, it will show the blank image icon.
 //! There is no way to provide a fallback in `<picture>` if a specific `max-width` source fails to load.
 //! Browsers will not automatically try to load the other sources!

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .. import components, datatypes
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import catch_and_log_exceptions
 
 
 class Box2DFormat(Enum):
@@ -41,7 +41,7 @@ class Boxes2DExt:
         half_sizes: datatypes.Vec2DArrayLike | None = None,
         centers: datatypes.Vec2DArrayLike | None = None,
         array: npt.ArrayLike | None = None,
-        array_format: Box2DFormat = Box2DFormat.XYWH,
+        array_format: Box2DFormat | None = None,
         radii: components.RadiusArrayLike | None = None,
         colors: datatypes.ColorArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
@@ -66,6 +66,7 @@ class Boxes2DExt:
             Only valid when used together with either `sizes` or `half_sizes`.
         array:
             An array of boxes in the format specified by `array_format`.
+            *Requires* specifying `array_format`.
             Incompatible with `sizes`, `half_sizes`, `mins` and `centers`.
         array_format:
             How to interpret the data in `array`.
@@ -92,14 +93,16 @@ class Boxes2DExt:
 
         with catch_and_log_exceptions(context=self.__class__.__name__):
             if array is not None:
+                if array_format is None:
+                    raise ValueError("Must specify `array_format` when specifying `array`.")
                 if half_sizes is not None:
-                    _send_warning("Cannot specify both `array` and `half_sizes` at the same time.", 1)
+                    raise ValueError("Cannot specify both `array` and `half_sizes` at the same time.")
                 if sizes is not None:
-                    _send_warning("Cannot specify both `array` and `sizes` at the same time.", 1)
+                    raise ValueError("Cannot specify both `array` and `sizes` at the same time.")
                 if mins is not None:
-                    _send_warning("Cannot specify both `array` and `mins` at the same time.", 1)
+                    raise ValueError("Cannot specify both `array` and `mins` at the same time.")
                 if centers is not None:
-                    _send_warning("Cannot specify both `array` and `centers` at the same time.", 1)
+                    raise ValueError("Cannot specify both `array` and `centers` at the same time.")
 
                 if np.any(array):
                     array = np.asarray(array, dtype="float32")
@@ -136,19 +139,18 @@ class Boxes2DExt:
             else:
                 if sizes is not None:
                     if half_sizes is not None:
-                        _send_warning("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
+                        raise ValueError("Cannot specify both `sizes` and `half_sizes` at the same time.")
 
                     sizes = np.asarray(sizes, dtype=np.float32)
                     half_sizes = sizes / 2.0
 
                 if mins is not None:
                     if centers is not None:
-                        _send_warning("Cannot specify both `mins` and `centers` at the same time.", 1)
+                        raise ValueError("Cannot specify both `mins` and `centers` at the same time.")
 
                     # already converted `sizes` to `half_sizes`
                     if half_sizes is None:
-                        _send_warning("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
-                        half_sizes = np.asarray([1, 1], dtype=np.float32)
+                        raise ValueError("Cannot specify `mins` without `sizes` or `half_sizes`.")
 
                     mins = np.asarray(mins, dtype=np.float32)
                     half_sizes = np.asarray(half_sizes, dtype=np.float32)

--- a/rerun_py/tests/unit/test_box2d.py
+++ b/rerun_py/tests/unit/test_box2d.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 from typing import Optional, cast
 
+import pytest
 import rerun as rr
 from rerun.components import (
     DrawOrderLike,
@@ -134,6 +135,32 @@ def test_with_array_xcycwh() -> None:
 
 def test_with_array_xcycw2h2() -> None:
     assert rr.Boxes2D(mins=[1, 1], sizes=[2, 4]) == rr.Boxes2D(array=[2, 3, 1, 2], array_format=rr.Box2DFormat.XCYCW2H2)
+
+
+def test_invalid_parameter_combinations() -> None:
+    rr.set_strict_mode(True)
+
+    # invalid size/position combinations
+    with pytest.raises(ValueError):
+        rr.Boxes2D(half_sizes=[1, 2], sizes=[3, 4])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(centers=[1, 2], mins=[3, 4])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(mins=[3, 4])
+
+    # with array
+    with pytest.raises(ValueError):
+        rr.Boxes2D(array=[3, 4, 5, 6])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(array=[3, 4, 5, 6], array_format=rr.Box2DFormat.XYWH, half_sizes=[1, 2])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(array=[3, 4, 5, 6], array_format=rr.Box2DFormat.XYWH, sizes=[1, 2])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(array=[3, 4, 5, 6], array_format=rr.Box2DFormat.XYWH, mins=[1, 2])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(array=[3, 4, 5, 6], array_format=rr.Box2DFormat.XYWH, centers=[1, 2])
+    with pytest.raises(ValueError):
+        rr.Boxes2D(array=[3, 4, 5, 6], array_format="bonkers")  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

*  Fixes #3587

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3600) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3600)
- [Docs preview](https://rerun.io/preview/f6dfeba2bb4400199d6408a8d6a40f5e029a3587/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f6dfeba2bb4400199d6408a8d6a40f5e029a3587/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)