### PR TITLE
Fix extra whitespace on rust datatype docs

### DIFF
--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  The `AnnotationContext` provides additional information on how to display entities.
+/// **Archetype**: The `AnnotationContext` provides additional information on how to display entities.
 ///
 /// Entities can use `ClassId`s and `KeypointId`s to provide annotations, and
 /// the labels and colors will be looked up in the appropriate

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  3D arrows with optional colors, radii, labels, etc.
+/// **Archetype**: 3D arrows with optional colors, radii, labels, etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
+/// **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 ///
 /// See also [`Mesh3D`][crate::archetypes::Mesh3D].
 ///

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A bar chart.
+/// **Archetype**: A bar chart.
 ///
 /// The x values will be the indices of the array, and the bar heights will be the provided values.
 ///

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  2D boxes with half-extents and optional center, rotations, rotations, colors etc.
+/// **Archetype**: 2D boxes with half-extents and optional center, rotations, rotations, colors etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  3D boxes with half-extents and optional center, rotations, rotations, colors etc.
+/// **Archetype**: 3D boxes with half-extents and optional center, rotations, rotations, colors etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/clear.rs
+++ b/crates/re_types/src/archetypes/clear.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  Empties all the components of an entity.
+/// **Archetype**: Empties all the components of an entity.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A depth image.
+/// **Archetype**: A depth image.
 ///
 /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
 /// Each pixel corresponds to a depth value in units specified by `meter`.

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  Specifies that the entity path at which this is logged is disconnected from its parent.
+/// **Archetype**: Specifies that the entity path at which this is logged is disconnected from its parent.
 ///
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 ///

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A monochrome or color image.
+/// **Archetype**: A monochrome or color image.
 ///
 /// The shape of the `TensorData` must be mappable to:
 /// - A `HxW` tensor, treated as a grayscale image.

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  2D line strips with positions and optional colors, radii, labels, etc.
+/// **Archetype**: 2D line strips with positions and optional colors, radii, labels, etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  3D line strips with positions and optional colors, radii, labels, etc.
+/// **Archetype**: 3D line strips with positions and optional colors, radii, labels, etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
+/// **Archetype**: A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
 ///
 /// See also [`Asset3D`][crate::archetypes::Asset3D].
 ///

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  Camera perspective projection (a.k.a. intrinsics).
+/// **Archetype**: Camera perspective projection (a.k.a. intrinsics).
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A 2D point cloud with positions and optional colors, radii, labels, etc.
+/// **Archetype**: A 2D point cloud with positions and optional colors, radii, labels, etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A 3D point cloud with positions and optional colors, radii, labels, etc.
+/// **Archetype**: A 3D point cloud with positions and optional colors, radii, labels, etc.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  An image made up of integer class-ids
+/// **Archetype**: An image made up of integer class-ids
 ///
 /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
 /// Each pixel corresponds to a depth value in units specified by meter.

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A generic n-dimensional Tensor.
+/// **Archetype**: A generic n-dimensional Tensor.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A text element intended to be displayed in its own text-box.
+/// **Archetype**: A text element intended to be displayed in its own text-box.
 ///
 /// Supports raw text and markdown.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A log entry in a text log, comprised of a text body and its log level.
+/// **Archetype**: A log entry in a text log, comprised of a text body and its log level.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  Log a double-precision scalar that will be visualized as a time-series plot.
+/// **Archetype**: Log a double-precision scalar that will be visualized as a time-series plot.
 ///
 /// The current simulation time will be used for the time/X-axis, hence scalars
 /// cannot be timeless!

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  A 3D transform.
+/// **Archetype**: A 3D transform.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Archetype**:  How we interpret the coordinate system of an entity/space.
+/// **Archetype**: How we interpret the coordinate system of an entity/space.
 ///
 /// For instance: What is "up"? What does the Z axis mean? Is this right-handed or left-handed?
 ///

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  The `AnnotationContext` provides additional information on how to display entities.
+/// **Component**: The `AnnotationContext` provides additional information on how to display entities.
 ///
 /// Entities can use `ClassId`s and `KeypointId`s to provide annotations, and
 /// the labels and colors will be looked up in the appropriate

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A binary blob of data.
+/// **Component**: A binary blob of data.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Blob(pub crate::ArrowBuffer<u8>);

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A 16-bit ID representing a type of semantic class.
+/// **Component**: A 16-bit ID representing a type of semantic class.
 ///
 /// Used to look up a [`crate::datatypes::ClassDescription`] within the [`crate::components::AnnotationContext`].
 #[derive(

