### PR TITLE
Fix performance regression when viewing images and tensors

### DIFF
--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -38,6 +38,7 @@ pub mod test_util;
 pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
 pub use self::store_gc::{Deleted, GarbageCollectionOptions, GarbageCollectionTarget};
+pub use self::store_helpers::VersionedComponent;
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats, EntityStats};
 pub use self::store_write::{WriteError, WriteResult};

--- a/crates/re_data_store/src/instance_path.rs
+++ b/crates/re_data_store/src/instance_path.rs
@@ -123,7 +123,7 @@ fn test_parse_instance_path() {
 /// Hashes of the components of an [`InstancePath`].
 ///
 /// This is unique to either a specific instance of an entity, or the whole entity (splat).
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Eq)]
 pub struct InstancePathHash {
     pub entity_path_hash: EntityPathHash,
 
@@ -133,6 +133,21 @@ pub struct InstancePathHash {
     ///
     /// Note that this is NOT hashed, because we don't need to (it's already small).
     pub instance_key: InstanceKey,
+}
+
+impl std::fmt::Debug for InstancePathHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            entity_path_hash,
+            instance_key,
+        } = self;
+        write!(
+            f,
+            "InstancePathHash({:016X}, {})",
+            entity_path_hash.hash64(),
+            instance_key.0
+        )
+    }
 }
 
 impl std::hash::Hash for InstancePathHash {

--- a/crates/re_data_store/src/versioned_instance_path.rs
+++ b/crates/re_data_store/src/versioned_instance_path.rs
@@ -47,10 +47,23 @@ impl std::fmt::Display for VersionedInstancePath {
 ///
 /// The easiest way to construct this type is to use either [`crate::InstancePathHash::versioned`]
 /// or [`crate::VersionedInstancePath::hash`].
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Eq)]
 pub struct VersionedInstancePathHash {
     pub instance_path_hash: InstancePathHash,
     pub row_id: RowId,
+}
+
+impl std::fmt::Debug for VersionedInstancePathHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            instance_path_hash,
+            row_id,
+        } = self;
+        write!(
+            f,
+            "VersionedInstancePathHash({instance_path_hash:?}, {row_id})"
+        )
+    }
 }
 
 impl std::hash::Hash for VersionedInstancePathHash {

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -32,7 +32,7 @@ impl EntityDataUi for re_types::components::TensorData {
     ) {
         re_tracing::profile_function!();
 
-        let row_id = ctx
+        let tensor_data_row_id = ctx
             .store_db
             .entity_db
             .data_store
@@ -40,10 +40,11 @@ impl EntityDataUi for re_types::components::TensorData {
             .map_or(RowId::ZERO, |tensor| tensor.row_id);
 
         // NOTE: Tensors don't support batches at the moment so always splat.
-        let tensor_path_hash = InstancePathHash::entity_splat(entity_path).versioned(row_id);
+        let tensor_path_hash =
+            InstancePathHash::entity_splat(entity_path).versioned(tensor_data_row_id);
         let decoded = ctx
             .cache
-            .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash, self.0.clone()));
+            .entry(|c: &mut TensorDecodeCache| c.entry(tensor_data_row_id, self.0.clone()));
         match decoded {
             Ok(decoded) => {
                 let annotations = crate::annotations(ctx, query, entity_path);
@@ -80,7 +81,7 @@ fn tensor_ui(
     // Even if not, we will show info about the tensor.
     let tensor_stats = ctx
         .cache
-        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash, tensor));
+        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
     let debug_name = entity_path.to_string();
 
     let meaning = image_meaning_for_entity(entity_path, ctx);

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -1,7 +1,6 @@
 use egui::{Color32, Vec2};
 use itertools::Itertools as _;
 
-use re_data_store::{InstancePathHash, VersionedInstancePathHash};
 use re_log_types::RowId;
 use re_renderer::renderer::ColormappedTexture;
 use re_types::components::{ClassId, DepthMeter};
@@ -39,9 +38,6 @@ impl EntityDataUi for re_types::components::TensorData {
             .query_latest_component::<re_types::components::TensorData>(entity_path, query)
             .map_or(RowId::ZERO, |tensor| tensor.row_id);
 
-        // NOTE: Tensors don't support batches at the moment so always splat.
-        let tensor_path_hash =
-            InstancePathHash::entity_splat(entity_path).versioned(tensor_data_row_id);
         let decoded = ctx
             .cache
             .entry(|c: &mut TensorDecodeCache| c.entry(tensor_data_row_id, self.0.clone()));
@@ -54,7 +50,7 @@ impl EntityDataUi for re_types::components::TensorData {
                     verbosity,
                     entity_path,
                     &annotations,
-                    tensor_path_hash,
+                    tensor_data_row_id,
                     &self.0,
                     &decoded,
                 );
@@ -73,7 +69,7 @@ fn tensor_ui(
     verbosity: UiVerbosity,
     entity_path: &re_data_store::EntityPath,
     annotations: &Annotations,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     original_tensor: &TensorData,
     tensor: &DecodedTensor,
 ) {
@@ -81,7 +77,7 @@ fn tensor_ui(
     // Even if not, we will show info about the tensor.
     let tensor_stats = ctx
         .cache
-        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
+        .entry(|c: &mut TensorStatsCache| c.entry(tensor_data_row_id, tensor));
     let debug_name = entity_path.to_string();
 
     let meaning = image_meaning_for_entity(entity_path, ctx);
@@ -98,7 +94,7 @@ fn tensor_ui(
     let texture_result = gpu_bridge::tensor_to_gpu(
         ctx.render_ctx,
         &debug_name,
-        tensor_path_hash,
+        tensor_data_row_id,
         tensor,
         meaning,
         &tensor_stats,
@@ -200,7 +196,7 @@ fn tensor_ui(
                             ctx.render_ctx,
                             ui,
                             response,
-                            tensor_path_hash,
+                            tensor_data_row_id,
                             tensor,
                             &tensor_stats,
                             annotations,
@@ -424,7 +420,7 @@ fn show_zoomed_image_region_tooltip(
     render_ctx: &mut re_renderer::RenderContext,
     parent_ui: &egui::Ui,
     response: egui::Response,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     tensor: &DecodedTensor,
     tensor_stats: &TensorStats,
     annotations: &Annotations,
@@ -457,7 +453,7 @@ fn show_zoomed_image_region_tooltip(
                     show_zoomed_image_region(
                         render_ctx,
                         ui,
-                        tensor_path_hash,
+                        tensor_data_row_id,
                         tensor,
                         tensor_stats,
                         annotations,
@@ -513,7 +509,7 @@ pub fn show_zoomed_image_region_area_outline(
 pub fn show_zoomed_image_region(
     render_ctx: &mut re_renderer::RenderContext,
     ui: &mut egui::Ui,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     tensor: &DecodedTensor,
     tensor_stats: &TensorStats,
     annotations: &Annotations,
@@ -525,7 +521,7 @@ pub fn show_zoomed_image_region(
     if let Err(err) = try_show_zoomed_image_region(
         render_ctx,
         ui,
-        tensor_path_hash,
+        tensor_data_row_id,
         tensor,
         tensor_stats,
         annotations,
@@ -543,7 +539,7 @@ pub fn show_zoomed_image_region(
 fn try_show_zoomed_image_region(
     render_ctx: &mut re_renderer::RenderContext,
     ui: &mut egui::Ui,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     tensor: &DecodedTensor,
     tensor_stats: &TensorStats,
     annotations: &Annotations,
@@ -559,7 +555,7 @@ fn try_show_zoomed_image_region(
     let texture = gpu_bridge::tensor_to_gpu(
         render_ctx,
         debug_name,
-        tensor_path_hash,
+        tensor_data_row_id,
         tensor,
         meaning,
         tensor_stats,

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -151,10 +151,8 @@ pub struct TextureManager2D {
 
 #[derive(Default)]
 struct Inner {
-    /// Caches textures using a `VersionedInstancePathHash`, i.e. a specific instance of a specific
-    /// entity path for a specific row in the store.
-    ///
-    /// For dependency reasons, the versioned path has to be provided pre-hashed as a u64 by the user.
+    /// Caches textures using a unique id, which in practice is the hash of the
+    /// row id of the tensor data (`tensor_data_row_id`).
     ///
     /// Any texture which wasn't accessed on the previous frame is ejected from the cache
     /// during [`Self::begin_frame`].

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -71,7 +71,7 @@ fn to_textured_rect(
     let debug_name = ent_path.to_string();
     let tensor_stats = ctx
         .cache
-        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash, tensor));
+        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
 
     match gpu_bridge::tensor_to_gpu(
         ctx.render_ctx,
@@ -239,12 +239,13 @@ impl ImagesPart {
                 return Ok(());
             }
 
+            let tensor_data_row_id = arch_view.primary_row_id();
             // NOTE: Tensors don't support batches at the moment so always splat.
             let tensor_path_hash =
-                InstancePathHash::entity_splat(ent_path).versioned(arch_view.primary_row_id());
+                InstancePathHash::entity_splat(ent_path).versioned(tensor_data_row_id);
             let tensor = match ctx
                 .cache
-                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash, tensor.0))
+                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_data_row_id, tensor.0))
             {
                 Ok(tensor) => tensor,
                 Err(err) => {
@@ -330,12 +331,13 @@ impl ImagesPart {
                 return Ok(());
             }
 
+            let tensor_data_row_id = arch_view.primary_row_id();
             // NOTE: Tensors don't support batches at the moment so always splat.
             let tensor_path_hash =
-                InstancePathHash::entity_splat(ent_path).versioned(arch_view.primary_row_id());
+                InstancePathHash::entity_splat(ent_path).versioned(tensor_data_row_id);
             let tensor = match ctx
                 .cache
-                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash, tensor.0))
+                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_data_row_id, tensor.0))
             {
                 Ok(tensor) => tensor,
                 Err(err) => {
@@ -447,12 +449,13 @@ impl ImagesPart {
                 return Ok(());
             }
 
+            let tensor_data_row_id = arch_view.primary_row_id();
             // NOTE: Tensors don't support batches at the moment so always splat.
             let tensor_path_hash =
                 InstancePathHash::entity_splat(ent_path).versioned(arch_view.primary_row_id());
             let tensor = match ctx
                 .cache
-                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash, tensor.0))
+                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_data_row_id, tensor.0))
             {
                 Ok(tensor) => tensor,
                 Err(err) => {
@@ -543,7 +546,7 @@ impl ImagesPart {
         let debug_name = ent_path.to_string();
         let tensor_stats = ctx
             .cache
-            .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash, tensor));
+            .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
         let depth_texture = re_viewer_context::gpu_bridge::depth_tensor_to_gpu(
             ctx.render_ctx,
             &debug_name,

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -621,7 +621,7 @@ pub fn picking(
                             ui_clip_rect,
                             coords,
                             space_from_ui,
-                            tensor_path_hash,
+                            tensor_path_hash.row_id,
                             annotations,
                             meaning,
                             meter,
@@ -682,7 +682,7 @@ fn image_hover_ui(
     ui_clip_rect: egui::Rect,
     coords: [u32; 2],
     space_from_ui: egui::emath::RectTransform,
-    tensor_path_hash: re_data_store::VersionedInstancePathHash,
+    tensor_data_row_id: re_log_types::RowId,
     annotations: &AnnotationSceneContext,
     meaning: TensorDataMeaning,
     meter: Option<f32>,
@@ -720,17 +720,17 @@ fn image_hover_ui(
 
             let decoded_tensor = ctx
                 .cache
-                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash.row_id, tensor.0));
+                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_data_row_id, tensor.0));
             match decoded_tensor {
                 Ok(decoded_tensor) => {
                     let annotations = annotations.0.find(&instance_path.entity_path);
                     let tensor_stats = ctx.cache.entry(|c: &mut TensorStatsCache| {
-                        c.entry(tensor_path_hash.row_id, &decoded_tensor)
+                        c.entry(tensor_data_row_id, &decoded_tensor)
                     });
                     show_zoomed_image_region(
                         ctx.render_ctx,
                         ui,
-                        tensor_path_hash,
+                        tensor_data_row_id,
                         &decoded_tensor,
                         &tensor_stats,
                         &annotations,

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -720,12 +720,12 @@ fn image_hover_ui(
 
             let decoded_tensor = ctx
                 .cache
-                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash, tensor.0));
+                .entry(|c: &mut TensorDecodeCache| c.entry(tensor_path_hash.row_id, tensor.0));
             match decoded_tensor {
                 Ok(decoded_tensor) => {
                     let annotations = annotations.0.find(&instance_path.entity_path);
                     let tensor_stats = ctx.cache.entry(|c: &mut TensorStatsCache| {
-                        c.entry(tensor_path_hash, &decoded_tensor)
+                        c.entry(tensor_path_hash.row_id, &decoded_tensor)
                     });
                     show_zoomed_image_region(
                         ctx.render_ctx,

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -101,7 +101,7 @@ impl PerTensorState {
 
         let tensor_stats = ctx
             .cache
-            .entry(|c: &mut TensorStatsCache| c.entry(*tensor_path_hash, tensor));
+            .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
         ctx.re_ui
             .selection_grid(ui, "tensor_selection_ui")
             .show(ui, |ui| {
@@ -327,7 +327,7 @@ fn paint_tensor_slice(
 
     let tensor_stats = ctx
         .cache
-        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash, tensor));
+        .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
     let colormapped_texture = super::tensor_slice_to_gpu::colormapped_texture(
         ctx.render_ctx,
         tensor_path_hash,

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -4,8 +4,6 @@ use eframe::emath::Align2;
 use egui::{epaint::TextShape, NumExt as _, Vec2};
 use ndarray::Axis;
 
-use re_data_store::InstancePath;
-use re_data_store::VersionedInstancePathHash;
 use re_data_ui::tensor_summary_ui_grid_contents;
 use re_log_types::{EntityPath, RowId};
 use re_renderer::Colormap;
@@ -14,11 +12,10 @@ use re_types::{
     datatypes::{TensorData, TensorDimension},
     tensor_data::{DecodedTensor, TensorDataMeaning},
 };
-use re_viewer_context::gpu_bridge::colormap_dropdown_button_ui;
 use re_viewer_context::{
-    gpu_bridge, SpaceViewClass, SpaceViewClassName, SpaceViewClassRegistryError, SpaceViewId,
-    SpaceViewState, SpaceViewSystemExecutionError, TensorStatsCache, ViewContextCollection,
-    ViewPartCollection, ViewQuery, ViewerContext,
+    gpu_bridge, gpu_bridge::colormap_dropdown_button_ui, SpaceViewClass, SpaceViewClassName,
+    SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewSystemExecutionError,
+    TensorStatsCache, ViewContextCollection, ViewPartCollection, ViewQuery, ViewerContext,
 };
 
 use crate::{tensor_dimension_mapper::dimension_mapping_ui, view_part_system::TensorSystem};
@@ -29,9 +26,9 @@ pub struct TensorSpaceView;
 #[derive(Default)]
 pub struct ViewTensorState {
     /// Selects in [`Self::state_tensors`].
-    pub selected_tensor: Option<InstancePath>,
+    pub selected_tensor: Option<EntityPath>,
 
-    pub state_tensors: ahash::HashMap<InstancePath, PerTensorState>,
+    pub state_tensors: ahash::HashMap<EntityPath, PerTensorState>,
 }
 
 impl SpaceViewState for ViewTensorState {
@@ -66,14 +63,11 @@ pub struct PerTensorState {
 
     /// Last viewed tensor, copied each frame.
     /// Used for the selection view.
-    tensor: Option<(VersionedInstancePathHash, DecodedTensor)>,
+    tensor: Option<(RowId, DecodedTensor)>,
 }
 
 impl PerTensorState {
-    pub fn create(
-        tensor_path_hash: VersionedInstancePathHash,
-        tensor: &DecodedTensor,
-    ) -> PerTensorState {
+    pub fn create(tensor_data_row_id: RowId, tensor: &DecodedTensor) -> PerTensorState {
         Self {
             slice: SliceSelection {
                 dim_mapping: DimensionMapping::create(tensor.shape()),
@@ -81,7 +75,7 @@ impl PerTensorState {
             },
             color_mapping: ColorMapping::default(),
             texture_settings: TextureSettings::default(),
-            tensor: Some((tensor_path_hash, tensor.clone())),
+            tensor: Some((tensor_data_row_id, tensor.clone())),
         }
     }
 
@@ -94,14 +88,14 @@ impl PerTensorState {
     }
 
     pub fn ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
-        let Some((tensor_path_hash, tensor)) = &self.tensor else {
+        let Some((tensor_data_row_id, tensor)) = &self.tensor else {
             ui.label("No Tensor shown in this Space View.");
             return;
         };
 
         let tensor_stats = ctx
             .cache
-            .entry(|c: &mut TensorStatsCache| c.entry(tensor_path_hash.row_id, tensor));
+            .entry(|c: &mut TensorStatsCache| c.entry(*tensor_data_row_id, tensor));
         ctx.re_ui
             .selection_grid(ui, "tensor_selection_ui")
             .show(ui, |ui| {
@@ -224,13 +218,12 @@ impl SpaceViewClass for TensorSpaceView {
             }
 
             if let Some(selected_tensor) = &state.selected_tensor {
-                if let Some((row_id, tensor)) = tensors.get(selected_tensor) {
-                    let tensor_path_hash = selected_tensor.hash().versioned(*row_id);
+                if let Some((tensor_data_row_id, tensor)) = tensors.get(selected_tensor) {
                     let state_tensor = state
                         .state_tensors
                         .entry(selected_tensor.clone())
-                        .or_insert_with(|| PerTensorState::create(tensor_path_hash, tensor));
-                    view_tensor(ctx, ui, state_tensor, tensor_path_hash, tensor);
+                        .or_insert_with(|| PerTensorState::create(*tensor_data_row_id, tensor));
+                    view_tensor(ctx, ui, state_tensor, *tensor_data_row_id, tensor);
                 }
             }
         }
@@ -243,12 +236,12 @@ fn view_tensor(
     ctx: &mut ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut PerTensorState,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     tensor: &DecodedTensor,
 ) {
     re_tracing::profile_function!();
 
-    state.tensor = Some((tensor_path_hash, tensor.clone()));
+    state.tensor = Some((tensor_data_row_id, tensor.clone()));
 
     if !state.slice.dim_mapping.is_valid(tensor.num_dim()) {
         state.slice.dim_mapping = DimensionMapping::create(tensor.shape());
@@ -289,14 +282,9 @@ fn view_tensor(
     };
 
     egui::ScrollArea::both().show(ui, |ui| {
-        if let Err(err) = tensor_slice_ui(
-            ctx,
-            ui,
-            state,
-            tensor_path_hash.row_id,
-            tensor,
-            dimension_labels,
-        ) {
+        if let Err(err) =
+            tensor_slice_ui(ctx, ui, state, tensor_data_row_id, tensor, dimension_labels)
+        {
             ui.label(ctx.re_ui.error_text(err.to_string()));
         }
     });

--- a/crates/re_space_view_tensor/src/tensor_slice_to_gpu.rs
+++ b/crates/re_space_view_tensor/src/tensor_slice_to_gpu.rs
@@ -1,4 +1,4 @@
-use re_data_store::VersionedInstancePathHash;
+use re_log_types::RowId;
 use re_renderer::{
     renderer::ColormappedTexture,
     resource_managers::{GpuTexture2D, Texture2DCreationDesc, TextureManager2DError},
@@ -25,7 +25,7 @@ pub enum TensorUploadError {
 
 pub fn colormapped_texture(
     render_ctx: &re_renderer::RenderContext,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     tensor: &DecodedTensor,
     tensor_stats: &TensorStats,
     state: &PerTensorState,
@@ -34,7 +34,8 @@ pub fn colormapped_texture(
 
     let range = tensor_data_range_heuristic(tensor_stats, tensor.dtype())
         .map_err(|err| TextureManager2DError::DataCreation(err.into()))?;
-    let texture = upload_texture_slice_to_gpu(render_ctx, tensor_path_hash, tensor, state.slice())?;
+    let texture =
+        upload_texture_slice_to_gpu(render_ctx, tensor_data_row_id, tensor, state.slice())?;
 
     let color_mapping = state.color_mapping();
 
@@ -52,11 +53,11 @@ pub fn colormapped_texture(
 
 fn upload_texture_slice_to_gpu(
     render_ctx: &re_renderer::RenderContext,
-    tensor_path_hash: VersionedInstancePathHash,
+    tensor_data_row_id: RowId,
     tensor: &DecodedTensor,
     slice_selection: &SliceSelection,
 ) -> Result<GpuTexture2D, TextureManager2DError<TensorUploadError>> {
-    let id = egui::util::hash((tensor_path_hash, slice_selection));
+    let id = egui::util::hash((tensor_data_row_id, slice_selection));
 
     gpu_bridge::try_get_or_create_texture(render_ctx, id, || {
         texture_desc_from_tensor(tensor, slice_selection)

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -1,11 +1,9 @@
 use re_arrow_store::{LatestAtQuery, VersionedComponent};
-use re_data_store::{EntityPath, EntityProperties, InstancePath};
+use re_data_store::{EntityPath, EntityProperties};
 use re_log_types::RowId;
 use re_types::{
-    archetypes::Tensor,
-    components::{InstanceKey, TensorData},
-    tensor_data::DecodedTensor,
-    Archetype, ComponentNameSet,
+    archetypes::Tensor, components::TensorData, tensor_data::DecodedTensor, Archetype,
+    ComponentNameSet,
 };
 use re_viewer_context::{
     NamedViewSystem, SpaceViewSystemExecutionError, TensorDecodeCache, ViewContextCollection,
@@ -14,7 +12,7 @@ use re_viewer_context::{
 
 #[derive(Default)]
 pub struct TensorSystem {
-    pub tensors: std::collections::BTreeMap<InstancePath, (RowId, DecodedTensor)>,
+    pub tensors: std::collections::BTreeMap<EntityPath, (RowId, DecodedTensor)>,
 }
 
 impl NamedViewSystem for TensorSystem {
@@ -75,9 +73,8 @@ impl TensorSystem {
             .entry(|c: &mut TensorDecodeCache| c.entry(tensor.row_id, tensor.value.0))
         {
             Ok(decoded_tensor) => {
-                let instance_path = InstancePath::instance(ent_path.clone(), InstanceKey(0));
                 self.tensors
-                    .insert(instance_path, (tensor.row_id, decoded_tensor));
+                    .insert(ent_path.clone(), (tensor.row_id, decoded_tensor));
             }
             Err(err) => {
                 re_log::warn_once!("Failed to decode decoding tensor at path {ent_path}: {err}");

--- a/crates/re_viewer_context/src/tensor/tensor_decode_cache.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_decode_cache.rs
@@ -1,4 +1,5 @@
 use re_data_store::VersionedInstancePathHash;
+use re_log_types::RowId;
 use re_types::{
     datatypes::TensorData,
     tensor_data::{DecodedTensor, TensorImageLoadError},
@@ -17,11 +18,11 @@ struct DecodedTensorResult {
     last_use_generation: u64,
 }
 
-/// Caches decoded tensors using a [`VersionedInstancePathHash`], i.e. a specific instance of
-/// a specific entity path for a specific row in the store.
+/// Caches decoded tensors using a [`RowId`], i.e. a specific instance of
+/// a `TensorData` component.
 #[derive(Default)]
 pub struct TensorDecodeCache {
-    cache: ahash::HashMap<VersionedInstancePathHash, DecodedTensorResult>,
+    cache: ahash::HashMap<RowId, DecodedTensorResult>,
     memory_used: u64,
     generation: u64,
 }
@@ -39,6 +40,8 @@ impl TensorDecodeCache {
         maybe_encoded_tensor: TensorData,
     ) -> Result<DecodedTensor, TensorImageLoadError> {
         re_tracing::profile_function!();
+
+        let key = key.row_id;
 
         match DecodedTensor::try_from(maybe_encoded_tensor) {
             Ok(decoded_tensor) => Ok(decoded_tensor),

--- a/crates/re_viewer_context/src/tensor/tensor_decode_cache.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_decode_cache.rs
@@ -1,4 +1,3 @@
-use re_data_store::VersionedInstancePathHash;
 use re_log_types::RowId;
 use re_types::{
     datatypes::TensorData,
@@ -31,17 +30,19 @@ pub struct TensorDecodeCache {
 impl TensorDecodeCache {
     /// Decode some [`TensorData`] if necessary and cache the result.
     ///
+    /// The key should be the `RowId` of the `TensorData`.
+    /// NOTE: `TensorData` is never batched (they are mono-components),
+    /// so we don't need the instance id here.
+    ///
     /// This is a no-op for tensors that are not compressed.
     ///
     /// Currently supports JPEG encoded tensors.
     pub fn entry(
         &mut self,
-        key: VersionedInstancePathHash,
+        key: RowId,
         maybe_encoded_tensor: TensorData,
     ) -> Result<DecodedTensor, TensorImageLoadError> {
         re_tracing::profile_function!();
-
-        let key = key.row_id;
 
         match DecodedTensor::try_from(maybe_encoded_tensor) {
             Ok(decoded_tensor) => Ok(decoded_tensor),

--- a/crates/re_viewer_context/src/tensor/tensor_stats.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_stats.rs
@@ -11,6 +11,8 @@ pub struct TensorStats {
 
 impl TensorStats {
     pub fn new(tensor: &re_types::datatypes::TensorData) -> Self {
+        re_tracing::profile_function!();
+
         use half::f16;
         use ndarray::ArrayViewD;
         use re_types::tensor_data::TensorDataType;

--- a/crates/re_viewer_context/src/tensor/tensor_stats_cache.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_stats_cache.rs
@@ -1,4 +1,3 @@
-use re_data_store::VersionedInstancePathHash;
 use re_log_types::RowId;
 use re_types::datatypes::TensorData;
 
@@ -11,9 +10,11 @@ use crate::Cache;
 pub struct TensorStatsCache(ahash::HashMap<RowId, TensorStats>);
 
 impl TensorStatsCache {
-    pub fn entry(&mut self, key: VersionedInstancePathHash, tensor: &TensorData) -> TensorStats {
+    /// The key should be the `RowId` of the `TensorData`.
+    /// NOTE: `TensorData` is never batched (they are mono-components),
+    /// so we don't need the instance id here.
+    pub fn entry(&mut self, key: RowId, tensor: &TensorData) -> TensorStats {
         re_tracing::profile_function!();
-        let key = key.row_id;
 
         *self
             .0

--- a/crates/re_viewer_context/src/tensor/tensor_stats_cache.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_stats_cache.rs
@@ -1,16 +1,20 @@
 use re_data_store::VersionedInstancePathHash;
+use re_log_types::RowId;
 use re_types::datatypes::TensorData;
 
 use super::TensorStats;
 use crate::Cache;
 
-/// Caches tensor stats using a [`VersionedInstancePathHash`], i.e. a specific instance of
-/// a specific entity path for a specific row in the store.
+/// Caches tensor stats using a [`RowId`], i.e. a specific instance of
+/// a `TensorData` component
 #[derive(Default)]
-pub struct TensorStatsCache(ahash::HashMap<VersionedInstancePathHash, TensorStats>);
+pub struct TensorStatsCache(ahash::HashMap<RowId, TensorStats>);
 
 impl TensorStatsCache {
     pub fn entry(&mut self, key: VersionedInstancePathHash, tensor: &TensorData) -> TensorStats {
+        re_tracing::profile_function!();
+        let key = key.row_id;
+
         *self
             .0
             .entry(key)


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3762

When hovering images the `InstanceKey` corresponds to the hovered pixel value (tensors are mono-components; their elements are their instances). We accidentally were using this instance key as the key for several of our caches, which means we would get constant cache misses when hovering an image, leading to huge performance degradation.

This PR switches to using `RowId` as the primary key for tensors. In particular, it is the row id of the `TensorData` component, so I call it `tensor_data_row_id` everywhere for consistency and clarity. There can never be more than on `TensorData` per row, and each row has a unique `RowId`, so this works well.

This simplifies a lot of the code too, removing most uses of `VersionedInstancePath` and `VersionedInstancePathHash`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3767) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3767)
- [Docs preview](https://rerun.io/preview/aae5c4a3a1d755e1e99e21d721188ca2b946429b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/aae5c4a3a1d755e1e99e21d721188ca2b946429b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)