### PR TITLE
Update generated doc pages to the new python urls

### DIFF
--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -163,10 +163,11 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
         // TODO(#3651): s/nightly/stable
         putln!(
             page,
-            " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/nightly/package/rerun/{}/{}/)",
+            " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/nightly/common/{}#rerun.{}.{})",
             object.name,
             object.kind.plural_snake_case(),
-            object.snake_case_name()
+            object.kind.plural_snake_case(),
+            object.name
         );
         // TODO(#3651): s/0.9.0-alpha.10/latest
         putln!(

--- a/docs/content/reference/types/archetypes/annotation_context.md
+++ b/docs/content/reference/types/archetypes/annotation_context.md
@@ -15,7 +15,7 @@ path.
 **Required**: [`AnnotationContext`](../components/annotation_context.md)
 
 ## Links
- * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/annotation_context/)
+ * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.AnnotationContext)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.AnnotationContext.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -13,7 +13,7 @@ title: "Arrows3D"
 **Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/arrows3d/)
+ * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Arrows3D)
  * 🦀 [Rust API docs for `Arrows3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Arrows3D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -13,7 +13,7 @@ A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 **Optional**: [`OutOfTreeTransform3D`](../components/out_of_tree_transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/asset3d/)
+ * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Asset3D)
  * 🦀 [Rust API docs for `Asset3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Asset3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -11,7 +11,7 @@ The x values will be the indices of the array, and the bar heights will be the p
 **Required**: [`TensorData`](../components/tensor_data.md)
 
 ## Links
- * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/bar_chart/)
+ * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.BarChart)
  * 🦀 [Rust API docs for `BarChart`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.BarChart.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -13,7 +13,7 @@ title: "Boxes2D"
 **Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/boxes2d/)
+ * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Boxes2D)
  * 🦀 [Rust API docs for `Boxes2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Boxes2D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -13,7 +13,7 @@ title: "Boxes3D"
 **Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/boxes3d/)
+ * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Boxes3D)
  * 🦀 [Rust API docs for `Boxes3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Boxes3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -9,7 +9,7 @@ Empties all the components of an entity.
 **Required**: [`ClearIsRecursive`](../components/clear_is_recursive.md)
 
 ## Links
- * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/clear/)
+ * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Clear)
  * 🦀 [Rust API docs for `Clear`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Clear.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/depth_image.md
+++ b/docs/content/reference/types/archetypes/depth_image.md
@@ -14,7 +14,7 @@ Each pixel corresponds to a depth value in units specified by `meter`.
 **Optional**: [`DepthMeter`](../components/depth_meter.md), [`DrawOrder`](../components/draw_order.md)
 
 ## Links
- * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/depth_image/)
+ * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.DepthImage)
  * 🦀 [Rust API docs for `DepthImage`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.DepthImage.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -14,7 +14,7 @@ will be ignored.
 **Required**: [`DisconnectedSpace`](../components/disconnected_space.md)
 
 ## Links
- * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/disconnected_space/)
+ * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.DisconnectedSpace)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.DisconnectedSpace.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -19,7 +19,7 @@ Leading and trailing unit-dimensions are ignored, so that
 **Optional**: [`DrawOrder`](../components/draw_order.md)
 
 ## Links
- * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/image/)
+ * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Image)
  * 🦀 [Rust API docs for `Image`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Image.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -13,7 +13,7 @@ title: "LineStrips2D"
 **Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/line_strips2d/)
+ * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.LineStrips2D)
  * 🦀 [Rust API docs for `LineStrips2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.LineStrips2D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -13,7 +13,7 @@ title: "LineStrips3D"
 **Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/line_strips3d/)
+ * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.LineStrips3D)
  * 🦀 [Rust API docs for `LineStrips3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.LineStrips3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -13,7 +13,7 @@ A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
 **Optional**: [`Color`](../components/color.md), [`Material`](../components/material.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/mesh3d/)
+ * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Mesh3D)
  * 🦀 [Rust API docs for `Mesh3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Mesh3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/pinhole.md
+++ b/docs/content/reference/types/archetypes/pinhole.md
@@ -13,7 +13,7 @@ Camera perspective projection (a.k.a. intrinsics).
 **Optional**: [`ViewCoordinates`](../components/view_coordinates.md)
 
 ## Links
- * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/pinhole/)
+ * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Pinhole)
  * 🦀 [Rust API docs for `Pinhole`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Pinhole.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -13,7 +13,7 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 **Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/points2d/)
+ * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Points2D)
  * 🦀 [Rust API docs for `Points2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Points2D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -13,7 +13,7 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 **Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/points3d/)
+ * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Points3D)
  * 🦀 [Rust API docs for `Points3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Points3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -17,7 +17,7 @@ Leading and trailing unit-dimensions are ignored, so that
 **Optional**: [`DrawOrder`](../components/draw_order.md)
 
 ## Links
- * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/segmentation_image/)
+ * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.SegmentationImage)
  * 🦀 [Rust API docs for `SegmentationImage`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.SegmentationImage.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/tensor.md
+++ b/docs/content/reference/types/archetypes/tensor.md
@@ -9,7 +9,7 @@ A generic n-dimensional Tensor.
 **Required**: [`TensorData`](../components/tensor_data.md)
 
 ## Links
- * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/tensor/)
+ * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Tensor)
  * 🦀 [Rust API docs for `Tensor`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Tensor.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/text_document.md
+++ b/docs/content/reference/types/archetypes/text_document.md
@@ -13,7 +13,7 @@ Supports raw text and markdown.
 **Optional**: [`MediaType`](../components/media_type.md)
 
 ## Links
- * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/text_document/)
+ * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.TextDocument)
  * 🦀 [Rust API docs for `TextDocument`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.TextDocument.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/text_log.md
+++ b/docs/content/reference/types/archetypes/text_log.md
@@ -11,7 +11,7 @@ A log entry in a text log, comprised of a text body and its log level.
 **Recommended**: [`TextLogLevel`](../components/text_log_level.md)
 
 ## Links
- * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/text_log/)
+ * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.TextLog)
  * 🦀 [Rust API docs for `TextLog`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.TextLog.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/time_series_scalar.md
+++ b/docs/content/reference/types/archetypes/time_series_scalar.md
@@ -16,7 +16,7 @@ cannot be timeless!
 **Optional**: [`Text`](../components/text.md), [`ScalarScattering`](../components/scalar_scattering.md)
 
 ## Links
- * 🐍 [Python API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/time_series_scalar/)
+ * 🐍 [Python API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.TimeSeriesScalar)
  * 🦀 [Rust API docs for `TimeSeriesScalar`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.TimeSeriesScalar.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -9,7 +9,7 @@ A 3D transform.
 **Required**: [`Transform3D`](../components/transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/transform3d/)
+ * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.Transform3D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/view_coordinates.md
+++ b/docs/content/reference/types/archetypes/view_coordinates.md
@@ -16,7 +16,7 @@ down, and the Z axis points forward.
 **Required**: [`ViewCoordinates`](../components/view_coordinates.md)
 
 ## Links
- * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/nightly/package/rerun/archetypes/view_coordinates/)
+ * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/nightly/common/archetypes#rerun.archetypes.ViewCoordinates)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/archetypes/struct.ViewCoordinates.html)
 
 ## Example

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -15,7 +15,7 @@ path.
 * class_map: [`ClassDescriptionMapElem`](../datatypes/class_description_map_elem.md)
 
 ## Links
- * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/annotation_context/)
+ * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.AnnotationContext)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.AnnotationContext.html)
 
 

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -6,7 +6,7 @@ A binary blob of data.
 
 
 ## Links
- * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/blob/)
+ * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Blob)
  * 🦀 [Rust API docs for `Blob`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Blob.html)
 
 

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -9,7 +9,7 @@ A 16-bit ID representing a type of semantic class.
 * id: [`ClassId`](../datatypes/class_id.md)
 
 ## Links
- * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/class_id/)
+ * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.ClassId)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.ClassId.html)
 
 

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -6,7 +6,7 @@ Configures how a clear operation should behave - recursive or not?
 
 
 ## Links
- * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/clear_is_recursive/)
+ * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.ClearIsRecursive)
  * 🦀 [Rust API docs for `ClearIsRecursive`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.ClearIsRecursive.html)
 
 

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -12,7 +12,7 @@ byte is `R` and the least significant byte is `A`.
 * rgba: [`Rgba32`](../datatypes/rgba32.md)
 
 ## Links
- * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/color/)
+ * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Color)
  * 🦀 [Rust API docs for `Color`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Color.html)
 
 

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -6,7 +6,7 @@ A component indicating how long a meter is, expressed in native units.
 
 
 ## Links
- * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/depth_meter/)
+ * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.DepthMeter)
  * 🦀 [Rust API docs for `DepthMeter`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.DepthMeter.html)
 
 

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -10,7 +10,7 @@ If a transform or pinhole is logged on the same path, this component will be ign
 
 
 ## Links
- * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/disconnected_space/)
+ * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.DisconnectedSpace)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.DisconnectedSpace.html)
 
 

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -12,7 +12,7 @@ Draw order for entities with the same draw order is generally undefined.
 
 
 ## Links
- * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/draw_order/)
+ * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.DrawOrder)
  * 🦀 [Rust API docs for `DrawOrder`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.DrawOrder.html)
 
 

--- a/docs/content/reference/types/components/half_sizes2d.md
+++ b/docs/content/reference/types/components/half_sizes2d.md
@@ -12,7 +12,7 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 * xy: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `HalfSizes2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/half_sizes2d/)
+ * 🐍 [Python API docs for `HalfSizes2D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.HalfSizes2D)
  * 🦀 [Rust API docs for `HalfSizes2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.HalfSizes2D.html)
 
 

