### PR TITLE
Add docs about 'rerun/' being reserved

### DIFF
--- a/docs/content/concepts/entity-path.md
+++ b/docs/content/concepts/entity-path.md
@@ -31,7 +31,7 @@ rr.log("camera/image/detections/points", rr.Points2D(points))
 ```
 Nothing needs to be explicitly logged to `"camera"` or `"camera/image/detection"` to make the above valid.
 
-#### Path parts
+### Path parts
 
 A path can look like this: `camera/"Left"/detection/#42/bbox`. Each part (between the slashes) can either be:
 
@@ -55,3 +55,7 @@ the relationship between that entity and its direct parent.
  * In the future, it will also be possible to use path-hierarchy to set default-values for descendants
    ([#1158](https://github.com/rerun-io/rerun/issues/1158)).
 
+### Reserved Paths
+
+The path prefix "rerun/" is considered reserved for use by the Rerun SDK itself and should not be used for logging
+user data. This is where Rerun will log additional information such as warnings.

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -68,6 +68,11 @@ def log(
     that implements the [`rerun.AsComponents`][] interface, or a collection of `ComponentBatchLike`
     objects.
 
+    When logging data, you must always provide an [entity_path](https://www.rerun.io/docs/concepts/entity-path)
+    for identifying the data. Note that the path prefix "rerun/" is considered reserved for use by the Rerun SDK
+    itself and should not be used for logging user data. This is where Rerun will log additional information
+    such as warnings.
+
     The most common way to log is with one of the rerun archetypes, all of which implement
     the `AsComponents` interface.
 


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3571

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3747) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3747)
- [Docs preview](https://rerun.io/preview/141c8f0ce82efab3eef025470992ae882f04aa45/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/141c8f0ce82efab3eef025470992ae882f04aa45/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)