### PR TITLE
Make it possible to use the Batch constructor strictly internally when we want it to raise

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -158,7 +158,7 @@ class BaseBatch(Generic[T]):
     _ARROW_TYPE: BaseExtensionType = None  # type: ignore[assignment]
     """The pyarrow type of this batch."""
 
-    def __init__(self, data: T | None) -> None:
+    def __init__(self, data: T | None, strict: bool | None = None) -> None:
         """
         Construct a new batch.
 
@@ -175,13 +175,16 @@ class BaseBatch(Generic[T]):
         ----------
         data : T | None
             The data to convert into an Arrow array.
+        strict : bool | None
+            Whether to raise an exception if the data cannot be converted into an Arrow array. If None, the value
+            defaults to the value of the `rerun.strict` global setting.
 
         Returns
         -------
         The Arrow array encapsulating the data.
         """
         if data is not None:
-            with catch_and_log_exceptions(self.__class__.__name__):
+            with catch_and_log_exceptions(self.__class__.__name__, strict=strict):
                 # If data is already an arrow array, use it
                 if isinstance(data, pa.Array) and data.type == self._ARROW_TYPE:
                     self.pa_array = data

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
@@ -101,17 +101,20 @@ def _optional_mat3x3_to_arrow(mat: Mat3x3 | None) -> pa.Array:
     if mat is None:
         return pa.nulls(1, Mat3x3Type().storage_type)
     else:
-        return Mat3x3Batch._native_to_pa_array(mat, Mat3x3Type().storage_type)
+        try:
+            return Mat3x3Batch(mat, strict=True).as_arrow_array().storage
+        except ValueError as err:
+            raise ValueError(f"mat3x3 must be compatible with Mat3x3: {err}")
 
 
-def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.Array:
+def _optional_translation_to_arrow(translation: Vec3D | None) -> pa.array:
     from . import Vec3DBatch, Vec3DType
 
     if translation is None:
         return pa.nulls(1, Vec3DType().storage_type)
     else:
         try:
-            return Vec3DBatch._native_to_pa_array(translation.xyz, Vec3DType().storage_type)
+            return Vec3DBatch(translation.xyz, strict=True).as_arrow_array().storage
         except ValueError as err:
             raise ValueError(f"translation must be compatible with Vec3D: {err}")
 
@@ -123,7 +126,7 @@ def _optional_rotation_to_arrow(rotation: Rotation3D | None, storage_type: pa.Da
         return pa.nulls(1, storage_type)
     else:
         try:
-            return Rotation3DBatch._native_to_pa_array(rotation, storage_type)
+            return Rotation3DBatch(rotation, strict=True).as_arrow_array().storage
         except ValueError as err:
             raise ValueError(f"rotation must be compatible with Rotation3D: {err}")
 

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -131,16 +131,23 @@ class catch_and_log_exceptions:
     """
 
     def __init__(
-        self, context: str | None = None, depth_to_user_code: int = 1, exception_return_value: Any = None
+        self,
+        context: str | None = None,
+        depth_to_user_code: int = 1,
+        exception_return_value: Any = None,
+        strict: bool | None = None,
     ) -> None:
         self.depth_to_user_code = depth_to_user_code
         self.context = context
         self.exception_return_value = exception_return_value
+        self.strict = strict
 
     def __enter__(self) -> catch_and_log_exceptions:
         # Track the original strict_mode setting in case it's being
         # overridden locally in this stack
         self.original_strict = getattr(_rerun_exception_ctx, "strict_mode", None)
+        if self.strict is not None:
+            _rerun_exception_ctx.strict_mode = self.strict
         if getattr(_rerun_exception_ctx, "depth", None) is None:
             _rerun_exception_ctx.depth = 1
         else:

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -34,6 +34,11 @@ def test_expected_warnings() -> None:
                 rr.log("test_transform", rr.Transform3D(rotation=[1, 2, 3, 4, 5])),
                 "rotation must be compatible with Rotation3D",
             ),
+            (
+                # TODO(jleibs): This should ideally capture the field name as mat3x3 as above
+                rr.log("test_transform", rr.Transform3D(mat3x3=[1, 2, 3, 4, 5])),
+                "cannot reshape array of size 5 into shape (3,3))",
+            ),
         ]
 
         assert len(warnings) == len(expected_warnings)


### PR DESCRIPTION
### What
I noticed some places that would be better served by using the Batch constructor, but needed to plumb through the strict-mode handling so we could catch and augment the exception.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3672) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3672)
- [Docs preview](https://rerun.io/preview/d1155fa6c582c8814d8deb76d507594d21129095/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d1155fa6c582c8814d8deb76d507594d21129095/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)