### PR TITLE
Use tau for rotations in Rust

### DIFF
--- a/crates/re_arrow_store/src/arrow_util.rs
+++ b/crates/re_arrow_store/src/arrow_util.rs
@@ -238,7 +238,7 @@ fn test_clean_for_polars_nomodify() {
 
 #[test]
 fn test_clean_for_polars_modify() {
-    use std::f32::consts::PI;
+    use std::f32::consts::TAU;
 
     use re_log_types::DataCell;
     use re_types::components::Transform3D;
@@ -247,7 +247,7 @@ fn test_clean_for_polars_modify() {
     let cell = DataCell::try_from_native([
         Transform3D::from_translation([1.0, 0.0, 0.0]), //
         Transform3D::from_rotation_scale(
-            RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(PI / 4.)),
+            RotationAxisAngle::new([0.0, 0.0, 1.0], Angle::Radians(TAU / 8.)),
             Scale3D::from(2.0),
         ),
     ])

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -13,7 +13,7 @@
 //! cargo run-wasm --example depth_cloud
 //! ```
 
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use glam::Vec3;
 use itertools::Itertools;
@@ -380,7 +380,7 @@ fn spiral(dimensions: glam::UVec2) -> impl Iterator<Item = (glam::UVec2, f32)> {
             let texcoords = (pos * factor).as_uvec2();
 
             i += 1;
-            angle_rad += 0.001 * PI;
+            angle_rad += 0.0005 * TAU;
 
             return Some((texcoords, radius));
         }

--- a/crates/re_types/tests/asset3d.rs
+++ b/crates/re_types/tests/asset3d.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use re_types::{
     archetypes::Asset3D,
@@ -22,7 +22,7 @@ fn roundtrip() {
                     translation: Some(Vec3D([1.0, 2.0, 3.0])),
                     rotation: Some(Rotation3D::AxisAngle(RotationAxisAngle {
                         axis: Vec3D([0.2, 0.2, 0.8]),
-                        angle: Angle::Radians(PI),
+                        angle: Angle::Radians(0.5 * TAU),
                     })),
                     scale: Some(Scale3D::Uniform(42.0)),
                     from_parent: true,
@@ -34,7 +34,7 @@ fn roundtrip() {
     let arch = Asset3D::from_bytes(BYTES, Some(MediaType::gltf())).with_transform(
         re_types::datatypes::Transform3D::from_translation_rotation_scale(
             [1.0, 2.0, 3.0],
-            RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(PI)),
+            RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(0.5 * TAU)),
             42.0,
         )
         .from_parent(),

--- a/crates/re_types/tests/fuzzy.rs
+++ b/crates/re_types/tests/fuzzy.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_clone)]
 
-use std::{collections::HashMap, f32::consts::PI};
+use std::{collections::HashMap, f32::consts::TAU};
 
 use arrow2::types::f16;
 use re_types::{
@@ -120,17 +120,17 @@ fn roundtrip() {
     ]));
 
     let fuzzy14_1 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Degrees(90.0));
-    let fuzzy14_2 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Radians(Some(PI)));
+    let fuzzy14_2 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Radians(Some(TAU / 2.0)));
     let fuzzy14_3 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Radians(None));
 
     let fuzzy15_1 = components::AffixFuzzer15(None);
     let fuzzy15_2 =
