### PR TITLE
Remove backticks from markdown headings

### DIFF
--- a/docs/content/concepts/entity-component.md
+++ b/docs/content/concepts/entity-component.md
@@ -37,7 +37,7 @@ component is associated with the same entity. These two components are recognize
 
 See the [Types](../reference/types.md) reference for a list of archetypes, components, and datatypes.
 
-### Extension Components
+### Adding custom data
 
 Although both the SDKs' archetype objects and the space view are based on the same archetype definition (and are actually implemented using code that is automatically generated based that definition), they both operate on arbitrary collection
 of components. Neither the SDKs nor the viewer enforce or require that an entity should contain a *specific* set of component.
@@ -48,7 +48,7 @@ Your entity could have any number of additional components as well. This isn't a
 aren't relevant to the scene that the space view is drawing are safely ignored. Also, Rerun even allows you to log your
 own set of components, bypassing archetypes altogether.
 
-In Python, the `rr.AnyValue` helper object can be used to add custom component(s) to an archetype:
+In Python, the [rr.AnyValues](https://ref.rerun.io/docs/python/nightly/common/custom_data/#rerun.AnyValues) helper object can be used to add custom component(s) to an archetype:
 
 code-example: extra_values
 

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -131,7 +131,7 @@ archetypes altogether.
 
 For more information on how the rerun data model works, refer to our section on [Entities and Components](../concepts/entity-component.md).
 
-Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/nigthly/common/demo_utilities/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
+Our [Python SDK](https://ref.rerun.io/docs/python) integrates with the rest of the Python ecosystem: the points and colors returned by [`build_color_spiral`](https://ref.rerun.io/docs/python/nightly/common/demo_utilities/#rerun_demo.data.build_color_spiral) in this example are vanilla `numpy` arrays.
 Rerun takes care of mapping those arrays to actual Rerun components depending on the context (e.g. we're calling [`rr.Points3D`](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D) in this case).
 
 `Entities & hierarchies`

--- a/docs/content/howto/limit-ram.md
+++ b/docs/content/howto/limit-ram.md
@@ -4,13 +4,13 @@ order: 1
 description: How to limit the memory of Rerun so that it doesn't run out of RAM.
 ---
 
-### `--memory-limit`
+### --memory-limit
 
 The Rerun Viewer can not yet view more data than fits in RAM. The more data you log, the more RAM the Rerun Viewer will use. When it reaches a certain limit, the oldest data will be dropped. The default limit it to use up to 75% of the total system RAM.
 
 You can set the limit by with the `--memory-limit` command-lint argument, or the `memory_limit` argument of [`rr.spawn`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.spawn).
 
-### `--drop-at-latency`
+### --drop-at-latency
 
 If you have multiple processes generating log data to Rerun it could happen that the Viewer builds up a backlog of unprocessed log messages. This can induce latency and also use up memory, which `--memory-limit` cannot fix. To handle this case, you can use `rerun --drop-at-latency 500ms` to start ignoring _new_ data if the input buffer exceeds 500ms of data.
 

--- a/docs/content/howto/ros2-nav-turtlebot.md
+++ b/docs/content/howto/ros2-nav-turtlebot.md
@@ -145,7 +145,7 @@ This timestamp will apply to all subsequent log calls on in this callback (on th
 again.
 
 
-### TF to `log_transform3d`
+### TF to log_transform3d
 Next, we need to map the [ROS TF2](https://docs.ros.org/en/humble/Concepts/About-Tf2.html) transforms to the
 corresponding [Rerun Transforms](../concepts/spaces-and-transforms.md#space-transformations).
 
@@ -207,7 +207,7 @@ Note that because we previously called `set_time_nanos` in this callback, this t
 be logged to the same point on the timeline as the data, using a timestamp looked up from TF at the
 matching timepoint.
 
-### Odometry to `log_scalar` and `log_transform3d`
+### Odometry to log_scalar and log_transform3d
 When receiving odometry messages, we log the linear and angular velocities using `rr.log_scalar`.
 Additionally, since we know that odometry will also update the `map/robot` transform, we use
 this as a cue to look up the corresponding transform and log it.
@@ -225,7 +225,7 @@ def odom_callback(self, odom: Odometry) -> None:
     self.log_tf_as_transform3d("map/robot", time)
 ```
 
-### CameraInfo to `log_pinhole`
+### CameraInfo to log_pinhole
 Not all Transforms are rigid as defined in TF. The other transform we want to log
 is the pinhole projection that is stored in the `CameraInfo` msg.
 
@@ -251,7 +251,7 @@ def cam_info_callback(self, info: CameraInfo) -> None:
     )
 ```
 
-### Image to `log_image`
+### Image to log_image
 ROS Images can also be mapped to Rerun very easily, using the `cv_bridge` package.
 The output of `cv_bridge.imgmsg_to_cv2` can be fed directly into `rr.log_image`:
 ```python
@@ -268,7 +268,7 @@ def image_callback(self, img: Image) -> None:
     self.log_tf_as_transform3d("map/robot/camera", time)
 ```
 
-### PointCloud2 to `log_points`
+### PointCloud2 to log_points
 The ROS [PointCloud2](https://github.com/ros2/common_interfaces/blob/humble/sensor_msgs/msg/PointCloud2.msg) message
 is stored as a binary blob that needs to be reinterpreted using the details about its fields. Each field is
 a named collection of offsets into the data buffer, and datatypes. The `sensor_msgs_py` package includes a `point_cloud2`
@@ -312,7 +312,7 @@ def points_callback(self, points: PointCloud2) -> None:
     self.log_tf_as_transform3d("map/robot/camera/points", time)
 ```
 
-### LaserScan to `log_line_segments`
+### LaserScan to log_line_segments
 Rerun does not yet have native support for a `LaserScan` style primitive so we need
 to do a bit of additional transformation logic (see: [#1534](https://github.com/rerun-io/rerun/issues/1534).)
 
@@ -350,7 +350,7 @@ def scan_callback(self, scan: LaserScan) -> None:
     self.log_tf_as_transform3d("map/robot/scan", time)
 ```
 
-### URDF to `log_mesh`
+### URDF to log_mesh
 The URDF conversion is actually the most complex operation in this example. As such the functionality
 is split out into a separate [rerun/examples/python/ros_node/rerun_urdf.py](https://github.com/rerun-io/rerun/blob/main/examples/python/ros_node/rerun_urdf.py)
 helper.

--- a/docs/content/reference/migration-0-9.md
+++ b/docs/content/reference/migration-0-9.md
@@ -43,7 +43,7 @@ In most cases migrating your code to the new APIs should be straightforward. The
 deprecated and the deprecation warning should point you to the correct Archetype to use instead.  Additionally, in most
 cases, the old parameter names match the parameters taken by the new Archetype constructors, though exceptions are noted below.
 
-### `log_annotation_context`
+### log_annotation_context
 Replace with [AnnotationContext](types/archetypes/annotation_context.md)
 
 Python docs: [AnnotationContext](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.AnnotationContext)
@@ -53,7 +53,7 @@ Notes:
  - `rr.ClassDescription` now requires `info` to be provided rather than defaulting to 0.
  - `rr.AnnotationInfo` now requires `id` to be provided rather than defaulting to 0.
 
-### `log_arrow`
+### log_arrow
 Replace with [Arrows3D](types/archetypes/arrows3d.md)
 
 Python docs: [Arrows3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Arrows3D)
@@ -62,12 +62,12 @@ Notes:
  - `with_scale` has become `radii`, which entails dividing by 2 as necessary.
  - `identifiers` has become `instance_keys`.
 
-### `log_cleared`
+### log_cleared
 Replace with [Clear](types/archetypes/clear.md)
 
 Python docs: [Clear](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Clear)
 
-### `log_depth_image`
+### log_depth_image
 Replace with [DepthImage](types/archetypes/depth_image.md)
 
 Python docs: [DepthImage](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Clear)
@@ -75,12 +75,12 @@ Python docs: [DepthImage](https://ref.rerun.io/docs/python/nightly/common/archet
 Notes:
  * `image` has become `data`
 
-### `log_disconnected_space`
+### log_disconnected_space
 Replace with [DisconnectedSpace](types/archetypes/disconnected_space.md)
 
 Python docs: [DisconnectedSpace](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.DisconnectedSpace)
 
-### `log_extension_components`
+### log_extension_components
 Replace with `AnyValues`
 
 Python docs: TODO(jleibs): Link pending
@@ -89,7 +89,7 @@ Notes:
  - Instead of passing `ext` as a dictionary, `AnyValues` now maps all keyword arguments directly to components.
    - `rr.log_extension_components(…, ext={'mydata': 1})` becomes `rr.log(… rr.AnyValues(mydata=1))`
 
-### `log_image`
+### log_image
 Replace with [Image](types/archetypes/image.md)
 
 Python docs: [Image](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Image)
@@ -98,7 +98,7 @@ Notes:
  * `image` has become `data`
  * `jpeg_quality` is now handled by calling `.compress(jpeg_quality=…)` on the image after constructing it.
 
-### `log_image_file`
+### log_image_file
 Replace with `ImageEncoded`
 
 Python docs: [ImageEncoded](https://ref.rerun.io/docs/python/nightly/common/image_helpers/#rerun.ImageEncoded)
@@ -107,7 +107,7 @@ Notes:
  - `img_bytes` and `img_path`
 
 
-### `log_line_strip`, `log_line_strips_2d`, `log_line_strips_3d`, `log_line_segments`
+### log_line_strip, log_line_strips_2d, log_line_strips_3d, log_line_segments
 Replace with [LineStrips2D](types/archetypes/line_strips2d.md) or [LineStrips3D](types/archetypes/line_strips3d.md)
 
 Python docs: [LineStrips2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips2D), [LineStrips3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.LineStrips3D)
@@ -125,7 +125,7 @@ line_strips3d=line_segments.reshape(-1, 2, 3)
  - `stroke_width` has become `radii`, which entails dividing by 2 as necessary.
  - `identifiers` has become `instance_keys`.
 
-### `log_mesh`, `log_meshes`
+### log_mesh, log_meshes
 Replace with [Mesh3D](types/archetypes/mesh3d.md)
 
 Python docs: [Mesh3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Mesh3D)
@@ -138,7 +138,7 @@ Notes:
  - `albedo_factor` has become `mesh_material`, and can be logged using `rr.Material(albedo_factor=…)`.
  - `identifiers` has become `instance_keys`.
 
-### `log_mesh_file`
+### log_mesh_file
 Replace with [Asset3D](types/archetypes/asset3d.md)
 
 Python docs: [Asset3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Asset3D)
@@ -150,7 +150,7 @@ Notes:
  - `transform` can now take anything that is compatible with `rr.Transform3D` instead of an affine 3x4 matrix.
    - To convert an existing affine 3x4 matrix to an `rr.Transform3D`, you can use, `rr.Transform3D(translation=transform[:,3], mat3x3=transform[:,0:3])`
 
-### `log_obb`, `log_obbs`
+### log_obb, log_obbs
 Replace with [Boxes3D](types/archetypes/boxes3d.md)
 
 Python docs: [Boxes3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes3D)
@@ -162,7 +162,7 @@ Notes:
  - `stroke_width` has become `radii`, which entails dividing by 2 as necessary.
  - `identifiers` has become `instance_keys`.
 
-### `log_pinhole`
+### log_pinhole
 Replace with [Pinhole](types/archetypes/pinhole.md)
 
 Python docs: [Pinhole](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Pinhole)
@@ -174,7 +174,7 @@ Notes:
  - New argument `resolution` to specify width and height using `Vec2D`
  - `camera_xyz` no longer take a string. Now use one of the constants from `rr.ViewCoordinates`
 
-### `log_point`, `log_points`
+### log_point, log_points
 Replace with [Points2D](types/archetypes/points2d.md) or [Points3D](types/archetypes/points3d.md).
 
 Python docs: [Points2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points2D), [Points3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Points3D)
@@ -183,7 +183,7 @@ Notes:
  - `stroke_width` has become `radii`, which entails dividing by 2 as necessary.
  - `identifiers` has become `instance_keys`
 
-### `log_rect`, `log_rects`
+### log_rect, log_rects
 Replace with [Boxes2D](types/archetypes/boxes2d.md)
 
 Python docs: [Boxes2D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Boxes2D)
@@ -194,12 +194,12 @@ Notes:
    `array_format` takes an `rr.Box2DFormat`.
  - `identifiers` has become `instance_keys`.
 
-### `log_scalar`
+### log_scalar
 Replace with [TimeSeriesScalar](types/archetypes/time_series_scalar.md)
 
 Python docs: [TimeSeriesScalar](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.TimeSeriesScalar)
 
-### `log_segmentation_image`
+### log_segmentation_image
 Replace with [SegmentationImage](types/archetypes/segmentation_image.md)
 
 Python docs: [SegmentationImage](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.SegmentationImage)
@@ -207,7 +207,7 @@ Python docs: [SegmentationImage](https://ref.rerun.io/docs/python/nightly/common
 Notes:
  * `image` has become `data`
 
-### `log_tensor`
+### log_tensor
 Replace with [Tensor](types/archetypes/tensor.md)
 
 Python docs: [Tensor](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Tensor)
@@ -219,12 +219,12 @@ Notes:
  - 1D Tensors can now be logged with [BarChart](types/archetypes/bar_chart.md)
 
 
-### `log_text_entry`
+### log_text_entry
 Replace with [TextLog](types/archetypes/text_log.md)
 
 Python docs: [TextLog](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.TextLog)
 
-### `log_transform3d`
+### log_transform3d
 Replace with [Transform3D](types/archetypes/transform3d.md)
 
 Python docs: [Transform3D](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.Transform3D)
@@ -232,7 +232,7 @@ Python docs: [Transform3D](https://ref.rerun.io/docs/python/nightly/common/arche
 Notes:
  - Now takes optional parameters for `translation`, `rotation`, `scale`, or `mat3x3` to simplify construction.
 
-### `log_view_coordinates`
+### log_view_coordinates
 Replace with [ViewCoordinates](types/archetypes/view_coordinates.md)
 
 Python docs: [ViewCoordinates](https://ref.rerun.io/docs/python/nightly/common/archetypes/#rerun.archetypes.ViewCoordinates)
@@ -245,7 +245,7 @@ Notes:
 
 Rust already used a more type oriented interface, so the changes are not as drastic as to the Python API.
 
-## Removal of `MsgSender`
+## Removal of MsgSender
 
 The biggest change that `MsgSender` is gone and all logging happens instead directly on the [`RecordingStream::RecordingStream`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/struct.RecordingStream.html)
 using its [`log`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/struct.RecordingStream.html#method.log) and [`RecordingStream::log_timeless`](https://docs.rs/rerun/0.9.0-alpha.10/rerun/struct.RecordingStream.html#method.log_timeless) functions.

--- a/docs/content/reference/migration-0-9.md
+++ b/docs/content/reference/migration-0-9.md
@@ -83,7 +83,7 @@ Python docs: [DisconnectedSpace](https://ref.rerun.io/docs/python/nightly/common
 ### log_extension_components
 Replace with `AnyValues`
 
-Python docs: TODO(jleibs): Link pending
+Python docs: [AnyValues](https://ref.rerun.io/docs/python/nightly/common/custom_data/#rerun.AnyValues)
 
 Notes:
  - Instead of passing `ext` as a dictionary, `AnyValues` now maps all keyword arguments directly to components.

--- a/docs/content/reference/sdk-micro-batching.md
+++ b/docs/content/reference/sdk-micro-batching.md
@@ -10,19 +10,19 @@ The flushing is triggered by both time and space thresholds, whichever happens t
 
 You can configure these thresholds using the following environment variables:
 
-#### `RERUN_FLUSH_TICK_SECS`
+#### RERUN_FLUSH_TICK_SECS
 
 Sets the duration of the periodic tick that triggers the time threshold, in seconds.
 
 Defaults to `RERUN_FLUSH_TICK_SECS=0.008` (8ms).
 
-#### `RERUN_FLUSH_NUM_BYTES`
+#### RERUN_FLUSH_NUM_BYTES
 
 Sets the size limit that triggers the space threshold, in bytes.
 
 Defaults to `RERUN_FLUSH_NUM_BYTES=1048576` (1MiB).
 
-#### `RERUN_FLUSH_NUM_ROWS`
+#### RERUN_FLUSH_NUM_ROWS
 
 Sets the number of rows that drives the space threshold.
 

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -18,11 +18,11 @@ All four of them are optional: when none of these modes are active, the client w
 
 This is the default behavior you get when running all of our Python & Rust examples, and is generally the most convenient when you're experimenting.
 
-#### `Python`
+#### Python
 
 Call [`rr.spawn`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.spawn) once at the start of your program to start a Rerun Viewer in an external process and stream all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
-#### `Rust`
+#### Rust
 
 [`rerun::native_viewer::spawn`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.spawn.html) spawns a new viewer on the main thread (for platform compatibility reasons) and continues executing user code on a new thread, streaming data between the two in real-time using an in-memory channel.
 
@@ -32,11 +32,11 @@ Connects to a remote Rerun Viewer and streams all the data via TCP.
 
 You will need to start a stand-alone viewer first by typing `rerun` in your terminal.
 
-#### `Python`
+#### Python
 
 [`rr.connect`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.connect)
 
-#### `Rust`
+#### Rust
 
 [`RecordingStream::connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.connect)
 
@@ -44,11 +44,11 @@ You will need to start a stand-alone viewer first by typing `rerun` in your term
 
 This starts the web version of the Rerun Viewer in your browser, and streams data to it in real-time using WebSockets.
 
-#### `Python`
+#### Python
 
 Use [`rr.serve`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.serve).
 
-#### `Rust`
+#### Rust
 
 [`RecordingStream::serve`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.serve)
 
@@ -60,11 +60,11 @@ To view the saved file, use `rerun path/to/file.rrd`.
 
 ⚠️  [RRD files don't yet handle versioning!](https://github.com/rerun-io/rerun/issues/873) ⚠️
 
-#### `Python`
+#### Python
 
 Use [`rr.save`](https://ref.rerun.io/docs/python/nightly/common/initialization_functions/#rerun.save).
 
-#### `Rust`
+#### Rust
 
 Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.save).
 


### PR DESCRIPTION
### What
I believe the code-highlighting is causing backticks to be replaced by something that then becomes `object` in the markdown slugs we generating for headings.

Removing the usages.

Before: https://www.rerun.io/preview/208dc7bf810fe2a9c137932c2d4cae40d551aaab/docs/reference/migration-0-9#object-object

After: https://www.rerun.io/preview/bb629baeed788c6cd88471f85c6a0ceec84f9523/docs/reference/migration-0-9#logarrow

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3690) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3690)
- [Docs preview](https://rerun.io/preview/13655d86e273e38896743172ab0faa393b6cc6c9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/13655d86e273e38896743172ab0faa393b6cc6c9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)