### PR TITLE
Display space views using view coordinates from closest ancestor.

### DIFF
--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -325,8 +325,8 @@ pub fn view_3d(
     let view_coordinates = ctx
         .store_db
         .store()
-        .query_latest_component(query.space_origin, &ctx.current_query())
-        .map(|c| c.value);
+        .query_latest_component_at_closest_ancestor(query.space_origin, &ctx.current_query())
+        .map(|(_, c)| c.value);
 
     let (rect, mut response) =
         ui.allocate_at_least(ui.available_size(), egui::Sense::click_and_drag());

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -325,6 +325,8 @@ pub fn view_3d(
     let view_coordinates = ctx
         .store_db
         .store()
+        // Allow logging view-coordinates to `/` and have it apply to `/world` etc.
+        // See https://github.com/rerun-io/rerun/issues/3538        
         .query_latest_component_at_closest_ancestor(query.space_origin, &ctx.current_query())
         .map(|(_, c)| c.value);
 

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -326,7 +326,7 @@ pub fn view_3d(
         .store_db
         .store()
         // Allow logging view-coordinates to `/` and have it apply to `/world` etc.
-        // See https://github.com/rerun-io/rerun/issues/3538        
+        // See https://github.com/rerun-io/rerun/issues/3538
         .query_latest_component_at_closest_ancestor(query.space_origin, &ctx.current_query())
         .map(|(_, c)| c.value);
 


### PR DESCRIPTION
### What
View coordinates are a bit special -- we want to respect them even if they are not explicitly part of the given space-view.

Resolves: https://github.com/rerun-io/rerun/issues/3538

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3748) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3748)
- [Docs preview](https://rerun.io/preview/ea7380bd1404e786eb1f733fa81ac7a06902b677/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ea7380bd1404e786eb1f733fa81ac7a06902b677/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)