### PR TITLE
Replace `list(zip(...))` with `np.stack(..., axis=1)`

### DIFF
--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -158,7 +158,7 @@ We can represent the scaffolding using a batch of 3D line strips:
 ```python
 rr.log(
     "dna/structure/scaffolding",
-    rr.LineStrips3D(list(zip(points1, points2)), colors=[128, 128, 128])
+    rr.LineStrips3D(np.stack(points1, points2, axis=1), colors=[128, 128, 128])
 )
 ```
 

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -60,7 +60,7 @@ def log_data() -> None:
     rr.log("helix/structure/left", rr.Points3D(points1, colors=colors1, radii=0.08))
     rr.log("helix/structure/right", rr.Points3D(points2, colors=colors2, radii=0.08))
 
-    rr.log("helix/structure/scaffolding", rr.LineStrips3D(list(zip(points1, points2)), colors=[128, 128, 128]))
+    rr.log("helix/structure/scaffolding", rr.LineStrips3D(np.stack((points1, points2), axis=1), colors=[128, 128, 128]))
 
     time_offsets = np.random.rand(NUM_POINTS)
     for i in range(400):

--- a/rerun_py/rerun_sdk/rerun_demo/data.py
+++ b/rerun_py/rerun_sdk/rerun_demo/data.py
@@ -81,7 +81,7 @@ def build_rect_pyramid(count=20, width=100, height=100):
     y = np.linspace(0, height, count)
     widths = np.linspace(float(width) / count, width, count)
     heights = 0.8 * np.ones(count) * height / count
-    rects = np.array(list(zip(x, y, widths, heights)))
+    rects = np.stack((x, y, widths, heights), axis=1)
     colors = turbo_colormap_data[np.linspace(0, len(turbo_colormap_data) - 1, count, dtype=int)]
 
     return RectPyramid(rects, RectFormat.XCYCWH, colors)


### PR DESCRIPTION
#3625 was already mostly addressed by #3620, but used `list(zip(...))` instead of `np.stack`. The latter seems like the better approach, since it avoids splitting up the array into lots of smaller arrays.

So this is replacing the `list(zip(...))` pattern with `np.stack(..., axis=1)`.

Closes #3625.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3768) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3768)
- [Docs preview](https://rerun.io/preview/6250711b55c9c4f6c7f28ce8bccf32c0d7c111a6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6250711b55c9c4f6c7f28ce8bccf32c0d7c111a6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)