### PR TITLE
rr.ClearEntity -> rr.Clear in docs

### DIFF
--- a/docs/content/howto/short-lived-entities.md
+++ b/docs/content/howto/short-lived-entities.md
@@ -6,7 +6,7 @@ description: How to log data that isn't valid for the whole recording
 In order to create coherent views of streaming data, the Rerun Viewer shows the latest values for each visible entity at the current timepoint. But some data may not be valid for the entire recording even if there are no updated values. How do you tell Rerun that something you've logged should no longer be shown?
 
 ## Log entities as cleared
-The most straight forward option is to explicitly log that an entity has been cleared. Rerun allows you to do this by logging a special `ClearEntity` to any path. The timepoint at which the `ClearEntity` is logged is the time point after which that entity will no longer be visible in your views.
+The most straight forward option is to explicitly log that an entity has been cleared. Rerun allows you to do this by logging a special `Clear` to any path. The timepoint at which the `Clear` is logged is the time point after which that entity will no longer be visible in your views.
 
 For example, if you have an object tracking application, your code might look something like this:
 ```python
@@ -19,7 +19,7 @@ for frame in sensors.read():
     if tracker.is_lost:
         # Clear everything on or below `tracked/{tracker.id}`
         # and that happened on or before `frame == frame.id`
-        rr.log(f"tracked/{tracker.id}", rr.ClearEntity(recursive=True))
+        rr.log(f"tracked/{tracker.id}", rr.Clear(recursive=True))
     else:
         # Log data to the main entity and a child entity
         rr.log(f"tracked/{tracker.id}", rr.Rect2D(tracker.bounds))
@@ -44,7 +44,7 @@ for frame in sensors.read():
         # same frequency as the input data and thus look strange
         rr.log("input/detections", rr.Rect2D(detection.bounds))
 ```
-You could fix this example by logging `rr.ClearEntity`, but in this case it makes more sense to change what you log to better express what is happening. Re-logging the image to another namespace on only the frames where the detection runs makes it explicit which frame was used as the input to the detector. This will create a second view in the viewer that always allows you to see the frame that was used for the current detection input.
+You could fix this example by logging `rr.Clear`, but in this case it makes more sense to change what you log to better express what is happening. Re-logging the image to another namespace on only the frames where the detection runs makes it explicit which frame was used as the input to the detector. This will create a second view in the viewer that always allows you to see the frame that was used for the current detection input.
 
 Here is an example fix:
 ```python
@@ -88,5 +88,5 @@ rr.log("short_lived", rr.Tensor(one_second_tensor))
 rr.set_time_seconds("time", start_time + 1.0)
 # Set the time back so other data isn't accidentally logged in the future.
 rr.set_time_seconds("time", start_time)
-rr.log("short_lived", rr.ClearEntity())
+rr.log("short_lived", rr.Clear(recursive=False))  # or `rr.Clear.flat()`
 ```


### PR DESCRIPTION
### What
We forgot to update the code in the how-to guide from `rr.ClearEntity` to `rr.Clear` when we changed the name. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3740) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3740)
- [Docs preview](https://rerun.io/preview/7bd1d3138bbe2fddcf0ef744a44419bf1876a325/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7bd1d3138bbe2fddcf0ef744a44419bf1876a325/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)