### PR TITLE
Remove unused `.isort.cfg` file

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-profile=black


### PR DESCRIPTION
### What

This file dates back from when we were using `isort` (now superseded by `ruff`), and is not useful.

Fixes https://github.com/rerun-io/rerun/issues/3636

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3765) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3765)
- [Docs preview](https://rerun.io/preview/38604f4b335ed9a5b2b109f28643f8b8e22b789e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/38604f4b335ed9a5b2b109f28643f8b8e22b789e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)