### PR TITLE
Handle single line strips better

### DIFF
--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d_ext.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import numbers
 from collections.abc import Sized
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import pyarrow as pa
@@ -42,13 +43,36 @@ class LineStrip2DExt:
         elif isinstance(data, Sequence):
             if len(data) == 0:
                 inners = []
-            elif isinstance(data[0], np.ndarray):
-                inners = [Vec2DBatch(datum).as_arrow_array().storage for datum in data]  # type: ignore[arg-type]
-            elif isinstance(data[0], LineStrip2D):
-                inners = [Vec2DBatch(datum.points).as_arrow_array().storage for datum in data]  # type: ignore[union-attr]
             else:
-                inners = [Vec2DBatch(datum).as_arrow_array().storage for datum in data]  # type: ignore[arg-type]
+                # Is it a single strip or several?
+                # It could be a sequence of the style `[[0, 0], [1, 1]]` which is a single strip.
+                if all(
+                    isinstance(elem, Sequence) and len(elem) > 0 and isinstance(elem[0], numbers.Number)
+                    for elem in data
+                ):
+                    if all(len(elem) == 2 for elem in data):  # type: ignore[arg-type]
+                        inners = [Vec2DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                    else:
+                        raise ValueError(
+                            "Expected a sequence of sequences of 2D vectors, but the inner sequence length was not equal to 2."
+                        )
+                # It could be a sequence of the style `[np.array([0, 0]), np.array([1, 1])]` which is a single strip.
+                elif all(isinstance(elem, np.ndarray) and elem.shape == (2,) for elem in data):
+                    inners = [Vec2DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                # .. otherwise assume that it's several strips.
+                else:
 
+                    def to_vec2d_batch(strip: Any) -> Vec2DBatch:
+                        if isinstance(strip, LineStrip2D):
+                            return Vec2DBatch(strip.points)
+                        else:
+                            if isinstance(strip, np.ndarray) and (strip.ndim != 2 or strip.shape[1] != 2):
+                                raise ValueError(
+                                    "Expected a sequence of 2D vectors, instead got array with shape {strip.shape}."
+                                )
+                            return Vec2DBatch(strip)
+
+                    inners = [to_vec2d_batch(strip).as_arrow_array().storage for strip in data]
         else:
             inners = [Vec2DBatch(data).storage]
 

--- a/rerun_py/tests/unit/test_line_strips2d.py
+++ b/rerun_py/tests/unit/test_line_strips2d.py
@@ -35,20 +35,16 @@ strips_arrays: list[LineStrip2DArrayLike] = [
     [],
     np.array([]),
     [
+        [[0, 0], [2, 1], [4, -1], [6, 0]],  # type: ignore[list-item]
+        [[0, 3], [1, 4], [2, 2], [3, 4], [4, 2], [5, 4], [6, 3]],  # type: ignore[list-item]
+    ],
+    [
         [Vec2D([0, 0]), (2, 1), [4, -1], (6, 0)],  # type: ignore[list-item]
         [Vec2D([0, 3]), (1, 4), [2, 2], (3, 4), [4, 2], (5, 4), [6, 3]],  # type: ignore[list-item]
     ],
     [
-        [0, 0, 2, 1, 4, -1, 6, 0],
-        [0, 3, 1, 4, 2, 2, 3, 4, 4, 2, 5, 4, 6, 3],
-    ],
-    [
         np.array([[0, 0], (2, 1), [4, -1], (6, 0)], dtype=np.float32),
         np.array([[0, 3], (1, 4), [2, 2], (3, 4), [4, 2], (5, 4), [6, 3]], dtype=np.float32),
-    ],
-    [
-        np.array([0, 0, 2, 1, 4, -1, 6, 0], dtype=np.float32),
-        np.array([0, 3, 1, 4, 2, 2, 3, 4, 4, 2, 5, 4, 6, 3], dtype=np.float32),
     ],
     # NOTE: Not legal -- non-homogeneous.
     # np.array([
@@ -140,6 +136,58 @@ def test_line_segments2d(data: LineStrip2DArrayLike) -> None:
             [[4, -1], [6, 0]],
         ]
     )
+
+
+def test_single_line_strip2d() -> None:
+    # Regression test for #3643
+    # Single linestrip can be passed and is not interpreted as batch of zero sized line strips.
+    reference = rr.LineStrips2D([rr.components.LineStrip2D([[0, 0], [1, 1]])])
+    assert len(reference.strips) == 1
+    assert reference == rr.LineStrips2D(rr.components.LineStrip2D([[0, 0], [1, 1]]))
+    assert reference == rr.LineStrips2D([[[0, 0], [1, 1]]])
+    assert reference == rr.LineStrips2D([[0, 0], [1, 1]])
+    assert reference == rr.LineStrips2D(np.array([[0, 0], [1, 1]]))
+    assert reference == rr.LineStrips2D([np.array([0, 0]), np.array([1, 1])])
+
+
+def test_line_strip2d_invalid_shapes() -> None:
+    rr.set_strict_mode(True)
+
+    # We used to support flat arrays but this becomes too ambigious when passing a single strip.
+    with pytest.raises(ValueError):
+        rr.LineStrips2D(
+            [
+                [0, 0, 2, 1, 4, -1, 6, 0],
+                [0, 3, 1, 4, 2, 2, 3, 4, 4, 2, 5, 4, 6, 3],
+            ],
+        )
+    with pytest.raises(ValueError):
+        rr.LineStrips2D(
+            [
+                np.array([0, 0, 2, 1, 4, -1, 6, 0], dtype=np.float32),
+                np.array([0, 3, 1, 4, 2, 2, 3, 4, 4, 2, 5, 4, 6, 3], dtype=np.float32),
+            ],
+        )
+
+    # not homogenous numpy arrays
+    with pytest.raises(ValueError):
+        rr.LineStrips2D(
+            np.array(
+                [
+                    [[0, 0], (2, 1), [4, -1], (6, 0)],
+                    [[0, 3], (1, 4), [2, 2], (3, 4), [4, 2], (5, 4), [6, 3]],
+                ]
+            )
+        )
+    with pytest.raises(ValueError):
+        rr.LineStrips2D(
+            np.array(
+                [
+                    [0, 0, 2, 1, 4, -1, 6, 0],
+                    [0, 3, 1, 4, 2, 2, 3, 4, 4, 2, 5, 4, 6, 3],
+                ]
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

* Fixes #3643 

And disallow line strips from flat number lists. I though this would break legacy API, but according to legacy api documentation it shouldn't.

Tried to make the linestrip method simpler but thoroughly failed in that quest. Naturally, added plenty more unit tests to see if it does what it's supposed to.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~I've included a screenshot or gif (if applicable)~
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