--- a/docs/content/reference/types/components/half_sizes3d.md
+++ b/docs/content/reference/types/components/half_sizes3d.md
@@ -12,7 +12,7 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 * xyz: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `HalfSizes3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/half_sizes3d/)
+ * 🐍 [Python API docs for `HalfSizes3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.HalfSizes3D)
  * 🦀 [Rust API docs for `HalfSizes3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.HalfSizes3D.html)
 
 

--- a/docs/content/reference/types/components/instance_key.md
+++ b/docs/content/reference/types/components/instance_key.md
@@ -6,7 +6,7 @@ A unique numeric identifier for each individual instance within a batch.
 
 
 ## Links
- * 🐍 [Python API docs for `InstanceKey`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/instance_key/)
+ * 🐍 [Python API docs for `InstanceKey`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.InstanceKey)
  * 🦀 [Rust API docs for `InstanceKey`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.InstanceKey.html)
 
 

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -9,7 +9,7 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 * id: [`KeypointId`](../datatypes/keypoint_id.md)
 
 ## Links
- * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/keypoint_id/)
+ * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.KeypointId)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.KeypointId.html)
 
 

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -20,7 +20,7 @@ The points will be connected in order, like so:
 * points: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/line_strip2d/)
+ * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.LineStrip2D)
  * 🦀 [Rust API docs for `LineStrip2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.LineStrip2D.html)
 
 

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -20,7 +20,7 @@ The points will be connected in order, like so:
 * points: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/line_strip3d/)
+ * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.LineStrip3D)
  * 🦀 [Rust API docs for `LineStrip3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.LineStrip3D.html)
 
 

--- a/docs/content/reference/types/components/material.md
+++ b/docs/content/reference/types/components/material.md
@@ -9,7 +9,7 @@ Material properties of a mesh.
 * material: [`Material`](../datatypes/material.md)
 
 ## Links
- * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/material/)
+ * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Material)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Material.html)
 
 

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -12,7 +12,7 @@ consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 * value: [`Utf8`](../datatypes/utf8.md)
 
 ## Links
- * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/media_type/)
+ * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.MediaType)
  * 🦀 [Rust API docs for `MediaType`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.MediaType.html)
 
 

--- a/docs/content/reference/types/components/mesh_properties.md
+++ b/docs/content/reference/types/components/mesh_properties.md
@@ -9,7 +9,7 @@ Optional triangle indices for a mesh.
 * props: [`MeshProperties`](../datatypes/mesh_properties.md)
 
 ## Links
- * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/mesh_properties/)
+ * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.MeshProperties)
  * 🦀 [Rust API docs for `MeshProperties`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.MeshProperties.html)
 
 

--- a/docs/content/reference/types/components/out_of_tree_transform3d.md
+++ b/docs/content/reference/types/components/out_of_tree_transform3d.md
@@ -11,7 +11,7 @@ An out-of-tree affine transform between two 3D spaces, represented in a given di
 * repr: [`Transform3D`](../datatypes/transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/out_of_tree_transform3d/)
+ * 🐍 [Python API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.OutOfTreeTransform3D)
  * 🦀 [Rust API docs for `OutOfTreeTransform3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.OutOfTreeTransform3D.html)
 
 

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -19,7 +19,7 @@ Example:
 * image_from_camera: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## Links
- * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/pinhole_projection/)
+ * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.PinholeProjection)
  * 🦀 [Rust API docs for `PinholeProjection`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.PinholeProjection.html)
 
 

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -9,7 +9,7 @@ A position in 2D space.
 * xy: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/position2d/)
+ * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Position2D)
  * 🦀 [Rust API docs for `Position2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Position2D.html)
 
 

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -9,7 +9,7 @@ A position in 3D space.
 * xyz: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/position3d/)
+ * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Position3D)
  * 🦀 [Rust API docs for `Position3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Position3D.html)
 
 

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -6,7 +6,7 @@ A Radius component.
 
 
 ## Links
- * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/radius/)
+ * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Radius)
  * 🦀 [Rust API docs for `Radius`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Radius.html)
 
 

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -11,7 +11,7 @@ Typically in integer units, but for some use cases floating point may be used.
 * resolution: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/resolution/)
+ * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Resolution)
  * 🦀 [Rust API docs for `Resolution`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Resolution.html)
 
 

--- a/docs/content/reference/types/components/rotation3d.md
+++ b/docs/content/reference/types/components/rotation3d.md
@@ -9,7 +9,7 @@ A 3D rotation, represented either by a quaternion or a rotation around axis.
 * repr: [`Rotation3D`](../datatypes/rotation3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/rotation3d/)
+ * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Rotation3D)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Rotation3D.html)
 
 

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -8,7 +8,7 @@ Used for time series plots.
 
 
 ## Links
- * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/scalar/)
+ * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Scalar)
  * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Scalar.html)
 
 

--- a/docs/content/reference/types/components/scalar_scattering.md
+++ b/docs/content/reference/types/components/scalar_scattering.md
@@ -6,7 +6,7 @@ If true, a scalar will be shown as individual point in a scatter plot.
 
 
 ## Links
- * 🐍 [Python API docs for `ScalarScattering`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/scalar_scattering/)
+ * 🐍 [Python API docs for `ScalarScattering`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.ScalarScattering)
  * 🦀 [Rust API docs for `ScalarScattering`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.ScalarScattering.html)
 
 

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -9,7 +9,7 @@ A multi-dimensional `Tensor` with optionally named arguments.
 * data: [`TensorData`](../datatypes/tensor_data.md)
 
 ## Links
- * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/tensor_data/)
+ * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.TensorData)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.TensorData.html)
 
 

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -9,7 +9,7 @@ A string of text, e.g. for labels and text documents
 * value: [`Utf8`](../datatypes/utf8.md)
 
 ## Links
- * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/text/)
+ * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Text)
  * 🦀 [Rust API docs for `Text`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Text.html)
 
 

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -17,7 +17,7 @@ Recommended to be one of:
 * value: [`Utf8`](../datatypes/utf8.md)
 
 ## Links
- * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/text_log_level/)
+ * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.TextLogLevel)
  * 🦀 [Rust API docs for `TextLogLevel`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.TextLogLevel.html)
 
 

--- a/docs/content/reference/types/components/transform3d.md
+++ b/docs/content/reference/types/components/transform3d.md
@@ -9,7 +9,7 @@ An affine transform between two 3D spaces, represented in a given direction.
 * repr: [`Transform3D`](../datatypes/transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/transform3d/)
+ * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Transform3D.html)
 
 

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -9,7 +9,7 @@ A vector in 3D space.
 * vector: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/vector3d/)
+ * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.Vector3D)
  * 🦀 [Rust API docs for `Vector3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.Vector3D.html)
 
 

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -21,7 +21,7 @@ The following constants are used to represent the different directions.
 
 
 ## Links
- * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/nightly/package/rerun/components/view_coordinates/)
+ * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/nightly/common/components#rerun.components.ViewCoordinates)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/components/struct.ViewCoordinates.html)
 
 

--- a/docs/content/reference/types/datatypes/angle.md
+++ b/docs/content/reference/types/datatypes/angle.md
@@ -6,7 +6,7 @@ Angle in either radians or degrees.
 
 
 ## Links
- * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/angle/)
+ * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Angle)
  * 🦀 [Rust API docs for `Angle`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/enum.Angle.html)
 
 

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -13,7 +13,7 @@ The id refers either to a class or key-point id
 * color: [`Rgba32`](../datatypes/rgba32.md)
 
 ## Links
- * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/annotation_info/)
+ * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.AnnotationInfo)
  * 🦀 [Rust API docs for `AnnotationInfo`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.AnnotationInfo.html)
 
 

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -24,7 +24,7 @@ colored as described by the class's `AnnotationInfo`.
 * keypoint_connections: [`KeypointPair`](../datatypes/keypoint_pair.md)
 
 ## Links
- * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/class_description/)
+ * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.ClassDescription)
  * 🦀 [Rust API docs for `ClassDescription`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.ClassDescription.html)
 
 

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -12,7 +12,7 @@ This is internal to the `AnnotationContext` structure.
 * class_description: [`ClassDescription`](../datatypes/class_description.md)
 
 ## Links
- * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/class_description_map_elem/)
+ * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.ClassDescriptionMapElem)
  * 🦀 [Rust API docs for `ClassDescriptionMapElem`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.ClassDescriptionMapElem.html)
 
 

--- a/docs/content/reference/types/datatypes/class_id.md
+++ b/docs/content/reference/types/datatypes/class_id.md
@@ -6,7 +6,7 @@ A 16-bit ID representing a type of semantic class.
 
 
 ## Links
- * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/class_id/)
+ * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.ClassId)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.ClassId.html)
 
 

--- a/docs/content/reference/types/datatypes/float32.md
+++ b/docs/content/reference/types/datatypes/float32.md
@@ -6,7 +6,7 @@ A single-precision 32-bit IEEE 754 floating point number.
 
 
 ## Links
- * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/float32/)
+ * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Float32)
  * 🦀 [Rust API docs for `Float32`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Float32.html)
 
 

--- a/docs/content/reference/types/datatypes/keypoint_id.md
+++ b/docs/content/reference/types/datatypes/keypoint_id.md
@@ -6,7 +6,7 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 
 
 ## Links
- * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/keypoint_id/)
+ * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.KeypointId)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.KeypointId.html)
 
 

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -10,7 +10,7 @@ A connection between two `Keypoints`.
 * keypoint1: [`KeypointId`](../datatypes/keypoint_id.md)
 
 ## Links
- * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/keypoint_pair/)
+ * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.KeypointPair)
  * 🦀 [Rust API docs for `KeypointPair`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.KeypointPair.html)
 
 

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -15,7 +15,7 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 
 
 ## Links
- * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/mat3x3/)
+ * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Mat3x3)
  * 🦀 [Rust API docs for `Mat3x3`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Mat3x3.html)
 
 

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -16,7 +16,7 @@ row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 
 
 ## Links
- * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/mat4x4/)
+ * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Mat4x4)
  * 🦀 [Rust API docs for `Mat4x4`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Mat4x4.html)
 
 

--- a/docs/content/reference/types/datatypes/material.md
+++ b/docs/content/reference/types/datatypes/material.md
@@ -9,7 +9,7 @@ Material properties of a mesh.
 * albedo_factor: [`Rgba32`](../datatypes/rgba32.md)
 
 ## Links
- * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/material/)
+ * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Material)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Material.html)
 
 

--- a/docs/content/reference/types/datatypes/mesh_properties.md
+++ b/docs/content/reference/types/datatypes/mesh_properties.md
@@ -6,7 +6,7 @@ Optional triangle indices for a mesh.
 
 
 ## Links
- * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/mesh_properties/)
+ * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.MeshProperties)
  * 🦀 [Rust API docs for `MeshProperties`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.MeshProperties.html)
 
 

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -9,7 +9,7 @@ datastore as provided, when used in the viewer Quaternions will always be normal
 
 
 ## Links
- * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/quaternion/)
+ * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Quaternion)
  * 🦀 [Rust API docs for `Quaternion`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Quaternion.html)
 
 

--- a/docs/content/reference/types/datatypes/rgba32.md
+++ b/docs/content/reference/types/datatypes/rgba32.md
@@ -9,7 +9,7 @@ byte is `R` and the least significant byte is `A`.
 
 
 ## Links
- * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/rgba32/)
+ * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Rgba32)
  * 🦀 [Rust API docs for `Rgba32`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Rgba32.html)
 
 

--- a/docs/content/reference/types/datatypes/rotation3d.md
+++ b/docs/content/reference/types/datatypes/rotation3d.md
@@ -10,7 +10,7 @@ A 3D rotation.
 * AxisAngle: [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
 
 ## Links
- * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/rotation3d/)
+ * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Rotation3D)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/enum.Rotation3D.html)
 
 

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -10,7 +10,7 @@ title: "RotationAxisAngle"
 * angle: [`Angle`](../datatypes/angle.md)
 
 ## Links
- * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/rotation_axis_angle/)
+ * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.RotationAxisAngle)
  * 🦀 [Rust API docs for `RotationAxisAngle`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.RotationAxisAngle.html)
 
 

--- a/docs/content/reference/types/datatypes/scale3d.md
+++ b/docs/content/reference/types/datatypes/scale3d.md
@@ -9,7 +9,7 @@ title: "Scale3D"
 * ThreeD: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/scale3d/)
+ * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Scale3D)
  * 🦀 [Rust API docs for `Scale3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/enum.Scale3D.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -8,7 +8,7 @@ Tensor elements are stored in a contiguous buffer of a single type.
 
 
 ## Links
- * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/tensor_buffer/)
+ * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.TensorBuffer)
  * 🦀 [Rust API docs for `TensorBuffer`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/enum.TensorBuffer.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -17,7 +17,7 @@ which stores a contiguous array of typed values.
 * buffer: [`TensorBuffer`](../datatypes/tensor_buffer.md)
 
 ## Links
- * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/tensor_data/)
+ * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.TensorData)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.TensorData.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -6,7 +6,7 @@ A single dimension within a multi-dimensional tensor.
 
 
 ## Links
- * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/tensor_dimension/)
+ * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.TensorDimension)
  * 🦀 [Rust API docs for `TensorDimension`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.TensorDimension.html)
 
 

--- a/docs/content/reference/types/datatypes/transform3d.md
+++ b/docs/content/reference/types/datatypes/transform3d.md
@@ -10,7 +10,7 @@ Representation of a 3D affine transform.
 * TranslationRotationScale: [`TranslationRotationScale3D`](../datatypes/translation_rotation_scale3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/transform3d/)
+ * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/enum.Transform3D.html)
 
 

--- a/docs/content/reference/types/datatypes/translation_and_mat3x3.md
+++ b/docs/content/reference/types/datatypes/translation_and_mat3x3.md
@@ -12,7 +12,7 @@ First applies the matrix, then the translation.
 * mat3x3: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## Links
- * 🐍 [Python API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/translation_and_mat3x3/)
+ * 🐍 [Python API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.TranslationAndMat3x3)
  * 🦀 [Rust API docs for `TranslationAndMat3x3`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.TranslationAndMat3x3.html)
 
 

--- a/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
+++ b/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
@@ -11,7 +11,7 @@ Representation of an affine transform via separate translation, rotation & scale
 * scale: [`Scale3D`](../datatypes/scale3d.md)
 
 ## Links
- * 🐍 [Python API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/translation_rotation_scale3d/)
+ * 🐍 [Python API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.TranslationRotationScale3D)
  * 🦀 [Rust API docs for `TranslationRotationScale3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.TranslationRotationScale3D.html)
 
 

--- a/docs/content/reference/types/datatypes/utf8.md
+++ b/docs/content/reference/types/datatypes/utf8.md
@@ -6,7 +6,7 @@ A string of text, encoded as UTF-8.
 
 
 ## Links
- * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/utf8/)
+ * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Utf8)
  * 🦀 [Rust API docs for `Utf8`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Utf8.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -6,7 +6,7 @@ A uint32 vector in 2D space.
 
 
 ## Links
- * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/uvec2d/)
+ * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.UVec2D)
  * 🦀 [Rust API docs for `UVec2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.UVec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -6,7 +6,7 @@ A uint32 vector in 3D space.
 
 
 ## Links
- * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/uvec3d/)
+ * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.UVec3D)
  * 🦀 [Rust API docs for `UVec3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.UVec3D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -6,7 +6,7 @@ A uint vector in 4D space.
 
 
 ## Links
- * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/uvec4d/)
+ * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.UVec4D)
  * 🦀 [Rust API docs for `UVec4D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.UVec4D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -6,7 +6,7 @@ A vector in 2D space.
 
 
 ## Links
- * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/vec2d/)
+ * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Vec2D)
  * 🦀 [Rust API docs for `Vec2D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Vec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -6,7 +6,7 @@ A vector in 3D space.
 
 
 ## Links
- * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/vec3d/)
+ * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Vec3D)
  * 🦀 [Rust API docs for `Vec3D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Vec3D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -6,7 +6,7 @@ A vector in 4D space.
 
 
 ## Links
- * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/nightly/package/rerun/datatypes/vec4d/)
+ * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/nightly/common/datatypes#rerun.datatypes.Vec4D)
  * 🦀 [Rust API docs for `Vec4D`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/datatypes/struct.Vec4D.html)
 
 


### PR DESCRIPTION
### What
Aligns the generated links with: https://github.com/rerun-io/rerun/pull/3678

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3684) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3684)
- [Docs preview](https://rerun.io/preview/ff8dcc50d6d95ac128dd67c42260d53e096bcae0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ff8dcc50d6d95ac128dd67c42260d53e096bcae0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)