### PR TITLE
Export the `RecordingStreamError` type from `re_sdk` and `rerun`.

### DIFF
--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -25,7 +25,9 @@ mod log_integration;
 // -------------
 // Public items:
 
-pub use self::recording_stream::{RecordingStream, RecordingStreamBuilder, RecordingStreamResult};
+pub use self::recording_stream::{
+    RecordingStream, RecordingStreamBuilder, RecordingStreamError, RecordingStreamResult,
+};
 
 pub use re_sdk_comms::{default_flush_timeout, default_server_addr};
 


### PR DESCRIPTION
### What

Fixes #3735 by exporting the previously effectively-private type `RecordingStreamError` from `re_sdk`.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] I've included a screenshot or gif (if applicable)
* [X] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3786) (if applicable)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3786)
- [Docs preview](https://rerun.io/preview/8473b8e3dfe96af30429dc6b088819fc65fee234/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8473b8e3dfe96af30429dc6b088819fc65fee234/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)