### PR TITLE
Update component prefix for AnyBatchValue to .any.value

### DIFF
--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -47,7 +47,7 @@ to the [points entity](recording://points):
 ```python
 rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
 ```
-**Note:** we added some [custom per-point errors](recording://points.ext.error) that you can see when you
+**Note:** we added some [custom per-point errors](recording://points.any.value.error) that you can see when you
 hover over the points in the 3D view.
 """.strip()
 

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -10,7 +10,7 @@ from .error_utils import _send_warning
 
 ANY_VALUE_TYPE_REGISTRY: dict[str, Any] = {}
 
-COMPONENT_PREFIX = "user.components."
+COMPONENT_PREFIX = "any."
 
 
 class AnyBatchValue(ComponentBatchLike):

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -10,7 +10,7 @@ from .error_utils import _send_warning
 
 ANY_VALUE_TYPE_REGISTRY: dict[str, Any] = {}
 
-COMPONENT_PREFIX = "any."
+COMPONENT_PREFIX = "any.value."
 
 
 class AnyBatchValue(ComponentBatchLike):

--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -14,8 +14,8 @@ def test_any_value() -> None:
     foo_batch = batches[0]
     bar_batch = batches[1]
 
-    assert foo_batch.component_name() == "user.components.foo"
-    assert bar_batch.component_name() == "user.components.bar"
+    assert foo_batch.component_name() == "any.value.foo"
+    assert bar_batch.component_name() == "any.value.bar"
     assert len(foo_batch.as_arrow_array()) == 3
     assert len(bar_batch.as_arrow_array()) == 1
     assert np.all(foo_batch.as_arrow_array().to_numpy() == np.array([1.0, 2.0, 3.0]))
@@ -28,7 +28,7 @@ def test_any_value_datatypes() -> None:
 
     foo_batch = batches[0]
 
-    assert foo_batch.component_name() == "user.components.my_points"
+    assert foo_batch.component_name() == "any.value.my_points"
     assert len(foo_batch.as_arrow_array()) == 3
 
 


### PR DESCRIPTION
### What
⬆️ 
![Screenshot 2023-10-03 at 14 45 14](https://github.com/rerun-io/rerun/assets/2624717/9d594763-fe74-4272-834e-a66bdb3d153c)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3623) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3623)
- [Docs preview](https://rerun.io/preview/a5b29233ca9317e80e23a8768647a6881313cf96/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a5b29233ca9317e80e23a8768647a6881313cf96/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)