### PR TITLE
`MediaType::guess_from_path`: enforce `.obj` extension to be Wavefront Obj

### DIFF
--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -29,7 +29,7 @@
 /// fn main() -> anyhow::Result<()> {
 ///     let args = std::env::args().collect::<Vec<_>>();
 ///     let Some(path) = args.get(1) else {
-///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
+///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
 ///     };
 ///
 ///     let (rec, storage) =

--- a/crates/re_types/src/components/media_type_ext.rs
+++ b/crates/re_types/src/components/media_type_ext.rs
@@ -73,7 +73,12 @@ impl MediaType {
         let path = path.as_ref();
 
         // `mime_guess` considers `.obj` to be a a tgif… but really it's way more likely to be an obj.
-        if path.extension().and_then(|ext| ext.to_str()) == Some("obj") {
+        if path
+            .extension()
+            .and_then(|ext| ext.to_str().map(|s| s.to_lowercase()))
+            .as_deref()
+            == Some("obj")
+        {
             return Some(Self::obj());
         }
 

--- a/crates/re_types/src/components/media_type_ext.rs
+++ b/crates/re_types/src/components/media_type_ext.rs
@@ -72,7 +72,7 @@ impl MediaType {
     pub fn guess_from_path(path: impl AsRef<std::path::Path>) -> Option<Self> {
         let path = path.as_ref();
 
-        // `mime_guess` considers `.obj` to be a a tgif... but really it's way more likely to be an obj.
+        // `mime_guess` considers `.obj` to be a a tgif… but really it's way more likely to be an obj.
         if path.extension().and_then(|ext| ext.to_str()) == Some("obj") {
             return Some(Self::obj());
         }

--- a/crates/re_types/src/components/media_type_ext.rs
+++ b/crates/re_types/src/components/media_type_ext.rs
@@ -70,6 +70,13 @@ impl MediaType {
     /// Tries to guess the media type of the file at `path` based on its extension.
     #[inline]
     pub fn guess_from_path(path: impl AsRef<std::path::Path>) -> Option<Self> {
+        let path = path.as_ref();
+
+        // `mime_guess` considers `.obj` to be a a tgif... but really it's way more likely to be an obj.
+        if path.extension().and_then(|ext| ext.to_str()) == Some("obj") {
+            return Some(Self::obj());
+        }
+
         mime_guess::from_path(path)
             .first_raw()
             .map(ToOwned::to_owned)

--- a/docs/code-examples/asset3d_simple.cpp
+++ b/docs/code-examples/asset3d_simple.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::string> args(argv, argv + argc);
 
     if (args.size() < 2) {
-        std::cerr << "Usage: " << args[0] << " <path_to_asset.[gltf|glb]>" << std::endl;
+        std::cerr << "Usage: " << args[0] << " <path_to_asset.[gltf|glb|obj]>" << std::endl;
         return 1;
     }
 

--- a/docs/code-examples/asset3d_simple.py
+++ b/docs/code-examples/asset3d_simple.py
@@ -4,7 +4,7 @@ import sys
 import rerun as rr
 
 if len(sys.argv) < 2:
-    print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb]>")
+    print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb|obj]>")
     sys.exit(1)
 
 rr.init("rerun_example_asset3d_simple", spawn=True)

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -5,7 +5,7 @@ use rerun::external::anyhow;
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
     let Some(path) = args.get(1) else {
-        anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
+        anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
     };
 
     let (rec, storage) =

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -11,6 +11,7 @@
 #include "../data_cell.hpp"
 #include "../result.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -42,7 +43,7 @@ namespace rerun {
         ///     std::vector<std::string> args(argv, argv + argc);
         ///
         ///     if (args.size() <2) {
-        ///         std::cerr <<"Usage: " <<args[0] <<" <path_to_asset.[gltf|glb]>" <<std::endl;
+        ///         std::cerr <<"Usage: " <<args[0] <<" <path_to_asset.[gltf|glb|obj]>" <<std::endl;
         ///         return 1;
         ///     }
         ///
@@ -87,6 +88,7 @@ namespace rerun {
             ) {
                 std::filesystem::path file_path(path);
                 std::string ext = file_path.extension().string();
+                std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
                 if (ext == ".glb") {
                     return rerun::components::MediaType::glb();

--- a/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -17,6 +18,7 @@ namespace rerun {
         ) {
             std::filesystem::path file_path(path);
             std::string ext = file_path.extension().string();
+            std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
             if (ext == ".glb") {
                 return rerun::components::MediaType::glb();

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -30,7 +30,7 @@ class Asset3D(Asset3DExt, Archetype):
     import rerun as rr
 
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb]>")
+        print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb|obj]>")
         sys.exit(1)
 
     rr.init("rerun_example_asset3d_simple", spawn=True)

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
@@ -15,7 +15,7 @@ def guess_media_type(path: str) -> MediaType | None:
 
     from ..components import MediaType
 
-    ext = Path(path).suffix
+    ext = Path(path).suffix.lower()
     if ext == ".glb":
         return MediaType.GLB
     elif ext == ".gltf":


### PR DESCRIPTION
[`mime_guess` maps `.obj` to `tgif` files...](https://github.com/abonander/mime_guess/blob/fa5759c1bed87abea7af341ab2e50f51b0599326/src/mime_types.rs#L787) but let's be real: nobody expects a `tgif` file.

This also made me realize that `mime_guess` is unmaintained and missing some important stuff (e.g. JPEG XL) and we should switch to `mime_guess2`... but for that we must first switch `egui_commonmark` to `mime_guess2` :sob:  

Also, we don't load associated mtl files when loading objs, which makes their use pretty limited...

```
$ rerun  /tmp/bm/bmw.obj
```
![image](https://github.com/rerun-io/rerun/assets/2910679/127b7be4-5b51-4450-b9cf-b246262e6c01)

- Fixes #3703

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3772) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3772)
- [Docs preview](https://rerun.io/preview/39f55fe7d1c1045ab18f7024ff23a41e8ed17873/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/39f55fe7d1c1045ab18f7024ff23a41e8ed17873/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)