### PR TITLE
Improve transform conversion errors

### DIFF
--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
@@ -105,12 +105,15 @@ def _optional_mat3x3_to_arrow(mat: Mat3x3 | None) -> pa.Array:
 
 
 def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.Array:
-    from . import Vec3DType
+    from . import Vec3DBatch, Vec3DType
 
     if translation is None:
         return pa.nulls(1, Vec3DType().storage_type)
     else:
-        return pa.FixedSizeListArray.from_arrays(translation.xyz, type=Vec3DType().storage_type)
+        try:
+            return Vec3DBatch._native_to_pa_array(translation.xyz, Vec3DType().storage_type)
+        except ValueError as err:
+            raise ValueError(f"translation must be compatible with Vec3D: {err}")
 
 
 def _optional_rotation_to_arrow(rotation: Rotation3D | None, storage_type: pa.DataType) -> pa.Array:
@@ -119,7 +122,10 @@ def _optional_rotation_to_arrow(rotation: Rotation3D | None, storage_type: pa.Da
     if rotation is None:
         return pa.nulls(1, storage_type)
     else:
-        return Rotation3DBatch._native_to_pa_array(rotation, storage_type)
+        try:
+            return Rotation3DBatch._native_to_pa_array(rotation, storage_type)
+        except ValueError as err:
+            raise ValueError(f"rotation must be compatible with Rotation3D: {err}")
 
 
 def _build_struct_array_from_translation_mat3x3(

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -26,6 +26,14 @@ def test_expected_warnings() -> None:
                 rr.log("points", rr.Points2D([1, 2, 3, 4, 5])),
                 "Expected either a flat array with a length multiple of 2 elements, or an array with shape (`num_elements`, 2). Shape of passed array was (5,).",
             ),
+            (
+                rr.log("test_transform", rr.Transform3D(translation=[1, 2, 3, 4])),
+                "translation must be compatible with Vec3D",
+            ),
+            (
+                rr.log("test_transform", rr.Transform3D(rotation=[1, 2, 3, 4, 5])),
+                "rotation must be compatible with Rotation3D",
+            ),
         ]
 
         assert len(warnings) == len(expected_warnings)


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3641

For code:
```
a = [1, 2, 3, 4]
b = [1, 2, 3, 4, 5]

rr.log("test_transform", rr.Transform3D(translation=a, rotation=b))
```

Before:
```
/home/jleibs/rerun/test.py:6: RerunWarning: Transform3DBatch: ArrowInvalid(The length of the values Array needs to be a multiple of the list size)
  rr.log("test_transform", rr.Transform3D(translation=a, rotation=b))
```

After:
```
/home/jleibs/rerun/test.py:6: RerunWarning: Transform3DBatch: ValueError(translation must be compatible with Vec3D: Expected either a flat array with a length multiple of 3 elements, or an array with shape (`num_elements`, 3). Shape of passed array was (4,).)
  rr.log("test_transform", rr.Transform3D(translation=a, rotation=b))
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3669) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3669)
- [Docs preview](https://rerun.io/preview/5de433c702d3435747aaa600cda0418cc718a774/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5de433c702d3435747aaa600cda0418cc718a774/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)