### PR TITLE
Fix default stroke width handling in `log_line_strip_Xd` and `log_obbs`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/log_deprecated/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/__init__.py
@@ -49,12 +49,16 @@ def _normalize_ids(class_ids: OptionalClassIds = None) -> npt.NDArray[np.uint16]
         return np.atleast_1d(np.array(class_ids, dtype=np.uint16, copy=False))
 
 
-def _normalize_radii(radii: npt.ArrayLike | None = None) -> npt.NDArray[np.float32]:
-    """Normalize flexible radii arrays."""
+def _stroke_width_to_radii(radii: npt.ArrayLike | None = None) -> npt.NDArray[np.float32] | None:
+    """
+    Normalize and converts stroke widths to radii.
+
+    Returns None if radii is None.
+    """
     if radii is None:
-        return np.array((), dtype=np.float32)
+        return None
     else:
-        return np.atleast_1d(np.array(radii, dtype=np.float32, copy=False))
+        return np.atleast_1d(np.array(radii, dtype=np.float32, copy=False)) / 2.0
 
 
 def _normalize_labels(labels: str | Sequence[str] | None) -> Sequence[str]:

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/__init__.py
@@ -49,16 +49,16 @@ def _normalize_ids(class_ids: OptionalClassIds = None) -> npt.NDArray[np.uint16]
         return np.atleast_1d(np.array(class_ids, dtype=np.uint16, copy=False))
 
 
-def _stroke_width_to_radii(radii: npt.ArrayLike | None = None) -> npt.NDArray[np.float32] | None:
+def _radii_from_stroke_width(stroke_width: npt.ArrayLike | None = None) -> npt.NDArray[np.float32] | None:
     """
     Normalize and converts stroke widths to radii.
 
     Returns None if radii is None.
     """
-    if radii is None:
+    if stroke_width is None:
         return None
     else:
