### PR TITLE
Warn/raise when passing incompatible objects to log

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -123,14 +123,24 @@ def log(
     # structural checks in performance-sensitive code. hasattr is
     if hasattr(entity, "as_component_batches"):
         components = list(entity.as_component_batches())
-    else:
+    elif isinstance(entity, Iterable):
         components = list(entity)
+    else:
+        raise TypeError(
+            f"Expected an object implementing rerun.AsComponents or an iterable of rerun.ComponentBatchLike, "
+            f"but got {type(entity)} instead."
+        )
 
     for ext in extra:
         if hasattr(ext, "as_component_batches"):
             components.extend(ext.as_component_batches())
-        else:
+        elif isinstance(ext, Iterable):
             components.extend(ext)
+        else:
+            raise TypeError(
+                f"Expected an object implementing rerun.AsComponents or an iterable of rerun.ComponentBatchLike, "
+                f"but got {type(entity)} instead."
+            )
 
     if hasattr(entity, "num_instances"):
         num_instances = entity.num_instances()

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -40,7 +40,7 @@ def test_expected_warnings() -> None:
                 "cannot reshape array of size 5 into shape (3,3))",
             ),
             (
-                rr.log("test_transform", rr.TranslationAndMat3x3(translation=[1, 0, 0])),
+                rr.log("test_transform", rr.TranslationAndMat3x3(translation=[1, 0, 0])),  # type: ignore[arg-type]
                 "Expected an object implementing rerun.AsComponents or an iterable of rerun.ComponentBatchLike, but got",
             ),
         ]

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -39,6 +39,10 @@ def test_expected_warnings() -> None:
                 rr.log("test_transform", rr.Transform3D(mat3x3=[1, 2, 3, 4, 5])),
                 "cannot reshape array of size 5 into shape (3,3))",
             ),
+            (
+                rr.log("test_transform", rr.TranslationAndMat3x3(translation=[1, 0, 0])),
+                "Expected an object implementing rerun.AsComponents or an iterable of rerun.ComponentBatchLike, but got",
+            ),
         ]
 
         assert len(warnings) == len(expected_warnings)


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/3710

Before:
```
transform3d_simple.py:11: RerunWarning: log: TypeError('TranslationAndMat3x3' object is not iterable)
  rr.log("base/translated", rr.TranslationAndMat3x3(translation=[1, 0, 0]))
```

After:
```
transform3d_simple.py:11: RerunWarning: log: TypeError(Expected an object implementing rerun.AsComponents or an iterable of rerun.ComponentBatchLike, but got <class 'rerun.datatypes.translation_and_mat3x3.TranslationAndMat3x3'> instead.)
  rr.log("base/translated", rr.TranslationAndMat3x3(translation=[1, 0, 0]))
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3727) (if applicable)

- [PR Build Summary](https://build.rerun.io/pr/3727)
- [Docs preview](https://rerun.io/preview/379b347a96593ecf6a7efc5bf7b98d3e248e5489/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/379b347a96593ecf6a7efc5bf7b98d3e248e5489/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)