### PR TITLE
Add obj mesh support to viewer

### DIFF
--- a/crates/re_renderer/src/importer/obj.rs
+++ b/crates/re_renderer/src/importer/obj.rs
@@ -15,7 +15,7 @@ use crate::{
 pub fn load_obj_from_buffer(
     buffer: &[u8],
     lifetime: ResourceLifeTime,
-    ctx: &mut RenderContext,
+    ctx: &RenderContext,
 ) -> anyhow::Result<Vec<MeshInstance>> {
     re_tracing::profile_function!();
 

--- a/crates/re_space_view_spatial/Cargo.toml
+++ b/crates/re_space_view_spatial/Cargo.toml
@@ -24,7 +24,7 @@ re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
 re_query.workspace = true
-re_renderer = { workspace = true, features = ["import-gltf"] }
+re_renderer = { workspace = true, features = ["import-gltf", "import-obj"] }
 re_types = { workspace = true, features = ["ecolor", "glam", "image"] }
 re_tracing.workspace = true
 re_ui.workspace = true

--- a/crates/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/re_space_view_spatial/src/mesh_loader.rs
@@ -38,17 +38,20 @@ impl LoadedMesh {
     ) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 
-        let mesh_instances = if media_type == &MediaType::gltf() || media_type == &MediaType::glb()
-        {
-            re_renderer::importer::gltf::load_gltf_from_buffer(
+        let mesh_instances = match media_type.as_str() {
+            MediaType::GLTF | MediaType::GLB => re_renderer::importer::gltf::load_gltf_from_buffer(
                 &name,
                 bytes,
                 ResourceLifeTime::LongLived,
                 render_ctx,
-            )
-        } else {
-            anyhow::bail!("{media_type} files are not supported")
-        }?;
+            )?,
+            MediaType::OBJ => re_renderer::importer::obj::load_obj_from_buffer(
+                bytes,
+                ResourceLifeTime::LongLived,
+                render_ctx,
+            )?,
+            _ => anyhow::bail!("{media_type} files are not supported"),
+        };
 
         let bbox = re_renderer::importer::calculate_bounding_box(&mesh_instances);
 

--- a/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
@@ -26,9 +26,9 @@ table Asset3D (
 
   /// The Media Type of the asset.
   ///
-  /// For instance:
+  /// Supported values:
   /// * `model/gltf-binary`
-  /// * `model/obj`
+  /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
   ///
   /// If omitted, the viewer will try to guess from the data blob.
   /// If it cannot guess, it won't be able to render the asset.

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -58,9 +58,9 @@ pub struct Asset3D {
 
     /// The Media Type of the asset.
     ///
-    /// For instance:
+    /// Supported values:
     /// * `model/gltf-binary`
-    /// * `model/obj`
+    /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
     ///
     /// If omitted, the viewer will try to guess from the data blob.
     /// If it cannot guess, it won't be able to render the asset.

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -61,9 +61,10 @@ namespace rerun {
 
             /// The Media Type of the asset.
             ///
-            /// For instance:
+            /// Supported values:
             /// * `model/gltf-binary`
-            /// * `model/obj`
+            /// * `model/obj` (.mtl material files are not supported yet, references are silently
+            /// ignored)
             ///
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
@@ -141,9 +142,10 @@ namespace rerun {
 
             /// The Media Type of the asset.
             ///
-            /// For instance:
+            /// Supported values:
             /// * `model/gltf-binary`
-            /// * `model/obj`
+            /// * `model/obj` (.mtl material files are not supported yet, references are silently
+            /// ignored)
             ///
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -81,9 +81,9 @@ class Asset3D(Asset3DExt, Archetype):
     )
     # The Media Type of the asset.
     #
-    # For instance:
+    # Supported values:
     # * `model/gltf-binary`
-    # * `model/obj`
+    # * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
     #
     # If omitted, the viewer will try to guess from the data blob.
     # If it cannot guess, it won't be able to render the asset.


### PR DESCRIPTION
### What

* Fixes #3653 

More like "enable". Works fine, but naturally doesn't support mtl files yet.

⚠️  Let's have a look on the Wasm size tracking for this one before merge ⚠️


Tested using the checked in blender exported obj file https://github.com/rerun-io/rerun/blob/main/crates/re_renderer/examples/rerun.obj.zip, unpacked and then `python ./docs/code-examples/asset3d_simple.py crates/re_renderer/examples/rerun.obj`
![image](https://github.com/rerun-io/rerun/assets/1220815/058471b4-7590-4dbe-ba12-6f16d5ffae2e)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3670) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3670)
- [Docs preview](https://rerun.io/preview/08419a32a3ba8fee8c08e6a5b1fbcdc28e42467d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/08419a32a3ba8fee8c08e6a5b1fbcdc28e42467d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)