### PR TITLE
Fix open photogrammetry example not working on Windows

### DIFF
--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -80,7 +80,7 @@ class OPFProject:
         import os
 
         self.path = path
-        # TODO(Pix4D/pyopf#6):
+        # TODO(Pix4D/pyopf#6): https://github.com/Pix4D/pyopf/issues/6
         # pyopf doesn't seem to work with regular windows paths, but a "UNC dos path" works
         path_as_str = "\\\\.\\" + str(path.absolute()) if os.name == "nt" else str(path)
         self.project = resolve(load(path_as_str))

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -80,6 +80,7 @@ class OPFProject:
         import os
 
         self.path = path
+        # TODO(Pix4D/pyopf#6):
         # pyopf doesn't seem to work with regular windows paths, but a "UNC dos path" works
         path_as_str = "\\\\.\\" + str(path.absolute()) if os.name == "nt" else str(path)
         self.project = resolve(load(path_as_str))

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Load an Open Photogrammetry Format (OFP) project and display the cameras and point cloud.
+Load an Open Photogrammetry Format (OPF) project and display the cameras and point cloud.
 
 OPF specification: https://pix4d.github.io/opf-spec/index.html
 Dataset source: https://support.pix4d.com/hc/en-us/articles/360000235126-Example-projects-real-photogrammetry-data#OPF1
@@ -77,8 +77,12 @@ class OPFProject:
         log_as_frames : bool, optional
             Whether to log the cameras as individual frames, by default True
         """
+        import os
+
         self.path = path
-        self.project = resolve(load(str(path)))
+        # pyopf doesn't seem to work with regular windows paths, but a "UNC dos path" works
+        path_as_str = "\\\\.\\" + str(path.absolute())  if os.name == 'nt' else str(path)
+        self.project = resolve(load(path_as_str))
         self.log_as_frames = log_as_frames
 
     @classmethod

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -81,7 +81,7 @@ class OPFProject:
 
         self.path = path
         # pyopf doesn't seem to work with regular windows paths, but a "UNC dos path" works
-        path_as_str = "\\\\.\\" + str(path.absolute())  if os.name == 'nt' else str(path)
+        path_as_str = "\\\\.\\" + str(path.absolute()) if os.name == "nt" else str(path)
         self.project = resolve(load(path_as_str))
         self.log_as_frames = log_as_frames
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -30,7 +30,7 @@ ellipsis = re.compile(r"[^.]\.\.\.([^\-.0-9a-zA-Z]|$)")
 
 any_todo_pattern = re.compile(r"TODO\(.*\)")
 legal_todo_inner_pattern = re.compile(
-    r"TODO\(((?:[a-zA-Z\-_/]+)?#\d+|[a-zA-Z]+)(?:,\s*((?:[a-zA-Z\-_/]+)?#\d+|[a-zA-Z]+))*\)"
+    r"TODO\(((?:[a-zA-Z\-_/]+[a-zA-Z\-_/\d]+)?#\d+|[a-zA-Z]+)(?:,\s*((?:[a-zA-Z\-_/]+)?#\d+|[a-zA-Z]+))*\)"
 )
 
 anyhow_result = re.compile(r"Result<.*, anyhow::Error>")
@@ -132,6 +132,7 @@ def test_lint_line() -> None:
         "TODO(#42):",
         "TODO(#42,#43):",
         "TODO(#42, #43):",
+        "TODO(n4m3/w1th-numb3r5#42)",
         "TODO(rust-lang/rust#42):",
         "TODO(rust-lang/rust#42,rust-lang/rust#43):",
         "TODO(rust-lang/rust#42, rust-lang/rust#43):",


### PR DESCRIPTION
### What

Fixes `python .\examples\python\open_photogrammetry_format\main.py` on Windows

Was getting 
```
Traceback (most recent call last):
  File "C:\dev\rerun\rerun\examples\python\open_photogrammetry_format\main.py", line 220, in <module>
    main()
  File "C:\dev\rerun\rerun\examples\python\open_photogrammetry_format\main.py", line 209, in main
    project = OPFProject.from_dataset(args.dataset, log_as_frames=not args.no_frames)
  File "C:\dev\rerun\rerun\examples\python\open_photogrammetry_format\main.py", line 107, in from_dataset
    return cls(DATASET_DIR / spec.dir_name / "project.opf", log_as_frames=log_as_frames)
  File "C:\dev\rerun\rerun\examples\python\open_photogrammetry_format\main.py", line 85, in __init__
    self.project = resolve(load(str(path)))
  File "C:\Python310\lib\site-packages\pyopf\io\loaders.py", line 143, in load
    accepted, params = test(resource, base_uri, additional_resources)
  File "C:\Python310\lib\site-packages\pyopf\io\loaders.py", line 73, in _test_json_resource
    uri = join_uris(resource, base_uri)
  File "C:\Python310\lib\site-packages\pyopf\io\loaders.py", line 31, in join_uris
    raise RuntimeError("Non-file URIs are not supported")
RuntimeError: Non-file URIs are not supported
```
before. With the fix here it runs fine 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3705) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3705)
- [Docs preview](https://rerun.io/preview/84ac386ff07a956250309089cfef448d39195327/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/84ac386ff07a956250309089cfef448d39195327/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)