### PR TITLE
Remove deleted text-logging from example manifest

### DIFF
--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -127,9 +127,6 @@ root:
         - name: plots
           python: python/plots
 
-        - name: text-logging
-          python: python/text_logging
-
     - name: paper-visualizations
       title: Paper Visualizations
       prelude: |


### PR DESCRIPTION
### What
⬆️ 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
