### PR TITLE
Update to ewebsock 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,28 +438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,17 +1704,13 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "ewebsock"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689197e24a57aee379b3bbef527e70607fc6d4b58fae4f1d98a2c6d91503e230"
+checksum = "7340666282406cb008c4d7206e6d7e157a82486afddd26deaad3ce9ebff3f238"
 dependencies = [
- "async-stream",
- "futures",
- "futures-util",
+ "document-features",
  "js-sys",
- "tokio",
- "tokio-tungstenite",
- "tracing",
+ "log",
  "tungstenite",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5985,17 +5959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6003,12 +5966,8 @@ checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
  "tokio",
- "tokio-rustls",
  "tungstenite",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ emath = "0.23.0"
 enumset = "1.0.12"
 env_logger = "0.10"
 epaint = "0.23.0"
-ewebsock = "0.2"
+ewebsock = "0.4.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"

--- a/crates/re_data_source/src/web_sockets.rs
+++ b/crates/re_data_source/src/web_sockets.rs
@@ -35,7 +35,6 @@ pub fn connect_to_ws_url(
         }
     };
 
-    let connection = re_ws_comms::Connection::viewer_to_server(url.to_owned(), callback)?;
-    std::mem::drop(connection); // Never close the connection. TODO(emilk): is this wise?
+    re_ws_comms::viewer_to_server(url.to_owned(), callback)?;
     Ok(rx)
 }

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -35,4 +35,4 @@ crossbeam.workspace = true
 document-features.workspace = true
 rand = { workspace = true, features = ["std", "std_rng", "small_rng"] }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["net"] }

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -35,4 +35,4 @@ crossbeam.workspace = true
 document-features.workspace = true
 rand = { workspace = true, features = ["std", "std_rng", "small_rng"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["io-util", "net"] }

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -1,10 +1,10 @@
 use std::{io::ErrorKind, time::Instant};
 
 use rand::{Rng as _, SeedableRng};
+use tokio::net::{TcpListener, TcpStream};
 
 use re_log_types::{LogMsg, TimePoint, TimeType, TimelineName};
 use re_smart_channel::{Receiver, Sender};
-use tokio::net::{TcpListener, TcpStream};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ServerError {

--- a/crates/re_ws_comms/src/client.rs
+++ b/crates/re_ws_comms/src/client.rs
@@ -1,60 +1,51 @@
 use std::ops::ControlFlow;
 
-use ewebsock::{WsEvent, WsMessage, WsSender};
+use ewebsock::{WsEvent, WsMessage};
 
 // TODO(jleibs): use thiserror
 pub type Result<T> = anyhow::Result<T>;
 
-/// Represents a connection to the server.
-/// Disconnects on drop.
-#[must_use]
-pub struct Connection(WsSender);
-
-impl Connection {
-    /// Connect viewer to server
-    pub fn viewer_to_server(
-        url: String,
-        on_binary_msg: impl Fn(Vec<u8>) -> ControlFlow<()> + Send + 'static,
-    ) -> Result<Self> {
-        re_log::info!("Connecting to {url:?}…");
-        let sender = ewebsock::ws_connect(
-            url,
-            Box::new(move |event: WsEvent| match event {
-                WsEvent::Opened => {
-                    re_log::info!("Connection established");
+/// Connect viewer to server
+pub fn viewer_to_server(
+    url: String,
+    on_binary_msg: impl Fn(Vec<u8>) -> ControlFlow<()> + Send + 'static,
+) -> Result<()> {
+    re_log::info!("Connecting to {url:?}…");
+    ewebsock::ws_receive(
+        url,
+        Box::new(move |event: WsEvent| match event {
+            WsEvent::Opened => {
+                re_log::info!("Connection established");
+                ControlFlow::Continue(())
+            }
+            WsEvent::Message(message) => match message {
+                WsMessage::Binary(binary) => on_binary_msg(binary),
+                WsMessage::Text(text) => {
+                    re_log::warn!("Unexpected text message: {text:?}");
                     ControlFlow::Continue(())
                 }
-                WsEvent::Message(message) => match message {
-                    WsMessage::Binary(binary) => on_binary_msg(binary),
-                    WsMessage::Text(text) => {
-                        re_log::warn!("Unexpected text message: {text:?}");
-                        ControlFlow::Continue(())
-                    }
-                    WsMessage::Unknown(text) => {
-                        re_log::warn!("Unknown message: {text:?}");
-                        ControlFlow::Continue(())
-                    }
-                    WsMessage::Ping(_data) => {
-                        re_log::warn!("Unexpected PING");
-                        ControlFlow::Continue(())
-                    }
-                    WsMessage::Pong(_data) => {
-                        re_log::warn!("Unexpected PONG");
-                        ControlFlow::Continue(())
-                    }
-                },
-                WsEvent::Error(error) => {
-                    re_log::error!("Connection error: {error}");
-                    ControlFlow::Break(())
+                WsMessage::Unknown(text) => {
+                    re_log::warn!("Unknown message: {text:?}");
+                    ControlFlow::Continue(())
                 }
-                WsEvent::Closed => {
-                    re_log::info!("Connection to server closed.");
-                    ControlFlow::Break(())
+                WsMessage::Ping(_data) => {
+                    re_log::warn!("Unexpected PING");
+                    ControlFlow::Continue(())
                 }
-            }),
-        )
-        .map_err(|err| anyhow::format_err!("ewebsock: {err}"))?;
-
-        Ok(Self(sender))
-    }
+                WsMessage::Pong(_data) => {
+                    re_log::warn!("Unexpected PONG");
+                    ControlFlow::Continue(())
+                }
+            },
+            WsEvent::Error(error) => {
+                re_log::error!("Connection error: {error}");
+                ControlFlow::Break(())
+            }
+            WsEvent::Closed => {
+                re_log::info!("Connection to server closed.");
+                ControlFlow::Break(())
+            }
+        }),
+    )
+    .map_err(|err| anyhow::format_err!("ewebsock: {err}"))
 }

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -9,7 +9,7 @@ mod client;
 use std::{fmt::Display, str::FromStr};
 
 #[cfg(feature = "client")]
-pub use client::Connection;
+pub use client::viewer_to_server;
 
 #[cfg(feature = "server")]
 mod server;

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -70,6 +70,7 @@ impl RerunServer {
             let (tcp_stream, _) = tokio::select! {
                 res = self.listener.accept() => res?,
                 _ = shutdown_rx.recv() => {
+                    re_log::debug!("Shutting down WebSocket server");
                     return Ok(());
                 }
             };


### PR DESCRIPTION
This unblocks us from updating `tunstenite` to fix RUSTSEC-2023-0065

This also removes a few dependencies, thanks to:
* https://github.com/rerun-io/ewebsock/pull/24

I've tested that it still works.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3729) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3729)
- [Docs preview](https://rerun.io/preview/1378634af462a895fea11b44a2dd08e766ed7176/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1378634af462a895fea11b44a2dd08e766ed7176/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)