### PR TITLE
1D tensors as bar charts

### DIFF
--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -2,7 +2,11 @@ use std::collections::BTreeMap;
 
 use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
-use re_types::{archetypes::BarChart, datatypes::TensorData, Archetype, ComponentNameSet};
+use re_types::{
+    archetypes::{BarChart, Tensor},
+    datatypes::TensorData,
+    Archetype, ComponentNameSet,
+};
 use re_viewer_context::{
     default_heuristic_filter, NamedViewSystem, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
@@ -29,7 +33,12 @@ impl ViewPartSystem for BarChartViewPartSystem {
     }
 
     fn indicator_components(&self) -> ComponentNameSet {
-        std::iter::once(BarChart::indicator().name()).collect()
+        // TODO(#3342): For now, we relax the indicator component heuristics on bar charts so that
+        // logging a 1D tensor also results in a bar chart view, rather than a broken viewer (see #3709).
+        // Ideally though, this should be implemented using an heuristic fallback mechanism.
+        [BarChart::indicator().name(), Tensor::indicator().name()]
+            .into_iter()
+            .collect()
     }
 
     fn heuristic_filter(


### PR DESCRIPTION
Relax the bar-chart view's requirements, and strengthen the tensor view's requirements:
- make bar-chart look for either `BarChartIndicator` _or_ `TensorIndicator`
- make tensor ignore anything with less than 2 dimensions (it can't display those anyway!)

---

```py
import rerun as rr
import torch
rr.init("tensor", spawn=True)
rr.log("tensor", rr.Tensor(torch.rand(10,)))
```
![image](https://github.com/rerun-io/rerun/assets/2910679/1e1e0a7a-9ded-46e1-861f-5d2197fff07d)


---

- Resolves #3709  

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3769) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3769)
- [Docs preview](https://rerun.io/preview/dcd03363c86c6242023a10c9715643cf9f601d58/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/dcd03363c86c6242023a10c9715643cf9f601d58/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)