### PR TITLE
Refactor `rerun.AnyValues  to handle `None` input more gracefully

### DIFF
--- a/rerun_py/mkdocs.yml
+++ b/rerun_py/mkdocs.yml
@@ -24,6 +24,7 @@ plugins:
         python:
           paths: ["rerun_sdk"] # Lookup python modules relative to this path
           import: # Cross-references for python and numpy
+            - https://arrow.apache.org/docs/objects.inv
             - https://docs.python.org/3/objects.inv
             - https://numpy.org/doc/stable/objects.inv
             - https://ipython.readthedocs.io/en/stable/objects.inv

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -7,7 +7,7 @@ import rerun_bindings as bindings
 
 from . import components as cmp
 from ._baseclasses import AsComponents, ComponentBatchLike
-from .error_utils import _send_warning, catch_and_log_exceptions
+from .error_utils import _send_warning_or_raise, catch_and_log_exceptions
 from .recording_stream import RecordingStream
 
 __all__ = ["log", "IndicatorComponentBatch", "AsComponents"]
@@ -207,7 +207,7 @@ def log_components(
 
         # Skip components which were logged multiple times.
         if name in added:
-            _send_warning(
+            _send_warning_or_raise(
                 f"Component {name} was included multiple times. Only the first instance will be used.",
                 depth_to_user_code=1,
             )

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyarrow as pa
 
 from ._log import AsComponents, ComponentBatchLike
-from .error_utils import _send_warning
+from .error_utils import _send_warning_or_raise
 
 ANY_VALUE_TYPE_REGISTRY: dict[str, Any] = {}
 
@@ -70,14 +70,14 @@ class AnyBatchValue(ComponentBatchLike):
                     self.pa_array = pa.array(np_value, type=pa_type)
                 else:
                     if value is None:
-                        _send_warning(f"AnyValues '{name}' of unknown type has no data. Ignoring.", 1)
+                        _send_warning_or_raise(f"AnyValues '{name}' of unknown type has no data. Ignoring.", 1)
                     else:
                         np_value = np.atleast_1d(np.array(value, copy=False))
                         self.pa_array = pa.array(np_value)
                         ANY_VALUE_TYPE_REGISTRY[name] = (np_value.dtype, self.pa_array.type)
 
         except Exception as ex:
-            _send_warning(
+            _send_warning_or_raise(
                 f"Error converting data to arrow for AnyValues '{name}'. Ignoring.\n{type(ex).__name__}: {ex}",
                 1,
             )

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -30,7 +30,7 @@ class AnyBatchValue(ComponentBatchLike):
         this function so it's possible to pass them directly to AnyValues.
 
         If the object doesn't implement `as_arrow_array()`, it will be passed as an argument
-        to [pyarrow.array](https://arrow.apache.org/docs/python/generated/pyarrow.array.html).
+        to [pyarrow.array][] .
 
         Note: rerun requires that a given component only take on a single type.
         The first type logged will be the type that is used for all future logs
@@ -102,8 +102,7 @@ class AnyValues(AsComponents):
         Each kwarg will be logged as a separate component using the provided data.
          - The key will be used as the name of the component
          - The value must be able to be converted to an array of arrow types. In general, if
-           you can pass it to [pyarrow.array](https://arrow.apache.org/docs/python/generated/pyarrow.array.html),
-           you can log it as a extension component.
+           you can pass it to [pyarrow.array][] you can log it as a extension component.
 
         All values must either have the same length, or be singular in which case they will be
         treated as a splat.

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -154,7 +154,6 @@ class AnyValues(AsComponents):
         kwargs:
             The components to be logged.
 
-        ```
         """
         global ANY_VALUE_TYPE_REGISTRY
 

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -124,10 +124,10 @@ class AnyValues(AsComponents):
         The first type logged will be the type that is used for all future logs
         of that component. The API will make a best effort to do type conversion
         if supported by numpy and arrow. Any components that can't be converted
-        will result in a warning, or an exception in strict mode.
+        will result in a warning (or an exception in strict mode).
 
         `None` values provide a particular challenge as they have no type
-        information, until after the component has been logged with a particular
+        information until after the component has been logged with a particular
         type. By default, these values are dropped. This should generally be
         fine as logging `None` to clear the value before it has been logged is
         meaningless unless you are logging out-of-order data. In such cases,
@@ -135,8 +135,8 @@ class AnyValues(AsComponents):
         [rerun.ComponentBatchLike][].
 
         You can change this behavior by setting `drop_untyped_nones` to `False`,
-        but be aware that this will result in potential warnings or exceptions
-        if you are running in strict mode.
+        but be aware that this will result in potential warnings (or exceptions
+        in strict mode).
 
         If you are want to inspect how your component will be converted to the
         underlying arrow code, the following snippet is what is happening

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -24,7 +24,7 @@ class BarChartExt:
         shape_dims = tensor_data.as_arrow_array()[0].value["shape"].values.field(0).to_numpy()
 
         if len(shape_dims) != 1:
-            _send_warning(
+            _send_warning_or_raise(
                 f"Bar chart data should only be 1D. Got values with shape: {shape_dims}",
                 2,
                 recording=None,

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
@@ -5,7 +5,7 @@ from typing import Any
 import numpy as np
 
 from .. import components, datatypes
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 
 class Boxes3DExt:
@@ -59,18 +59,18 @@ class Boxes3DExt:
         with catch_and_log_exceptions(context=self.__class__.__name__):
             if sizes is not None:
                 if half_sizes is not None:
-                    _send_warning("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
+                    _send_warning_or_raise("Cannot specify both `sizes` and `half_sizes` at the same time.", 1)
 
                 sizes = np.asarray(sizes, dtype=np.float32)
                 half_sizes = sizes / 2.0
 
             if mins is not None:
                 if centers is not None:
-                    _send_warning("Cannot specify both `mins` and `centers` at the same time.", 1)
+                    _send_warning_or_raise("Cannot specify both `mins` and `centers` at the same time.", 1)
 
                 # already converted `sizes` to `half_sizes`
                 if half_sizes is None:
-                    _send_warning("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
+                    _send_warning_or_raise("Cannot specify `mins` without `sizes` or `half_sizes`.", 1)
                     half_sizes = np.asarray([1, 1, 1], dtype=np.float32)
 
                 mins = np.asarray(mins, dtype=np.float32)

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyarrow as pa
 
 from .._validators import find_non_empty_dim_indices
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -36,7 +36,7 @@ class DepthImageExt:
 
         # TODO(#3239): What `recording` should we be passing here? How should we be getting it?
         if num_non_empty_dims != 2:
-            _send_warning(f"Expected depth image, got array of shape {shape_dims}", 1, recording=None)
+            _send_warning_or_raise(f"Expected depth image, got array of shape {shape_dims}", 1, recording=None)
 
         # IF no labels are set, add them
         # TODO(jleibs): Again, needing to do this at the arrow level is awful

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 
 from .._validators import find_non_empty_dim_indices
 from ..datatypes import TensorBufferType
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from .._image import ImageEncoded
@@ -48,7 +48,7 @@ class ImageExt:
             tensor_data_arrow = self.data.as_arrow_array()
 
             if tensor_data_arrow[0].value["buffer"].type_code == self.JPEG_TYPE_ID:
-                _send_warning(
+                _send_warning_or_raise(
                     "Image is already compressed as JPEG. Ignoring compression request.",
                     1,
                     recording=None,
@@ -104,12 +104,12 @@ class ImageExt:
 
         # TODO(#3239): What `recording` should we be passing here? How should we be getting it?
         if num_non_empty_dims < 2 or 3 < num_non_empty_dims:
-            _send_warning(f"Expected image, got array of shape {shape_dims}", 1, recording=None)
+            _send_warning_or_raise(f"Expected image, got array of shape {shape_dims}", 1, recording=None)
 
         if num_non_empty_dims == 3:
             depth = shape_dims[non_empty_dims[-1]]
             if depth not in (3, 4):
-                _send_warning(
+                _send_warning_or_raise(
                     f"Expected image 3 (RGB) or 4 (RGBA). Instead got array of shape {shape_dims}",
                     1,
                     recording=None,

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole_ext.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 from ..components import ViewCoordinatesLike
 from ..datatypes.mat3x3 import Mat3x3Like
 from ..datatypes.vec2d import Vec2D, Vec2DLike
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 
 class PinholeExt:
@@ -84,7 +84,7 @@ class PinholeExt:
             if resolution is None and width is not None and height is not None:
                 resolution = [width, height]
             elif resolution is not None and (width is not None or height is not None):
-                _send_warning("Can't set both resolution and width/height", 1)
+                _send_warning_or_raise("Can't set both resolution and width/height", 1)
 
             # TODO(andreas): Use a union type for the Pinhole component instead ~Zof converting to a matrix here
             if image_from_camera is None:
@@ -96,7 +96,7 @@ class PinholeExt:
                 height = cast(float, resolution.xy[1])
 
                 if focal_length is None:
-                    _send_warning("either image_from_camera or focal_length must be set", 1)
+                    _send_warning_or_raise("either image_from_camera or focal_length must be set", 1)
                     focal_length = (width * height) ** 0.5  # a reasonable default
                 if principal_point is None:
                     principal_point = [width / 2, height / 2]
@@ -109,7 +109,7 @@ class PinholeExt:
                         fl_x = focal_length[0]  # type: ignore[index]
                         fl_y = focal_length[1]  # type: ignore[index]
                     except Exception:
-                        _send_warning("Expected focal_length to be one or two floats", 1)
+                        _send_warning_or_raise("Expected focal_length to be one or two floats", 1)
                         fl_x = width / 2
                         fl_y = fl_x
 
@@ -117,16 +117,16 @@ class PinholeExt:
                     u_cen = principal_point[0]  # type: ignore[index]
                     v_cen = principal_point[1]  # type: ignore[index]
                 except Exception:
-                    _send_warning("Expected principal_point to be one or two floats", 1)
+                    _send_warning_or_raise("Expected principal_point to be one or two floats", 1)
                     u_cen = width / 2
                     v_cen = height / 2
 
                 image_from_camera = [[fl_x, 0, u_cen], [0, fl_y, v_cen], [0, 0, 1]]  # type: ignore[assignment]
             else:
                 if focal_length is not None:
-                    _send_warning("Both image_from_camera and focal_length set", 1)
+                    _send_warning_or_raise("Both image_from_camera and focal_length set", 1)
                 if principal_point is not None:
-                    _send_warning("Both image_from_camera and principal_point set", 1)
+                    _send_warning_or_raise("Both image_from_camera and principal_point set", 1)
 
             self.__attrs_init__(image_from_camera=image_from_camera, resolution=resolution, camera_xyz=camera_xyz)
             return

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image_ext.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 from .._validators import find_non_empty_dim_indices
 from ..datatypes import TensorBufferType
 from ..datatypes.tensor_data_ext import _build_buffer_array
-from ..error_utils import _send_warning, catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     from ..components import TensorDataBatch
@@ -43,7 +43,7 @@ class SegmentationImageExt:
 
         # TODO(#3239): What `recording` should we be passing here? How should we be getting it?
         if num_non_empty_dims != 2:
-            _send_warning(f"Expected segmentation image, got array of shape {shape_dims}", 1, recording=None)
+            _send_warning_or_raise(f"Expected segmentation image, got array of shape {shape_dims}", 1, recording=None)
 
         tensor_data_type = TensorDataType().storage_type
         shape_data_type = TensorDimensionType().storage_type

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3_ext.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pyarrow as pa
 
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 
 if TYPE_CHECKING:
     from . import Mat3x3ArrayLike, Mat3x3Like
@@ -19,7 +19,7 @@ class Mat3x3Ext:
 
         if rows is not None:
             if columns is not None:
-                _send_warning("Can't specify both columns and rows of matrix.", 1, recording=None)
+                _send_warning_or_raise("Can't specify both columns and rows of matrix.", 1, recording=None)
 
             if isinstance(rows, Mat3x3):
                 self.flat_columns = rows.flat_columns
@@ -32,7 +32,7 @@ class Mat3x3Ext:
             arr = np.array(columns, dtype=np.float32).reshape(3, 3)
             self.flat_columns = arr.flatten("C")
         else:
-            _send_warning("Need to specify either columns or columns of matrix.", 1, recording=None)
+            _send_warning_or_raise("Need to specify either columns or columns of matrix.", 1, recording=None)
             self.flat_columns = np.identity(3, dtype=np.float32).flatten()
 
     @staticmethod

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4_ext.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pyarrow as pa
 
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 
 if TYPE_CHECKING:
     from . import Mat4x4ArrayLike, Mat4x4Like
@@ -19,7 +19,7 @@ class Mat4x4Ext:
 
         if rows is not None:
             if columns is not None:
-                _send_warning("Can't specify both columns and rows of matrix.", 1, recording=None)
+                _send_warning_or_raise("Can't specify both columns and rows of matrix.", 1, recording=None)
 
             if isinstance(rows, Mat4x4):
                 self.flat_columns = rows.flat_columns
@@ -32,7 +32,7 @@ class Mat4x4Ext:
             arr = np.array(columns, dtype=np.float32).reshape(4, 4)
             self.flat_columns = arr.flatten()
         else:
-            _send_warning("Need to specify either columns or columns of matrix.", 1, recording=None)
+            _send_warning_or_raise("Need to specify either columns or columns of matrix.", 1, recording=None)
             self.flat_columns = np.identity(4, dtype=np.float32).flatten()
 
     @staticmethod

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 
 from .._unions import build_dense_union
 
@@ -103,7 +103,7 @@ class TensorDataExt:
             if resolved_shape:
                 shape_tuple = tuple(d.size for d in resolved_shape)
                 if shape_tuple != array.shape:
-                    _send_warning(
+                    _send_warning_or_raise(
                         (
                             f"Provided array ({array.shape}) does not match shape argument ({shape_tuple}). "
                             + "Ignoring shape argument."
@@ -115,7 +115,7 @@ class TensorDataExt:
             if resolved_shape is None:
                 if dim_names:
                     if len(array.shape) != len(dim_names):
-                        _send_warning(
+                        _send_warning_or_raise(
                             (
                                 f"len(array.shape) = {len(array.shape)} != "
                                 + f"len(dim_names) = {len(dim_names)}. Dropping tensor dimension names."

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -70,19 +70,28 @@ def _send_warning_or_raise(
     message: str,
     depth_to_user_code: int,
     recording: RecordingStream | None = None,
+    exception_type: type[Exception] = ValueError,
 ) -> None:
     """
     Sends a warning about the usage of the Rerun SDK.
 
