### PR TITLE
Move the `jpeg_quality` argument from TensorData -> `image.compress`

### DIFF
--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -402,7 +402,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
                 colors_list,
             )
 
-            rr.log(f"{lowres_posed_entity_id}/rgb", rr.Image(rr.TensorData(array=rgb, jpeg_quality=95)))
+            rr.log(f"{lowres_posed_entity_id}/rgb", rr.Image(rgb).compress())
             rr.log(f"{lowres_posed_entity_id}/depth", rr.DepthImage(depth, meter=1000))
 
         # log the high res camera
@@ -427,7 +427,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
 
             highres_rgb = cv2.cvtColor(highres_bgr, cv2.COLOR_BGR2RGB)
 
-            rr.log(f"{highres_entity_id}/rgb", rr.Image(rr.TensorData(array=highres_rgb, jpeg_quality=75)))
+            rr.log(f"{highres_entity_id}/rgb", rr.Image(highres_rgb).compress(jpeg_quality=75))
             rr.log(f"{highres_entity_id}/depth", rr.DepthImage(highres_depth, meter=1000))
 
 

--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -85,7 +85,7 @@ class Detector:
         _, _, scaled_height, scaled_width = inputs["pixel_values"].shape
         scaled_size = (scaled_width, scaled_height)
         rgb_scaled = cv2.resize(rgb, scaled_size)
-        rr.log("image_scaled/rgb", rr.Image(rr.TensorData(array=rgb_scaled, jpeg_quality=85)))
+        rr.log("image_scaled/rgb", rr.Image(rgb_scaled).compress(jpeg_quality=85))
 
         logging.debug("Pass image to detection network")
         outputs = self.model(**inputs)
@@ -339,7 +339,7 @@ def track_objects(video_path: str) -> None:
             break
 
         rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-        rr.log("image/rgb", rr.Image(rr.TensorData(array=rgb, jpeg_quality=85)))
+        rr.log("image/rgb", rr.Image(rgb).compress(jpeg_quality=85))
 
         if not trackers or frame_idx % 40 == 0:
             detections = detector.detect_objects_to_track(rgb=rgb, frame_idx=frame_idx)

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -52,7 +52,7 @@ def track_pose(video_path: str, segment: bool) -> None:
             rgb = cv2.cvtColor(bgr_frame.data, cv2.COLOR_BGR2RGB)
             rr.set_time_seconds("time", bgr_frame.time)
             rr.set_time_sequence("frame_idx", bgr_frame.idx)
-            rr.log("video/rgb", rr.Image(rr.TensorData(array=rgb, jpeg_quality=75)))
+            rr.log("video/rgb", rr.Image(rgb).compress(jpeg_quality=75))
 
             results = pose.process(rgb)
             h, w, _ = rgb.shape

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -72,7 +72,7 @@ def log_nyud_data(recording_path: Path, subset_idx: int = 0) -> None:
             if f.filename.endswith(".ppm"):
                 buf = archive.read(f)
                 img_rgb = read_image_rgb(buf)
-                rr.log("world/camera/image/rgb", rr.Image(rr.TensorData(array=img_rgb, jpeg_quality=95)))
+                rr.log("world/camera/image/rgb", rr.Image(img_rgb).compress(jpeg_quality=95))
 
             elif f.filename.endswith(".pgm"):
                 buf = archive.read(f)

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -173,7 +173,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
             bgr = cv2.imread(str(image_file))
             bgr = cv2.resize(bgr, resize)
             rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-            rr.log("camera/image", rr.Image(rr.TensorData(array=rgb, jpeg_quality=75)))
+            rr.log("camera/image", rr.Image(rgb).compress(jpeg_quality=75))
         else:
             rr.log("camera/image", rr.ImageEncoded(path=dataset_path / "images" / image.name))
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from attrs import define, field
 
-from .. import components
+from .. import components, datatypes
 from .._baseclasses import Archetype
+from ..error_utils import catch_and_log_exceptions
 from .image_ext import ImageExt
 
 __all__ = ["Image"]
@@ -52,7 +55,24 @@ class Image(ImageExt, Archetype):
     </picture>
     """
 
-    # __init__ can be found in image_ext.py
+    def __init__(self: Any, data: datatypes.TensorDataLike, *, draw_order: components.DrawOrderLike | None = None):
+        """
+        Create a new instance of the Image archetype.
+
+        Parameters
+        ----------
+        data:
+             The image data. Should always be a rank-2 or rank-3 tensor.
+        draw_order:
+             An optional floating point value that specifies the 2D drawing order.
+             Objects with higher values are drawn on top of those with lower values.
+        """
+
+        # You can define your own __init__ function as a member of ImageExt in image_ext.py
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            self.__attrs_init__(data=data, draw_order=draw_order)
+            return
+        self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -5,13 +5,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from attrs import define, field
 
-from .. import components, datatypes
+from .. import components
 from .._baseclasses import Archetype
-from ..error_utils import catch_and_log_exceptions
 from .image_ext import ImageExt
 
 __all__ = ["Image"]
@@ -55,24 +52,7 @@ class Image(ImageExt, Archetype):
     </picture>
     """
 
