### PR TITLE
Add alternate download location for RGBD dataset

### DIFF
--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 DEPTH_IMAGE_SCALING: Final = 1e4
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
 DATASET_URL_BASE: Final = "http://horatio.cs.nyu.edu/mit/silberman/nyu_depth_v2"
+DATASET_URL_BASE_ALTERNATE: Final = "https://static.rerun.io/rgbd_dataset"
 AVAILABLE_RECORDINGS: Final = ["cafe", "basements", "studies", "office_kitchens", "playroooms"]
 
 
@@ -98,13 +99,18 @@ def ensure_recording_downloaded(name: str) -> Path:
         return recording_path
 
     url = f"{DATASET_URL_BASE}/{recording_filename}"
-    print(f"downloading {url} to {recording_path}")
+    alternate_url = f"{DATASET_URL_BASE_ALTERNATE}/{recording_filename}"
+
     os.makedirs(DATASET_DIR, exist_ok=True)
     try:
-        download_progress(url, recording_path)
+        try:
+            print(f"downloading {url} to {recording_path}")
+            download_progress(url, recording_path)
+        except ValueError:
+            print(f"retry: downloading {url} to {recording_path}")
+            download_progress(alternate_url, recording_path)
     except BaseException as e:
-        if recording_path.exists():
-            os.remove(recording_path)
+        recording_path.unlink(missing_ok=True)
         raise e
 
     return recording_path
@@ -117,6 +123,8 @@ def download_progress(url: str, dst: Path) -> None:
     From: https://gist.github.com/yanqd0/c13ed29e29432e3cf3e7c38467f42f51
     """
     resp = requests.get(url, stream=True)
+    if resp.status_code != 200:
+        raise ValueError("Failed to download file")
     total = int(resp.headers.get("content-length", 0))
     chunk_size = 1024 * 1024
     # Can also replace 'file' with a io.BytesIO object

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -107,7 +107,7 @@ def ensure_recording_downloaded(name: str) -> Path:
             print(f"downloading {url} to {recording_path}")
             download_progress(url, recording_path)
         except ValueError:
-            print(f"retry: downloading {url} to {recording_path}")
+            print(f"Failed to download from {url}, trying backup URL {alternate_url} instead")
             download_progress(alternate_url, recording_path)
     except BaseException as e:
         recording_path.unlink(missing_ok=True)

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -22,8 +22,8 @@ from tqdm import tqdm
 
 DEPTH_IMAGE_SCALING: Final = 1e4
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
-DATASET_URL_BASE: Final = "http://horatio.cs.nyu.edu/mit/silberman/nyu_depth_v2"
-DATASET_URL_BASE_ALTERNATE: Final = "https://static.rerun.io/rgbd_dataset"
+DATASET_URL_BASE: Final = "https://static.rerun.io/rgbd_dataset"
+DATASET_URL_BASE_ALTERNATE: Final = "http://horatio.cs.nyu.edu/mit/silberman/nyu_depth_v2"
 AVAILABLE_RECORDINGS: Final = ["cafe", "basements", "studies", "office_kitchens", "playroooms"]
 
 
@@ -124,7 +124,7 @@ def download_progress(url: str, dst: Path) -> None:
     """
     resp = requests.get(url, stream=True)
     if resp.status_code != 200:
-        raise ValueError("Failed to download file")
+        raise ValueError(f"Failed to download file (status code: {resp.status_code})")
     total = int(resp.headers.get("content-length", 0))
     chunk_size = 1024 * 1024
     # Can also replace 'file' with a io.BytesIO object


### PR DESCRIPTION
### What

The datasets for the RGBD dataset are apparently no longer available (temporarily?). This PR add an alternate download location (from `static.rerun.io`), which currently only has `cafe.zip` available.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3692) (if applicable)~~

- [PR Build Summary](https://build.rerun.io/pr/3692)
- [Docs preview](https://rerun.io/preview/72b840a67e4df815b06272b6228518d7c298f556/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/72b840a67e4df815b06272b6228518d7c298f556/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)