### PR TITLE
Fix return type of `entity_path!()` and `entity_path_vec!()` on empty input.

### DIFF
--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -72,12 +72,13 @@ impl From<Index> for EntityPathPart {
 /// Build a `Vec<EntityPathPart>`:
 /// ```
 /// # use re_log_types::*;
-/// entity_path_vec!("foo", Index::Sequence(123));
+/// let parts: Vec<EntityPathPart> = entity_path_vec!("foo", Index::Sequence(123));
 /// ```
 #[macro_export]
 macro_rules! entity_path_vec {
     () => {
-        vec![]
+        // A vector of no elements that nevertheless has the expected concrete type.
+        ::std::vec::Vec::<$crate::EntityPathPart>::new()
     };
     ($($part: expr),* $(,)?) => {
         vec![ $($crate::EntityPathPart::from($part),)+ ]
@@ -87,14 +88,23 @@ macro_rules! entity_path_vec {
 /// Build a `EntityPath`:
 /// ```
 /// # use re_log_types::*;
-/// entity_path!("foo", Index::Sequence(123));
+/// let path: EntityPath = entity_path!("foo", Index::Sequence(123));
 /// ```
 #[macro_export]
 macro_rules! entity_path {
-    () => {
-        vec![]
-    };
     ($($part: expr),* $(,)?) => {
-        $crate::EntityPath::from(vec![ $($crate::EntityPathPart::from($part),)+ ])
+        $crate::EntityPath::from($crate::entity_path_vec![ $($part,)* ])
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entity_path_macros_empty() {
+        // If the type weren't constrained, this would be an ambiguous type error.
+        assert_eq!(entity_path_vec!(), vec![]);
+        assert_eq!(entity_path!(), EntityPath::from(vec![]));
+    }
 }


### PR DESCRIPTION
### What

Previously,

* `entity_path!()` would return a `Vec` instead of an `EntityPath`.
* `entity_path_vec!()` would return a `Vec` of unknown element type.

Now `entity_path_vec!` always returns a typed vector and `entity_path!`
makes use of `entity_path_vec!`.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] I've included a screenshot or gif (if applicable)
* [X] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3734) (if applicable)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3734)
- [Docs preview](https://rerun.io/preview/2c7e66c0c6c8277fd4e83de1efb3f61852a7ccba/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2c7e66c0c6c8277fd4e83de1efb3f61852a7ccba/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)