### PR TITLE
Fix crash when loading huge image

### DIFF
--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -93,6 +93,13 @@ pub enum TextureCreationError {
     #[error("Texture with debug label {0:?} has zero width or height!")]
     ZeroSize(DebugLabel),
 
+    #[error("Texture was {width}x{height}, larger that the max of {max_texture_dimension_2d}")]
+    TooLarge {
+        width: u32,
+        height: u32,
+        max_texture_dimension_2d: u32,
+    },
+
     #[error(
         "Texture with debug label {label:?} has a format {format:?} that data can't be transferred to!"
     )]
@@ -337,6 +344,17 @@ impl TextureManager2D {
 
         if creation_desc.width == 0 || creation_desc.height == 0 {
             return Err(TextureCreationError::ZeroSize(creation_desc.label.clone()));
+        }
+
+        let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
+        if creation_desc.width > max_texture_dimension_2d
+            || creation_desc.height > max_texture_dimension_2d
+        {
+            return Err(TextureCreationError::TooLarge {
+                width: creation_desc.width,
+                height: creation_desc.height,
+                max_texture_dimension_2d,
+            });
         }
 
         let size = wgpu::Extent3d {

--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -93,7 +93,7 @@ pub enum TextureCreationError {
     #[error("Texture with debug label {0:?} has zero width or height!")]
     ZeroSize(DebugLabel),
 
-    #[error("Texture was {width}x{height}, larger that the max of {max_texture_dimension_2d}")]
+    #[error("Texture was {width}x{height}, larger than the max of {max_texture_dimension_2d}")]
     TooLarge {
         width: u32,
         height: u32,

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -121,7 +121,7 @@ fn to_textured_rect(
             })
         }
         Err(err) => {
-            re_log::error_once!("Failed to create texture from tensor for {debug_name:?}: {err}");
+            re_log::error_once!("Failed to create texture for {debug_name:?}: {err}");
             None
         }
     }

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -113,7 +113,7 @@ pub fn color_tensor_to_gpu(
             height,
         })
     })
-    .map_err(|err| anyhow::anyhow!("Failed to create texture for color tensor: {err}"))?;
+    .map_err(|err| anyhow::anyhow!("{err}"))?;
 
     let texture_format = texture_handle.format();
 
@@ -215,7 +215,7 @@ pub fn class_id_tensor_to_gpu(
     let main_texture_handle = try_get_or_create_texture(render_ctx, hash(tensor_path_hash), || {
         general_texture_creation_desc_from_tensor(debug_name, tensor)
     })
-    .map_err(|err| anyhow::anyhow!("Failed to create texture for class id tensor: {err}"))?;
+    .map_err(|err| anyhow::anyhow!("{err}"))?;
 
     Ok(ColormappedTexture {
         texture: main_texture_handle,


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/3337

Test code:

```py
import numpy as np
import rerun as rr

rr.init("rerun_example_huge_image", spawn=True)

image = np.zeros((80, 120_000, 3), dtype=np.uint8)
image[:, :, 0] = 255
image[0:40, 0:60_000] = (0, 255, 0)
rr.log("huge_image", rr.Image(image))
```

Output:
> [2023-10-10T11:25:43Z ERROR re_space_view_spatial::parts::images] Failed to create texture for "huge_image": Texture was 120000x80, larger that the max of 16384

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3775) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3775)
- [Docs preview](https://rerun.io/preview/2c5ace544350e2417411c8004c788ac19c801236/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2c5ace544350e2417411c8004c788ac19c801236/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)