--- a/crates/re_types/src/components/clear_is_recursive.rs
+++ b/crates/re_types/src/components/clear_is_recursive.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Configures how a clear operation should behave - recursive or not?
+/// **Component**: Configures how a clear operation should behave - recursive or not?
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct ClearIsRecursive(
     /// If true, also clears all recursive children entities.

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+/// **Component**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
 ///
 /// The color is stored as a 32-bit integer, where the most significant
 /// byte is `R` and the least significant byte is `A`.

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A component indicating how long a meter is, expressed in native units.
+/// **Component**: A component indicating how long a meter is, expressed in native units.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct DepthMeter(pub f32);

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Specifies that the entity path at which this is logged is disconnected from its parent.
+/// **Component**: Specifies that the entity path at which this is logged is disconnected from its parent.
 ///
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 ///

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Draw order used for the display order of 2D elements.
+/// **Component**: Draw order used for the display order of 2D elements.
 ///
 /// Higher values are drawn on top of lower values.
 /// An entity can have only a single draw order component.

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Half-sizes (extents) of a 2D box along its local axis, starting at its local origin/center.
+/// **Component**: Half-sizes (extents) of a 2D box along its local axis, starting at its local origin/center.
 ///
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Half-sizes (extents) of a 3D box along its local axis, starting at its local origin/center.
+/// **Component**: Half-sizes (extents) of a 3D box along its local axis, starting at its local origin/center.
 ///
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.

--- a/crates/re_types/src/components/instance_key.rs
+++ b/crates/re_types/src/components/instance_key.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A unique numeric identifier for each individual instance within a batch.
+/// **Component**: A unique numeric identifier for each individual instance within a batch.
 #[derive(Clone, Debug, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct InstanceKey(pub u64);

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A 16-bit ID representing a type of semantic keypoint within a class.
+/// **Component**: A 16-bit ID representing a type of semantic keypoint within a class.
 ///
 /// `KeypointId`s are only meaningful within the context of a [`crate::datatypes::ClassDescription`].
 ///

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A line strip in 2D space.
+/// **Component**: A line strip in 2D space.
 ///
 /// A line strip is a list of points connected by line segments. It can be used to draw
 /// approximations of smooth curves.

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A line strip in 3D space.
+/// **Component**: A line strip in 3D space.
 ///
 /// A line strip is a list of points connected by line segments. It can be used to draw
 /// approximations of smooth curves.

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Material properties of a mesh.
+/// **Component**: Material properties of a mesh.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Material(pub crate::datatypes::Material);
 

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A standardized media type (RFC2046, formerly known as MIME types), encoded as a utf8 string.
+/// **Component**: A standardized media type (RFC2046, formerly known as MIME types), encoded as a utf8 string.
 ///
 /// The complete reference of officially registered media types is maintained by the IANA and can be
 /// consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.

--- a/crates/re_types/src/components/mesh_properties.rs
+++ b/crates/re_types/src/components/mesh_properties.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Optional triangle indices for a mesh.
+/// **Component**: Optional triangle indices for a mesh.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MeshProperties(pub crate::datatypes::MeshProperties);
 

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  An out-of-tree affine transform between two 3D spaces, represented in a given direction.
+/// **Component**: An out-of-tree affine transform between two 3D spaces, represented in a given direction.
 ///
 /// "Out-of-tree" means that the transform only affects its own entity: children don't inherit from it.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Camera projection, from image coordinates to view coordinates.
+/// **Component**: Camera projection, from image coordinates to view coordinates.
 ///
 /// Child from parent.
 /// Image coordinates from camera view coordinates.

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A position in 2D space.
+/// **Component**: A position in 2D space.
 #[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Position2D(pub crate::datatypes::Vec2D);

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A position in 3D space.
+/// **Component**: A position in 3D space.
 #[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Position3D(pub crate::datatypes::Vec3D);

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A Radius component.
+/// **Component**: A Radius component.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Radius(pub f32);

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  Pixel resolution width & height, e.g. of a camera sensor.
+/// **Component**: Pixel resolution width & height, e.g. of a camera sensor.
 ///
 /// Typically in integer units, but for some use cases floating point may be used.
 #[derive(Clone, Debug, Copy, PartialEq)]

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A 3D rotation, represented either by a quaternion or a rotation around axis.
+/// **Component**: A 3D rotation, represented either by a quaternion or a rotation around axis.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Rotation3D(
     /// Representation of the rotation.

--- a/crates/re_types/src/components/scalar.rs
+++ b/crates/re_types/src/components/scalar.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A double-precision scalar.
+/// **Component**: A double-precision scalar.
 ///
 /// Used for time series plots.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]

--- a/crates/re_types/src/components/scalar_scattering.rs
+++ b/crates/re_types/src/components/scalar_scattering.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  If true, a scalar will be shown as individual point in a scatter plot.
+/// **Component**: If true, a scalar will be shown as individual point in a scatter plot.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, Eq)]
 pub struct ScalarScattering(pub bool);
 

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A multi-dimensional `Tensor` with optionally named arguments.
+/// **Component**: A multi-dimensional `Tensor` with optionally named arguments.
 #[derive(Clone, Debug, PartialEq)]
 #[repr(transparent)]
 pub struct TensorData(pub crate::datatypes::TensorData);

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A string of text, e.g. for labels and text documents
+/// **Component**: A string of text, e.g. for labels and text documents
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Text(pub crate::datatypes::Utf8);

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  The severity level of a text log message.
+/// **Component**: The severity level of a text log message.
 ///
 /// Recommended to be one of:
 /// * `"CRITICAL"`

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  An affine transform between two 3D spaces, represented in a given direction.
+/// **Component**: An affine transform between two 3D spaces, represented in a given direction.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Transform3D(
     /// Representation of the transform.

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  A vector in 3D space.
+/// **Component**: A vector in 3D space.
 #[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Vector3D(pub crate::datatypes::Vec3D);

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Component**:  How we interpret the coordinate system of an entity/space.
+/// **Component**: How we interpret the coordinate system of an entity/space.
 ///
 /// For instance: What is "up"? What does the Z axis mean? Is this right-handed or left-handed?
 ///

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Angle in either radians or degrees.
+/// **Datatype**: Angle in either radians or degrees.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Angle {
     Radians(f32),

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Annotation info annotating a class id or key-point id.
+/// **Datatype**: Annotation info annotating a class id or key-point id.
 ///
 /// Color and label will be used to annotate entities/keypoints which reference the id.
 /// The id refers either to a class or key-point id

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  The description of a semantic Class.
+/// **Datatype**: The description of a semantic Class.
 ///
 /// If an entity is annotated with a corresponding `ClassId`, rerun will use
 /// the attached `AnnotationInfo` to derive labels and colors.

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A helper type for mapping class IDs to class descriptions.
+/// **Datatype**: A helper type for mapping class IDs to class descriptions.
 ///
 /// This is internal to the `AnnotationContext` structure.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A 16-bit ID representing a type of semantic class.
+/// **Datatype**: A 16-bit ID representing a type of semantic class.
 ///
 /// Used to look up a [`crate::datatypes::ClassDescription`] within the [`crate::components::AnnotationContext`].
 #[derive(

--- a/crates/re_types/src/datatypes/float32.rs
+++ b/crates/re_types/src/datatypes/float32.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A single-precision 32-bit IEEE 754 floating point number.
+/// **Datatype**: A single-precision 32-bit IEEE 754 floating point number.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct Float32(pub f32);
 

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A 16-bit ID representing a type of semantic keypoint within a class.
+/// **Datatype**: A 16-bit ID representing a type of semantic keypoint within a class.
 ///
 /// `KeypointId`s are only meaningful within the context of a [`crate::datatypes::ClassDescription`].
 ///

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A connection between two `Keypoints`.
+/// **Datatype**: A connection between two `Keypoints`.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct KeypointPair {
     /// The first point of the pair.

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A 3x3 Matrix.
+/// **Datatype**: A 3x3 Matrix.
 ///
 /// Matrices in Rerun are stored as flat list of coefficients in column-major order:
 /// ```text

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A 4x4 Matrix.
+/// **Datatype**: A 4x4 Matrix.
 ///
 /// Matrices in Rerun are stored as flat list of coefficients in column-major order:
 /// ```text

--- a/crates/re_types/src/datatypes/material.rs
+++ b/crates/re_types/src/datatypes/material.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Material properties of a mesh.
+/// **Datatype**: Material properties of a mesh.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
 pub struct Material {
     /// Optional color multiplier.

--- a/crates/re_types/src/datatypes/mesh_properties.rs
+++ b/crates/re_types/src/datatypes/mesh_properties.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Optional triangle indices for a mesh.
+/// **Datatype**: Optional triangle indices for a mesh.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MeshProperties {
     /// A flattened array of vertex indices that describe the mesh's triangles.

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A Quaternion represented by 4 real numbers.
+/// **Datatype**: A Quaternion represented by 4 real numbers.
 ///
 /// Note: although the x,y,z,w components of the quaternion will be passed through to the
 /// datastore as provided, when used in the viewer Quaternions will always be normalized.

--- a/crates/re_types/src/datatypes/rgba32.rs
+++ b/crates/re_types/src/datatypes/rgba32.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
+/// **Datatype**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
 ///
 /// The color is stored as a 32-bit integer, where the most significant
 /// byte is `R` and the least significant byte is `A`.

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A 3D rotation.
+/// **Datatype**: A 3D rotation.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Rotation3D {
     /// Rotation defined by a quaternion.

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  3D rotation represented by a rotation around a given axis.
+/// **Datatype**: 3D rotation represented by a rotation around a given axis.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct RotationAxisAngle {
     /// Axis to rotate around.

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  3D scaling factor, part of a transform representation.
+/// **Datatype**: 3D scaling factor, part of a transform representation.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum Scale3D {
     /// Individual scaling factors for each axis, distorting the original object.

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  The underlying storage for a `Tensor`.
+/// **Datatype**: The underlying storage for a `Tensor`.
 ///
 /// Tensor elements are stored in a contiguous buffer of a single type.
 #[derive(Clone, PartialEq)]

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A multi-dimensional `Tensor` of data.
+/// **Datatype**: A multi-dimensional `Tensor` of data.
 ///
 /// The number of dimensions and their respective lengths is specified by the `shape` field.
 /// The dimensions are ordered from outermost to innermost. For example, in the common case of

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A single dimension within a multi-dimensional tensor.
+/// **Datatype**: A single dimension within a multi-dimensional tensor.
 #[derive(Clone, Default, Eq, PartialEq)]
 pub struct TensorDimension {
     /// The length of this dimension.

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Representation of a 3D affine transform.
+/// **Datatype**: Representation of a 3D affine transform.
 ///
 /// Rarely used directly, prefer using the underlying representation classes and pass them
 /// directly to `Transform3D::child_from_parent` or `Transform3D::parent_from_child`.

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Representation of an affine transform via a 3x3 affine matrix paired with a translation.
+/// **Datatype**: Representation of an affine transform via a 3x3 affine matrix paired with a translation.
 ///
 /// First applies the matrix, then the translation.
 #[derive(Clone, Debug, Copy, PartialEq)]

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  Representation of an affine transform via separate translation, rotation & scale.
+/// **Datatype**: Representation of an affine transform via separate translation, rotation & scale.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct TranslationRotationScale3D {
     /// 3D translation vector, applied last.

--- a/crates/re_types/src/datatypes/utf8.rs
+++ b/crates/re_types/src/datatypes/utf8.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A string of text, encoded as UTF-8.
+/// **Datatype**: A string of text, encoded as UTF-8.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Utf8(pub crate::ArrowString);

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A uint32 vector in 2D space.
+/// **Datatype**: A uint32 vector in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UVec2D(pub [u32; 2usize]);

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A uint32 vector in 3D space.
+/// **Datatype**: A uint32 vector in 3D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UVec3D(pub [u32; 3usize]);

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A uint vector in 4D space.
+/// **Datatype**: A uint vector in 4D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UVec4D(pub [u32; 4usize]);

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A vector in 2D space.
+/// **Datatype**: A vector in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Vec2D(pub [f32; 2usize]);

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A vector in 3D space.
+/// **Datatype**: A vector in 3D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Vec3D(pub [f32; 3usize]);

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-/// **Datatype**:  A vector in 4D space.
+/// **Datatype**: A vector in 4D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Vec4D(pub [f32; 4usize]);

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -507,7 +507,7 @@ fn quote_obj_docs(reporter: &Reporter, obj: &Object) -> TokenStream {
 
     // Prefix first line with `**Datatype**: ` etc:
     if let Some(first) = lines.first_mut() {
-        *first = format!("**{}**: {}", obj.kind.singular_name(), first);
+        *first = format!("**{}**: {}", obj.kind.singular_name(), first.trim());
     } else if !obj.is_testing() {
         reporter.error(&obj.virtpath, &obj.fqname, "Missing documentation for");
     }


### PR DESCRIPTION
Followup to #3648

Didn't affect any other languages apparently

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~I've included a screenshot or gif (if applicable)~
* [x] ~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3659) (if applicable)~

- [PR Build Summary](https://build.rerun.io/pr/3659)
- [Docs preview](https://rerun.io/preview/875762bb8aa8356fec3c258939991702cac4dec5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/875762bb8aa8356fec3c258939991702cac4dec5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)