### PR TITLE
Python docs update: getting-started section

### DIFF
--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -124,7 +124,7 @@ of components that are recognized and correctly displayed by the Rerun viewer.
 
 `Components`
 
-Under the hood, the Rerun [Python SDK](https://ref.rerun.io/docs/python) logs individual components like positions, colors, 
+Under the hood, the Rerun [Python SDK](https://ref.rerun.io/docs/python) logs individual *components* like positions, colors, 
 and radii. Archetypes are just one high-level, convenient way of building such collections of components. For advanced use
 cases, it's possible to add custom components to archetypes, or even log entirely custom sets of components, bypassing
 archetypes altogether.
@@ -138,7 +138,7 @@ Rerun takes care of mapping those arrays to actual Rerun components depending on
 
 Note the two strings we're passing in: `"dna/structure/left"` & `"dna/structure/right"`.
 
-These are [*entity paths*](../concepts/entity-component.md), which uniquely identify each *entity* in our scene. Every Entity is made up of a path and one or more Components.
+These are [*entity paths*](../concepts/entity-component.md), which uniquely identify each entity in our scene. Every entity is made up of a path and one or more components.
 [Entity paths typically form a hierarchy](../concepts/entity-path.md) which plays an important role in how data is visualized and transformed (as we shall soon see).
 
 `Batches`

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -145,7 +145,7 @@ These are [*entity paths*](../concepts/entity-component.md), which uniquely iden
 
 One final observation: notice how we're logging a whole batch of points and colors all at once here.
 [Batches of data](../concepts/batches.md) are first-class citizens in Rerun and come with all sorts of performance benefits and dedicated features.
-You're looking at one of these dedicated features right now in fact: notice how we're only logging a single radius for all these points, yet somehow it applies to all of them. We call that *splatting*.
+You're looking at one of these dedicated features right now in fact: notice how we're only logging a single radius for all these points, yet somehow it applies to all of them. We call this *splatting*.
 
 ---
 

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -129,7 +129,7 @@ and radii. Archetypes are just one high-level, convenient way of building such c
 cases, it's possible to add custom components to archetypes, or even log entirely custom sets of components, bypassing
 archetypes altogether.
  
-For more information on how the rerun data model works, refer to our section on [entities and components](../concepts/entity-component.md).
+For more information on how the rerun data model works, refer to our section on [Entities and Components](../concepts/entity-component.md).
 
 Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/latest/package/rerun_demo/data/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
 Rerun takes care of mapping those arrays to actual Rerun components depending on the context (e.g. we're calling [`log_points`](https://ref.rerun.io/docs/python/latest/common/spatial_primitives/#rerun.log_points) in this case).

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -124,11 +124,11 @@ of components that are recognized and correctly displayed by the Rerun viewer.
 
 `Components`
 
-Under the hood, the Rerun [Python SDK](https://ref.rerun.io/docs/python) logs individual *components* like positions, colors, 
+Under the hood, the Rerun [Python SDK](https://ref.rerun.io/docs/python) logs individual *components* like positions, colors,
 and radii. Archetypes are just one high-level, convenient way of building such collections of components. For advanced use
 cases, it's possible to add custom components to archetypes, or even log entirely custom sets of components, bypassing
 archetypes altogether.
- 
+
 For more information on how the rerun data model works, refer to our section on [Entities and Components](../concepts/entity-component.md).
 
 Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/latest/package/rerun_demo/data/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -120,7 +120,7 @@ This tiny snippet of code actually holds much more than meets the eye...
 `Archetypes`
 
 The easiest way to log geometric primitives is the use the [`rr.log`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) function with one of the built-in archetype class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). Archetypes take care of building batches
-of components that are recognised and correctly displayed by the Rerun viewer.
+of components that are recognized and correctly displayed by the Rerun viewer.
 
 `Components`
 

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -5,7 +5,7 @@ order: 4
 
 In this section we'll log and visualize our first non-trivial dataset, putting many of Rerun's core concepts and features to use.
 
-In a few lines of code, we'll go from a blank sheet to something you don't see everyday: an animated, interactive, DNA-shaped abacus:
+In a few lines of code, we'll go from a blank sheet to something you don't see every day: an animated, interactive, DNA-shaped abacus:
 <video width="100%" autoplay loop muted controls>
     <source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
 </video>
@@ -55,14 +55,12 @@ Now you can run your application just as you would any other python script:
 And with that, we're ready to start sending out data:
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data2_waiting/51c09ff974ee4789c0e500af5b8fa347c5294ac0/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/logging_data2_waiting/51c09ff974ee4789c0e500af5b8fa347c5294ac0/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/logging_data2_waiting/51c09ff974ee4789c0e500af5b8fa347c5294ac0/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/logging_data2_waiting/51c09ff974ee4789c0e500af5b8fa347c5294ac0/1200w.png">
-  <img src="https://static.rerun.io/logging_data2_waiting/51c09ff974ee4789c0e500af5b8fa347c5294ac0/full.png" alt="screenshot of the waiting screen">
+  <img src="https://static.rerun.io/logging_data2_empty/2915f4ef35db229caee6e5cb380b47aa4ecc0b33/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data2_empty/2915f4ef35db229caee6e5cb380b47aa4ecc0b33/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/logging_data2_empty/2915f4ef35db229caee6e5cb380b47aa4ecc0b33/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/logging_data2_empty/2915f4ef35db229caee6e5cb380b47aa4ecc0b33/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/logging_data2_empty/2915f4ef35db229caee6e5cb380b47aa4ecc0b33/1200w.png">
 </picture>
-
-
 
 By default, the SDK will start a viewer in another process and automatically pipe the data through.
 There are other means of sending data to a viewer as we'll see at the end of this section, but for now this default will work great as we experiment.
@@ -74,7 +72,7 @@ We will do so incrementally, but if you just want to update your imports once an
 from math import tau
 import numpy as np
 from rerun_demo.data import build_color_spiral
-from rerun_demo.util import bounce_lerp, interleave
+from rerun_demo.util import bounce_lerp
 from scipy.spatial.transform import Rotation
 ```
 ---
@@ -83,6 +81,7 @@ from scipy.spatial.transform import Rotation
 
 The core structure of our DNA looking shape can easily be described using two point clouds shaped like spirals.
 Add the following to your file:
+
 ```python
 # new imports
 from rerun_demo.data import build_color_spiral
@@ -94,20 +93,21 @@ NUM_POINTS = 100
 points1, colors1 = build_color_spiral(NUM_POINTS)
 points2, colors2 = build_color_spiral(NUM_POINTS, angular_offset=tau*0.5)
 
-rr.log_points("dna/structure/left", points1, colors=colors1, radii=0.08)
-rr.log_points("dna/structure/right", points2, colors=colors2, radii=0.08)
+rr.log("dna/structure/left", rr.Points3D(points1, colors=colors1, radii=0.08))
+rr.log("dna/structure/right", rr.Points3D(points2, colors=colors2, radii=0.08))
 ```
 
 Run your script once again and you should now see this scene in the viewer.
 Note that if the viewer was still running, Rerun will simply connect to this existing session and replace the data with this new [_recording_](../concepts/apps-and-recordings.md).
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data3_first_points/bb8ec9fb325e7912124d1d5dbbaf6f52178046b8/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/logging_data3_first_points/bb8ec9fb325e7912124d1d5dbbaf6f52178046b8/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/logging_data3_first_points/bb8ec9fb325e7912124d1d5dbbaf6f52178046b8/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/logging_data3_first_points/bb8ec9fb325e7912124d1d5dbbaf6f52178046b8/1200w.png">
-  <img src="https://static.rerun.io/logging_data3_first_points/bb8ec9fb325e7912124d1d5dbbaf6f52178046b8/full.png" alt="screenshot after logging the first points">
+  <img src="https://static.rerun.io/logging_data3_first_points/95c9c556160159eb2e47fb160ced89c899f2fcef/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data3_first_points/95c9c556160159eb2e47fb160ced89c899f2fcef/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/logging_data3_first_points/95c9c556160159eb2e47fb160ced89c899f2fcef/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/logging_data3_first_points/95c9c556160159eb2e47fb160ced89c899f2fcef/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/logging_data3_first_points/95c9c556160159eb2e47fb160ced89c899f2fcef/1200w.png">
 </picture>
+
 
 
 _This is a good time to make yourself familiar with the viewer: try interacting with the scene and exploring the different menus._
@@ -117,9 +117,19 @@ _Checkout the [Viewer Walkthrough](viewer-walkthrough.md) and [viewer reference]
 
 This tiny snippet of code actually holds much more than meets the eye...
 
+`Archetypes`
+
+The easiest way to log geometric primitives is the use the [`rr.log`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) function with one of the built-in archetype class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). Archetypes take care of building batches
+of components that are recognised and correctly displayed by the Rerun viewer.
+
 `Components`
 
-Although the Rerun [Python SDK](https://ref.rerun.io/docs/python) exposes concepts related to logging primitives such as points, and lines, under the hood these primitives are made up of individual components like positions, colors, and radii. For more information on how the rerun data model works, refer to our section on [entities and components](../concepts/entity-component.md).
+Under the hood, the Rerun [Python SDK](https://ref.rerun.io/docs/python) logs individual components like positions, colors, 
+and radii. Archetypes are just one high-level, convenient way of building such collections of components. For advanced use
+cases, it's possible to add custom components to archetypes, or even log entirely custom sets of components, bypassing
+archetypes altogether.
+ 
+For more information on how the rerun data model works, refer to our section on [entities and components](../concepts/entity-component.md).
 
 Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/latest/package/rerun_demo/data/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
 Rerun takes care of mapping those arrays to actual Rerun components depending on the context (e.g. we're calling [`log_points`](https://ref.rerun.io/docs/python/latest/common/spatial_primitives/#rerun.log_points) in this case).
@@ -128,29 +138,28 @@ Rerun takes care of mapping those arrays to actual Rerun components depending on
 
 Note the two strings we're passing in: `"dna/structure/left"` & `"dna/structure/right"`.
 
-These are [Entity Paths](../concepts/entity-component.md), which uniquely identify each Entity in our scene. Every Entity is made up of a path and one or more Components.
+These are [*entity paths*](../concepts/entity-component.md), which uniquely identify each *entity* in our scene. Every Entity is made up of a path and one or more Components.
 [Entity paths typically form a hierarchy](../concepts/entity-path.md) which plays an important role in how data is visualized and transformed (as we shall soon see).
 
 `Batches`
 
 One final observation: notice how we're logging a whole batch of points and colors all at once here.
 [Batches of data](../concepts/batches.md) are first-class citizens in Rerun and come with all sorts of performance benefits and dedicated features.
-You're looking at one of these dedicated features right now in fact: notice how we're only logging a single radius for all these points, yet somehow it applies to all of them.
+You're looking at one of these dedicated features right now in fact: notice how we're only logging a single radius for all these points, yet somehow it applies to all of them. We call that *splatting*.
 
 ---
 
 A _lot_ is happening in these two simple function calls.
-Good news is: once you've digested all of the above, logging any other Component will simply be more of the same. In fact, let's go ahead and log everything else in the scene now.
+Good news is: once you've digested all of the above, logging any other Entity will simply be more of the same. In fact, let's go ahead and log everything else in the scene now.
 
 ## Adding the missing pieces
 
-We can represent the scaffolding using a batch of 3D line segments:
+We can represent the scaffolding using a batch of 3D line strips:
 ```python
-# new imports
-from rerun_demo.util import interleave
-
-points = interleave(points1, points2)
-rr.log_line_segments("dna/structure/scaffolding", points, color=[128, 128, 128])
+rr.log(
+    "dna/structure/scaffolding",
+    rr.LineStrips3D(list(zip(points1, points2)), colors=[128, 128, 128])
+)
 ```
 
 Which only leaves the beads:
@@ -162,18 +171,21 @@ from rerun_demo.util import bounce_lerp
 offsets = np.random.rand(NUM_POINTS)
 beads = [bounce_lerp(points1[n], points2[n], offsets[n]) for n in range(NUM_POINTS)]
 colors = [[int(bounce_lerp(80, 230, offsets[n] * 2))] for n in range(NUM_POINTS)]
-rr.log_points("dna/structure/scaffolding/beads", beads, radii=0.06, colors=np.repeat(colors, 3, axis=-1))
+rr.log(
+    "dna/structure/scaffolding/beads",
+    rr.Points3D(beads, radii=0.06, colors=np.repeat(colors, 3, axis=-1)),
+)
 ```
 
 Once again, although we are getting fancier and fancier with our [`numpy` incantations](https://ref.rerun.io/docs/python/latest/package/rerun_demo/util/#rerun_demo.util.bounce_lerp),
 there is nothing new here: it's all about building out `numpy` arrays and feeding them to the Rerun API.
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data5_beads/af49e7cd040ec6caab56ec3e45a732a943341088/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/logging_data5_beads/af49e7cd040ec6caab56ec3e45a732a943341088/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/logging_data5_beads/af49e7cd040ec6caab56ec3e45a732a943341088/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/logging_data5_beads/af49e7cd040ec6caab56ec3e45a732a943341088/1200w.png">
-  <img src="https://static.rerun.io/logging_data5_beads/af49e7cd040ec6caab56ec3e45a732a943341088/full.png" alt="screenshot after logging beads">
+  <img src="https://static.rerun.io/logging_data5_beads/53afa6ca96259c4451a8b7722a8856252c2fdba6/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data5_beads/53afa6ca96259c4451a8b7722a8856252c2fdba6/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/logging_data5_beads/53afa6ca96259c4451a8b7722a8856252c2fdba6/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/logging_data5_beads/53afa6ca96259c4451a8b7722a8856252c2fdba6/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/logging_data5_beads/53afa6ca96259c4451a8b7722a8856252c2fdba6/1200w.png">
 </picture>
 
 
@@ -183,7 +195,7 @@ there is nothing new here: it's all about building out `numpy` arrays and feedin
 
 Up until this point, we've completely set aside one of the core concepts of Rerun: [Time and Timelines](../concepts/timelines.md).
 
-Even so, if you look at your [Timeline View](../reference/viewer/timeline.md) right now, you'll notice that Rerun has kept track of time on your behalf anyways by memorizing when each log call occurred.
+Even so, if you look at your [Timeline View](../reference/viewer/timeline.md) right now, you'll notice that Rerun has kept track of time on your behalf anyway by memorizing when each log call occurred.
 
 <picture>
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data6_timeline/f22a3c92ae4f9f3a04901ec907a245e03e9dad68/480w.png">
@@ -197,7 +209,7 @@ Even so, if you look at your [Timeline View](../reference/viewer/timeline.md) ri
 Unfortunately, the logging time isn't particularly helpful to us in this case: we can't have our beads animate depending on the logging time, else they would move at different speeds depending on the performance of the logging process!
 For that, we need to introduce our own custom timeline that uses a deterministic clock which we control.
 
-Rerun has rich support for time: whether you want concurrent or disjoint timelines, out-of-order insertions or even data that lives _outside_ of the timeline(s)… you'll find a lot of flexibility in there.
+Rerun has rich support for time: whether you want concurrent or disjoint timelines, out-of-order insertions or even data that lives _outside_ the timeline(s). You will find a lot of flexibility in there.
 
 Let's add our custom timeline:
 ```python
@@ -212,12 +224,15 @@ for i in range(400):
     times = np.repeat(time, NUM_POINTS) + time_offsets
     beads = [bounce_lerp(points1[n], points2[n], times[n]) for n in range(NUM_POINTS)]
     colors = [[int(bounce_lerp(80, 230, times[n] * 2))] for n in range(NUM_POINTS)]
-    rr.log_points("dna/structure/scaffolding/beads", beads, radii=0.06, colors=np.repeat(colors, 3, axis=-1))
+    rr.log(
+        "dna/structure/scaffolding/beads",
+        rr.Points3D(beads, radii=0.06, colors=np.repeat(colors, 3, axis=-1)),
+    )
 ```
 
 A call to [`set_time_seconds`](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_seconds) will create our new `Timeline` and make sure that any logging calls that follow gets assigned that time.
 
-⚠️  If you run this code as is, the result will be.. surprising: the beads are animating as expected, but everything we've logged until that point is gone! ⚠️
+⚠️ If you run this code as is, the result will be… surprising: the beads are animating as expected, but everything we've logged until that point is gone! ⚠️
 
 <picture>
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/logging_data7_wat/2a3b65f4a0e1e948184d85bab497e4bffdda0b7e/480w.png">
@@ -228,7 +243,7 @@ A call to [`set_time_seconds`](https://ref.rerun.io/docs/python/latest/common/ti
 </picture>
 
 
-Enter...
+Enter…
 
 ### Latest At semantics
 
@@ -269,9 +284,9 @@ from scipy.spatial.transform import Rotation
 for i in range(400):
     time = i * 0.01
     rr.set_time_seconds("stable_time", time)
-    rr.log_transform3d(
+    rr.log(
         "dna/structure",
-        rr.RotationAxisAngle(axis=[0, 0, 1], radians=time / 4.0 * tau),
+        rr.Transform3D(rotation=rr.RotationAxisAngle(axis=[0, 0, 1], radians=time / 4.0 * tau)),
     )
 ```
 
@@ -284,9 +299,9 @@ Voila!
 
 ## Other ways of logging & visualizing data
 
-[`rr.spawn`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.spawn) is great when you're experimenting on a single machine like we did in this tutorial, but what if the process that's doing the logging doesn't have a graphical interface to begin with?
+[`rr.spawn`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.spawn) is great when you're experimenting on a single machine like we did in this tutorial, but what if the logging happens on, for example, a headless computer?
 
-Rerun offers several solutions for these use cases.
+Rerun offers several solutions for such use cases.
 
 ### Logging data over the network
 
@@ -308,7 +323,7 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 ⚠️  [RRD files don't yet handle versioning!](https://github.com/rerun-io/rerun/issues/873) ⚠️
 
-### Closing
+## Closing
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -16,7 +16,7 @@ You are now ready to start logging and visualizing data.
 
 ## Trying out the viewer
 
-The Rerun SDK comes packaged with a simple demo so you can quickly get a feel for the viewer. You can launch it with
+The Rerun SDK comes packaged with a simple demo to quickly get a feel for the viewer. You can launch it with:
 ```bash
 $ python3 -m rerun_demo
 ```
@@ -49,7 +49,7 @@ Try out the following to interact with the viewer:
  * Mouse over the "?" icons to find out about more controls.
  * Grab the time-slider and move it to see the cube at different time-points.
  * Click the "play" button to animate the cube.
- * Click on the cube to select all of the points.
+ * Click on the cube to select all the points.
  * Hover and select individual points to see more information.
 
 This is just a taste of some of what you can do with the viewer. We will cover other functionality in much
@@ -60,6 +60,7 @@ Now instead of using a prepackaged demo, let's create some data ourselves. We wi
 extremely simplified version of this dataset that just logs 1 dimension of points instead of 3.
 
 Create a new python script with the following code:
+
 ```python
 import rerun as rr  # NOTE: `rerun`, not `rerun-sdk`!
 import numpy as np
@@ -72,23 +73,29 @@ positions[:,0] = np.linspace(-10,10,10)
 colors = np.zeros((10,3), dtype=np.uint8)
 colors[:,0] = np.linspace(0,255,10)
 
-rr.log_points("my_points", positions=positions, colors=colors, radii=0.5)
+rr.log(
+    "my_points",
+    rr.Points3D(positions, colors=colors, radii=0.5)
+)
 ```
 
 When you run this script you will again be greeted with the [Rerun Viewer](../reference/viewer/overview.md), this time
 only showing a simple line of red points.
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/quickstart1_line/37d42194bc99cbb805e3ca53eba11c2896616893/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/quickstart1_line/37d42194bc99cbb805e3ca53eba11c2896616893/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/quickstart1_line/37d42194bc99cbb805e3ca53eba11c2896616893/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/quickstart1_line/37d42194bc99cbb805e3ca53eba11c2896616893/1200w.png">
-  <img src="https://static.rerun.io/quickstart1_line/37d42194bc99cbb805e3ca53eba11c2896616893/full.png" alt="simple line">
+  <img src="https://static.rerun.io/quickstart1_line/969a72007a8354bc2638d5794fa7d47176135d0c/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/quickstart1_line/969a72007a8354bc2638d5794fa7d47176135d0c/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/quickstart1_line/969a72007a8354bc2638d5794fa7d47176135d0c/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/quickstart1_line/969a72007a8354bc2638d5794fa7d47176135d0c/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/quickstart1_line/969a72007a8354bc2638d5794fa7d47176135d0c/1200w.png">
 </picture>
 
 
-The [rr.log_points](https://ref.rerun.io/docs/python/latest/common/spatial_primitives/#rerun.log_points) function can
-take any Nx2 or Nx3 numpy array as a collection of positions.
+
+The [`rr.log`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) is the primary way to log data. It's a flexible
+call that can accept a variety of correctly-formatted data—including your own. The easiest way to use it is to use an instance of
+one of the built-in *archetype* class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). Archetypes take care of gathering the various
+components representing, in this case, a batch of 3D points such that it is recognised and correctly displayed by the Rerun viewer. The `rr.Points3D` archetype accepts any collection of positions that can be converted to a Nx3 Numpy array, along with other components such as colors, radii, etc.
 
 Feel free to modify the code to log a different set of points. If you want to generate the colored cube from the
 built-in demo, you can use the following numpy incantation.
@@ -106,15 +113,18 @@ positions = np.vstack([d.reshape(-1) for d in pos_grid]).T
 col_grid = np.meshgrid(*[np.linspace(0, 255, SIZE)]*3)
 colors = np.vstack([c.reshape(-1) for c in col_grid]).astype(np.uint8).T
 
-rr.log_points("my_points", positions=positions, colors=colors, radii=0.5)
+rr.log(
+    "my_points",
+    rr.Points3D(positions, colors=colors, radii=0.5)
+)
 ```
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/quickstart2_simple_cube/56b44aef7d6875c222219dcff2bc3a3d470c8891/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/quickstart2_simple_cube/56b44aef7d6875c222219dcff2bc3a3d470c8891/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/quickstart2_simple_cube/56b44aef7d6875c222219dcff2bc3a3d470c8891/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/quickstart2_simple_cube/56b44aef7d6875c222219dcff2bc3a3d470c8891/1200w.png">
-  <img src="https://static.rerun.io/quickstart2_simple_cube/56b44aef7d6875c222219dcff2bc3a3d470c8891/full.png" alt="">
+  <img src="https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/1200w.png">
 </picture>
 
 ## What's next

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -95,7 +95,7 @@ only showing a simple line of red points.
 The [`rr.log`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) is the primary way to log data. It's a flexible
 call that can accept a variety of correctly-formatted data—including your own. The easiest way to use it is to use an instance of
 one of the built-in *archetype* class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). Archetypes take care of gathering the various
-components representing, in this case, a batch of 3D points such that it is recognised and correctly displayed by the Rerun viewer. The `rr.Points3D` archetype accepts any collection of positions that can be converted to a Nx3 Numpy array, along with other components such as colors, radii, etc.
+components representing, in this case, a batch of 3D points such that it is recognized and correctly displayed by the Rerun viewer. The `rr.Points3D` archetype accepts any collection of positions that can be converted to a Nx3 Numpy array, along with other components such as colors, radii, etc.
 
 Feel free to modify the code to log a different set of points. If you want to generate the colored cube from the
 built-in demo, you can use the following numpy incantation.

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -12,7 +12,7 @@ from math import tau
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
 from rerun_demo.data import build_color_spiral
-from rerun_demo.util import bounce_lerp, interleave
+from rerun_demo.util import bounce_lerp
 
 
 def log_data() -> None:
@@ -26,8 +26,7 @@ def log_data() -> None:
     rr.log("helix/structure/left", rr.Points3D(points1, colors=colors1, radii=0.08))
     rr.log("helix/structure/right", rr.Points3D(points2, colors=colors2, radii=0.08))
 
-    points = interleave(points1, points2)
-    rr.log("helix/structure/scaffolding", rr.LineStrips3D(points.reshape(-1, 2, 3), colors=[128, 128, 128]))
+    rr.log("helix/structure/scaffolding", rr.LineStrips3D(list(zip(points1, points2)), colors=[128, 128, 128]))
 
     time_offsets = np.random.rand(NUM_POINTS)
     for i in range(400):


### PR DESCRIPTION
### What

I'm updating Python docs to new API and will slice that effort in multiple PRs. Here is the "getting started" section already.
I've updated some screenshots in the process, and done a minor improvement the helix example.

Related:
* #3273

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3620) (if applicable)~~

- [PR Build Summary](https://build.rerun.io/pr/3620)
- [Docs preview](https://rerun.io/preview/42e11f139ee5f9404b97e2e7e72fc771acf32ef2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/42e11f139ee5f9404b97e2e7e72fc771acf32ef2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)