-    Used for recoverable problems.
-    You can also use this for unrecoverable problems,
-    or raise an exception and let the @log_decorator handle it instead.
+    Note: in strict mode this will instead raise the specified exception type
+    (defaults to ValueError).
+
+    This will both send a message to the Rerun viewer and log a warning using
+    `warning.warn` with a custom `RerunWarning` class.
+
+    This should generally be used for recoverable problems where you want execution
+    to continue in the local scope.
+
+    For unrecoverable problems where execution cannot otherwise continue, you should
+    instead raise an exception and let the `catch_and_log_exceptions` handle it.
     """
     from rerun._log import log
     from rerun.archetypes import TextLog
 
     if strict_mode():
-        raise TypeError(message)
+        raise exception_type(message)
 
     # Send the warning to the user first
     warnings.warn(message, category=RerunWarning, stacklevel=depth_to_user_code + 1)

--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, TypeVar, cast
 from .recording_stream import RecordingStream
 
 __all__ = [
-    "_send_warning",
+    "_send_warning_or_raise",
 ]
 
 _TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
@@ -66,7 +66,7 @@ def _build_warning_context_string(skip_first: int) -> str:
     return "\n".join(f'File "{frame.filename}", line {frame.lineno}, in {frame.function}' for frame in outer_stack)
 
 
-def _send_warning(
+def _send_warning_or_raise(
     message: str,
     depth_to_user_code: int,
     recording: RecordingStream | None = None,
@@ -199,7 +199,7 @@ class catch_and_log_exceptions:
                     _rerun_exception_ctx.depth = None
 
                     for warning in pending_warnings:
-                        _send_warning(warning, depth_to_user_code=self.depth_to_user_code + 2)
+                        _send_warning_or_raise(warning, depth_to_user_code=self.depth_to_user_code + 2)
 
             # If we're back to the top of the stack, send out the pending warnings
 

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/extension_components.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/extension_components.py
@@ -60,7 +60,7 @@ def _add_extension_components(
                 pa_value = pa.array(np_value)
                 EXT_COMPONENT_TYPES[name] = (np_value.dtype, pa_value.type)
         except Exception as ex:
-            rerun.error_utils._send_warning(
+            rerun.error_utils._send_warning_or_raise(
                 f"Error converting extension data to arrow for component {name}. Dropping.\n{type(ex).__name__}: {ex}",
                 1,
             )
@@ -145,7 +145,7 @@ def log_extension_components(
             identifiers = [int(id) for id in identifiers]
             identifiers_np = np.array(identifiers, dtype="uint64")
         except ValueError:
-            rerun.error_utils._send_warning("Only integer identifiers supported", 1)
+            rerun.error_utils._send_warning_or_raise("Only integer identifiers supported", 1)
 
     instanced: dict[str, Any] = {}
     splats: dict[str, Any] = {}

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/lines.py
@@ -9,7 +9,7 @@ from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 from rerun._log import log
 from rerun.any_value import AnyValues
 from rerun.archetypes import LineStrips2D, LineStrips3D
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 from rerun.log_deprecated import Color, Colors, _radii_from_stroke_width
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
@@ -183,7 +183,7 @@ def log_line_strips_2d(
         try:
             identifiers_np = np.require(identifiers, dtype="uint64")
         except ValueError:
-            _send_warning("Only integer identifiers supported", 1)
+            _send_warning_or_raise("Only integer identifiers supported", 1)
 
     # New types use Sequence, not Iterable
     if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):
@@ -271,7 +271,7 @@ def log_line_strips_3d(
         try:
             identifiers_np = np.require(identifiers, dtype="uint64")
         except ValueError:
-            _send_warning("Only integer identifiers supported", 1)
+            _send_warning_or_raise("Only integer identifiers supported", 1)
 
     # New types use Sequence, not Iterable
     if not isinstance(line_strips, Sequence) and isinstance(line_strips, Iterable):

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/points.py
@@ -9,7 +9,7 @@ from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 from rerun._log import log
 from rerun.any_value import AnyValues
 from rerun.archetypes import Points2D, Points3D
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 from rerun.log_deprecated import (
     Color,
     Colors,
@@ -240,7 +240,7 @@ def log_points(
         try:
             identifiers_np = np.require(identifiers, dtype="uint64")
         except ValueError:
-            _send_warning("Only integer identifiers supported", 1)
+            _send_warning_or_raise("Only integer identifiers supported", 1)
 
     if positions.shape[1] == 2:
         points2d = Points2D(

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/rects.py
@@ -10,7 +10,7 @@ from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 from rerun._log import log
 from rerun.any_value import AnyValues
 from rerun.archetypes import Boxes2D
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 from rerun.log_deprecated import Color, Colors, OptionalClassIds
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
@@ -208,7 +208,7 @@ def log_rects(
         try:
             identifiers_np = np.require(identifiers, dtype="uint64")
         except ValueError:
-            _send_warning("Only integer identifiers supported", 1)
+            _send_warning_or_raise("Only integer identifiers supported", 1)
 
     box2d_format = Box2DFormat.XYWH
     if rect_format == RectFormat.XYWH:

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/tensor.py
@@ -9,7 +9,7 @@ from rerun._log import log
 from rerun.any_value import AnyValues
 from rerun.archetypes import BarChart, Tensor
 from rerun.datatypes.tensor_data import TensorData, TensorDataLike
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
 
@@ -69,7 +69,9 @@ def log_tensor(
 
     """
     if meter is not None:
