### PR TITLE
Show transform arrows for entities with only Transform3D-related components

### DIFF
--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -223,14 +223,16 @@ fn update_transform3d_lines_heuristics(
 
         let mut properties = entity_properties.get(ent_path);
         if properties.transform_3d_visible.is_auto() {
-            // By default show the transform if it is a camera extrinsic or if it's the only component on this entity path.
-            let single_component = ctx
-                .store_db
-                .store()
-                .all_components(&ctx.current_query().timeline, ent_path)
-                .map_or(false, |c| c.len() == 1);
+            // By default show the transform if it is a camera extrinsic
+            // or if it has the indicator component for the `Transform3D` archetype
+            use re_types::Archetype as _;
+            let has_transform3d_indicator = ctx.store_db.store().entity_has_component(
+                &ctx.current_query().timeline,
+                ent_path,
+                &re_types::archetypes::Transform3D::indicator().name(),
+            );
             properties.transform_3d_visible = EditableAutoValue::Auto(
-                single_component
+                has_transform3d_indicator
                     || is_pinhole_extrinsics_of(ctx.store_db.store(), ent_path, ctx).is_some(),
             );
         }

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -8,6 +8,7 @@ use re_log_types::EntityPath;
 use re_types::{
     components::{DepthMeter, TensorData},
     tensor_data::TensorDataMeaning,
+    Archetype as _,
 };
 use re_viewer_context::{
     AutoSpawnHeuristic, NamedViewSystem, PerSystemEntities, SpaceViewClassName, ViewerContext,
@@ -223,16 +224,18 @@ fn update_transform3d_lines_heuristics(
 
         let mut properties = entity_properties.get(ent_path);
         if properties.transform_3d_visible.is_auto() {
-            // By default show the transform if it is a camera extrinsic
-            // or if it has the indicator component for the `Transform3D` archetype
-            use re_types::Archetype as _;
-            let has_transform3d_indicator = ctx.store_db.store().entity_has_component(
-                &ctx.current_query().timeline,
-                ent_path,
-                &re_types::archetypes::Transform3D::indicator().name(),
-            );
+            // By default show the transform if it is a camera extrinsic,
+            // or if this entity only contains Transform3D components.
+            let only_has_transform_components = ctx
+                .store_db
+                .store()
+                .all_components(&ctx.current_query().timeline, ent_path)
+                .map_or(false, |c| {
+                    c.iter()
+                        .all(|c| re_types::archetypes::Transform3D::all_components().contains(c))
+                });
             properties.transform_3d_visible = EditableAutoValue::Auto(
-                has_transform3d_indicator
+                only_has_transform_components
                     || is_pinhole_extrinsics_of(ctx.store_db.store(), ent_path, ctx).is_some(),
             );
         }


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/3675

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3676) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3676)
- [Docs preview](https://rerun.io/preview/5a2c09dde803a3b686840a665881348b68d9a2a8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5a2c09dde803a3b686840a665881348b68d9a2a8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)