### PR TITLE
Small tweaks to legacy logging API to improve 0.8 compatibility

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
@@ -226,6 +226,15 @@ def log_points(
 
     positions = np.require(positions, dtype="float32")
 
+    if positions.shape[0] == 0:
+        # We used to support sending zero points and a long list of radii, but no more
+        radii = None
+        colors = None
+        labels = None
+        class_ids = None
+        keypoint_ids = None
+        identifiers = None
+
     identifiers_np = None
     if identifiers is not None:
         try:

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
@@ -100,6 +100,9 @@ def log_rect(
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
 
     """
+    if rect is None:
+        rect = []
+
     log_rects(
         entity_path,
         rects=rect,

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -100,7 +100,6 @@ def collect_examples(fast: bool) -> list[str]:
             "examples/python/rgbd",
             "examples/python/signed_distance_fields",
             "examples/python/structure_from_motion",
-            "examples/python/text_logging",
         ]
     else:
         examples = []


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3362

No big blockers found!

These are the small tweaks that were needed; the rest are documented in
https://www.notion.so/rerunio/0-9-migration-notes-2b3debe9947f47a38428267b2da4cc1b?pvs=4

Methodology:
* Check out `main` and run `pip3 install "./rerun_py"`
* Check out `0.8.2` branch and run `scripts/run_all.py --skip-build --save`
* Run `scripts/run_all.py --skip-build --load` and check that it all looks ok

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3633) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3633)
- [Docs preview](https://rerun.io/preview/c3ff37b1d19faebceb56355664faf3c30c72dfc7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c3ff37b1d19faebceb56355664faf3c30c72dfc7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)