-        _send_warning("The `meter` argument is deprecated for use with `log_tensor`. Use `log_depth_image` instead.", 1)
+        _send_warning_or_raise(
+            "The `meter` argument is deprecated for use with `log_tensor`. Use `log_depth_image` instead.", 1
+        )
 
     _log_tensor(
         entity_path,

--- a/rerun_py/rerun_sdk/rerun/log_deprecated/transform.py
+++ b/rerun_py/rerun_sdk/rerun/log_deprecated/transform.py
@@ -17,7 +17,7 @@ from rerun.datatypes import (
     TranslationRotationScale3D,
     Vec3D,
 )
-from rerun.error_utils import _send_warning
+from rerun.error_utils import _send_warning_or_raise
 from rerun.log_deprecated.log_decorator import log_decorator
 from rerun.recording_stream import RecordingStream
 
@@ -134,10 +134,10 @@ def log_view_coordinates(
     recording = RecordingStream.to_native(recording)
 
     if xyz == "" and up == "":
-        _send_warning("You must set either 'xyz' or 'up'. Ignoring log.", 1)
+        _send_warning_or_raise("You must set either 'xyz' or 'up'. Ignoring log.", 1)
         return
     if xyz != "" and up != "":
-        _send_warning("You must set either 'xyz' or 'up', but not both. Dropping up.", 1)
+        _send_warning_or_raise("You must set either 'xyz' or 'up', but not both. Dropping up.", 1)
         up = ""
     if xyz != "":
         xyz = xyz.upper()

--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -43,4 +43,4 @@ def test_bad_any_value() -> None:
 
         assert len(batches) == 0
         assert len(warnings) == 1
-        assert "Error converting data to arrow for AnyValues 'bad_data'" in str(warnings[0].message)
+        assert "Converting data for 'bad_data':" in str(warnings[0].message)

--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -44,3 +44,57 @@ def test_bad_any_value() -> None:
         assert len(batches) == 0
         assert len(warnings) == 1
         assert "Converting data for 'bad_data':" in str(warnings[0].message)
+
+    with pytest.warns(RerunWarning) as warnings:
+        values = rr.AnyValues(good_data=1)
+
+        batches = list(values.as_component_batches())
+
+        assert len(batches) == 1
+        assert len(warnings) == 0
+
+        # Now using a different type fails
+        values = rr.AnyValues(good_data="foo")
+
+        batches = list(values.as_component_batches())
+
+        assert len(batches) == 0
+        assert len(warnings) == 1
+
+        assert "Converting data for 'good_data':" in str(warnings[0].message)
+
+
+def test_none_any_value() -> None:
+    with pytest.warns(RerunWarning) as warnings:
+        # Log as None -- ignored with no warnings
+        values = rr.AnyValues(none_data=None)
+        batches = list(values.as_component_batches())
+
+        assert len(batches) == 0
+        assert len(warnings) == 0
+
+        # Log as None -- ignored with warning
+        values = rr.AnyValues(none_data=None, drop_untyped_nones=False)
+        batches = list(values.as_component_batches())
+
+        assert len(batches) == 0
+        assert len(warnings) == 1
+
+        assert (
+            "Converting data for 'none_data': ValueError(Cannot convert None to arrow array. Type is unknown.)"
+            in str(warnings[0].message)
+        )
+
+        # Log as not None
+        values = rr.AnyValues(none_data=7, drop_untyped_nones=False)
+        batches = list(values.as_component_batches())
+
+        assert len(batches) == 1
+        assert len(warnings) == 1  # no new warnings
+
+        # Log as None is now logged successfully
+        values = rr.AnyValues(none_data=None, drop_untyped_nones=False)
+        batches = list(values.as_component_batches())
+
+        assert len(batches) == 1
+        assert len(warnings) == 1  # no new warnings

--- a/rerun_py/tests/unit/test_depth_image.py
+++ b/rerun_py/tests/unit/test_depth_image.py
@@ -72,5 +72,5 @@ def test_depth_image_shapes() -> None:
         rr.DepthImage(img)
 
     for img in BAD_IMAGE_INPUTS:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             rr.DepthImage(img)

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -88,7 +88,7 @@ def test_image_shapes() -> None:
         rr.Image(img)
 
     for img in BAD_IMAGE_INPUTS:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             rr.Image(img)
 
 

--- a/rerun_py/tests/unit/test_segmentation_image.py
+++ b/rerun_py/tests/unit/test_segmentation_image.py
@@ -69,7 +69,7 @@ def test_segmentation_image_shapes() -> None:
         rr.DepthImage(img)
 
     for img in BAD_IMAGE_INPUTS:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             rr.DepthImage(img)
 
 

--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -99,14 +99,14 @@ def test_bad_tensors() -> None:
     # TODO(jleibs) send_warning bottoms out in TypeError but these ought to be ValueErrors
 
     # Wrong number of names
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         TensorData(
             dim_names=["a", "b", "c"],
             array=RANDOM_TENSOR_SOURCE,
         ),
 
     # Shape disagrees with array
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         TensorData(
             shape=[
                 TensorDimension(8, name="a"),


### PR DESCRIPTION
### What
 - Rename `_send_warning` -> `_send_warning_or_raise` to make the behavior clearer.
 - Default to ignore Nones in AnyValues when the type is unknown. 
 - Update the docstrings.
 - Expand the unit-tests.

Resolves:
 - https://github.com/rerun-io/rerun/issues/3715
 - https://github.com/rerun-io/rerun/issues/3716


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3725) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3725)
- [Docs preview](https://rerun.io/preview/5540cb4172d7bbef4749daf200ee14672af010e7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5540cb4172d7bbef4749daf200ee14672af010e7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)