-        return np.atleast_1d(np.array(radii, dtype=np.float32, copy=False)) / 2.0
+        return np.atleast_1d(np.array(stroke_width, dtype=np.float32, copy=False)) / 2.0
 
 
 def _normalize_labels(labels: str | Sequence[str] | None) -> Sequence[str]:

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
@@ -14,7 +14,7 @@ from rerun.log_deprecated import (
     Color,
     Colors,
     OptionalClassIds,
-    _stroke_width_to_radii,
+    _radii_from_stroke_width,
 )
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
@@ -178,7 +178,7 @@ def log_obbs(
     else:
         rotations = None
 
-    radii = _stroke_width_to_radii(stroke_widths)
+    radii = _radii_from_stroke_width(stroke_widths)
 
     arch = Boxes3D(
         half_sizes=half_sizes,

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/bounding_box.py
@@ -14,6 +14,7 @@ from rerun.log_deprecated import (
     Color,
     Colors,
     OptionalClassIds,
+    _stroke_width_to_radii,
 )
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
@@ -177,11 +178,7 @@ def log_obbs(
     else:
         rotations = None
 
-    if stroke_widths is not None:
-        radii = np.asarray(stroke_widths, dtype="float32")
-        radii /= 2.0
-    else:
-        radii = None
+    radii = _stroke_width_to_radii(stroke_widths)
 
     arch = Boxes3D(
         half_sizes=half_sizes,

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
@@ -10,7 +10,7 @@ from rerun._log import log
 from rerun.any_value import AnyValues
 from rerun.archetypes import LineStrips2D, LineStrips3D
 from rerun.error_utils import _send_warning
-from rerun.log_deprecated import Color, Colors, _normalize_radii
+from rerun.log_deprecated import Color, Colors, _stroke_width_to_radii
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
 
@@ -86,8 +86,7 @@ def log_line_strip(
 
     recording = RecordingStream.to_native(recording)
 
-    stroke_widths = _normalize_radii(stroke_width)
-    radii = stroke_widths / 2.0
+    radii = _stroke_width_to_radii(stroke_width)
 
     positions = np.require(positions, dtype="float32")
     if positions.shape[1] == 2:
@@ -190,8 +189,7 @@ def log_line_strips_2d(
     if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
         line_strips = list(line_strips)
 
-    stroke_widths = _normalize_radii(stroke_widths)
-    radii = stroke_widths / 2.0
+    radii = _stroke_width_to_radii(stroke_widths)
 
     arch = LineStrips2D(
         line_strips,
@@ -279,8 +277,7 @@ def log_line_strips_3d(
     if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
         line_strips = list(line_strips)
 
-    stroke_widths = _normalize_radii(stroke_widths)
-    radii = stroke_widths / 2.0
+    radii = _stroke_width_to_radii(stroke_widths)
 
     arch = LineStrips3D(
         line_strips,

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
@@ -10,7 +10,7 @@ from rerun._log import log
 from rerun.any_value import AnyValues
 from rerun.archetypes import LineStrips2D, LineStrips3D
 from rerun.error_utils import _send_warning
-from rerun.log_deprecated import Color, Colors, _stroke_width_to_radii
+from rerun.log_deprecated import Color, Colors, _radii_from_stroke_width
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
 
@@ -86,7 +86,7 @@ def log_line_strip(
 
     recording = RecordingStream.to_native(recording)
 
-    radii = _stroke_width_to_radii(stroke_width)
+    radii = _radii_from_stroke_width(stroke_width)
 
     positions = np.require(positions, dtype="float32")
     if positions.shape[1] == 2:
@@ -189,7 +189,7 @@ def log_line_strips_2d(
     if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
         line_strips = list(line_strips)
 
-    radii = _stroke_width_to_radii(stroke_widths)
+    radii = _radii_from_stroke_width(stroke_widths)
 
     arch = LineStrips2D(
         line_strips,
@@ -277,7 +277,7 @@ def log_line_strips_3d(
     if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
         line_strips = list(line_strips)
 
-    radii = _stroke_width_to_radii(stroke_widths)
+    radii = _radii_from_stroke_width(stroke_widths)
 
     arch = LineStrips3D(
         line_strips,


### PR DESCRIPTION
### What

Fixes:
- #3711 

Tested with:

```python
import rerun as rr

rr.init("rerun_example_line_strip3d", spawn=True)

points_3d = [
    [0, 0, 0],
    [0, 0, 1],
    [1, 0, 0],
    [1, 0, 1],
    [1, 1, 0],
    [1, 1, 1],
    [0, 1, 0],
    [0, 1, 1],
]

points_2d = [
    [
        [0, 0],
        [1, 0],
        [1, 1],
        [0, 1],
    ],
    [
        [2, 2],
        [3, 3],
        [3, 4],
        [5, 2],
    ],
]

rr.log_line_strips_3d("strip", [points_3d])
rr.log_line_strips_2d("strip2", points_2d)
rr.log_obbs("obb", positions=[[0, 0, 0], [10, 10, 10]], half_sizes=[[1, 1, 1], [2, 2, 2]])

rr.log_transform3d("with_width", rr.Translation3D([3, 3, 3]))
rr.log_line_strips_3d("with_width/strip", [points_3d], stroke_widths=0.2)
rr.log_line_strips_2d("with_width/strip2", points_2d, stroke_widths=[0.2, 0.3])
rr.log_obbs("with_width/obb", positions=[[0, 0, 0], [10, 10, 10]], half_sizes=[[1, 1, 1], [2, 2, 2]], stroke_widths=[0.2, 0.3])
```

<img width="1137" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/44190351-bde5-4103-b2f5-e7f8c51444da">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] ~~I have tested [demo.rerun.io](https://demo.rerun.io/pr/3720) (if applicable)~~

- [PR Build Summary](https://build.rerun.io/pr/3720)
- [Docs preview](https://rerun.io/preview/d4a3314f43e1e62547478362cc04b157a34b462c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d4a3314f43e1e62547478362cc04b157a34b462c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)