### PR TITLE
Remove gratuitous np.array inside call to from_quat

### DIFF
--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -192,7 +192,7 @@ def project_3d_bboxes_to_2d_keypoints(
     translation, rotation_q = camera_from_world.translation, camera_from_world.rotation
     # We know we stored the rotation as a quaternion, so extract it again.
     # TODO(#3467): This shouldn't directly access rotation.inner
-    rotation = R.from_quat(np.array(rotation_q.inner))  # type: ignore[union-attr]
+    rotation = R.from_quat(rotation_q.inner)  # type: ignore[union-attr]
 
     # Transform 3D keypoints from world to camera frame
     world_to_camera_rotation = rotation.as_matrix()


### PR DESCRIPTION
### What
Cleaning up as part of migration.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3639) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3639)
- [Docs preview](https://rerun.io/preview/1e616c2653f944c55e50ccece3429854a2a9b60a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1e616c2653f944c55e50ccece3429854a2a9b60a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)