-    def __init__(self: Any, data: datatypes.TensorDataLike, *, draw_order: components.DrawOrderLike | None = None):
-        """
-        Create a new instance of the Image archetype.
-
-        Parameters
-        ----------
-        data:
-             The image data. Should always be a rank-2 or rank-3 tensor.
-        draw_order:
-             An optional floating point value that specifies the 2D drawing order.
-             Objects with higher values are drawn on top of those with lower values.
-        """
-
-        # You can define your own __init__ function as a member of ImageExt in image_ext.py
-        with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(data=data, draw_order=draw_order)
-            return
-        self.__attrs_clear__()
+    # __init__ can be found in image_ext.py
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
@@ -84,9 +84,13 @@ def log_image(
 
     """
 
+    img = Image(image, draw_order=draw_order)
+    if jpeg_quality is not None:
+        img = img.compress(jpeg_quality=jpeg_quality)  # type: ignore[assignment]
+
     log(
         entity_path,
-        Image(image, draw_order=draw_order, jpeg_quality=jpeg_quality),
+        img,
         AnyValues(**(ext or {})),
         timeless=timeless,
         recording=recording,

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/image.py
@@ -84,11 +84,9 @@ def log_image(
 
     """
 
-    tensor_data = TensorData(array=image, jpeg_quality=jpeg_quality)
-
     log(
         entity_path,
-        Image(tensor_data, draw_order=draw_order),
+        Image(image, draw_order=draw_order, jpeg_quality=jpeg_quality),
         AnyValues(**(ext or {})),
         timeless=timeless,
         recording=recording,

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -87,3 +87,16 @@ def test_image_shapes() -> None:
     for img in BAD_IMAGE_INPUTS:
         with pytest.raises(TypeError):
             rr.Image(img)
+
+
+def test_image_invalid_arguments() -> None:
+    import rerun as rr
+
+    rr.set_strict_mode(True)
+
+    image_data = np.asarray(rng.uniform(0, 255, (10, 20, 3)), dtype=np.uint8)
+
+    with pytest.raises(ValueError):
+        rr.Image(data=TensorData(array=image_data), jpeg_quality=80)
+    # This however, should not throw!
+    rr.Image(image_data, jpeg_quality=80)

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import io
 from typing import Any
 
 import numpy as np
 import pytest
 import rerun as rr
+from PIL import Image as PILImage
 from rerun.datatypes import TensorBuffer, TensorData, TensorDataLike, TensorDimension
 from rerun.datatypes.tensor_data import TensorDataBatch
+from rerun.error_utils import RerunWarning
 
 rng = np.random.default_rng(12345)
 RANDOM_IMAGE_SOURCE = rng.uniform(0.0, 1.0, (10, 20, 3))
@@ -89,14 +92,34 @@ def test_image_shapes() -> None:
             rr.Image(img)
 
 
-def test_image_invalid_arguments() -> None:
-    import rerun as rr
-
-    rr.set_strict_mode(True)
+def test_image_compress() -> None:
+    rr.set_strict_mode(False)
 
     image_data = np.asarray(rng.uniform(0, 255, (10, 20, 3)), dtype=np.uint8)
 
-    with pytest.raises(ValueError):
-        rr.Image(data=TensorData(array=image_data), jpeg_quality=80)
-    # This however, should not throw!
-    rr.Image(image_data, jpeg_quality=80)
+    compressed = rr.Image(image_data).compress(jpeg_quality=80)
+    assert type(compressed) == rr.ImageEncoded
+
+    with pytest.warns(RerunWarning) as warnings:
+        image_data = np.asarray(rng.uniform(0, 255, (10, 20)), dtype=np.uint8)
+        compressed = rr.Image(data=TensorData(array=image_data)).compress(jpeg_quality=80)
+
+        assert len(warnings) == 1
+        assert "Only RGB images are supported for JPEG compression" in str(warnings[0])
+
+        # Should still be an Image
+        assert type(compressed) == rr.Image
+
+    bin = io.BytesIO()
+    image = PILImage.new("RGB", (300, 200), color=(0, 0, 0))
+    image.save(bin, format="jpeg")
+
+    # Jump through some hoops to make a pre-compressed image
+    img_encoded = rr.ImageEncoded(contents=bin)
+    img = rr.Image(img_encoded.data)
+
+    with pytest.warns(RerunWarning) as warnings:
+        img.compress()
+        print(list(str(w) for w in warnings))
+        assert len(warnings) == 1
+        assert "Image is already compressed as JPEG" in str(warnings[0])


### PR DESCRIPTION
### What
Even though TensorData has a JPEG variant at the moment for historical reasons, we strongly suspect this will go away and be replaced by a custom component for storing encoded data. This will likely be part of the ImageEncoded archetype in the future.

Remove the convenience helper for compressing TensorData and instead place it on the `Image` archetype. This now converts `Image` -> `ImageEncoded` which aligns better with the future representations.

Resolves: https://github.com/rerun-io/rerun/issues/3551

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
