### PR TITLE
Fix a bunch of lints found by Rust 1.73

### DIFF
--- a/crates/re_arrow_store/src/store_dump.rs
+++ b/crates/re_arrow_store/src/store_dump.rs
@@ -225,5 +225,6 @@ fn filter_column<'a, T: 'a + Clone>(
     col_time
         .iter()
         .zip(column)
-        .filter_map(move |(time, v)| time_filter.contains((*time).into()).then(|| v.clone()))
+        .filter(move |(time, _)| time_filter.contains((**time).into()))
+        .map(|(_, v)| v.clone())
 }

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -80,7 +80,7 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
 }
 
 fn annotation_info(
-    ctx: &mut re_viewer_context::ViewerContext<'_>,
+    ctx: &re_viewer_context::ViewerContext<'_>,
     entity_path: &re_log_types::EntityPath,
     query: &re_arrow_store::LatestAtQuery,
     keypoint_id: KeypointId,

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -421,7 +421,7 @@ pub fn tensor_summary_ui(
 #[allow(clippy::too_many_arguments)]
 fn show_zoomed_image_region_tooltip(
     render_ctx: &mut re_renderer::RenderContext,
-    parent_ui: &mut egui::Ui,
+    parent_ui: &egui::Ui,
     response: egui::Response,
     tensor_path_hash: VersionedInstancePathHash,
     tensor: &DecodedTensor,

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -199,7 +199,7 @@ impl DataUi for PathOp {
 // ---------------------------------------------------------------------------
 
 pub fn annotations(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     query: &re_arrow_store::LatestAtQuery,
     entity_path: &re_data_store::EntityPath,
 ) -> std::sync::Arc<re_viewer_context::Annotations> {

--- a/crates/re_log_types/src/load_file.rs
+++ b/crates/re_log_types/src/load_file.rs
@@ -73,13 +73,12 @@ fn image_indicator_cell() -> DataCell {
     use re_types::Archetype as _;
 
     let indicator = re_types::archetypes::Image::indicator();
-    let indicator_cell = DataCell::from_arrow(
+    DataCell::from_arrow(
         indicator.name(),
         indicator
             .to_arrow()
             .expect("Serializing an indicator component should always work"),
-    );
-    indicator_cell
+    )
 }
 
 pub fn data_cells_from_file_contents(

--- a/crates/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/re_renderer/src/draw_phases/picking_layer.rs
@@ -259,7 +259,7 @@ impl PickingLayerProcessor {
         );
 
         let bind_group_0 = ctx.shared_renderer_data.global_bindings.create_bind_group(
-            &mut ctx.gpu_resources,
+            &ctx.gpu_resources,
             &ctx.device,
             frame_uniform_buffer,
         );

--- a/crates/re_renderer/src/global_bindings.rs
+++ b/crates/re_renderer/src/global_bindings.rs
@@ -125,7 +125,7 @@ impl GlobalBindings {
     /// Creates a bind group that follows the global bind group layout.
     pub fn create_bind_group(
         &self,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
         frame_uniform_buffer_binding: BindGroupEntry,
     ) -> GpuBindGroup {

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -456,7 +456,7 @@ impl ViewBuilder {
         );
 
         let bind_group_0 = ctx.shared_renderer_data.global_bindings.create_bind_group(
-            &mut ctx.gpu_resources,
+            &ctx.gpu_resources,
             &ctx.device,
             frame_uniform_buffer,
         );

--- a/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
@@ -176,8 +176,8 @@ impl GpuRenderPipelinePool {
         &mut self,
         device: &wgpu::Device,
         frame_index: u64,
-        shader_modules: &mut GpuShaderModulePool,
-        pipeline_layouts: &mut GpuPipelineLayoutPool,
+        shader_modules: &GpuShaderModulePool,
+        pipeline_layouts: &GpuPipelineLayoutPool,
     ) {
         re_tracing::profile_function!();
         self.pool.current_frame_index = frame_index;

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -66,7 +66,7 @@ pub fn auto_spawn_heuristic(
 }
 
 pub fn update_object_property_heuristics(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     per_system_entities: &PerSystemEntities,
     entity_properties: &mut re_data_store::EntityPropertyMap,
     scene_bbox_accum: &macaw::BoundingBox,
@@ -140,7 +140,7 @@ fn update_pinhole_property_heuristics(
 }
 
 fn update_depth_cloud_property_heuristics(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     per_system_entities: &PerSystemEntities,
     entity_properties: &mut re_data_store::EntityPropertyMap,
     spatial_kind: SpatialSpaceViewKind,

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -30,7 +30,7 @@ impl Default for Asset3DPart {
 impl Asset3DPart {
     fn process_arch_view(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         instances: &mut Vec<MeshInstance>,
         arch_view: &ArchetypeView<Asset3D>,
         ent_path: &EntityPath,

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -54,7 +54,7 @@ pub struct ViewerImage {
 
 #[allow(clippy::too_many_arguments)]
 fn to_textured_rect(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ent_path: &EntityPath,
     ent_context: &SpatialSceneEntityContext<'_>,
     tensor_path_hash: VersionedInstancePathHash,
@@ -203,7 +203,7 @@ impl ImagesPart {
     #[allow(clippy::too_many_arguments)]
     fn process_image_arch_view(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         transforms: &TransformContext,
         _ent_props: &EntityProperties,
         arch_view: &ArchetypeView<Image>,
@@ -292,7 +292,7 @@ impl ImagesPart {
     #[allow(clippy::too_many_arguments)]
     fn process_depth_image_arch_view(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         depth_clouds: &mut Vec<DepthCloud>,
         transforms: &TransformContext,
         ent_props: &EntityProperties,
@@ -412,7 +412,7 @@ impl ImagesPart {
     #[allow(clippy::too_many_arguments)]
     fn process_segmentation_image_arch_view(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         transforms: &TransformContext,
         _ent_props: &EntityProperties,
         arch_view: &ArchetypeView<SegmentationImage>,
@@ -499,7 +499,7 @@ impl ImagesPart {
 
     #[allow(clippy::too_many_arguments)]
     fn process_entity_view_as_depth_cloud(
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         transforms: &TransformContext,
         ent_context: &SpatialSceneEntityContext<'_>,
         properties: &EntityProperties,

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -30,7 +30,7 @@ impl Default for Mesh3DPart {
 impl Mesh3DPart {
     fn process_arch_view(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         instances: &mut Vec<MeshInstance>,
         arch_view: &ArchetypeView<Mesh3D>,
         ent_path: &EntityPath,

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -221,7 +221,7 @@ where
         if let (Some(keypoint_id), Some(class_id), primary) = (keypoint_id, class_id, primary) {
             keypoints
                 .entry((class_id, query.latest_at.as_i64()))
-                .or_insert_with(Default::default)
+                .or_default()
                 .insert(keypoint_id.0, primary_into_position(&primary));
             class_description.annotation_info_with_keypoint(keypoint_id.0)
         } else {

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -308,7 +308,7 @@ pub fn create_labels(
     labels: &[UiLabel],
     ui_from_canvas: egui::emath::RectTransform,
     eye3d: &Eye,
-    parent_ui: &mut egui::Ui,
+    parent_ui: &egui::Ui,
     highlights: &SpaceViewHighlights,
     spatial_kind: SpatialSpaceViewKind,
 ) -> (Vec<egui::Shape>, Vec<PickableUiRect>) {
@@ -454,7 +454,7 @@ pub fn picking(
     mut response: egui::Response,
     space_from_ui: egui::emath::RectTransform,
     ui_clip_rect: egui::Rect,
-    parent_ui: &mut egui::Ui,
+    parent_ui: &egui::Ui,
     eye: Eye,
     view_builder: &mut re_renderer::view_builder::ViewBuilder,
     state: &mut SpatialSpaceViewState,

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -622,7 +622,7 @@ pub fn view_3d(
 }
 
 fn show_projections_from_2d_space(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     line_builder: &mut LineStripSeriesBuilder,
     space_cameras: &[SpaceCamera3D],
     tracked_space_camera: &Option<EntityPath>,

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -300,7 +300,7 @@ fn view_tensor(
 fn tensor_slice_ui(
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
-    state: &mut PerTensorState,
+    state: &PerTensorState,
     tensor_path_hash: VersionedInstancePathHash,
     tensor: &DecodedTensor,
     dimension_labels: [(String, bool); 2],
@@ -319,7 +319,7 @@ fn tensor_slice_ui(
 fn paint_tensor_slice(
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
-    state: &mut PerTensorState,
+    state: &PerTensorState,
     tensor_path_hash: VersionedInstancePathHash,
     tensor: &DecodedTensor,
 ) -> anyhow::Result<(egui::Response, egui::Painter, egui::Rect)> {
@@ -573,7 +573,7 @@ fn dimension_name(shape: &[TensorDimension], dim_idx: usize) -> String {
 }
 
 fn paint_axis_names(
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     painter: &egui::Painter,
     rect: egui::Rect,
     font_id: egui::FontId,

--- a/crates/re_space_view_tensor/src/tensor_slice_to_gpu.rs
+++ b/crates/re_space_view_tensor/src/tensor_slice_to_gpu.rs
@@ -24,7 +24,7 @@ pub enum TensorUploadError {
 }
 
 pub fn colormapped_texture(
-    render_ctx: &mut re_renderer::RenderContext,
+    render_ctx: &re_renderer::RenderContext,
     tensor_path_hash: VersionedInstancePathHash,
     tensor: &DecodedTensor,
     tensor_stats: &TensorStats,
@@ -51,7 +51,7 @@ pub fn colormapped_texture(
 }
 
 fn upload_texture_slice_to_gpu(
-    render_ctx: &mut re_renderer::RenderContext,
+    render_ctx: &re_renderer::RenderContext,
     tensor_path_hash: VersionedInstancePathHash,
     tensor: &DecodedTensor,
     slice_selection: &SliceSelection,

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -65,7 +65,7 @@ impl ViewPartSystem for TensorSystem {
 impl TensorSystem {
     fn load_tensor_entity(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ent_path: &EntityPath,
         row_id: RowId,
         _props: &EntityProperties,

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -225,7 +225,7 @@ impl ViewTextFilters {
 
     // Checks whether new values are available for any of the filters, and updates everything
     // accordingly.
-    fn update(&mut self, ctx: &mut ViewerContext<'_>, entries: &[&Entry]) {
+    fn update(&mut self, ctx: &ViewerContext<'_>, entries: &[&Entry]) {
         re_tracing::profile_function!();
 
         let Self {
@@ -267,7 +267,7 @@ fn get_time_point(ctx: &ViewerContext<'_>, entry: &Entry) -> Option<TimePoint> {
 fn table_ui(
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
-    state: &mut TextSpaceViewState,
+    state: &TextSpaceViewState,
     entries: &[&Entry],
     scroll_to_row: Option<usize>,
 ) {

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -110,7 +110,7 @@ impl ViewPartSystem for TimeSeriesSystem {
 impl TimeSeriesSystem {
     fn load_scalars(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();

--- a/crates/re_time_panel/src/data_density_graph.rs
+++ b/crates/re_time_panel/src/data_density_graph.rs
@@ -370,7 +370,7 @@ pub fn data_density_graph_ui(
     ctx: &mut ViewerContext<'_>,
     time_area_response: &egui::Response,
     time_area_painter: &egui::Painter,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     num_timeless_messages: usize,
     time_histogram: &TimeHistogram,
     row_rect: Rect,
@@ -500,7 +500,7 @@ pub fn data_density_graph_ui(
     }
 }
 
-fn graph_color(ctx: &mut ViewerContext<'_>, item: &Item, ui: &mut egui::Ui) -> Color32 {
+fn graph_color(ctx: &ViewerContext<'_>, item: &Item, ui: &egui::Ui) -> Color32 {
     let is_selected = ctx.selection().contains(item);
     if is_selected {
         make_brighter(ui.visuals().widgets.active.fg_stroke.color)

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -688,7 +688,7 @@ impl TimePanel {
 
 /// Draw the hovered/selected highlight background for a timeline row.
 fn highlight_timeline_row(
-    ui: &mut Ui,
+    ui: &Ui,
     ctx: &ViewerContext<'_>,
     painter: &Painter,
     item: &Item,
@@ -808,7 +808,7 @@ fn current_time_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
 // ----------------------------------------------------------------------------
 
 fn initialize_time_ranges_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     time_x_range: Rangef,
     mut time_view: Option<TimeView>,
 ) -> TimeRangesUi {
@@ -875,7 +875,7 @@ fn view_everything(x_range: &Rangef, timeline_axis: &TimelineAxis) -> TimeView {
 fn paint_time_ranges_gaps(
     time_ranges_ui: &TimeRangesUi,
     re_ui: &re_ui::ReUi,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     painter: &egui::Painter,
     y_range: Rangef,
 ) {
@@ -1015,7 +1015,7 @@ fn paint_time_ranges_gaps(
 fn interact_with_streams_rect(
     time_ranges_ui: &TimeRangesUi,
     time_ctrl: &mut TimeControl,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     full_rect: &Rect,
     streams_rect: &Rect,
 ) -> egui::Response {
@@ -1077,7 +1077,7 @@ fn time_marker_ui(
     time_ranges_ui: &TimeRangesUi,
     time_ctrl: &mut TimeControl,
     re_ui: &re_ui::ReUi,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     time_area_painter: &egui::Painter,
     timeline_rect: &Rect,
 ) {

--- a/crates/re_time_panel/src/paint_ticks.rs
+++ b/crates/re_time_panel/src/paint_ticks.rs
@@ -9,7 +9,7 @@ use super::time_ranges_ui::TimeRangesUi;
 
 pub fn paint_time_ranges_and_ticks(
     time_ranges_ui: &TimeRangesUi,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     time_area_painter: &egui::Painter,
     line_y_range: RangeInclusive<f32>,
     time_type: TimeType,
@@ -58,7 +58,7 @@ pub fn paint_time_ranges_and_ticks(
 }
 
 fn paint_time_range_ticks(
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     rect: &Rect,
     time_type: TimeType,
     time_range: &TimeRangeF,

--- a/crates/re_time_panel/src/time_selection_ui.rs
+++ b/crates/re_time_panel/src/time_selection_ui.rs
@@ -10,7 +10,7 @@ pub fn loop_selection_ui(
     store_db: &StoreDb,
     time_ctrl: &mut TimeControl,
     time_ranges_ui: &TimeRangesUi,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     time_area_painter: &egui::Painter,
     timeline_rect: &Rect,
 ) {
@@ -205,7 +205,7 @@ fn initial_time_selection(
 }
 
 fn drag_right_loop_selection_edge(
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     time_ranges_ui: &TimeRangesUi,
     selected_range: &mut TimeRangeF,
     right_edge_id: Id,
@@ -233,7 +233,7 @@ fn drag_right_loop_selection_edge(
 }
 
 fn drag_left_loop_selection_edge(
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     time_ranges_ui: &TimeRangesUi,
     selected_range: &mut TimeRangeF,
     left_edge_id: Id,
@@ -261,7 +261,7 @@ fn drag_left_loop_selection_edge(
 }
 
 fn on_drag_loop_selection(
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     time_ranges_ui: &TimeRangesUi,
     selected_range: &mut TimeRangeF,
 ) -> Option<()> {
@@ -290,9 +290,9 @@ fn on_drag_loop_selection(
 }
 
 fn paint_range_text(
-    time_ctrl: &mut TimeControl,
+    time_ctrl: &TimeControl,
     selected_range: TimeRangeF,
-    ui: &mut egui::Ui,
+    ui: &egui::Ui,
     painter: &egui::Painter,
     selection_rect: Rect,
 ) {

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -345,7 +345,8 @@ impl Docs {
                     cur_tag.clone(),
                     tagged_lines
                         .iter()
-                        .filter_map(|(tag, line)| (cur_tag == tag).then(|| line.clone()))
+                        .filter(|(tag, _)| cur_tag == tag)
+                        .map(|(_, line)| line.clone())
                         .collect(),
                 );
             }

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -645,7 +645,7 @@ impl ReUi {
     ///
     /// Alternative to [`egui::collapsing_header::paint_default_icon`].
     pub fn paint_collapsing_triangle(
-        ui: &mut egui::Ui,
+        ui: &egui::Ui,
         openness: f32,
         rect: Rect,
         response: &egui::Response,
@@ -706,7 +706,7 @@ impl ReUi {
 
     /// Draws a shadow into the given rect with the shadow direction given from dark to light
     #[allow(clippy::unused_self)]
-    pub fn draw_shadow_line(&self, ui: &mut egui::Ui, rect: Rect, direction: egui::Direction) {
+    pub fn draw_shadow_line(&self, ui: &egui::Ui, rect: Rect, direction: egui::Direction) {
         let color_dark = self.design_tokens.shadow_gradient_dark_start;
         let color_bright = Color32::TRANSPARENT;
 

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -267,7 +267,7 @@ impl<'a> ListItem<'a> {
         /// Compute the "ideal" desired width of the item, accounting for text and icon(s) (but not
         /// buttons).
         fn icons_and_label_width(
-            ui: &mut egui::Ui,
+            ui: &egui::Ui,
             item: &ListItem<'_>,
             collapse_extra: f32,
             icon_extra: f32,

--- a/crates/re_ui/src/toasts.rs
+++ b/crates/re_ui/src/toasts.rs
@@ -128,7 +128,7 @@ impl Toasts {
     }
 }
 
-fn default_toast_contents(ui: &mut egui::Ui, toast: &mut Toast) -> egui::Response {
+fn default_toast_contents(ui: &mut egui::Ui, toast: &Toast) -> egui::Response {
     egui::Frame::window(ui.style())
         .inner_margin(10.0)
         .show(ui, |ui| {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -895,7 +895,7 @@ impl App {
     /// The welcome screen can be displayed only when a blueprint is available (and no recording is
     /// loaded). This function implements the heuristic which determines when the welcome screen
     /// should show up.
-    fn should_show_welcome_screen(&mut self, store_hub: &mut StoreHub) -> bool {
+    fn should_show_welcome_screen(&mut self, store_hub: &StoreHub) -> bool {
         // Don't show the welcome screen if we have actual data to display.
         if store_hub.current_recording().is_some() || store_hub.selected_application_id().is_some()
         {
@@ -1058,7 +1058,7 @@ impl eframe::App for App {
 
         // Heuristic to set the app_id to the welcome screen blueprint.
         // Must be called before `read_context` below.
-        if self.should_show_welcome_screen(&mut store_hub) {
+        if self.should_show_welcome_screen(&store_hub) {
             store_hub.set_app_id(StoreHub::welcome_screen_app_id());
         }
 
@@ -1127,7 +1127,7 @@ fn populate_space_view_class_registry_with_builtin(
     Ok(())
 }
 
-fn paint_background_fill(ui: &mut egui::Ui) {
+fn paint_background_fill(ui: &egui::Ui) {
     // This is required because the streams view (time panel)
     // has rounded top corners, which leaves a gap.
     // So we fill in that gap (and other) here.

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -127,7 +127,7 @@ impl AppState {
         // If the blueprint is invalid, reset it.
         if viewport.blueprint.is_invalid() {
             re_log::warn!("Incompatible blueprint detected. Resetting to default.");
-            viewport.blueprint.reset(&mut ctx, &spaces_info);
+            viewport.blueprint.reset(&ctx, &spaces_info);
         }
 
         viewport.on_frame_start(&mut ctx, &spaces_info);

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -25,7 +25,7 @@ pub fn blueprint_panel_ui(
 
 fn reset_button_ui(
     blueprint: &mut ViewportBlueprint<'_>,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
 ) {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -46,7 +46,7 @@ pub fn recordings_panel_ui(
 }
 
 fn loading_receivers_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     rx: &ReceiveSet<LogMsg>,
     ui: &mut egui::Ui,
 ) -> bool {
@@ -297,7 +297,7 @@ fn data_source_string(data_source: &re_smart_channel::SmartChannelSource) -> Str
     }
 }
 
-fn add_button_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
+fn add_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     use re_ui::UICommandSender;
 
     if ctx

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -444,7 +444,7 @@ fn colormap_props_ui(
 }
 
 fn pinhole_props_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     entity_path: &EntityPath,
     entity_props: &mut EntityProperties,
@@ -575,7 +575,7 @@ fn backproject_radius_scale_ui(ui: &mut egui::Ui, property: &mut EditableAutoVal
 }
 
 fn transform3d_visualization_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     entity_path: &EntityPath,
     entity_props: &mut EntityProperties,

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -212,7 +212,7 @@ impl AnnotationMap {
     /// An entity is considered its own (nearest) ancestor.
     pub fn load<'a>(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         time_query: &LatestAtQuery,
         entities: impl Iterator<Item = &'a EntityPath>,
     ) {

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -20,7 +20,7 @@ impl SpaceViewEntityPicker {
     pub fn ui(
         &mut self,
         ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
+        ui: &egui::Ui,
         space_view: &mut SpaceViewBlueprint,
     ) -> bool {
         // This function fakes a modal window, since egui doesn't have them yet: https://github.com/emilk/egui/issues/686
@@ -295,9 +295,9 @@ struct EntityAddInfo {
 }
 
 fn create_entity_add_info(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     tree: &EntityTree,
-    space_view: &mut SpaceViewBlueprint,
+    space_view: &SpaceViewBlueprint,
     spaces_info: &SpaceInfoCollection,
 ) -> IntMap<EntityPath, EntityAddInfo> {
     let mut meta_data: IntMap<EntityPath, EntityAddInfo> = IntMap::default();

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -445,7 +445,7 @@ fn is_entity_processed_by_part_collection(
 }
 
 pub fn identify_entities_per_system_per_class(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
 ) -> EntitiesPerSystemPerClass {
     re_tracing::profile_function!();
 

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -81,7 +81,7 @@ impl<'a> ViewportBlueprint<'a> {
     }
 
     /// Reset the blueprint to a default state using some heuristics.
-    pub fn reset(&mut self, ctx: &mut ViewerContext<'_>, spaces_info: &SpaceInfoCollection) {
+    pub fn reset(&mut self, ctx: &ViewerContext<'_>, spaces_info: &SpaceInfoCollection) {
         // TODO(jleibs): When using blueprint API, "reset" should go back to the initially transmitted
         // blueprint, not the default blueprint.
         re_tracing::profile_function!();

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -88,7 +88,7 @@ impl ViewportBlueprint<'_> {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         tile_id: egui_tiles::TileId,
-        container: &mut egui_tiles::Container,
+        container: &egui_tiles::Container,
     ) {
         if let Some(child_id) = container.only_child() {
             // Maybe a tab container with only one child - collapse it in the tree view to make it more easily understood.


### PR DESCRIPTION
Fix a bunch of lints found by Rust 1.73

I also enabled the new `clippy::needless_pass_by_ref_mut` lint, which I already love.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3714) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3714)
- [Docs preview](https://rerun.io/preview/e5ecd5c70154e2e7cd593d24bb48faed14b9e4e5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e5ecd5c70154e2e7cd593d24bb48faed14b9e4e5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)