-        components::AffixFuzzer15(Some(datatypes::AffixFuzzer3::Radians(Some(PI / 4.0))));
+        components::AffixFuzzer15(Some(datatypes::AffixFuzzer3::Radians(Some(TAU / 8.0))));
 
     let fuzzy16_1 = components::AffixFuzzer16(vec![
-        datatypes::AffixFuzzer3::Radians(None),           //
-        datatypes::AffixFuzzer3::Degrees(45.0),           //
-        datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
+        datatypes::AffixFuzzer3::Radians(None),      //
+        datatypes::AffixFuzzer3::Degrees(45.0),      //
+        datatypes::AffixFuzzer3::Radians(Some(TAU)), //
     ]);
     let fuzzy16_2 = components::AffixFuzzer16(vec![
         datatypes::AffixFuzzer3::Degrees(20.0),           //
@@ -165,9 +165,9 @@ fn roundtrip() {
     ]));
     let fuzzy18_3 = components::AffixFuzzer18(Some(vec![
         datatypes::AffixFuzzer4::ManyRequired(vec![
-            datatypes::AffixFuzzer3::Radians(None),           //
-            datatypes::AffixFuzzer3::Degrees(45.0),           //
-            datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
+            datatypes::AffixFuzzer3::Radians(None),      //
+            datatypes::AffixFuzzer3::Degrees(45.0),      //
+            datatypes::AffixFuzzer3::Radians(Some(TAU)), //
             datatypes::AffixFuzzer3::Craziness(vec![datatypes::AffixFuzzer1 {
                 single_float_optional: Some(3.0),
                 single_string_required: "c".into(),
@@ -186,9 +186,9 @@ fn roundtrip() {
 
     let fuzzy19_1 = components::AffixFuzzer19(datatypes::AffixFuzzer5 {
         single_optional_union: Some(datatypes::AffixFuzzer4::ManyRequired(vec![
-            datatypes::AffixFuzzer3::Radians(None),           //
-            datatypes::AffixFuzzer3::Degrees(45.0),           //
-            datatypes::AffixFuzzer3::Radians(Some(PI * 2.0)), //
+            datatypes::AffixFuzzer3::Radians(None),      //
+            datatypes::AffixFuzzer3::Degrees(45.0),      //
+            datatypes::AffixFuzzer3::Radians(Some(TAU)), //
             datatypes::AffixFuzzer3::Craziness(vec![datatypes::AffixFuzzer1 {
                 single_float_optional: Some(3.0),
                 single_string_required: "c".into(),

--- a/crates/re_types/tests/transform3d.rs
+++ b/crates/re_types/tests/transform3d.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, f32::consts::PI};
+use std::{collections::HashMap, f32::consts::TAU};
 
 use re_types::{
     archetypes::Transform3D,
@@ -39,7 +39,7 @@ fn roundtrip() {
                     translation: Some(Vec3D([1.0, 2.0, 3.0])),
                     rotation: Some(Rotation3D::AxisAngle(RotationAxisAngle {
                         axis: Vec3D([0.2, 0.2, 0.8]),
-                        angle: Angle::Radians(PI),
+                        angle: Angle::Radians(0.5 * TAU),
                     })),
                     scale: None,
                     from_parent: false,
@@ -52,7 +52,7 @@ fn roundtrip() {
                     translation: Some(Vec3D([1.0, 2.0, 3.0])),
                     rotation: Some(Rotation3D::AxisAngle(RotationAxisAngle {
                         axis: Vec3D([0.2, 0.2, 0.8]),
-                        angle: Angle::Radians(PI),
+                        angle: Angle::Radians(0.5 * TAU),
                     })),
                     scale: Some(Scale3D::Uniform(42.0)),
                     from_parent: true,
@@ -103,13 +103,13 @@ fn roundtrip() {
         Transform3D::new(datatypes::Transform3D::TranslationRotationScale(
             TranslationRotationScale3D::from_translation_rotation(
                 [1.0, 2.0, 3.0],
-                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(PI)),
+                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(0.5 * TAU)),
             ),
         )), //
         Transform3D::new(datatypes::Transform3D::TranslationRotationScale(
             TranslationRotationScale3D::from_translation_rotation_scale(
                 [1.0, 2.0, 3.0],
-                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(PI)),
+                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(0.5 * TAU)),
                 42.0,
             )
             .from_parent(),

--- a/tests/rust/roundtrips/transform3d/src/main.rs
+++ b/tests/rust/roundtrips/transform3d/src/main.rs
@@ -1,6 +1,6 @@
 //! Logs a `Transform3D` archetype for roundtrip checks.
 
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use rerun::{
     archetypes::Transform3D,
@@ -65,7 +65,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
         &Transform3D::new(datatypes::Transform3D::TranslationRotationScale(
             TranslationRotationScale3D::from_translation_rotation(
                 [1.0, 2.0, 3.0],
-                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(PI)),
+                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(0.5 * TAU)),
             ),
         )), //
     )?;
@@ -75,7 +75,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
         &Transform3D::new(datatypes::Transform3D::TranslationRotationScale(
             TranslationRotationScale3D::from_translation_rotation_scale(
                 [1.0, 2.0, 3.0],
-                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(PI)),
+                RotationAxisAngle::new([0.2, 0.2, 0.8], Angle::Radians(0.5 * TAU)),
                 42.0,
             )
             .from_parent(),

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -12,10 +12,7 @@
 //! cargo run -p test_api -- --test rects
 //! ```
 
-use std::{
-    collections::HashSet,
-    f32::consts::{PI, TAU},
-};
+use std::{collections::HashSet, f32::consts::TAU};
 
 use itertools::Itertools;
 use rerun::{
@@ -38,8 +35,8 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
             .with_rotations([Quaternion::from_xyzw([
                 0.0,
                 0.0,
-                (PI / 4.0).sin(),
-                (PI / 4.0).cos(),
+                (TAU / 8.0).sin(),
+                (TAU / 8.0).cos(),
             ])])
             .with_radii([0.005])
             .with_labels(["box/t0"]),
@@ -53,8 +50,8 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
             .with_rotations([Quaternion::from_xyzw([
                 0.0,
                 0.0,
-                (PI / 4.0).sin(),
-                (PI / 4.0).cos(),
+                (TAU / 8.0).sin(),
+                (TAU / 8.0).cos(),
             ])])
             .with_radii([0.01])
             .with_labels(["box/t1"]),


### PR DESCRIPTION
### What
Unfortunately some inferior languages has problems with modernity:

> AttributeError: module ‘numpy’ has no attribute ‘tau’

Anyways, pi has its uses (I guess) but for angles, TAU is strictly superior. One TAU = one turn. Accept no substitutes.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3605) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3605)
- [Docs preview](https://rerun.io/preview/252198d9f11570e5bc5d8728c16a86e375824744/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/252198d9f11570e5bc5d8728c16a86e375824744/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)