### PR TITLE
Fixed links to python docs

### DIFF
--- a/docs/content/concepts/annotation-context.md
+++ b/docs/content/concepts/annotation-context.md
@@ -53,7 +53,7 @@ The Annotation Context is defined as a list of Class Descriptions that define ho
 
 Annotation contexts are logged with:
 
-* Python: 🐍[`rr.AnnotationContext`](https://ref.rerun.io/docs/python/HEAD/common/annotations/#rerun.AnnotationContext)
+* Python: 🐍[`rr.AnnotationContext`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.AnnotationContext)
 * Rust: 🦀[`rerun::AnnotationContext`](https://docs.rs/rerun/0.9.0-alpha.6/rerun/archetypes/struct.AnnotationContext.html#)
 
 code-example: annotation-context
@@ -71,7 +71,7 @@ Segmentation images are single channel integer images/tensors where each pixel r
 By default, Rerun will automatically assign colors to each class id, but by defining an Annotation Context,
 you can explicitly determine the color of each class.
 
-* Python: [`rr.SegmentationImage`](https://ref.rerun.io/docs/python/HEAD/common/images/#rerun.SegmentationImag)
+* Python: [`rr.SegmentationImage`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.SegmentationImage)
 * Rust: Log a [`rerun::SegmentationImage`](https://docs.rs/rerun/0.9.0-alpha.6/rerun/archetypes/struct.SegmentationImage.html)
 
 <picture>

--- a/docs/content/concepts/apps-and-recordings.md
+++ b/docs/content/concepts/apps-and-recordings.md
@@ -4,7 +4,7 @@ order: 8
 ---
 
 ## Application ID
-When you initialize rerun with [`rr.init`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.init) you need to set an Application ID.
+When you initialize rerun with [`rr.init`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.init) you need to set an Application ID.
 
 Your Rerun Viewer will store the Blueprint based on this Application ID.
 This means that you can run your app and set up the viewer to your liking,

--- a/docs/content/concepts/batches.md
+++ b/docs/content/concepts/batches.md
@@ -10,7 +10,7 @@ significant benefits in terms of storage and compute.
 Some examples of batched data include points in a point cloud, bounding boxes for detected objects, tracked keypoints
 in a skeleton, or a collection of line strips.
 
-In the Python APIs, the majority of archetypes are named with the plural form, for example [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.nightly/common/archetypes/#rerun.archetypes.Points3D). They accept both single elements (internally treated as an N=1 batch) or arrays corresponding to the batches.
+In the Python APIs, the majority of archetypes are named with the plural form, for example [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D). They accept both single elements (internally treated as an N=1 batch) or arrays corresponding to the batches.
 
 ## Terminology
 

--- a/docs/content/concepts/batches.md
+++ b/docs/content/concepts/batches.md
@@ -10,7 +10,7 @@ significant benefits in terms of storage and compute.
 Some examples of batched data include points in a point cloud, bounding boxes for detected objects, tracked keypoints
 in a skeleton, or a collection of line strips.
 
-In the Python APIs, the majority of archetypes are named with the plural form, for example [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). They accept both single elements (internally treated as an N=1 batch) or arrays corresponding to the batches.
+In the Python APIs, the majority of archetypes are named with the plural form, for example [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.nightly/common/archetypes/#rerun.archetypes.Points3D). They accept both single elements (internally treated as an N=1 batch) or arrays corresponding to the batches.
 
 ## Terminology
 

--- a/docs/content/concepts/entity-component.md
+++ b/docs/content/concepts/entity-component.md
@@ -9,7 +9,7 @@ The core of Rerun's data model is inspired by the ideas of the [Entity Component
 short, an ECS is a composition-oriented framework in which *entities* represent generic objects while *components* describe
 data associated with those entities.
 
- * *Entities* are the "things" that you log with the [`rr.log()`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log)function. They are represented by the
+ * *Entities* are the "things" that you log with the [`rr.log()`](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.log)function. They are represented by the
    [*entity path*](entity-path.md) string which is passed as first argument.
  * *Components*, however, are what contains the data that is associated with those "things". For example, position, color,
    pixel data, etc.
@@ -27,7 +27,7 @@ For example, consider the case of logging a point:
 rr.log("my_point", rr.Points2D([32.7, 45.9], color=[255, 0, 0]))
 ```
 
-This statement uses the [`rr.Points2D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points2D) archetype.
+This statement uses the [`rr.Points2D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points2D) archetype.
 Internally, this archetype builds a set of, in this case, two components: [`Position2D`](../reference/types/components/position2d.md) and [`Color`](../reference/types/components/color.md). Then, the
 `rr.log()` function records these two components and associate them with the `"my_point"` entity.
 

--- a/docs/content/concepts/spaces-and-transforms.md
+++ b/docs/content/concepts/spaces-and-transforms.md
@@ -72,10 +72,10 @@ Rerun transforms are currently limited to connections between _spatial_ views of
 transforms that can be logged:
 
 - Affine 3D transforms, which can define any combination of translation, rotation, and scale relationship between two paths (see
-  [`rr.Transform3D`](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.Transform3D)).
+  [`rr.Transform3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Transform3D)).
 - Pinhole transforms define a 3D -> 2D camera projection (see
-  [`rr.Pinhole`](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.Pinhole)).
-- A disconnected space specifies that the data cannot be transformed (see [`rr.DisconnectedSpace`](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.DisconnectedSpace)). In this case it will not be possible to combine the data into a single view, and you will need to create two separate views to explore the data.
+  [`rr.Pinhole`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Pinhole)).
+- A disconnected space specifies that the data cannot be transformed (see [`rr.DisconnectedSpace`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.DisconnectedSpace)). In this case it will not be possible to combine the data into a single view, and you will need to create two separate views to explore the data.
 
 In the future, Rerun will be adding support for additional types of transforms.
  - [#349: Log 2D -> 2D transformations in the transform hierarchy](https://github.com/rerun-io/rerun/issues/349)
@@ -108,11 +108,11 @@ Note that none of the names in the paths are special.
 
 
 ## View coordinates
-You can use [`rr.ViewCoordinates`](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.ViewCoordinates) to set your preferred view coordinate systems, giving semantic meaning to the XYZ axes of the space.
+You can use [`rr.ViewCoordinates`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.ViewCoordinates) to set your preferred view coordinate systems, giving semantic meaning to the XYZ axes of the space.
 
 For 3D spaces it can be used to log what the up-axis is in your coordinate system. This will help Rerun set a good default view of your 3D scene, as well as make the virtual eye interactions more natural. This can be done with `rr.log("world", rr.ViewCoordinates(up="+Z"), timeless=True)`.
 
-You can also use this `log_view_coordinates` for pinhole entities, but it is encouraged that you instead use [`rr.log(…, rr.Pinhole(camera_xyz=…))`](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.Pinhole) for this. The default coordinate system for pinhole entities is `RDF` (X=Right, Y=Down, Z=Forward).
+You can also use this `log_view_coordinates` for pinhole entities, but it is encouraged that you instead use [`rr.log(…, rr.Pinhole(camera_xyz=…))`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Pinhole) for this. The default coordinate system for pinhole entities is `RDF` (X=Right, Y=Down, Z=Forward).
 
 WARNING: unlike in 3D views where `rr.ViewCoordinates` only impacts how the rendered scene is oriented, applying `rr.ViewCoordinates` to a pinhole-camera will actually influence the projection transform chain. Under the hood this value inserts a hidden transform that re-orients the axis of projection. Different world-content will be projected into your camera with different orientations depending on how you choose this value. See for instance the `open_photogrammetry_format` example.
 

--- a/docs/content/concepts/timelines.md
+++ b/docs/content/concepts/timelines.md
@@ -7,7 +7,7 @@ order: 3
 Each piece of logged data is associated with one or more timelines.
 By default, each log is added to the `log_time` timeline, with a timestamp assigned by the SDK.
 
-In Python, use the _set time_ functions ([set_time_sequence](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_sequence), [set_time_seconds](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_seconds), [set_time_nanos](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_nanos)) to associate logs with other timestamps on other timelines. For example:
+In Python, use the _set time_ functions ([set_time_sequence](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.set_time_sequence), [set_time_seconds](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.set_time_seconds), [set_time_nanos](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.set_time_nanos)) to associate logs with other timestamps on other timelines. For example:
 
 ```python
 for frame in read_sensor_frames():
@@ -24,7 +24,7 @@ You can then choose which timeline you want to organize your data along in the e
 
 ## Timeless data
 
-The [`rr.log()`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) function has a `timeless=False` default argument.
+The [`rr.log()`](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.log) function has a `timeless=False` default argument.
 If `timeless=True` is used instead, the entity become *timeless*. Timeless entities belong to all timelines (existing ones, and ones not yet created) and are shown leftmost in the time panel in the viewer.
 This is useful for entities that aren't part of normal data capture, but set the scene for how they are shown.
 For instance, if you are logging cars on a street, perhaps you want to always show a street mesh as part of the scenery, and for that it makes sense for that data to be timeless.

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -25,7 +25,7 @@ For this tutorial you will also need to `pip install numpy scipy`.
 
 Start by opening your editor of choice and creating a new file called `dna_example.py`.
 
-The first thing we need to do is to import `rerun` and initialize the SDK by calling [`rr.init`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.init). This init call is required prior to using any of the global
+The first thing we need to do is to import `rerun` and initialize the SDK by calling [`rr.init`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.init). This init call is required prior to using any of the global
 logging calls, and allows us to name our recording using an `ApplicationId`.
 
 ```python
@@ -34,7 +34,7 @@ import rerun as rr
 rr.init("rerun_example_dna_abacus")
 ```
 
-Among other things, a stable [`ApplicationId`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.init) will make it so the [Rerun Viewer](../reference/viewer/overview.md) retains its UI state across runs for this specific dataset, which will make our lives much easier as we iterate.
+Among other things, a stable [`ApplicationId`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.init) will make it so the [Rerun Viewer](../reference/viewer/overview.md) retains its UI state across runs for this specific dataset, which will make our lives much easier as we iterate.
 
 Check out the reference to learn more about how Rerun deals with [applications and recordings](../concepts/apps-and-recordings.md).
 
@@ -119,7 +119,7 @@ This tiny snippet of code actually holds much more than meets the eye…
 
 `Archetypes`
 
-The easiest way to log geometric primitives is the use the [`rr.log`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) function with one of the built-in archetype class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). Archetypes take care of building batches
+The easiest way to log geometric primitives is the use the [`rr.log`](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.log) function with one of the built-in archetype class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D). Archetypes take care of building batches
 of components that are recognized and correctly displayed by the Rerun viewer.
 
 `Components`
@@ -132,7 +132,7 @@ archetypes altogether.
 For more information on how the rerun data model works, refer to our section on [Entities and Components](../concepts/entity-component.md).
 
 Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/latest/package/rerun_demo/data/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
-Rerun takes care of mapping those arrays to actual Rerun components depending on the context (e.g. we're calling [`log_points`](https://ref.rerun.io/docs/python/latest/common/spatial_primitives/#rerun.log_points) in this case).
+Rerun takes care of mapping those arrays to actual Rerun components depending on the context (e.g. we're calling [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D) in this case).
 
 `Entities & hierarchies`
 
@@ -230,7 +230,7 @@ for i in range(400):
     )
 ```
 
-A call to [`set_time_seconds`](https://ref.rerun.io/docs/python/latest/common/time/#rerun.set_time_seconds) will create our new `Timeline` and make sure that any logging calls that follow gets assigned that time.
+A call to [`set_time_seconds`](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.set_time_seconds) will create our new `Timeline` and make sure that any logging calls that follow gets assigned that time.
 
 ⚠️ If you run this code as is, the result will be… surprising: the beads are animating as expected, but everything we've logged until that point is gone! ⚠️
 
@@ -299,7 +299,7 @@ Voila!
 
 ## Other ways of logging & visualizing data
 
-[`rr.spawn`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.spawn) is great when you're experimenting on a single machine like we did in this tutorial, but what if the logging happens on, for example, a headless computer?
+[`rr.spawn`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.spawn) is great when you're experimenting on a single machine like we did in this tutorial, but what if the logging happens on, for example, a headless computer?
 
 Rerun offers several solutions for such use cases.
 
@@ -307,7 +307,7 @@ Rerun offers several solutions for such use cases.
 
 At any time, you can start a Rerun Viewer by running `rerun`. This viewer is in fact a server that's ready to accept data over TCP (it's listening on `0.0.0.0:9876` by default).
 
-On the logger side, simply use [`rr.connect`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.connect) instead of [`rr.spawn`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.spawn) to start sending the data over to any TCP address.
+On the logger side, simply use [`rr.connect`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.connect) instead of [`rr.spawn`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.spawn) to start sending the data over to any TCP address.
 
 Checkout `rerun --help` for more options.
 
@@ -316,7 +316,7 @@ Checkout `rerun --help` for more options.
 Sometimes, sending the data over the network is not an option. Maybe you'd like to share the data, attach it to a bug report, etc.
 
 Rerun has you covered:
-- Use [`rr.save`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.save) to stream all logged data to disk.
+- Use [`rr.save`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.save) to stream all logged data to disk.
 - View it with `rerun path/to/recording.rrd`
 
 You can also save a recording (or a portion of it) as you're visualizing it, directly from the viewer.

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -131,7 +131,7 @@ archetypes altogether.
 
 For more information on how the rerun data model works, refer to our section on [Entities and Components](../concepts/entity-component.md).
 
-Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/latest/package/rerun_demo/data/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
+Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/nigthly/common/demo_utilities/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
 Rerun takes care of mapping those arrays to actual Rerun components depending on the context (e.g. we're calling [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D) in this case).
 
 `Entities & hierarchies`
@@ -177,7 +177,7 @@ rr.log(
 )
 ```
 
-Once again, although we are getting fancier and fancier with our [`numpy` incantations](https://ref.rerun.io/docs/python/latest/package/rerun_demo/util/#rerun_demo.util.bounce_lerp),
+Once again, although we are getting fancier and fancier with our [`numpy` incantations](https://ref.rerun.io/docs/python/nightly/common/demo_utilities/#rerun_demo.util.bounce_lerp),
 there is nothing new here: it's all about building out `numpy` arrays and feeding them to the Rerun API.
 
 <picture>

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -92,9 +92,9 @@ only showing a simple line of red points.
 
 
 
-The [`rr.log`](https://ref.rerun.io/docs/python/HEAD/common/logging/#rerun.log) is the primary way to log data. It's a flexible
+The [`rr.log`](https://ref.rerun.io/docs/python/nightly/common/logging_functions/#rerun.log) is the primary way to log data. It's a flexible
 call that can accept a variety of correctly-formatted data—including your own. The easiest way to use it is to use an instance of
-one of the built-in *archetype* class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/HEAD/common/spatial_primitives/#rerun.Points3D). Archetypes take care of gathering the various
+one of the built-in *archetype* class, such as [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D). Archetypes take care of gathering the various
 components representing, in this case, a batch of 3D points such that it is recognized and correctly displayed by the Rerun viewer. The `rr.Points3D` archetype accepts any collection of positions that can be converted to a Nx3 Numpy array, along with other components such as colors, radii, etc.
 
 Feel free to modify the code to log a different set of points. If you want to generate the colored cube from the

--- a/docs/content/howto/limit-ram.md
+++ b/docs/content/howto/limit-ram.md
@@ -8,7 +8,7 @@ description: How to limit the memory of Rerun so that it doesn't run out of RAM.
 
 The Rerun Viewer can not yet view more data than fits in RAM. The more data you log, the more RAM the Rerun Viewer will use. When it reaches a certain limit, the oldest data will be dropped. The default limit it to use up to 75% of the total system RAM.
 
-You can set the limit by with the `--memory-limit` command-lint argument, or the `memory_limit` argument of [`rr.spawn`](https://ref.rerun.io/docs/python/latest/common/initialization/#rerun.spawn).
+You can set the limit by with the `--memory-limit` command-lint argument, or the `memory_limit` argument of [`rr.spawn`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.spawn).
 
 ### `--drop-at-latency`
 

--- a/docs/content/howto/notebook.md
+++ b/docs/content/howto/notebook.md
@@ -16,7 +16,7 @@ Rerun has been tested with:
 ## Basic Concept
 
 Rather than logging to a file or a remote server, you can also configure the Rerun SDK to store data in a local
-[MemoryRecording](https://ref.rerun.io/docs/python/latest/package/rerun/recording/#rerun.recording.MemoryRecording).
+[MemoryRecording](https://ref.rerun.io/docs/python/nightly/common/other_classes_and_functions/#rerun.MemoryRecording).
 
 This `MemoryRecording` can then used to produce an inline HTML snippet to be directly displayed in most notebook
 environments. The snippet includes an embedded copy of an RRD file and some javascript that loads that RRD file into an
@@ -35,7 +35,7 @@ This is similar to calling `rr.connect()` or `rr.save()` in that it configures t
 recording as a target for future API calls.
 
 After logging data to the recording you can display it in a cell by calling the
-[show()](https://ref.rerun.io/docs/python/latest/package/rerun/recording/#rerun.recording.MemoryRecording.show) method
+[show()](https://ref.rerun.io/docs/python/nightly/common/other_classes_and_functions/#rerun.MemoryRecording.show) method
 on the `MemoryRecording`. The `show()` method also takes optional arguments for specifying the width and height of the IFrame. For example:
 ```python
 rec.show(width=400, height=400)

--- a/docs/content/reference/migration-0-9.md
+++ b/docs/content/reference/migration-0-9.md
@@ -56,7 +56,7 @@ Notes:
 ### `log_arrow`
 Replace with [Arrows3D](types/archetypes/arrows3d.md)
 
-Python docs: [Arrows3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Arrows3D.__init__)
+Python docs: [Arrows3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Arrows3D)
 
 Notes:
  - `with_scale` has become `radii`, which entails dividing by 2 as necessary.
@@ -78,7 +78,7 @@ Notes:
 ### `log_disconnected_space`
 Replace with [DisconnectedSpace](types/archetypes/disconnected_space.md)
 
-Python docs: [DisconnectedSpace](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.DisconnectedSpace.__init__)
+Python docs: [DisconnectedSpace](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.DisconnectedSpace)
 
 ### `log_extension_components`
 Replace with `AnyValues`
@@ -110,7 +110,7 @@ Notes:
 ### `log_line_strip`, `log_line_strips_2d`, `log_line_strips_3d`, `log_line_segments`
 Replace with [LineStrips2D](types/archetypes/line_strips2d.md) or [LineStrips3D](types/archetypes/line_strips3d.md)
 
-Python docs: [LineStrips2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips2D.__init__), [LineStrips3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips3D.__init__)
+Python docs: [LineStrips2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips2D), [LineStrips3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips3D)
 
 Notes:
  - `log_line_segments` used to take an array of shape (2 * num_segments, 2 or 3) (where points were connected in
@@ -128,7 +128,7 @@ line_strips3d=line_segments.reshape(-1, 2, 3)
 ### `log_mesh`, `log_meshes`
 Replace with [Mesh3D](types/archetypes/mesh3d.md)
 
-Python docs: [Mesh3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Mesh3D.__init__)
+Python docs: [Mesh3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Mesh3D)
 
 Notes:
  - Meshes are no longer batch objects. Instead they are treated as a batch of vertices, as such there is no longer a
@@ -141,7 +141,7 @@ Notes:
 ### `log_mesh_file`
 Replace with [Asset3D](types/archetypes/asset3d.md)
 
-Python docs: [Asset3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Asset3D.__init__)
+Python docs: [Asset3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Asset3D)
 
 Notes:
  - `mesh_bytes` and `mesh_path` are both now jut `data`. Strings and paths will be opened as files, while
@@ -153,7 +153,7 @@ Notes:
 ### `log_obb`, `log_obbs`
 Replace with [Boxes3D](types/archetypes/boxes3d.md)
 
-Python docs: [Boxes3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes3D.__init__)
+Python docs: [Boxes3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes3D)
 
 Notes:
  - `positions` has become `centers`.
@@ -165,7 +165,7 @@ Notes:
 ### `log_pinhole`
 Replace with [Pinhole](types/archetypes/pinhole.md)
 
-Python docs: [Pinhole](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Pinhole.__init__)
+Python docs: [Pinhole](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Pinhole)
 
 Notes:
  - `child_from_parent` has become `image_from_parent`.
@@ -177,7 +177,7 @@ Notes:
 ### `log_point`, `log_points`
 Replace with [Points2D](types/archetypes/points2d.md) or [Points3D](types/archetypes/points3d.md).
 
-Python docs: [Points2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points2D.__init__), [Points3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D.__init__)
+Python docs: [Points2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points2D), [Points3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D)
 
 Notes:
  - `stroke_width` has become `radii`, which entails dividing by 2 as necessary.
@@ -186,7 +186,7 @@ Notes:
 ### `log_rect`, `log_rects`
 Replace with [Boxes2D](types/archetypes/boxes2d.md)
 
-Python docs: [Boxes2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes2D.__init__)
+Python docs: [Boxes2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes2D)
 
 Notes:
  - Can now be constructed with 2 arrays: `centers`, and either `half_sizes` o `sizes`.
@@ -235,7 +235,7 @@ Notes:
 ### `log_view_coordinates`
 Replace with [ViewCoordinates](types/archetypes/view_coordinates.md)
 
-Python docs: [ViewCoordinates](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.ViewCoordinates.__init__)
+Python docs: [ViewCoordinates](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.ViewCoordinates)
 
 Notes:
 - Rather than providing `xyz` or `up` as strings, `rr.ViewCoordinates` exposes a large number of constants that can be logged directly. For example: `rr.ViewCoordinates.RDF` or `rr.ViewCoordinates.RIGHT_HAND_Z_DOWN)`

--- a/docs/content/reference/migration-0-9.md
+++ b/docs/content/reference/migration-0-9.md
@@ -46,7 +46,7 @@ cases, the old parameter names match the parameters taken by the new Archetype c
 ### `log_annotation_context`
 Replace with [AnnotationContext](types/archetypes/annotation_context.md)
 
-Python docs: [AnnotationContext](https://ref.rerun.io/docs/python/HEAD/common/annotations/#rerun.AnnotationContext.__init__)
+Python docs: [AnnotationContext](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.AnnotationContext)
 
 Notes:
  - `class_descriptions` has become `context`
@@ -56,7 +56,7 @@ Notes:
 ### `log_arrow`
 Replace with [Arrows3D](types/archetypes/arrows3d.md)
 
-Python docs: [Arrows3D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Arrows3D.__init__)
+Python docs: [Arrows3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Arrows3D.__init__)
 
 Notes:
  - `with_scale` has become `radii`, which entails dividing by 2 as necessary.
@@ -65,12 +65,12 @@ Notes:
 ### `log_cleared`
 Replace with [Clear](types/archetypes/clear.md)
 
-Python docs: [Clear](https://ref.rerun.io/docs/python/HEAD/common/clearing_entities/#rerun.Clear.__init__)
+Python docs: [Clear](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Clear)
 
 ### `log_depth_image`
 Replace with [DepthImage](types/archetypes/depth_image.md)
 
-Python docs: [DepthImage](https://ref.rerun.io/docs/python/HEAD/common/images/#rerun.DepthImage.__init__)
+Python docs: [DepthImage](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Clear)
 
 Notes:
  * `image` has become `data`
@@ -78,7 +78,7 @@ Notes:
 ### `log_disconnected_space`
 Replace with [DisconnectedSpace](types/archetypes/disconnected_space.md)
 
-Python docs: [DisconnectedSpace](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.DisconnectedSpace.__init__)
+Python docs: [DisconnectedSpace](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.DisconnectedSpace.__init__)
 
 ### `log_extension_components`
 Replace with `AnyValues`
@@ -92,7 +92,7 @@ Notes:
 ### `log_image`
 Replace with [Image](types/archetypes/image.md)
 
-Python docs: [Image](https://ref.rerun.io/docs/python/HEAD/common/images/#rerun.Image.__init__)
+Python docs: [Image](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Image)
 
 Notes:
  * `image` has become `data`
@@ -101,7 +101,7 @@ Notes:
 ### `log_image_file`
 Replace with `ImageEncoded`
 
-Python docs: [ImageEncoded](https://ref.rerun.io/docs/python/HEAD/common/images/#rerun.ImageEncoded.__init__)
+Python docs: [ImageEncoded](https://ref.rerun.io/docs/python/nightly/common/image_helpers/#rerun.ImageEncoded)
 
 Notes:
  - `img_bytes` and `img_path`
@@ -110,7 +110,7 @@ Notes:
 ### `log_line_strip`, `log_line_strips_2d`, `log_line_strips_3d`, `log_line_segments`
 Replace with [LineStrips2D](types/archetypes/line_strips2d.md) or [LineStrips3D](types/archetypes/line_strips3d.md)
 
-Python docs: [LineStrips2D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.LineStrips2D.__init__), [LineStrips3D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.LineStrips3D.__init__)
+Python docs: [LineStrips2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips2D.__init__), [LineStrips3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips3D.__init__)
 
 Notes:
  - `log_line_segments` used to take an array of shape (2 * num_segments, 2 or 3) (where points were connected in
@@ -128,7 +128,7 @@ line_strips3d=line_segments.reshape(-1, 2, 3)
 ### `log_mesh`, `log_meshes`
 Replace with [Mesh3D](types/archetypes/mesh3d.md)
 
-Python docs: [Mesh3D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Mesh3D.__init__)
+Python docs: [Mesh3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Mesh3D.__init__)
 
 Notes:
  - Meshes are no longer batch objects. Instead they are treated as a batch of vertices, as such there is no longer a
@@ -141,7 +141,7 @@ Notes:
 ### `log_mesh_file`
 Replace with [Asset3D](types/archetypes/asset3d.md)
 
-Python docs: [Asset3D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Asset3D.__init__)
+Python docs: [Asset3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Asset3D.__init__)
 
 Notes:
  - `mesh_bytes` and `mesh_path` are both now jut `data`. Strings and paths will be opened as files, while
@@ -153,7 +153,7 @@ Notes:
 ### `log_obb`, `log_obbs`
 Replace with [Boxes3D](types/archetypes/boxes3d.md)
 
-Python docs: [Boxes3D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Boxes3D.__init__)
+Python docs: [Boxes3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes3D.__init__)
 
 Notes:
  - `positions` has become `centers`.
@@ -165,7 +165,7 @@ Notes:
 ### `log_pinhole`
 Replace with [Pinhole](types/archetypes/pinhole.md)
 
-Python docs: [Pinhole](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.Pinhole.__init__)
+Python docs: [Pinhole](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Pinhole.__init__)
 
 Notes:
  - `child_from_parent` has become `image_from_parent`.
@@ -177,7 +177,7 @@ Notes:
 ### `log_point`, `log_points`
 Replace with [Points2D](types/archetypes/points2d.md) or [Points3D](types/archetypes/points3d.md).
 
-Python docs: [Points2D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Points2D.__init__), [Points3D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Points3D.__init__)
+Python docs: [Points2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points2D.__init__), [Points3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D.__init__)
 
 Notes:
  - `stroke_width` has become `radii`, which entails dividing by 2 as necessary.
@@ -186,7 +186,7 @@ Notes:
 ### `log_rect`, `log_rects`
 Replace with [Boxes2D](types/archetypes/boxes2d.md)
 
-Python docs: [Boxes2D](https://ref.rerun.io/docs/python/HEAD/common/spatial_archetypes/#rerun.Boxes2D.__init__)
+Python docs: [Boxes2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes2D.__init__)
 
 Notes:
  - Can now be constructed with 2 arrays: `centers`, and either `half_sizes` o `sizes`.
@@ -197,12 +197,12 @@ Notes:
 ### `log_scalar`
 Replace with [TimeSeriesScalar](types/archetypes/time_series_scalar.md)
 
-Python docs: [TimeSeriesScalar](https://ref.rerun.io/docs/python/HEAD/common/plotting/#rerun.TimeSeriesScalar.__init__)
+Python docs: [TimeSeriesScalar](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.TimeSeriesScalar)
 
 ### `log_segmentation_image`
 Replace with [SegmentationImage](types/archetypes/segmentation_image.md)
 
-Python docs: [SegmentationImage](https://ref.rerun.io/docs/python/HEAD/common/images/#rerun.SegmentationImage.__init__)
+Python docs: [SegmentationImage](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.SegmentationImage)
 
 Notes:
  * `image` has become `data`
@@ -210,7 +210,7 @@ Notes:
 ### `log_tensor`
 Replace with [Tensor](types/archetypes/tensor.md)
 
-Python docs: [Tensor](https://ref.rerun.io/docs/python/HEAD/common/tensors/#rerun.Tensor.__init__)
+Python docs: [Tensor](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Tensor)
 
 Notes:
  - `tensor` has become `data`.
@@ -222,12 +222,12 @@ Notes:
 ### `log_text_entry`
 Replace with [TextLog](types/archetypes/text_log.md)
 
-Python docs: [TextLog](https://ref.rerun.io/docs/python/HEAD/common/text/#rerun.TextLog.__init__)
+Python docs: [TextLog](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.TextLog)
 
 ### `log_transform3d`
 Replace with [Transform3D](types/archetypes/transform3d.md)
 
-Python docs: [Transform3D](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.Transform3D.__init__)
+Python docs: [Transform3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Transform3D)
 
 Notes:
  - Now takes optional parameters for `translation`, `rotation`, `scale`, or `mat3x3` to simplify construction.
@@ -235,7 +235,7 @@ Notes:
 ### `log_view_coordinates`
 Replace with [ViewCoordinates](types/archetypes/view_coordinates.md)
 
-Python docs: [ViewCoordinates](https://ref.rerun.io/docs/python/HEAD/common/transforms_and_coordinate_systems/#rerun.ViewCoordinates.__init__)
+Python docs: [ViewCoordinates](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.ViewCoordinates.__init__)
 
 Notes:
 - Rather than providing `xyz` or `up` as strings, `rr.ViewCoordinates` exposes a large number of constants that can be logged directly. For example: `rr.ViewCoordinates.RDF` or `rr.ViewCoordinates.RIGHT_HAND_Z_DOWN)`

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -20,7 +20,7 @@ This is the default behavior you get when running all of our Python & Rust examp
 
 #### `Python`
 
-Call [`rr.spawn`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.spawn) once at the start of your program to start a Rerun Viewer in an external process and stream all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
+Call [`rr.spawn`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.spawn) once at the start of your program to start a Rerun Viewer in an external process and stream all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 #### `Rust`
 
@@ -34,7 +34,7 @@ You will need to start a stand-alone viewer first by typing `rerun` in your term
 
 #### `Python`
 
-[`rr.connect`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.connect)
+[`rr.connect`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.connect)
 
 #### `Rust`
 
@@ -46,7 +46,7 @@ This starts the web version of the Rerun Viewer in your browser, and streams dat
 
 #### `Python`
 
-Use [`rr.serve`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.serve).
+Use [`rr.serve`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.serve).
 
 #### `Rust`
 
@@ -62,7 +62,7 @@ To view the saved file, use `rerun path/to/file.rrd`.
 
 #### `Python`
 
-Use [`rr.save`](https://ref.rerun.io/docs/python/latest/package/rerun/__init__/#rerun.save).
+Use [`rr.save`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.save).
 
 #### `Rust`
 
@@ -72,7 +72,7 @@ Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.Recordin
 
 We provide helpers for both Python & Rust to effortlessly add and properly handle all of these flags in your programs.
 
-- For Python, checkout the [`script_helpers`](https://ref.rerun.io/docs/python/latest/package/rerun/script_helpers/) module.
+- For Python, checkout the [`script_helpers`](https://ref.rerun.io/docs/python/nightly/common/script_helpers/) module.
 - For Rust, checkout our [`clap`]() [integration](https://docs.rs/rerun/latest/rerun/clap/index.html).
 
 Have a look at the [official examples](/examples) to see these helpers in action.

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -69,6 +69,7 @@ class Section:
     mod_path: str = "rerun"
     show_tables: bool = True
     default_filters: bool = True
+    show_submodules: bool = False
 
 
 # This is the list of sections and functions that will be included in the index
@@ -238,7 +239,8 @@ SECTION_TABLE: Final[list[Section]] = [
     Section(
         title="Demo utilities",
         show_tables=False,
-        mod_path="rerun_demo.data",
+        mod_path="rerun_demo",
+        show_submodules=True,
     ),
     Section(
         title="Experimental",
@@ -367,6 +369,8 @@ overview of what's possible and how.
                         fd.write(f"        - {class_name}\n")
                 if not section.default_filters:
                     fd.write("      filters: []\n")
+                if section.show_submodules:
+                    fd.write("      show_submodules: True\n")
 
         # Write out a table for the section in the index_file
         if section.show_tables:


### PR DESCRIPTION
### What

All links to python docs now point to nightly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3687) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3687)
- [Docs preview](https://rerun.io/preview/42b220af1da8a57b01921d80a682964c4cb5e64d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/42b220af1da8a57b01921d80a682964c4cb5e64d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)