### PR TITLE
Add upcasting support to `ClassDescription`

### DIFF
--- a/crates/re_types/definitions/rerun/datatypes/class_description.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/class_description.fbs
@@ -21,6 +21,10 @@ namespace rerun.datatypes;
 /// defined, and both keypoints exist within the instance of the class, then the
 /// keypoints should be connected with an edge. The edge should be labeled and
 /// colored as described by the class's `AnnotationInfo`.
+///
+/// \py Note that a `ClassDescription` can be directly logged using `rerun.log`.
+/// \py This is equivalent to logging a `rerun.AnnotationContext` containing
+/// \py a single `ClassDescription`.
 table ClassDescription (
   "attr.python.aliases": "datatypes.AnnotationInfoLike",
   "attr.rust.derive": "Default, Eq, PartialEq"

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -116,10 +116,8 @@ class FaceDetectorLogger:
         # With this annotation, the viewer will connect the keypoints with some lines to improve visibility.
         rr.log(
             "video/detector",
-            rr.AnnotationContext(
-                rr.ClassDescription(
-                    info=rr.AnnotationInfo(id=0), keypoint_connections=[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4), (1, 5)]
-                )
+            rr.ClassDescription(
+                info=rr.AnnotationInfo(id=0), keypoint_connections=[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4), (1, 5)]
             ),
             timeless=True,
         )

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -27,12 +27,10 @@ def track_pose(video_path: str, segment: bool) -> None:
 
     rr.log(
         "/",
-        rr.AnnotationContext(
-            rr.ClassDescription(
-                info=rr.AnnotationInfo(id=0, label="Person"),
-                keypoint_annotations=[rr.AnnotationInfo(id=lm.value, label=lm.name) for lm in mp_pose.PoseLandmark],
-                keypoint_connections=mp_pose.POSE_CONNECTIONS,
-            )
+        rr.ClassDescription(
+            info=rr.AnnotationInfo(id=0, label="Person"),
+            keypoint_annotations=[rr.AnnotationInfo(id=lm.value, label=lm.name) for lm in mp_pose.PoseLandmark],
+            keypoint_connections=mp_pose.POSE_CONNECTIONS,
         ),
         timeless=True,
     )

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -28,7 +28,13 @@ class ComponentBatchLike(Protocol):
 
 
 class AsComponents(Protocol):
-    """Describes interface for interpreting an object as a bundle of Components."""
+    """
+    Describes interface for interpreting an object as a bundle of Components.
+
+    Note: the `num_instances()` function is an optional part of this interface. The method does not need to be
+    implemented as it is only used after checking for its existence. (There is unfortunately no way to express this
+    correctly with the Python typing system, see https://github.com/python/typing/issues/601).
+    """
 
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:
         """
@@ -41,18 +47,18 @@ class AsComponents(Protocol):
         """
         ...
 
-    def num_instances(self) -> int | None:
-        """
-        (Optional) The number of instances in each batch.
-
-        If not implemented, the number of instances will be determined by the longest
-        batch in the bundle.
-
-        Each batch returned by `as_component_batches` should have this number of
-        elements, or 1 in the case it is a splat, or 0 in the case that
-        component is being cleared.
-        """
-        return None
+    # def num_instances(self) -> int | None:
+    #     """
+    #     (Optional) The number of instances in each batch.
+    #
+    #     If not implemented, the number of instances will be determined by the longest
+    #     batch in the bundle.
+    #
+    #     Each batch returned by `as_component_batches` should have this number of
+    #     elements, or 1 in the case it is a splat, or 0 in the case that
+    #     component is being cleared.
+    #     """
+    #     return None
 
 
 @define

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
@@ -40,6 +40,10 @@ class ClassDescription(ClassDescriptionExt):
     defined, and both keypoints exist within the instance of the class, then the
     keypoints should be connected with an edge. The edge should be labeled and
     colored as described by the class's `AnnotationInfo`.
+
+    Note that a `ClassDescription` can be directly logged using `rerun.log`.
+    This is equivalent to logging a `rerun.AnnotationContext` containing
+    a single `ClassDescription`.
     """
 
     # __init__ can be found in class_description_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
@@ -64,6 +64,7 @@ class ClassDescriptionExt:
     # Implement the AsComponents protocol
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:
         from ..archetypes import AnnotationContext
+        from . import ClassDescription
 
         return AnnotationContext(cast(ClassDescription, self)).as_component_batches()
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Sequence, cast
 
 import pyarrow as pa
 
 from .keypoint_pair_ext import _keypoint_pair_converter
 
 if TYPE_CHECKING:
+    from .. import ComponentBatchLike
     from . import (
         AnnotationInfo,
         AnnotationInfoLike,
@@ -46,7 +47,7 @@ class ClassDescriptionExt:
         info:
             The `AnnotationInfo` for the class.
         keypoint_annotations:
-            The `AnnotationInfo` for all of the keypoints.
+            The `AnnotationInfo` for all the keypoints.
         keypoint_connections:
             The connections between keypoints.
         """
@@ -59,6 +60,12 @@ class ClassDescriptionExt:
         self.__attrs_init__(
             info=info, keypoint_annotations=keypoint_annotations, keypoint_connections=keypoint_connections
         )
+
+    # Implement the AsComponents protocol
+    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+        from ..archetypes import AnnotationContext
+
+        return AnnotationContext(cast(ClassDescription, self)).as_component_batches()
 
     @staticmethod
     def info__field_converter_override(


### PR DESCRIPTION
### What

This PR adds support for auto-upcasting of `rr.ClassDescrption` into `rr.AnnotationContext`, e.g.:

```python
# from humain_pose/tracking/main.py

rr.log(
        "/",
        rr.ClassDescription(
            info=rr.AnnotationInfo(id=0, label="Person"),
            keypoint_annotations=[rr.AnnotationInfo(id=lm.value, label=lm.name) for lm in mp_pose.PoseLandmark],
            keypoint_connections=mp_pose.POSE_CONNECTIONS,
        ),
        timeless=True,
    )
```

Also, to both appease the type checking and avoid circular reference and as per discussion with @jleibs, I removed `num_instance()` from the `AsComponents` protocol. I left it there commented as it's an "informal/optional" protocol method (called only if checked present). There is unfortunately no better way to model this with python's type system.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3603) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3603)
- [Docs preview](https://rerun.io/preview/33e47ec203b3fb7e7cf09d6277a270c0dcbca4b6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/33e47ec203b3fb7e7cf09d6277a270c0dcbca4b6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)