### PR TITLE
Don't warn if the only thing we're dropping is SetStoreInfo messages

### DIFF
--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -128,8 +128,14 @@ pub struct MemorySinkStorage {
 
 impl Drop for MemorySinkStorage {
     fn drop(&mut self) {
-        if !self.msgs.read().is_empty() {
-            re_log::warn!("Dropping data in MemorySink");
+        for msg in self.msgs.read().iter() {
+            // Sinks intentionally end up with pending SetStoreInfo messages
+            // these are fine to drop safely. Anything else should produce a
+            // warning.
+            if !matches!(msg, LogMsg::SetStoreInfo(_)) {
+                re_log::warn!("Dropping data in MemorySink");
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
### What
Avoids a spurious warning in notebooks.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3666) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3666)
- [Docs preview](https://rerun.io/preview/c09d9aa2ad59ba8d13ec532b311b6b6250ccf184/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c09d9aa2ad59ba8d13ec532b311b6b6250ccf184/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)