### PR TITLE
Python codegen cleanups - dead comment, unnecessary calls

### DIFF
--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -1490,9 +1490,6 @@ fn quote_arrow_support_from_obj(
                 @staticmethod
                 def _native_to_pa_array(data: {many_aliases}, data_type: pa.DataType) -> pa.Array:
                     {override_}
-
-            # TODO(cmc): bring back registration to pyarrow once legacy types are gone
-            # pa.register_extension_type({extension_type}())
             "#
         ))
     } else {
@@ -1504,9 +1501,6 @@ fn quote_arrow_support_from_obj(
 
             class {extension_batch}{batch_superclass_decl}:
                 _ARROW_TYPE = {extension_type}()
-
-            # TODO(cmc): bring back registration to pyarrow once legacy types are gone
-            # pa.register_extension_type({extension_type}())
             "#
         ))
     }

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -26,6 +26,10 @@ const ARRAY_METHOD: &str = "__array__";
 /// The method used to convert a native type into a pyarrow array
 const NATIVE_TO_PA_ARRAY_METHOD: &str = "native_to_pa_array_override";
 
+/// The method used for deferred patch class init.
+/// Use this for initialization constants that need to know the child (non-extension) class.
+const DEFERRED_PATCH_CLASS_METHOD: &str = "deferred_patch_class";
+
 /// The common suffix for method used to convert fields to their canonical representation.
 const FIELD_CONVERTER_SUFFIX: &str = "__field_converter_override";
 
