### PR TITLE
Fix code example links in the entity component doc

### DIFF
--- a/docs/content/concepts/entity-component.md
+++ b/docs/content/concepts/entity-component.md
@@ -50,15 +50,15 @@ own set of components, bypassing archetypes altogether.
 
 In Python, the `rr.AnyValue` helper object can be used to add custom component(s) to an archetype:
 
-code-example: extra_value
+code-example: extra_values
 
 It can also be used log an entirely custom set of components:
 
-code-example: any_value
+code-example: any_values
 
 For more complex use-cases, custom objects implementing the `rr.AsComponents` protocol can be used. For Rust, the `rerun::AsComponents` trait must be implemented:
 
-code-example: custom-data
+code-example: custom_data
 
 ### Empty Entities
 


### PR DESCRIPTION
### What
⬆️ 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
