### PR TITLE
Added support for PyTorch array to `Boxes2D`'s `array` convenience argument

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -67,7 +67,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 typing_extensions>=4.5
+          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 torch=2.1.0 typing_extensions>=4.5
 
       - name: Get version
         id: get-version

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -67,7 +67,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 torch=2.1.0 typing_extensions>=4.5
+          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 torch==2.1.0 typing_extensions>=4.5
 
       - name: Get version
         id: get-version

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -215,7 +215,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 typing_extensions>=4.5
+          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 torch=2.1.0 typing_extensions>=4.5
 
       - name: Get version
         id: get-version

--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -215,7 +215,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 torch=2.1.0 typing_extensions>=4.5
+          pip install attrs>=23.1.0 numpy>=1.23 pillow pyarrow==10.0.1 pytest==7.1.2 torch==2.1.0 typing_extensions>=4.5
 
       - name: Get version
         id: get-version

--- a/rerun_py/requirements-lint.txt
+++ b/rerun_py/requirements-lint.txt
@@ -3,6 +3,7 @@ black==23.3.0
 blackdoc==0.3.8
 mypy==1.4.1
 numpy>=1.24 # For mypy plugin
+torch>=2.1.0
 pip-check-reqs==2.4.4 # Checks for missing deps in requirements.txt files
 pytest  # For mypy to work
 ruff==0.0.276

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
@@ -106,8 +106,10 @@ class Boxes2DExt:
                 if centers is not None:
                     raise ValueError("Cannot specify both `array` and `centers` at the same time.")
 
+                if type(array) is not np.ndarray:
+                    array = np.array(array)
+
                 if np.any(array):
-                    array = np.asarray(array, dtype="float32")
                     if array.ndim == 1:
                         array = np.expand_dims(array, axis=0)
                 else:

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import torch
 from rerun.components import (
     ClassId,
     ClassIdBatch,
@@ -83,6 +84,8 @@ vec2ds_arrays: list[Vec2DArrayLike] = [
     np.array([1, 2, 3, 4], dtype=np.float32),
     # Vec2DArrayLike: npt.NDArray[np.float32]
     np.array([1, 2, 3, 4], dtype=np.float32).reshape((2, 2, 1, 1, 1)),
+    # PyTorch array
+    torch.asarray([1, 2, 3, 4], dtype=torch.float32),
 ]
 
 
@@ -118,6 +121,8 @@ vec3ds_arrays: list[Vec3DArrayLike] = [
     np.array([1, 2, 3, 4, 5, 6], dtype=np.float32),
     # Vec3DArrayLike: npt.NDArray[np.float32]
     np.array([1, 2, 3, 4, 5, 6], dtype=np.float32).reshape((2, 3, 1, 1, 1)),
+    # PyTorch array
+    torch.asarray([1, 2, 3, 4, 5, 6], dtype=torch.float32),
 ]
 
 
@@ -153,6 +158,8 @@ vec4ds_arrays: list[Vec4DArrayLike] = [
     np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.float32),
     # Vec4DArrayLike: npt.NDArray[np.float32]
     np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.float32).reshape((2, 4, 1, 1, 1)),
+    # PyTorch array
+    torch.asarray([1, 2, 3, 4, 5, 6, 7, 8], dtype=torch.float32),
 ]
 
 

--- a/rerun_py/tests/unit/test_box2d.py
+++ b/rerun_py/tests/unit/test_box2d.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import itertools
 from typing import Optional, cast
 
+import numpy as np
+import numpy.typing as npt
 import pytest
 import rerun as rr
+import torch
 from rerun.components import (
     DrawOrderLike,
     HalfSizes2DBatch,
@@ -135,6 +138,19 @@ def test_with_array_xcycwh() -> None:
 
 def test_with_array_xcycw2h2() -> None:
     assert rr.Boxes2D(mins=[1, 1], sizes=[2, 4]) == rr.Boxes2D(array=[2, 3, 1, 2], array_format=rr.Box2DFormat.XCYCW2H2)
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        [1, 2, 3, 4],
+        [1, 2, 3, 4],
+        np.array([1, 2, 3, 4], dtype=np.float32),
+        torch.asarray([1, 2, 3, 4], dtype=torch.float32),
+    ],
+)
+def test_with_array_types(array: npt.ArrayLike) -> None:
+    assert rr.Boxes2D(mins=[1, 2], sizes=[3, 4]) == rr.Boxes2D(array=array, array_format=rr.Box2DFormat.XYWH)
 
 
 def test_invalid_parameter_combinations() -> None:


### PR DESCRIPTION
### What

Fixes:
* #3708

Relates to (but doesn't implement):
* #3718 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] ~~I've included a screenshot or gif (if applicable)~~
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3719) (if applicable)~~

- [PR Build Summary](https://build.rerun.io/pr/3719)
- [Docs preview](https://rerun.io/preview/1b9c5d8d1d5ce8b9c29176c3b8b51e6fde4faced/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1b9c5d8d1d5ce8b9c29176c3b8b51e6fde4faced/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)