### PR TITLE
Only grow 3d view bounds with projected image if image plane has been user-edited

### DIFF
--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -130,7 +130,10 @@ fn update_pinhole_property_heuristics(
             let default_image_plane_distance = if scene_size.is_finite() && scene_size > 0.0 {
                 scene_size * 0.02 // Works pretty well for `examples/python/open_photogrammetry_format/main.py --no-frames`
             } else {
-                1.0
+                // This value somewhat arbitrary. In almost all cases where the scene has defined bounds
+                // the heuristic will change it or it will be user edited. In the case of non-defined bounds
+                // this value works better with the default camera setup.
+                0.3
             };
             properties.pinhole_image_plane_distance =
                 EditableAutoValue::Auto(default_image_plane_distance);

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -274,9 +274,9 @@ impl ImagesPart {
                 color.into(),
             ) {
                 // Only update the bounding box if the image_plane_distance is not auto.
-                // This is because in auto mode the bounds will change the image plane heuristic,
-                // and there's no good reason to grow the size of the bounds only to the shrink
-                // the image plane as a result.
+                // This is avoids a cyclic relationship where the image plane grows the bounds
+                // which in turn influence the size of the image plane.
+                // See: https://github.com/rerun-io/rerun/issues/3728
                 if !ent_props.pinhole_image_plane_distance.is_auto() {
                     self.extend_bbox(&textured_rect);
                 }
@@ -400,9 +400,9 @@ impl ImagesPart {
                 color.into(),
             ) {
                 // Only update the bounding box if the image_plane_distance is not auto.
-                // This is because in auto mode the bounds will change the image plane heuristic,
-                // and there's no good reason to grow the size of the bounds only to the shrink
-                // the image plane as a result.
+                // This is avoids a cyclic relationship where the image plane grows the bounds
+                // which in turn influence the size of the image plane.
+                // See: https://github.com/rerun-io/rerun/issues/3728
                 if !ent_props.pinhole_image_plane_distance.is_auto() {
                     self.extend_bbox(&textured_rect);
                 }
@@ -494,9 +494,9 @@ impl ImagesPart {
                 color.into(),
             ) {
                 // Only update the bounding box if the image_plane_distance is not auto.
-                // This is because in auto mode the bounds will change the image plane heuristic,
-                // and there's no good reason to grow the size of the bounds only to the shrink
-                // the image plane as a result.
+                // This is avoids a cyclic relationship where the image plane grows the bounds
+                // which in turn influence the size of the image plane.
+                // See: https://github.com/rerun-io/rerun/issues/3728
                 if !ent_props.pinhole_image_plane_distance.is_auto() {
                     self.extend_bbox(&textured_rect);
                 }

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -205,7 +205,7 @@ impl ImagesPart {
         &mut self,
         ctx: &ViewerContext<'_>,
         transforms: &TransformContext,
-        _ent_props: &EntityProperties,
+        ent_props: &EntityProperties,
         arch_view: &ArchetypeView<Image>,
         ent_path: &EntityPath,
         ent_context: &SpatialSceneEntityContext<'_>,
@@ -273,7 +273,13 @@ impl ImagesPart {
                 meaning,
                 color.into(),
             ) {
-                self.extend_bbox(&textured_rect);
+                // Only update the bounding box if the image_plane_distance is not auto.
+                // This is because in auto mode the bounds will change the image plane heuristic,
+                // and there's no good reason to grow the size of the bounds only to the shrink
+                // the image plane as a result.
+                if !ent_props.pinhole_image_plane_distance.is_auto() {
+                    self.extend_bbox(&textured_rect);
+                }
 
                 self.images.push(ViewerImage {
                     ent_path: ent_path.clone(),
@@ -393,7 +399,13 @@ impl ImagesPart {
                 meaning,
                 color.into(),
             ) {
-                self.extend_bbox(&textured_rect);
+                // Only update the bounding box if the image_plane_distance is not auto.
+                // This is because in auto mode the bounds will change the image plane heuristic,
+                // and there's no good reason to grow the size of the bounds only to the shrink
+                // the image plane as a result.
+                if !ent_props.pinhole_image_plane_distance.is_auto() {
+                    self.extend_bbox(&textured_rect);
+                }
 
                 self.images.push(ViewerImage {
                     ent_path: ent_path.clone(),
@@ -414,7 +426,7 @@ impl ImagesPart {
         &mut self,
         ctx: &ViewerContext<'_>,
         transforms: &TransformContext,
-        _ent_props: &EntityProperties,
+        ent_props: &EntityProperties,
         arch_view: &ArchetypeView<SegmentationImage>,
         ent_path: &EntityPath,
         ent_context: &SpatialSceneEntityContext<'_>,
@@ -481,7 +493,13 @@ impl ImagesPart {
                 meaning,
                 color.into(),
             ) {
-                self.extend_bbox(&textured_rect);
+                // Only update the bounding box if the image_plane_distance is not auto.
+                // This is because in auto mode the bounds will change the image plane heuristic,
+                // and there's no good reason to grow the size of the bounds only to the shrink
+                // the image plane as a result.
+                if !ent_props.pinhole_image_plane_distance.is_auto() {
+                    self.extend_bbox(&textured_rect);
+                }
 
                 self.images.push(ViewerImage {
                     ent_path: ent_path.clone(),


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3728

Previously if just logging a pinhole, the projected image rectangle would cause the accumulated bounding box to increase, but then the heuristic would cause it to shrink again.

This changes that behavior to only happen in the event that the image plane has been user-edited (in which case the heuristic no longer applies). This gives us somewhat of the best of both worlds where the bounds can't impact themselves, but if a user increases them manually then the bounding box will still grow appropriately.

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/571a47c6-b2c9-4058-828e-942e1d331a3c)


After:
![image](https://github.com/rerun-io/rerun/assets/3312232/82e8d123-a8e4-4036-8144-b60723ddca29)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3749) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3749)
- [Docs preview](https://rerun.io/preview/d35e59586cfc3fb3e8c0f51d5fd1bad06f4fef1e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d35e59586cfc3fb3e8c0f51d5fd1bad06f4fef1e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)