### PR TITLE
Connect to 127.0.0.1 when checking for existing viewer

### DIFF
--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -152,9 +152,9 @@ def _check_for_existing_viewer(port: int) -> bool:
         # Try opening a connection to the port to see if something is there
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(1)
-        s.connect(("0.0.0.0", port))
+        s.connect(("127.0.0.1", port))
         return True
-    except (socket.timeout, ConnectionRefusedError):
+    except Exception:
         # If the connection times out or is refused, the port is not open
         return False
     finally:


### PR DESCRIPTION
### What
0.0.0.0 isn't valid on some hosts.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3696) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3696)
- [Docs preview](https://rerun.io/preview/42af3a55fb4e9e5dcc8c4d1f74a983cf1fdbc648/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/42af3a55fb4e9e5dcc8c4d1f74a983cf1fdbc648/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)