@@ -177,6 +181,9 @@ struct ExtensionClass {
 
     /// Whether the `ObjectExt` contains __native_to_pa_array__()
     has_native_to_pa_array: bool,
+
+    /// Whether the `ObjectExt` contains a deferred_patch_class() method
+    has_deferred_patch_class: bool,
 }
 
 impl ExtensionClass {
@@ -205,6 +212,7 @@ impl ExtensionClass {
             let has_init = methods.contains(&INIT_METHOD);
             let has_array = methods.contains(&ARRAY_METHOD);
             let has_native_to_pa_array = methods.contains(&NATIVE_TO_PA_ARRAY_METHOD);
+            let has_deferred_patch_class = methods.contains(&DEFERRED_PATCH_CLASS_METHOD);
             let field_converter_overrides = methods
                 .into_iter()
                 .filter(|l| l.ends_with(FIELD_CONVERTER_SUFFIX))
@@ -220,6 +228,7 @@ impl ExtensionClass {
                 has_init,
                 has_array,
                 has_native_to_pa_array,
+                has_deferred_patch_class,
             }
         } else {
             ExtensionClass {
@@ -231,6 +240,7 @@ impl ExtensionClass {
                 has_init: false,
                 has_array: false,
                 has_native_to_pa_array: false,
+                has_deferred_patch_class: false,
             }
         }
     }
@@ -394,14 +404,9 @@ impl PythonCodeGenerator {
             };
             code.push_text(&obj_code, 1, 0);
 
-            if ext_class.found {
+            if ext_class.has_deferred_patch_class {
                 code.push_unindented_text(
-                    format!("if hasattr({}, 'deferred_patch_class'):", ext_class.name),
-                    1,
-                );
-                code.push_text(
                     format!("{}.deferred_patch_class({})", ext_class.name, obj.name),
-                    1,
                     1,
                 );
             }

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -138,7 +138,3 @@ class Arrows3D(Arrows3DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Arrows3DExt, "deferred_patch_class"):
-    Arrows3DExt.deferred_patch_class(Arrows3D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -125,7 +125,3 @@ class Asset3D(Asset3DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Asset3DExt, "deferred_patch_class"):
-    Asset3DExt.deferred_patch_class(Asset3D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -74,7 +74,3 @@ class BarChart(BarChartExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(BarChartExt, "deferred_patch_class"):
-    BarChartExt.deferred_patch_class(BarChart)

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -134,7 +134,3 @@ class Boxes2D(Boxes2DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Boxes2DExt, "deferred_patch_class"):
-    Boxes2DExt.deferred_patch_class(Boxes2D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -162,7 +162,3 @@ class Boxes3D(Boxes3DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Boxes3DExt, "deferred_patch_class"):
-    Boxes3DExt.deferred_patch_class(Boxes3D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -84,5 +84,4 @@ class Clear(ClearExt, Archetype):
     __repr__ = Archetype.__repr__
 
 
-if hasattr(ClearExt, "deferred_patch_class"):
-    ClearExt.deferred_patch_class(Clear)
+ClearExt.deferred_patch_class(Clear)

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -165,7 +165,3 @@ class DepthImage(DepthImageExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(DepthImageExt, "deferred_patch_class"):
-    DepthImageExt.deferred_patch_class(DepthImage)

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -108,7 +108,3 @@ class Image(ImageExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(ImageExt, "deferred_patch_class"):
-    ImageExt.deferred_patch_class(Image)

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -159,7 +159,3 @@ class Mesh3D(Mesh3DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Mesh3DExt, "deferred_patch_class"):
-    Mesh3DExt.deferred_patch_class(Mesh3D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -119,7 +119,3 @@ class Pinhole(PinholeExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(PinholeExt, "deferred_patch_class"):
-    PinholeExt.deferred_patch_class(Pinhole)

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -172,7 +172,3 @@ class Points2D(Points2DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Points2DExt, "deferred_patch_class"):
-    Points2DExt.deferred_patch_class(Points2D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -155,7 +155,3 @@ class Points3D(Points3DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Points3DExt, "deferred_patch_class"):
-    Points3DExt.deferred_patch_class(Points3D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -109,7 +109,3 @@ class SegmentationImage(SegmentationImageExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(SegmentationImageExt, "deferred_patch_class"):
-    SegmentationImageExt.deferred_patch_class(SegmentationImage)

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -93,7 +93,3 @@ class Tensor(TensorExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(TensorExt, "deferred_patch_class"):
-    TensorExt.deferred_patch_class(Tensor)

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -77,7 +77,3 @@ class Transform3D(Transform3DExt, Archetype):
 
     __str__ = Archetype.__str__
     __repr__ = Archetype.__repr__
-
-
-if hasattr(Transform3DExt, "deferred_patch_class"):
-    Transform3DExt.deferred_patch_class(Transform3D)

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -78,5 +78,4 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
     __repr__ = Archetype.__repr__
 
 
-if hasattr(ViewCoordinatesExt, "deferred_patch_class"):
-    ViewCoordinatesExt.deferred_patch_class(ViewCoordinates)
+ViewCoordinatesExt.deferred_patch_class(ViewCoordinates)

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -159,11 +159,3 @@ class AnnotationContextBatch(BaseBatch[AnnotationContextArrayLike], ComponentBat
     @staticmethod
     def _native_to_pa_array(data: AnnotationContextArrayLike, data_type: pa.DataType) -> pa.Array:
         return AnnotationContextExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AnnotationContextType())
-
-
-if hasattr(AnnotationContextExt, "deferred_patch_class"):
-    AnnotationContextExt.deferred_patch_class(AnnotationContext)

--- a/rerun_py/rerun_sdk/rerun/components/blob.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob.py
@@ -61,11 +61,3 @@ class BlobBatch(BaseBatch[BlobArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: BlobArrayLike, data_type: pa.DataType) -> pa.Array:
         return BlobExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(BlobType())
-
-
-if hasattr(BlobExt, "deferred_patch_class"):
-    BlobExt.deferred_patch_class(Blob)

--- a/rerun_py/rerun_sdk/rerun/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/class_id.py
@@ -26,7 +26,3 @@ class ClassIdType(datatypes.ClassIdType):
 
 class ClassIdBatch(datatypes.ClassIdBatch, ComponentBatchMixin):
     _ARROW_TYPE = ClassIdType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ClassIdType())

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -68,11 +68,3 @@ class ClearIsRecursiveBatch(BaseBatch[ClearIsRecursiveArrayLike], ComponentBatch
     @staticmethod
     def _native_to_pa_array(data: ClearIsRecursiveArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClearIsRecursiveExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ClearIsRecursiveType())
-
-
-if hasattr(ClearIsRecursiveExt, "deferred_patch_class"):
-    ClearIsRecursiveExt.deferred_patch_class(ClearIsRecursive)

--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -35,7 +35,3 @@ class ColorType(datatypes.Rgba32Type):
 
 class ColorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
     _ARROW_TYPE = ColorType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ColorType())

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -59,11 +59,3 @@ class DepthMeterBatch(BaseBatch[DepthMeterArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: DepthMeterArrayLike, data_type: pa.DataType) -> pa.Array:
         return DepthMeterExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(DepthMeterType())
-
-
-if hasattr(DepthMeterExt, "deferred_patch_class"):
-    DepthMeterExt.deferred_patch_class(DepthMeter)

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -64,11 +64,3 @@ class DisconnectedSpaceBatch(BaseBatch[DisconnectedSpaceArrayLike], ComponentBat
     @staticmethod
     def _native_to_pa_array(data: DisconnectedSpaceArrayLike, data_type: pa.DataType) -> pa.Array:
         return DisconnectedSpaceExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(DisconnectedSpaceType())
-
-
-if hasattr(DisconnectedSpaceExt, "deferred_patch_class"):
-    DisconnectedSpaceExt.deferred_patch_class(DisconnectedSpace)

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -67,11 +67,3 @@ class DrawOrderBatch(BaseBatch[DrawOrderArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: DrawOrderArrayLike, data_type: pa.DataType) -> pa.Array:
         return DrawOrderExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(DrawOrderType())
-
-
-if hasattr(DrawOrderExt, "deferred_patch_class"):
-    DrawOrderExt.deferred_patch_class(DrawOrder)

--- a/rerun_py/rerun_sdk/rerun/components/half_sizes2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_sizes2d.py
@@ -31,7 +31,3 @@ class HalfSizes2DType(datatypes.Vec2DType):
 
 class HalfSizes2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = HalfSizes2DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(HalfSizes2DType())

--- a/rerun_py/rerun_sdk/rerun/components/half_sizes3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_sizes3d.py
@@ -31,7 +31,3 @@ class HalfSizes3DType(datatypes.Vec3DType):
 
 class HalfSizes3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = HalfSizes3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(HalfSizes3DType())

--- a/rerun_py/rerun_sdk/rerun/components/instance_key.py
+++ b/rerun_py/rerun_sdk/rerun/components/instance_key.py
@@ -59,11 +59,3 @@ class InstanceKeyBatch(BaseBatch[InstanceKeyArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: InstanceKeyArrayLike, data_type: pa.DataType) -> pa.Array:
         return InstanceKeyExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(InstanceKeyType())
-
-
-if hasattr(InstanceKeyExt, "deferred_patch_class"):
-    InstanceKeyExt.deferred_patch_class(InstanceKey)

--- a/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
@@ -33,7 +33,3 @@ class KeypointIdType(datatypes.KeypointIdType):
 
 class KeypointIdBatch(datatypes.KeypointIdBatch, ComponentBatchMixin):
     _ARROW_TYPE = KeypointIdType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(KeypointIdType())

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -77,11 +77,3 @@ class LineStrip2DBatch(BaseBatch[LineStrip2DArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: LineStrip2DArrayLike, data_type: pa.DataType) -> pa.Array:
         return LineStrip2DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(LineStrip2DType())
-
-
-if hasattr(LineStrip2DExt, "deferred_patch_class"):
-    LineStrip2DExt.deferred_patch_class(LineStrip2D)

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -77,11 +77,3 @@ class LineStrip3DBatch(BaseBatch[LineStrip3DArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: LineStrip3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return LineStrip3DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(LineStrip3DType())
-
-
-if hasattr(LineStrip3DExt, "deferred_patch_class"):
-    LineStrip3DExt.deferred_patch_class(LineStrip3D)

--- a/rerun_py/rerun_sdk/rerun/components/material.py
+++ b/rerun_py/rerun_sdk/rerun/components/material.py
@@ -26,7 +26,3 @@ class MaterialType(datatypes.MaterialType):
 
 class MaterialBatch(datatypes.MaterialBatch, ComponentBatchMixin):
     _ARROW_TYPE = MaterialType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(MaterialType())

--- a/rerun_py/rerun_sdk/rerun/components/media_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type.py
@@ -34,9 +34,4 @@ class MediaTypeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = MediaTypeType()
 
 
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(MediaTypeType())
-
-
-if hasattr(MediaTypeExt, "deferred_patch_class"):
-    MediaTypeExt.deferred_patch_class(MediaType)
+MediaTypeExt.deferred_patch_class(MediaType)

--- a/rerun_py/rerun_sdk/rerun/components/mesh_properties.py
+++ b/rerun_py/rerun_sdk/rerun/components/mesh_properties.py
@@ -26,7 +26,3 @@ class MeshPropertiesType(datatypes.MeshPropertiesType):
 
 class MeshPropertiesBatch(datatypes.MeshPropertiesBatch, ComponentBatchMixin):
     _ARROW_TYPE = MeshPropertiesType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(MeshPropertiesType())

--- a/rerun_py/rerun_sdk/rerun/components/origin2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/origin2d.py
@@ -26,7 +26,3 @@ class Origin2DType(datatypes.Vec2DType):
 
 class Origin2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Origin2DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Origin2DType())

--- a/rerun_py/rerun_sdk/rerun/components/origin3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/origin3d.py
@@ -26,7 +26,3 @@ class Origin3DType(datatypes.Vec3DType):
 
 class Origin3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Origin3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Origin3DType())

--- a/rerun_py/rerun_sdk/rerun/components/out_of_tree_transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/out_of_tree_transform3d.py
@@ -30,7 +30,3 @@ class OutOfTreeTransform3DType(datatypes.Transform3DType):
 
 class OutOfTreeTransform3DBatch(datatypes.Transform3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = OutOfTreeTransform3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(OutOfTreeTransform3DType())

--- a/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
+++ b/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
@@ -39,7 +39,3 @@ class PinholeProjectionType(datatypes.Mat3x3Type):
 
 class PinholeProjectionBatch(datatypes.Mat3x3Batch, ComponentBatchMixin):
     _ARROW_TYPE = PinholeProjectionType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(PinholeProjectionType())

--- a/rerun_py/rerun_sdk/rerun/components/position2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position2d.py
@@ -26,7 +26,3 @@ class Position2DType(datatypes.Vec2DType):
 
 class Position2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Position2DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Position2DType())

--- a/rerun_py/rerun_sdk/rerun/components/position3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position3d.py
@@ -26,7 +26,3 @@ class Position3DType(datatypes.Vec3DType):
 
 class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Position3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Position3DType())

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -59,11 +59,3 @@ class RadiusBatch(BaseBatch[RadiusArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: RadiusArrayLike, data_type: pa.DataType) -> pa.Array:
         return RadiusExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(RadiusType())
-
-
-if hasattr(RadiusExt, "deferred_patch_class"):
-    RadiusExt.deferred_patch_class(Radius)

--- a/rerun_py/rerun_sdk/rerun/components/resolution.py
+++ b/rerun_py/rerun_sdk/rerun/components/resolution.py
@@ -30,7 +30,3 @@ class ResolutionType(datatypes.Vec2DType):
 
 class ResolutionBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = ResolutionType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ResolutionType())

--- a/rerun_py/rerun_sdk/rerun/components/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation3d.py
@@ -26,7 +26,3 @@ class Rotation3DType(datatypes.Rotation3DType):
 
 class Rotation3DBatch(datatypes.Rotation3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Rotation3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Rotation3DType())

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -63,11 +63,3 @@ class ScalarBatch(BaseBatch[ScalarArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: ScalarArrayLike, data_type: pa.DataType) -> pa.Array:
         return ScalarExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ScalarType())
-
-
-if hasattr(ScalarExt, "deferred_patch_class"):
-    ScalarExt.deferred_patch_class(Scalar)

--- a/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
@@ -58,11 +58,3 @@ class ScalarScatteringBatch(BaseBatch[ScalarScatteringArrayLike], ComponentBatch
     @staticmethod
     def _native_to_pa_array(data: ScalarScatteringArrayLike, data_type: pa.DataType) -> pa.Array:
         return ScalarScatteringExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ScalarScatteringType())
-
-
-if hasattr(ScalarScatteringExt, "deferred_patch_class"):
-    ScalarScatteringExt.deferred_patch_class(ScalarScattering)

--- a/rerun_py/rerun_sdk/rerun/components/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_data.py
@@ -26,7 +26,3 @@ class TensorDataType(datatypes.TensorDataType):
 
 class TensorDataBatch(datatypes.TensorDataBatch, ComponentBatchMixin):
     _ARROW_TYPE = TensorDataType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TensorDataType())

--- a/rerun_py/rerun_sdk/rerun/components/text.py
+++ b/rerun_py/rerun_sdk/rerun/components/text.py
@@ -26,7 +26,3 @@ class TextType(datatypes.Utf8Type):
 
 class TextBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = TextType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TextType())

--- a/rerun_py/rerun_sdk/rerun/components/text_log_level.py
+++ b/rerun_py/rerun_sdk/rerun/components/text_log_level.py
@@ -39,9 +39,4 @@ class TextLogLevelBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = TextLogLevelType()
 
 
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TextLogLevelType())
-
-
-if hasattr(TextLogLevelExt, "deferred_patch_class"):
-    TextLogLevelExt.deferred_patch_class(TextLogLevel)
+TextLogLevelExt.deferred_patch_class(TextLogLevel)

--- a/rerun_py/rerun_sdk/rerun/components/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform3d.py
@@ -26,7 +26,3 @@ class Transform3DType(datatypes.Transform3DType):
 
 class Transform3DBatch(datatypes.Transform3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Transform3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Transform3DType())

--- a/rerun_py/rerun_sdk/rerun/components/vector3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector3d.py
@@ -26,7 +26,3 @@ class Vector3DType(datatypes.Vec3DType):
 
 class Vector3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Vector3DType()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Vector3DType())

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -95,9 +95,4 @@ class ViewCoordinatesBatch(BaseBatch[ViewCoordinatesArrayLike], ComponentBatchMi
         return ViewCoordinatesExt.native_to_pa_array_override(data, data_type)
 
 
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ViewCoordinatesType())
-
-
-if hasattr(ViewCoordinatesExt, "deferred_patch_class"):
-    ViewCoordinatesExt.deferred_patch_class(ViewCoordinates)
+ViewCoordinatesExt.deferred_patch_class(ViewCoordinates)

--- a/rerun_py/rerun_sdk/rerun/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/angle.py
@@ -72,11 +72,3 @@ class AngleBatch(BaseBatch[AngleArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AngleArrayLike, data_type: pa.DataType) -> pa.Array:
         return AngleExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AngleType())
-
-
-if hasattr(AngleExt, "deferred_patch_class"):
-    AngleExt.deferred_patch_class(Angle)

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -125,11 +125,3 @@ class AnnotationInfoBatch(BaseBatch[AnnotationInfoArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AnnotationInfoArrayLike, data_type: pa.DataType) -> pa.Array:
         return AnnotationInfoExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AnnotationInfoType())
-
-
-if hasattr(AnnotationInfoExt, "deferred_patch_class"):
-    AnnotationInfoExt.deferred_patch_class(AnnotationInfo)

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
@@ -150,11 +150,3 @@ class ClassDescriptionBatch(BaseBatch[ClassDescriptionArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: ClassDescriptionArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClassDescriptionExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ClassDescriptionType())
-
-
-if hasattr(ClassDescriptionExt, "deferred_patch_class"):
-    ClassDescriptionExt.deferred_patch_class(ClassDescription)

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -142,11 +142,3 @@ class ClassDescriptionMapElemBatch(BaseBatch[ClassDescriptionMapElemArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: ClassDescriptionMapElemArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClassDescriptionMapElemExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ClassDescriptionMapElemType())
-
-
-if hasattr(ClassDescriptionMapElemExt, "deferred_patch_class"):
-    ClassDescriptionMapElemExt.deferred_patch_class(ClassDescriptionMapElem)

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -59,11 +59,3 @@ class ClassIdBatch(BaseBatch[ClassIdArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: ClassIdArrayLike, data_type: pa.DataType) -> pa.Array:
         return ClassIdExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(ClassIdType())
-
-
-if hasattr(ClassIdExt, "deferred_patch_class"):
-    ClassIdExt.deferred_patch_class(ClassId)

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -57,7 +57,3 @@ class Float32Batch(BaseBatch[Float32ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Float32ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in float32_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Float32Type())

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -66,11 +66,3 @@ class KeypointIdBatch(BaseBatch[KeypointIdArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: KeypointIdArrayLike, data_type: pa.DataType) -> pa.Array:
         return KeypointIdExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(KeypointIdType())
-
-
-if hasattr(KeypointIdExt, "deferred_patch_class"):
-    KeypointIdExt.deferred_patch_class(KeypointId)

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
@@ -78,11 +78,3 @@ class KeypointPairBatch(BaseBatch[KeypointPairArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: KeypointPairArrayLike, data_type: pa.DataType) -> pa.Array:
         return KeypointPairExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(KeypointPairType())
-
-
-if hasattr(KeypointPairExt, "deferred_patch_class"):
-    KeypointPairExt.deferred_patch_class(KeypointPair)

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -96,11 +96,3 @@ class Mat3x3Batch(BaseBatch[Mat3x3ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Mat3x3Ext.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Mat3x3Type())
-
-
-if hasattr(Mat3x3Ext, "deferred_patch_class"):
-    Mat3x3Ext.deferred_patch_class(Mat3x3)

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -98,11 +98,3 @@ class Mat4x4Batch(BaseBatch[Mat4x4ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Mat4x4Ext.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Mat4x4Type())
-
-
-if hasattr(Mat4x4Ext, "deferred_patch_class"):
-    Mat4x4Ext.deferred_patch_class(Mat4x4)

--- a/rerun_py/rerun_sdk/rerun/datatypes/material.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/material.py
@@ -75,11 +75,3 @@ class MaterialBatch(BaseBatch[MaterialArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: MaterialArrayLike, data_type: pa.DataType) -> pa.Array:
         return MaterialExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(MaterialType())
-
-
-if hasattr(MaterialExt, "deferred_patch_class"):
-    MaterialExt.deferred_patch_class(Material)

--- a/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
@@ -89,11 +89,3 @@ class MeshPropertiesBatch(BaseBatch[MeshPropertiesArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: MeshPropertiesArrayLike, data_type: pa.DataType) -> pa.Array:
         return MeshPropertiesExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(MeshPropertiesType())
-
-
-if hasattr(MeshPropertiesExt, "deferred_patch_class"):
-    MeshPropertiesExt.deferred_patch_class(MeshProperties)

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -61,11 +61,3 @@ class QuaternionBatch(BaseBatch[QuaternionArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: QuaternionArrayLike, data_type: pa.DataType) -> pa.Array:
         return QuaternionExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(QuaternionType())
-
-
-if hasattr(QuaternionExt, "deferred_patch_class"):
-    QuaternionExt.deferred_patch_class(Quaternion)

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -70,11 +70,3 @@ class Rgba32Batch(BaseBatch[Rgba32ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Rgba32ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Rgba32Ext.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Rgba32Type())
-
-
-if hasattr(Rgba32Ext, "deferred_patch_class"):
-    Rgba32Ext.deferred_patch_class(Rgba32)

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
@@ -100,11 +100,3 @@ class Rotation3DBatch(BaseBatch[Rotation3DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Rotation3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Rotation3DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Rotation3DType())
-
-
-if hasattr(Rotation3DExt, "deferred_patch_class"):
-    Rotation3DExt.deferred_patch_class(Rotation3D)

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
@@ -98,11 +98,3 @@ class RotationAxisAngleBatch(BaseBatch[RotationAxisAngleArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: RotationAxisAngleArrayLike, data_type: pa.DataType) -> pa.Array:
         return RotationAxisAngleExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(RotationAxisAngleType())
-
-
-if hasattr(RotationAxisAngleExt, "deferred_patch_class"):
-    RotationAxisAngleExt.deferred_patch_class(RotationAxisAngle)

--- a/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
@@ -87,11 +87,3 @@ class Scale3DBatch(BaseBatch[Scale3DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Scale3DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in scale3d_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Scale3DType())
-
-
-if hasattr(Scale3DExt, "deferred_patch_class"):
-    Scale3DExt.deferred_patch_class(Scale3D)

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -188,11 +188,3 @@ class TensorBufferBatch(BaseBatch[TensorBufferArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: TensorBufferArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in tensor_buffer_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TensorBufferType())
-
-
-if hasattr(TensorBufferExt, "deferred_patch_class"):
-    TensorBufferExt.deferred_patch_class(TensorBuffer)

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
@@ -172,11 +172,3 @@ class TensorDataBatch(BaseBatch[TensorDataArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: TensorDataArrayLike, data_type: pa.DataType) -> pa.Array:
         return TensorDataExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TensorDataType())
-
-
-if hasattr(TensorDataExt, "deferred_patch_class"):
-    TensorDataExt.deferred_patch_class(TensorData)

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
@@ -67,7 +67,3 @@ class TensorDimensionBatch(BaseBatch[TensorDimensionArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: TensorDimensionArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in tensor_dimension_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TensorDimensionType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
@@ -191,11 +191,3 @@ class Transform3DBatch(BaseBatch[Transform3DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Transform3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Transform3DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Transform3DType())
-
-
-if hasattr(Transform3DExt, "deferred_patch_class"):
-    Transform3DExt.deferred_patch_class(Transform3D)

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
@@ -116,11 +116,3 @@ class TranslationAndMat3x3Batch(BaseBatch[TranslationAndMat3x3ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: TranslationAndMat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in translation_and_mat3x3_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TranslationAndMat3x3Type())
-
-
-if hasattr(TranslationAndMat3x3Ext, "deferred_patch_class"):
-    TranslationAndMat3x3Ext.deferred_patch_class(TranslationAndMat3x3)

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
@@ -178,11 +178,3 @@ class TranslationRotationScale3DBatch(BaseBatch[TranslationRotationScale3DArrayL
     @staticmethod
     def _native_to_pa_array(data: TranslationRotationScale3DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in translation_rotation_scale3d_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(TranslationRotationScale3DType())
-
-
-if hasattr(TranslationRotationScale3DExt, "deferred_patch_class"):
-    TranslationRotationScale3DExt.deferred_patch_class(TranslationRotationScale3D)

--- a/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
@@ -53,11 +53,3 @@ class Utf8Batch(BaseBatch[Utf8ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Utf8ArrayLike, data_type: pa.DataType) -> pa.Array:
         return Utf8Ext.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Utf8Type())
-
-
-if hasattr(Utf8Ext, "deferred_patch_class"):
-    Utf8Ext.deferred_patch_class(Utf8)

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -62,7 +62,3 @@ class UVec2DBatch(BaseBatch[UVec2DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: UVec2DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in uvec2d_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(UVec2DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -62,7 +62,3 @@ class UVec3DBatch(BaseBatch[UVec3DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: UVec3DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in uvec3d_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(UVec3DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -62,7 +62,3 @@ class UVec4DBatch(BaseBatch[UVec4DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: UVec4DArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in uvec4d_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(UVec4DType())

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -63,11 +63,3 @@ class Vec2DBatch(BaseBatch[Vec2DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Vec2DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Vec2DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Vec2DType())
-
-
-if hasattr(Vec2DExt, "deferred_patch_class"):
-    Vec2DExt.deferred_patch_class(Vec2D)

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -63,11 +63,3 @@ class Vec3DBatch(BaseBatch[Vec3DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Vec3DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Vec3DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Vec3DType())
-
-
-if hasattr(Vec3DExt, "deferred_patch_class"):
-    Vec3DExt.deferred_patch_class(Vec3D)

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -63,11 +63,3 @@ class Vec4DBatch(BaseBatch[Vec4DArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: Vec4DArrayLike, data_type: pa.DataType) -> pa.Array:
         return Vec4DExt.native_to_pa_array_override(data, data_type)
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(Vec4DType())
-
-
-if hasattr(Vec4DExt, "deferred_patch_class"):
-    Vec4DExt.deferred_patch_class(Vec4D)

--- a/rerun_py/tests/test_types/components/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer1.py
@@ -25,7 +25,3 @@ class AffixFuzzer1Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer1Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer1Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer1Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -48,7 +48,3 @@ class AffixFuzzer10Batch(BaseBatch[AffixFuzzer10ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer10ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer10_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer10Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -56,7 +56,3 @@ class AffixFuzzer11Batch(BaseBatch[AffixFuzzer11ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer11ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer11_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer11Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -47,7 +47,3 @@ class AffixFuzzer12Batch(BaseBatch[AffixFuzzer12ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer12ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer12_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer12Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -47,7 +47,3 @@ class AffixFuzzer13Batch(BaseBatch[AffixFuzzer13ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer13ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer13_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer13Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer14.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer14.py
@@ -25,7 +25,3 @@ class AffixFuzzer14Type(datatypes.AffixFuzzer3Type):
 
 class AffixFuzzer14Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer14Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer14Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer15.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer15.py
@@ -25,7 +25,3 @@ class AffixFuzzer15Type(datatypes.AffixFuzzer3Type):
 
 class AffixFuzzer15Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer15Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer15Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -125,7 +125,3 @@ class AffixFuzzer16Batch(BaseBatch[AffixFuzzer16ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer16ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer16_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer16Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -125,7 +125,3 @@ class AffixFuzzer17Batch(BaseBatch[AffixFuzzer17ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer17ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer17_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer17Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -425,7 +425,3 @@ class AffixFuzzer18Batch(BaseBatch[AffixFuzzer18ArrayLike], ComponentBatchMixin)
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer18ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer18_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer18Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer19.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer19.py
@@ -25,7 +25,3 @@ class AffixFuzzer19Type(datatypes.AffixFuzzer5Type):
 
 class AffixFuzzer19Batch(datatypes.AffixFuzzer5Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer19Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer19Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer2.py
@@ -25,7 +25,3 @@ class AffixFuzzer2Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer2Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer2Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer2Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer20.py
@@ -25,7 +25,3 @@ class AffixFuzzer20Type(datatypes.AffixFuzzer20Type):
 
 class AffixFuzzer20Batch(datatypes.AffixFuzzer20Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer20Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer20Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer21.py
@@ -25,7 +25,3 @@ class AffixFuzzer21Type(datatypes.AffixFuzzer21Type):
 
 class AffixFuzzer21Batch(datatypes.AffixFuzzer21Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer21Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer21Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer3.py
@@ -25,7 +25,3 @@ class AffixFuzzer3Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer3Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer3Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer3Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer4.py
@@ -25,7 +25,3 @@ class AffixFuzzer4Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer4Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer4Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer4Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer5.py
@@ -25,7 +25,3 @@ class AffixFuzzer5Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer5Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer5Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer5Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer6.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer6.py
@@ -25,7 +25,3 @@ class AffixFuzzer6Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer6Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer6Type()
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer6Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -90,7 +90,3 @@ class AffixFuzzer7Batch(BaseBatch[AffixFuzzer7ArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer7ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer7_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer7Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -54,7 +54,3 @@ class AffixFuzzer8Batch(BaseBatch[AffixFuzzer8ArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer8ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer8_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer8Type())

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -48,7 +48,3 @@ class AffixFuzzer9Batch(BaseBatch[AffixFuzzer9ArrayLike], ComponentBatchMixin):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer9ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer9_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer9Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
@@ -131,7 +131,3 @@ class AffixFuzzer1Batch(BaseBatch[AffixFuzzer1ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer1ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer1_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer1Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
@@ -54,7 +54,3 @@ class AffixFuzzer2Batch(BaseBatch[AffixFuzzer2ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer2ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer2_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer2Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
@@ -73,7 +73,3 @@ class AffixFuzzer20Batch(BaseBatch[AffixFuzzer20ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer20ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer20_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer20Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
@@ -65,7 +65,3 @@ class AffixFuzzer21Batch(BaseBatch[AffixFuzzer21ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer21ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer21_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer21Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -129,7 +129,3 @@ class AffixFuzzer3Batch(BaseBatch[AffixFuzzer3ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer3ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer3_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer3Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
@@ -388,7 +388,3 @@ class AffixFuzzer4Batch(BaseBatch[AffixFuzzer4ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer4ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer4_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer4Type())

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -453,7 +453,3 @@ class AffixFuzzer5Batch(BaseBatch[AffixFuzzer5ArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer5ArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in affix_fuzzer5_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(AffixFuzzer5Type())

--- a/rerun_py/tests/test_types/datatypes/flattened_scalar.py
+++ b/rerun_py/tests/test_types/datatypes/flattened_scalar.py
@@ -62,7 +62,3 @@ class FlattenedScalarBatch(BaseBatch[FlattenedScalarArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: FlattenedScalarArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in flattened_scalar_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(FlattenedScalarType())

--- a/rerun_py/tests/test_types/datatypes/primitive_component.py
+++ b/rerun_py/tests/test_types/datatypes/primitive_component.py
@@ -60,7 +60,3 @@ class PrimitiveComponentBatch(BaseBatch[PrimitiveComponentArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: PrimitiveComponentArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in primitive_component_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(PrimitiveComponentType())

--- a/rerun_py/tests/test_types/datatypes/string_component.py
+++ b/rerun_py/tests/test_types/datatypes/string_component.py
@@ -54,7 +54,3 @@ class StringComponentBatch(BaseBatch[StringComponentArrayLike]):
     @staticmethod
     def _native_to_pa_array(data: StringComponentArrayLike, data_type: pa.DataType) -> pa.Array:
         raise NotImplementedError  # You need to implement native_to_pa_array_override in string_component_ext.py
-
-
-# TODO(cmc): bring back registration to pyarrow once legacy types are gone
-# pa.register_extension_type(StringComponentType())


### PR DESCRIPTION
### What

* call `deferred_patch_class` only if it's there, we know this statically
* remove old todo comment on doing extension type registration (which we no longer plan to do)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3619) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3619)
- [Docs preview](https://rerun.io/preview/80f5111555b1325e4c148732f57b035e57068399/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/80f5111555b1325e4c148732f57b035e57068399/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)