### PR TITLE
Lint against the the problem of writing "the the"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
  - In Rust, the `RecordingStream` now offers a stateful time API, similar to the Python APIs. [#2506](https://github.com/rerun-io/rerun/pull/2506)
    - You can now call `set_time_sequence`, `set_time_seconds`, and `set_time_nanos` directly on the `RecordingStream`,
      which will set the time for all subsequent logs using that stream.
-   - This can be used as an alternative to the the previous `MsgSender::with_time` APIs.
+   - This can be used as an alternative to the previous `MsgSender::with_time` APIs.
  - The Rerun SDK now defaults to 8ms long microbatches instead of 50ms. This makes the default behavior more suitable
 for use-cases like real-time video feeds. [#2220](https://github.com/rerun-io/rerun/pull/2220)
    - Check out [the microbatching docs](https://www.rerun.io/docs/reference/sdk-micro-batching) for more information

--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -210,7 +210,7 @@ impl DataStore {
         let mut deleted = Deleted::default();
 
         // The algorithm is straightforward:
-        // 1. Find the the oldest `RowId` that is not protected
+        // 1. Find the oldest `RowId` that is not protected
         // 2. Find all tables that potentially hold data associated with that `RowId`
         // 3. Drop the associated row and account for the space we got back
 

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -321,7 +321,7 @@ impl DataStore {
         None
     }
 
-    /// Iterates the datastore in order to return the cells of the the specified `components`,
+    /// Iterates the datastore in order to return the cells of the specified `components`,
     /// as seen from the point of view of the so-called `primary` component, for the given time
     /// range.
     ///
@@ -528,7 +528,7 @@ impl IndexedTable {
         None // primary component not found
     }
 
-    /// Iterates the table in order to return the cells of the the specified `components`,
+    /// Iterates the table in order to return the cells of the specified `components`,
     /// as seen from the point of view of the so-called `primary` component, for the given time
     /// range.
     ///
@@ -791,7 +791,7 @@ impl IndexedBucket {
         Some((col_row_id[secondary_row_nr as usize], cells))
     }
 
-    /// Iterates the bucket in order to return the cells of the the specified `components`,
+    /// Iterates the bucket in order to return the cells of the specified `components`,
     /// as seen from the point of view of the so-called `primary` component, for the given time
     /// range.
     ///
@@ -1088,7 +1088,7 @@ impl PersistentIndexedTable {
         Some((self.col_row_id[secondary_row_nr as usize], cells))
     }
 
-    /// Iterates the table in order to return the cells of the the specified `components`,
+    /// Iterates the table in order to return the cells of the specified `components`,
     /// as seen from the point of view of the so-called `primary` component, for the given time
     /// range.
     ///

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -209,7 +209,7 @@ impl EntityTree {
         pending_clears
     }
 
-    /// Add a path operation into the the entity tree.
+    /// Add a path operation into the entity tree.
     ///
     /// Returns a collection of paths to clear as a result of the operation
     /// Additional pending clear operations will be stored in the tree for future

--- a/crates/re_log_types/src/data_table_batcher.rs
+++ b/crates/re_log_types/src/data_table_batcher.rs
@@ -32,7 +32,7 @@ pub type DataTableBatcherResult<T> = Result<T, DataTableBatcherError>;
 
 // ---
 
-/// Defines the the different thresholds of the associated [`DataTableBatcher`].
+/// Defines the different thresholds of the associated [`DataTableBatcher`].
 ///
 /// See [`Self::default`] and [`Self::from_env`].
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -337,10 +337,10 @@ pub enum StoreSource {
 
     /// The official Rerun Rust Logging SDK
     RustSdk {
-        /// Rust version of the the code compiling the Rust SDK
+        /// Rust version of the code compiling the Rust SDK
         rustc_version: String,
 
-        /// LLVM version of the the code compiling the Rust SDK
+        /// LLVM version of the code compiling the Rust SDK
         llvm_version: String,
     },
 

--- a/crates/re_renderer/examples/outlines.rs
+++ b/crates/re_renderer/examples/outlines.rs
@@ -75,9 +75,9 @@ impl framework::Example for Outlines {
 
         let outline_mask_large_mesh = match ((seconds_since_startup * 0.5) as u64) % 5 {
             0 => OutlineMaskPreference::NONE,
-            1 => OutlineMaskPreference::some(1, 0), // Same as the the y spinning mesh.
+            1 => OutlineMaskPreference::some(1, 0), // Same as the y spinning mesh.
             2 => OutlineMaskPreference::some(2, 0), // Different than both meshes, outline A.
-            3 => OutlineMaskPreference::some(0, 1), // Same as the the x spinning mesh.
+            3 => OutlineMaskPreference::some(0, 1), // Same as the x spinning mesh.
             4 => OutlineMaskPreference::some(0, 2), // Different than both meshes, outline B.
             _ => unreachable!(),
         };

--- a/crates/re_renderer/examples/picking.rs
+++ b/crates/re_renderer/examples/picking.rs
@@ -101,7 +101,7 @@ impl framework::Example for Picking {
         while let Some(picking_result) =
             PickingLayerProcessor::next_readback_result::<()>(re_ctx, READBACK_IDENTIFIER)
         {
-            // Grab the middle pixel. usually we'd want to do something clever that snaps the the closest object of interest.
+            // Grab the middle pixel. usually we'd want to do something clever that snaps the closest object of interest.
             let picked_id = picking_result.picked_id(picking_result.rect.extent / 2);
             //let picked_position =
             //    picking_result.picked_world_position(picking_result.rect.extent / 2);

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -217,7 +217,7 @@ bitflags! {
         /// Adds a round cap at the end of a line strip (excludes other end caps).
         const FLAG_CAP_END_ROUND = 0b0000_0010;
 
-        /// By default, line caps end at the last/first position of the the line strip.
+        /// By default, line caps end at the last/first position of the line strip.
         /// This flag makes end caps extend outwards.
         const FLAG_CAP_END_EXTEND_OUTWARDS = 0b0000_0100;
 
@@ -227,7 +227,7 @@ bitflags! {
         /// Adds a round cap at the start of a line strip (excludes other start caps).
         const FLAG_CAP_START_ROUND = 0b0001_0000;
 
-        /// By default, line caps end at the last/first position of the the line strip.
+        /// By default, line caps end at the last/first position of the line strip.
         /// This flag makes end caps extend outwards.
         const FLAG_CAP_START_EXTEND_OUTWARDS = 0b0010_0000;
 

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -94,7 +94,7 @@ pub enum ColorMapper {
     /// Look up the color in this texture.
     ///
     /// The texture is indexed in a row-major fashion, so that the top left pixel
-    /// corresponds to the the normalized value of 0.0, and the
+    /// corresponds to the normalized value of 0.0, and the
     /// bottom right pixel is 1.0.
     ///
     /// The texture must have the format [`wgpu::TextureFormat::Rgba8UnormSrgb`].

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -235,7 +235,7 @@ impl TextureManager2D {
         //     );
         // }
 
-        // Currently we don't store any data in the the texture manager.
+        // Currently we don't store any data in the texture manager.
         // In the future we might handle (lazy?) mipmap generation in here or keep track of lazy upload processing.
 
         Self::create_and_upload_texture(&self.device, &self.queue, texture_pool, creation_desc)

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -425,7 +425,7 @@ impl TimePanel {
             return; // ignore entities that have no data for the current timeline, nor any timeless data.
         }
 
-        // The last part of the the path component
+        // The last part of the path component
         let text = if let Some(last_path_part) = last_path_part {
             if tree.is_leaf() {
                 last_path_part.to_string()

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -200,8 +200,8 @@ impl ViewerAnalytics {
                     rustc_version,
                     llvm_version,
                 } => {
-                    self.register("rust_version", rustc_version.to_string()); // Rust/LLVM version of the the code compiling the Rust SDK
-                    self.register("llvm_version", llvm_version.to_string()); // Rust/LLVM version of the the code compiling the Rust SDK
+                    self.register("rust_version", rustc_version.to_string()); // Rust/LLVM version of the code compiling the Rust SDK
+                    self.register("llvm_version", llvm_version.to_string()); // Rust/LLVM version of the code compiling the Rust SDK
                     self.deregister("python_version"); // can't be both!
                 }
                 StoreSource::PythonSdk(version) => {

--- a/crates/re_viewer_context/src/time_control.rs
+++ b/crates/re_viewer_context/src/time_control.rs
@@ -8,7 +8,7 @@ use crate::NeedsRepaint;
 /// The time range we are currently zoomed in on.
 #[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 pub struct TimeView {
-    /// Where start of the the range.
+    /// Where start of the range.
     pub min: TimeReal,
 
     /// How much time the full view covers.

--- a/docs/content/reference/viewer/blueprint.md
+++ b/docs/content/reference/viewer/blueprint.md
@@ -46,7 +46,7 @@ of blueprints.
 Adding Entities
 -----------------------------
 To (re-)add an Entity to a Space View, you need first need to select the respective Space View.
-You then can open a dedicated menu through a button in the the [Selection view](selection.md).
+You then can open a dedicated menu through a button in the [Selection view](selection.md).
 
 This allows you to add any Entity with a matching [category](viewport.md#Categories-of-Space-Views) and a valid [transform](../../concepts/spaces-and-transforms.md) to your
 Space View's path.

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -58,7 +58,7 @@ impl ViewPartSystem for InstanceColorSystem {
         query: &ViewQuery<'_>,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
-        // For each entity in the space view that should be displayed with the the `InstanceColorSystem`...
+        // For each entity in the space view that should be displayed with the `InstanceColorSystem`…
         for (ent_path, _props) in query.iter_entities_for_system(InstanceColorSystem::name()) {
             // ...gather all colors and their instance ids.
             if let Ok(arch_view) = query_archetype::<ColorArchetype>(

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -35,6 +35,8 @@ legal_todo_inner_pattern = re.compile(
 
 anyhow_result = re.compile(r"Result<.*, anyhow::Error>")
 
+double_the = re.compile(r"\bthe the\b")
+
 
 def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if line == "":
@@ -52,6 +54,9 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
 
         if " github " in line:
             return "It's 'GitHub', not 'github'"
+
+    if double_the.search(line.lower()):
+        return "Found 'the the'"
 
     if file_extension in ("md", "rs"):
         if ellipsis.search(line):
@@ -148,6 +153,7 @@ def test_lint_line() -> None:
         "{foo:?}",
         "rec",
         "anyhow::Result<()>",
+        "The theme is great",
     ]
 
     should_error = [
@@ -179,6 +185,7 @@ def test_lint_line() -> None:
         "rr_stream",
         "rec_stream",
         "Result<(), anyhow::Error>",
+        "The the problem with double words",
     ]
 
     for line in should_pass:


### PR DESCRIPTION
### What
This was a surprisingly common mistake that I found all over the the code!

* Sparked by https://github.com/rerun-io/rerun/pull/3630#discussion_r1344247993

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3635) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3635)
- [Docs preview](https://rerun.io/preview/b70a90e2370533482598b94013a9dfcefd3490a6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b70a90e2370533482598b94013a9dfcefd3490a6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)