### PR TITLE
Update `winit` to 0.28.7 (addresses a Sonoma-related UI glitch on startup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7043,9 +7043,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"
-version = "0.28.6"
+version = "0.28.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
+checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ wasm-bindgen-futures = "0.4.33"
 web-sys = "0.3.61"
 web-time = "0.2.0"
 webbrowser = "0.8"
-winit = "0.28.1"
+winit = "0.28.7"
 # TODO(andreas): Try to get rid of `fragile-send-sync-non-atomic-wasm`. This requires re_renderer being aware of single-thread restriction on resources.
 # See also https://gpuweb.github.io/gpuweb/explainer/#multithreading-transfer (unsolved part of the Spec as of writing!)
 wgpu = { version = "0.17.0", features = ["fragile-send-sync-non-atomic-wasm"] }


### PR DESCRIPTION
### What

winit had a macOS Sonoma issue related to windows size that would yield this sort of UI on launch:

<img width="1974" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/a2659416-ec6c-412e-8a84-3e1ac0f1ebd4">

It has been addressed in the latest release (see https://github.com/rust-windowing/winit/issues/2876), which this PR updates to.
 
Fixes #3761 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3763) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3763)
- [Docs preview](https://rerun.io/preview/ff2bed3995a12ebb34503ce4c787cbf51f278819/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ff2bed3995a12ebb34503ce4c787cbf51f278819/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)