### PR TITLE
Remove COMPONENT_PREFIX from AnyValuesBatch

### DIFF
--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -70,7 +70,7 @@ to the [points entity](recording://points):
 ```python
 rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
 ```
-**Note:** we added some [custom per-point errors](recording://points.any.value.error) that you can see when you
+**Note:** we added some [custom per-point errors](recording://points.error) that you can see when you
 hover over the points in the 3D view.
 """.strip()
 

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -10,8 +10,6 @@ from .error_utils import _send_warning
 
 ANY_VALUE_TYPE_REGISTRY: dict[str, Any] = {}
 
-COMPONENT_PREFIX = "any.value."
-
 
 class AnyBatchValue(ComponentBatchLike):
     """
@@ -26,8 +24,6 @@ class AnyBatchValue(ComponentBatchLike):
     def __init__(self, name: str, value: Any) -> None:
         """
         Construct a new AnyBatchValue.
-
-        The component will be named "user.components.<NAME>".
 
         The value will be attempted to be converted into an arrow array by first calling
         the `as_arrow_array()` method if it's defined. All Rerun Batch datatypes implement
@@ -90,7 +86,7 @@ class AnyBatchValue(ComponentBatchLike):
         return self.pa_array is not None
 
     def component_name(self) -> str:
-        return COMPONENT_PREFIX + self.name
+        return self.name
 
     def as_arrow_array(self) -> pa.Array | None:
         return self.pa_array

--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -14,8 +14,8 @@ def test_any_value() -> None:
     foo_batch = batches[0]
     bar_batch = batches[1]
 
-    assert foo_batch.component_name() == "any.value.foo"
-    assert bar_batch.component_name() == "any.value.bar"
+    assert foo_batch.component_name() == "foo"
+    assert bar_batch.component_name() == "bar"
     assert len(foo_batch.as_arrow_array()) == 3
     assert len(bar_batch.as_arrow_array()) == 1
     assert np.all(foo_batch.as_arrow_array().to_numpy() == np.array([1.0, 2.0, 3.0]))
@@ -28,7 +28,7 @@ def test_any_value_datatypes() -> None:
 
     foo_batch = batches[0]
 
-    assert foo_batch.component_name() == "any.value.my_points"
+    assert foo_batch.component_name() == "my_points"
     assert len(foo_batch.as_arrow_array()) == 3
 
 


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3606

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3660) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3660)
- [Docs preview](https://rerun.io/preview/1f2fd7ec1a474ef413a48e69ed60a5eb0e1ce5b2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1f2fd7ec1a474ef413a48e69ed60a5eb0e1ce5b2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)