### PR TITLE
Show all entities/components in the Streams UI, even if empty for the selected timeline

### DIFF
--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -23,11 +23,13 @@ impl DataUi for InstancePath {
 
         let Some(components) = store.all_components(&query.timeline, entity_path) else {
             if ctx.store_db.entity_db.is_known_entity(entity_path) {
-                ui.label(format!(
-                    "No components in entity {:?} on timeline {:?}",
-                    entity_path,
-                    query.timeline.name()
-                ));
+                ui.label(
+                    egui::RichText::new(format!(
+                        "No components logged on timeline {:?}",
+                        query.timeline.name()
+                    ))
+                    .color(egui::Color32::KHAKI),
+                );
             } else {
                 ui.label(
                     ctx.re_ui

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -23,13 +23,10 @@ impl DataUi for InstancePath {
 
         let Some(components) = store.all_components(&query.timeline, entity_path) else {
             if ctx.store_db.entity_db.is_known_entity(entity_path) {
-                ui.label(
-                    egui::RichText::new(format!(
-                        "No components logged on timeline {:?}",
-                        query.timeline.name()
-                    ))
-                    .color(egui::Color32::KHAKI),
-                );
+                ui.label(ctx.re_ui.warning_text(format!(
+                    "No components logged on timeline {:?}",
+                    query.timeline.name()
+                )));
             } else {
                 ui.label(
                     ctx.re_ui

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -417,13 +417,10 @@ impl TimePanel {
         tree: &EntityTree,
         ui: &mut egui::Ui,
     ) {
-        if !tree
+        let tree_has_data_in_current_timeline = tree
             .prefix_times
             .has_timeline(ctx.rec_cfg.time_ctrl.timeline())
-            && tree.num_timeless_messages() == 0
-        {
-            return; // ignore entities that have no data for the current timeline, nor any timeless data.
-        }
+            || tree.num_timeless_messages() > 0;
 
         // The last part of the path component
         let text = if let Some(last_path_part) = last_path_part {
@@ -478,7 +475,7 @@ impl TimePanel {
         let response_rect = response.rect;
         self.next_col_right = self.next_col_right.max(response_rect.right());
 
-        // From the left of the label, all the way to the rightmost of the time panel
+        // From the left of the label, all the way to the right-most of the time panel
         let full_width_rect = Rect::from_x_y_ranges(
             response_rect.left()..=ui.max_rect().right(),
             response_rect.y_range(),
@@ -489,7 +486,7 @@ impl TimePanel {
         // ----------------------------------------------
 
         // show the data in the time area:
-        if is_visible {
+        if is_visible && tree_has_data_in_current_timeline {
             let row_rect =
                 Rect::from_x_y_ranges(time_area_response.rect.x_range(), response_rect.y_range());
 
@@ -547,12 +544,9 @@ impl TimePanel {
             for component_name in re_data_ui::ui_visible_components(tree.components.keys()) {
                 let data = &tree.components[component_name];
 
-                if !data.times.has_timeline(ctx.rec_cfg.time_ctrl.timeline())
-                    && data.num_timeless_messages() == 0
-                {
-                    continue; // ignore fields that have no data for the current timeline
-                }
-
+                let component_has_data_in_current_timeline =
+                    data.times.has_timeline(ctx.rec_cfg.time_ctrl.timeline())
+                        || data.num_timeless_messages() > 0;
                 let component_path = ComponentPath::new(tree.path.clone(), *component_name);
                 let short_component_name = component_path.component_name.short_name();
                 let item = Item::ComponentPath(component_path);
@@ -587,29 +581,38 @@ impl TimePanel {
 
                 let response_rect = response.rect;
 
+                let empty_messages_over_time = TimeHistogram::default();
+                let messages_over_time = data
+                    .times
+                    .get(ctx.rec_cfg.time_ctrl.timeline())
+                    .unwrap_or(&empty_messages_over_time);
+
+                // `data.times` does not contain timeless. Need to add those manually:
+                let total_num_messages =
+                    messages_over_time.total_count() + data.num_timeless_messages() as u64;
+                response.on_hover_ui(|ui| {
+                    if total_num_messages == 0 {
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "No event logged on timeline {:?}",
+                                ctx.rec_cfg.time_ctrl.timeline().name()
+                            ))
+                            .color(Color32::KHAKI),
+                        );
+                    } else {
+                        ui.label(format!("Number of events: {total_num_messages}"));
+                    }
+                });
+
                 self.next_col_right = self.next_col_right.max(response_rect.right());
 
-                // From the left of the label, all the way to the rightmost of the time panel
+                // From the left of the label, all the way to the right-most of the time panel
                 let full_width_rect = Rect::from_x_y_ranges(
                     response_rect.left()..=ui.max_rect().right(),
                     response_rect.y_range(),
                 );
                 let is_visible = ui.is_rect_visible(full_width_rect);
-
-                if is_visible {
-                    let empty_messages_over_time = TimeHistogram::default();
-                    let messages_over_time = data
-                        .times
-                        .get(ctx.rec_cfg.time_ctrl.timeline())
-                        .unwrap_or(&empty_messages_over_time);
-
-                    // `data.times` does not contain timeless. Need to add those manually:
-                    let total_num_messages =
-                        messages_over_time.total_count() + data.num_timeless_messages() as u64;
-                    response.on_hover_ui(|ui| {
-                        ui.label(format!("Number of events: {total_num_messages}"));
-                    });
-
+                if is_visible && component_has_data_in_current_timeline {
                     // show the data in the time area:
                     let row_rect = Rect::from_x_y_ranges(
                         time_area_response.rect.x_range(),
@@ -859,7 +862,7 @@ fn view_everything(x_range: &Rangef, timeline_axis: &TimelineAxis) -> TimeView {
     let factor = if width_sans_gaps > 0.0 {
         width / width_sans_gaps
     } else {
-        1.0 // too narrow to fit everything anyways
+        1.0 // too narrow to fit everything anyway
     };
 
     let min = timeline_axis.min();

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -417,10 +417,7 @@ impl TimePanel {
         tree: &EntityTree,
         ui: &mut egui::Ui,
     ) {
-        let tree_has_data_in_current_timeline = tree
-            .prefix_times
-            .has_timeline(ctx.rec_cfg.time_ctrl.timeline())
-            || tree.num_timeless_messages() > 0;
+        let tree_has_data_in_current_timeline = ctx.tree_has_data_in_current_timeline(tree);
 
         // The last part of the path component
         let text = if let Some(last_path_part) = last_path_part {
@@ -545,8 +542,7 @@ impl TimePanel {
                 let data = &tree.components[component_name];
 
                 let component_has_data_in_current_timeline =
-                    data.times.has_timeline(ctx.rec_cfg.time_ctrl.timeline())
-                        || data.num_timeless_messages() > 0;
+                    ctx.component_has_data_in_current_timeline(data);
                 let component_path = ComponentPath::new(tree.path.clone(), *component_name);
                 let short_component_name = component_path.component_name.short_name();
                 let item = Item::ComponentPath(component_path);
@@ -592,13 +588,10 @@ impl TimePanel {
                     messages_over_time.total_count() + data.num_timeless_messages() as u64;
                 response.on_hover_ui(|ui| {
                     if total_num_messages == 0 {
-                        ui.label(
-                            egui::RichText::new(format!(
-                                "No event logged on timeline {:?}",
-                                ctx.rec_cfg.time_ctrl.timeline().name()
-                            ))
-                            .color(Color32::KHAKI),
-                        );
+                        ui.label(ctx.re_ui.warning_text(format!(
+                            "No event logged on timeline {:?}",
+                            ctx.rec_cfg.time_ctrl.timeline().name()
+                        )));
                     } else {
                         ui.label(format!("Number of events: {total_num_messages}"));
                     }

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -1,4 +1,5 @@
 use re_data_store::store_db::StoreDb;
+use re_data_store::{ComponentStats, EntityTree};
 
 use crate::{
     item::resolve_mono_instance_path_item, AppOptions, Caches, CommandSender, ComponentUiRegistry,
@@ -89,6 +90,21 @@ impl<'a> ViewerContext<'a> {
     /// The current time query, based on the current time control.
     pub fn current_query(&self) -> re_arrow_store::LatestAtQuery {
         self.rec_cfg.time_ctrl.current_query()
+    }
+
+    /// Returns whether the given tree has any data logged in the current timeline.
+    pub fn tree_has_data_in_current_timeline(&self, tree: &EntityTree) -> bool {
+        tree.prefix_times
+            .has_timeline(self.rec_cfg.time_ctrl.timeline())
+            || tree.num_timeless_messages() > 0
+    }
+
+    /// Returns whether the given component has any data logged in the current timeline.
+    pub fn component_has_data_in_current_timeline(&self, component_stat: &ComponentStats) -> bool {
+        component_stat
+            .times
+            .has_timeline(self.rec_cfg.time_ctrl.timeline())
+            || component_stat.num_timeless_messages() > 0
     }
 }
 


### PR DESCRIPTION
### What

Before, the Streams UI would only include those entities/components that either have data logged on the currently selected timeline, or timeless data logged. This means that depending on the user code, no data could end up being displayed, or the tree content could vary depending on the selected timeline.

This PR changes the behaviour such that all entities/components are now always displayed in the Streams UI, and it adds a conspicuous note in the tooltips to indicate why the timeline might be empty.

<img width="488" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/b566ebf8-7995-4b0f-b497-e4550c7c56c1">

This is a first step in addressing #3733. A follow-up PR should further enhance the styling of hidden entities/components to make it more obvious that they are "timeline-shadowed", and apply the same to the Blueprints Tree UI.

Partially addresses:
- https://github.com/rerun-io/rerun/issues/3733

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3779) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3779)
- [Docs preview](https://rerun.io/preview/017c367bbcd8f593ce0fcf0ebdca16cbbe1e4a85/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/017c367bbcd8f593ce0fcf0ebdca16cbbe1e4a85/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)